### PR TITLE
rust: every write-side check becomes debug_assert!, the idiom the runtime already uses

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -1043,9 +1043,9 @@ That is as far as matching goes, and the standard says so out loud:
 >
 > | value | meaning |
 > |---|---|
-> | `removed` | the build compiles its debug asserts AND its bounds/range checks away (C++ with `NDEBUG`/`SERIALIZE_RELEASE`) |
-> | `always` | the library keeps bounds checks, range validation and the sticky error check in **every** build by contract (Go by design; Rust because `serialize.rs` is `unsafe_code = "forbid"`; C# by its runtime's nature) |
-> | `contract` | the library's debug asserts compile out like `removed`, **but** validation that is part of the wire/API contract stays in every build — serialize.c: caller-error asserts vanish under `NDEBUG`, while the write-capacity check that doubles as the sticky-error flag is unconditional (`serialize.h`, `serialize_write_bits`: "kept as a real check where the C++ BitWriter only asserts") |
+> | `removed` | the build compiles its debug asserts AND its bounds/range checks away (C++ with `NDEBUG`/`SERIALIZE_RELEASE`; C with `-DNDEBUG` since serialize.c ruling #20; Rust with `debug-assertions = false` since the 2026-09-07 ruling made the generated write side `debug_assert!` — safe Rust's own slice bounds checks remain, a LANGUAGE residual this column does not price) |
+> | `always` | the library keeps bounds checks, range validation and the sticky error check in **every** build by contract (Go by design; C# by its runtime's nature) |
+> | `contract` | the library's debug asserts compile out like `removed`, **but** validation that is part of the wire/API contract stays in every build. Its exemplar was serialize.c's write path until ruling #20 (2026-08-17) moved C to `removed`; no leg records it today, and the value stays defined for a runtime that makes that promise. |
 >
 > `contract` was added 2026-08-15 because the two-value column could not
 > express serialize.c at all, and the hybrid it could not express was the
@@ -1058,10 +1058,11 @@ That is as far as matching goes, and the standard says so out loud:
 > values as a language comparison** — `removed` vs `always`, `removed` vs
 > `contract`, `contract` vs `always`, all of them. It may print the ratio
 > under `--label-checks`, and the caption MUST name **both sides' semantics**,
-> not just the values: *"C `checks=contract` (asserts compile out; the write
-> capacity + sticky-error check stays in every build) vs C++ `checks=removed`
-> (asserts and checks compile out) — this ratio includes the cost of a
-> different safety contract."*
+> not just the values: *"Go `checks=always` (bounds, range and sticky-error
+> checks in every build, by design) vs C++ `checks=removed` (asserts and
+> checks compile out) — this ratio includes the cost of a different safety
+> contract."* (The 2026-08-15 captions read C `checks=contract` against C++;
+> they stand as the record of that night.)
 
 Most of the published 6x Go read gap is this. It is a real difference and it should be
 measurable — but it is a *contract* difference, not a *language* difference, and the

--- a/bench/rust/src/main.rs
+++ b/bench/rust/src/main.rs
@@ -35,11 +35,28 @@ const NUM_VARIANTS: usize = 64; // read-path variant buffers
 // in sorted basename order, the basename bytes, a 0x00 byte, the contents.
 // The per-runner constants: family gen (these are the generated-code
 // benchmarks), linkage crate (the serialize.rs runtime compiles into the one
-// crate graph the bench monomorphizes over), checks always (the runtime is
-// unsafe_code = "forbid" — every load is bounds-checked in every build, plus
-// range validation and the sticky error check by contract), opt O3 (the cargo
-// release profile, opt-level 3), inline unknown until the verdict pass (§4.2)
-// backfills it.
+// crate graph the bench monomorphizes over), checks REMOVED (§3.4), opt O3
+// (the cargo release profile, opt-level 3), inline unknown until the verdict
+// pass (§4.2) backfills it.
+//
+// THE CHECKS COLUMN SAID `always` UNTIL 2026-09-07, when the maintainer ruled
+// the write side debug-only across the estate — "No runtime should ever
+// promise to keep checks in writing packets (asserts) in release build.
+// Removing them is the whole point" — and the Rust backend's generated
+// per-field write guards, which were `if ... { return Err(...) }` and ran in
+// THIS release binary, became `debug_assert!`. serialize.rs's own API-misuse
+// checks were already `debug_assert!` (src/stream.rs, `misuse_check!`). The
+// release profile sets `debug-assertions = false`, so this binary's write path
+// now carries NO caller-error check at all — the same model as the C and C++
+// legs under -DNDEBUG, which is why it takes their word.
+//
+// The residual this word does NOT cover, named rather than laundered: safe
+// Rust's own slice bounds checks survive `--release` and the C and C++ legs
+// have no equivalent. They are the LANGUAGE's, not the library's, and the read
+// path — where they mostly live — validates in every build in all three legs.
+// A ratio against C or C++ is still a ratio across the same library check
+// model; if the owner wants the language residual priced separately it needs a
+// fourth column value, not a different word in this one (#175).
 // family is per ROW now (gen | bits — §5.1); linkage/checks/inline stay
 // per-runner constants, and OPT IS READ FROM THE BUILD rather than asserted.
 //
@@ -64,7 +81,7 @@ const BENCH_OPT: &str = match option_env!("BENCH_OPT") {
 };
 
 fn csv_suffix() -> String {
-    format!("crate,always,{BENCH_OPT},unknown")
+    format!("crate,removed,{BENCH_OPT},unknown")
 }
 
 fn fnv1a64(mut h: u64, data: &[u8]) -> u64 {

--- a/compiler/countedbirth_test.go
+++ b/compiler/countedbirth_test.go
@@ -73,14 +73,13 @@ var bornAtMinimum = map[string]string{
 // targets that still hold the count that way. Go and Elixir are here by the
 // ruling — "For each language, do not force this in. If the language simply
 // doesn't have this concept (Golang) then it is not something we can do" — an
-// error-returning runtime in Go, an always-on raise in Elixir. Rust and C# are
-// here only until their own emitter changes land; they move to
-// assertsInDebug then, alongside every other write check in those backends.
+// error-returning runtime in Go, an always-on raise in Elixir. C# is here only
+// until its own emitter change lands; it moves to assertsInDebug then,
+// alongside every other write check in that backend.
 var refusesEveryBuild = map[string][]string{
 	"cs":     {"if (value.WindowCount < 2 || value.WindowCount > 8)"},
 	"elixir": {"if n < 2 do", "if n > 8 do", "raise ArgumentError"},
 	"go":     {"if value.WindowCount < 2 || value.WindowCount > 8 {", "return serialize.ErrValueOutOfRange"},
-	"rust":   {"if value.window_count < 2 || value.window_count > 8 {", "return Err("},
 }
 
 // assertsInDebug is the count's DEBUG-ONLY form in each target that has one:
@@ -92,6 +91,7 @@ var assertsInDebug = map[string][]string{
 	"java": {"assert value.windowCount >= 2;", "assert value.windowCount <= 8;"},
 	// js is not here: its debug-only idiom is not an assert statement but the
 	// PRODUCTION/checked fork of the flat writer, checked separately below.
+	"rust": {`debug_assert!(value.window_count >= 2 && value.window_count <= 8, "window_count out of range [2, 8]");`},
 }
 
 // goneFromRelease is the every-build refusal each assert target used to carry.
@@ -103,6 +103,7 @@ var goneFromRelease = map[string][]string{
 	},
 	"dart": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
 	"java": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
+	"rust": {"if value.window_count < 2 || value.window_count > 8 {"},
 }
 
 // assertToken is the build-removable predicate each target spells its writer
@@ -112,7 +113,6 @@ var assertToken = map[string][]string{
 	"cs":     {"Debug.Assert"},
 	"elixir": nil, // the BEAM has no compile-out assert, so the raise is always on
 	"go":     nil, // the runtime returns an error, in every build
-	"rust":   {"debug_assert", "assert!"},
 }
 
 // generatedText renders every file the target emits for the unit, joined, so a

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -815,8 +815,13 @@ and it holds in every language.
 backend uses `serialize_assert` — and so does the C backend, which has the
 same `assert` and the same `NDEBUG` (2026-09-07: "Every language, by design,
 compiles out asserts/checks in release build. This is the whole point!").
+Rust has `debug_assert!`, compiled out of release, and serialize.rs itself
+holds its API-misuse contracts with it (`src/stream.rs`, `misuse_check!`), so
+the Rust backend `debug_assert!`s (2026-09-07: "No runtime should ever promise
+to keep checks in writing packets (asserts) in release build. Removing them is
+the whole point... checks are *DEBUG ONLY*").
 Go has no assert idiom, so it returns
-`ErrValueOutOfRange`; C#, Rust and JavaScript likewise return failure
+`ErrValueOutOfRange`; C# and JavaScript likewise return failure
 rather than invent an assert. Dart has `assert` — active under
 `--enable-asserts`, compiled out of release and AOT builds — so the Dart
 writer asserts, exactly like C++; Java's `assert` is active under `-ea` and
@@ -828,9 +833,12 @@ correctness the way that language verifies correctness — not that every
 target behaves identically here.
 
 So writing `health = 2000` into a field declared `| min = 0, max = 1000`
-asserts in a C++, C, checked-Dart or `-ea` Java build, raises in Elixir,
-silently writes the truncated low bits in a C++ or C release (`NDEBUG`), Dart
-AOT or default-JVM build, and returns failure in the others.
+asserts in a C++, C, debug-Rust, checked-Dart or `-ea` Java build, raises in
+Elixir, silently writes the truncated low bits in a C++ or C release
+(`NDEBUG`), a Rust release (`debug-assertions = false`; a length or count
+past its array's end panics there on the slice instead, the language's own
+bounds check, which no profile removes), Dart AOT or default-JVM build, and
+returns failure in the others.
 
 Do not build on any of it. **Keep your values inside their declared bounds on
 the write side** — your simulation already knows they are, and that is the only

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -378,12 +378,8 @@ pub const REAL_PACKET_MAX_BYTES: usize = 232;
 
 #[inline(always)]
 pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Result {
-    if value.f001_int < -805495 || value.f001_int > 805495 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f003_int < -835897 || value.f003_int > 835897 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f001_int >= -805495 && value.f001_int <= 805495, "f001_int out of range [-805495, 805495]");
+    debug_assert!(value.f003_int >= -835897 && value.f003_int <= 835897, "f003_int out of range [-835897, 835897]");
     let f0: u64 = u64::from((value.f001_int as u32).wrapping_sub((-805495_i32) as u32));
     let f1: u64 = value.f002_f64.to_bits();
     let f2: u64 = u64::from((value.f003_int as u32).wrapping_sub((-835897_i32) as u32));
@@ -399,18 +395,10 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f004_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation
     }
-    if value.f005_uint > 7316 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f006_int < -1513 || value.f006_int > 1513 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f009_int < -22 || value.f009_int > 22 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f011_bits >= 1 << 10 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f005_uint <= 7316, "f005_uint out of range [0, 7316]");
+    debug_assert!(value.f006_int >= -1513 && value.f006_int <= 1513, "f006_int out of range [-1513, 1513]");
+    debug_assert!(value.f009_int >= -22 && value.f009_int <= 22, "f009_int out of range [-22, 22]");
+    debug_assert!(value.f011_bits < 1 << 10, "f011_bits above the bits(10) wire width");
     let f0: u64 = u64::from(value.f005_uint as u32);
     let f1: u64 = u64::from((value.f006_int as u32).wrapping_sub((-1513_i32) as u32));
     let f2: u64 = u64::from(value.f007_f32.to_bits());
@@ -432,12 +420,8 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     let mut w5 = ((f6 >> 1) | (f7 << 9)) as u32;
     stream.serialize_bits(&mut w5, 10)?;
     if value.f012_bool {
-        if value.f014_uint > 775 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f015_int < -21 || value.f015_int > 21 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f014_uint <= 775, "f014_uint out of range [0, 775]");
+        debug_assert!(value.f015_int >= -21 && value.f015_int <= 21, "f015_int out of range [-21, 21]");
         let f0: u64 = u64::from(value.f013_f32.to_bits());
         let f1: u64 = u64::from(value.f014_uint as u32);
         let f2: u64 = u64::from((value.f015_int as u32).wrapping_sub((-21_i32) as u32));
@@ -445,24 +429,18 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         stream.serialize_bits(&mut w0, 32)?;
         let mut w1 = (f1 | (f2 << 10)) as u32;
         stream.serialize_bits(&mut w1, 16)?;
-        if value.f016_fixed < -37748736 || value.f016_fixed > 37748736 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f016_fixed >= -37748736 && value.f016_fixed <= 37748736, "f016_fixed raw value out of range [-37748736, 37748736]");
         {
             let mut fixed_value = value.f016_fixed;
             stream.serialize_fixed(&mut fixed_value, 12, 20, -36, 36)?;
         }
-        if value.f017_uint > 4606 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f017_uint <= 4606, "f017_uint out of range [0, 4606]");
         {
             let mut offset_value = value.f017_uint as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
         }
     }
-    if value.f018_int < -834 || value.f018_int > 834 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f018_int >= -834 && value.f018_int <= 834, "f018_int out of range [-834, 834]");
     let f0: u64 = u64::from((value.f018_int as u32).wrapping_sub((-834_i32) as u32));
     let f1: u64 = value.f019_f64.to_bits();
     let f2: u64 = u64::from(value.f020_f32.to_bits());
@@ -474,16 +452,12 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     stream.serialize_bits(&mut w2, 32)?;
     let mut w3 = (f2 >> 21) as u32;
     stream.serialize_bits(&mut w3, 11)?;
-    if value.f021_ufixed > 102977536 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f021_ufixed <= 102977536, "f021_ufixed raw value out of range [0, 102977536]");
     {
         let mut fixed_value = value.f021_ufixed;
         stream.serialize_fixed(&mut fixed_value, 20, 12, 0, 25141)?;
     }
-    if value.f023_bits >= 1 << 25 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f023_bits < 1 << 25, "f023_bits above the bits(25) wire width");
     let f0: u64 = u64::from(value.f022_f32.to_bits());
     let f1: u64 = u64::from(value.f023_bits);
     let f2: u64 = u64::from(value.f024_f32.to_bits());
@@ -493,16 +467,12 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     stream.serialize_bits(&mut w1, 32)?;
     let mut w2 = (f2 >> 7) as u32;
     stream.serialize_bits(&mut w2, 25)?;
-    if value.f025_fixed < -30464 || value.f025_fixed > 30464 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f025_fixed >= -30464 && value.f025_fixed <= 30464, "f025_fixed raw value out of range [-30464, 30464]");
     {
         let mut fixed_value = value.f025_fixed;
         stream.serialize_fixed(&mut fixed_value, 8, 8, -119, 119)?;
     }
-    if value.f026_bits >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f026_bits < 1 << 9, "f026_bits above the bits(9) wire width");
     {
         let mut raw_value = value.f026_bits;
         stream.serialize_bits(&mut raw_value, 9)?;
@@ -511,30 +481,14 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f027_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation
     }
-    if value.f028_bits >= 1 << 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f031_bits >= 1 << 1 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f032_int < -3 || value.f032_int > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f033_uint > 142780 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f034_uint > 14149 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f035_bits >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f036_enum.0 > 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f039_bits >= 1 << 19 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f028_bits < 1 << 4, "f028_bits above the bits(4) wire width");
+    debug_assert!(value.f031_bits < 1 << 1, "f031_bits above the bits(1) wire width");
+    debug_assert!(value.f032_int >= -3 && value.f032_int <= 3, "f032_int out of range [-3, 3]");
+    debug_assert!(value.f033_uint <= 142780, "f033_uint out of range [0, 142780]");
+    debug_assert!(value.f034_uint <= 14149, "f034_uint out of range [0, 14149]");
+    debug_assert!(value.f035_bits < 1 << 9, "f035_bits above the bits(9) wire width");
+    debug_assert!(value.f036_enum.0 <= 5, "f036_enum above the PacketMode wire range [0, 5]");
+    debug_assert!(value.f039_bits < 1 << 19, "f039_bits above the bits(19) wire width");
     let f0: u64 = u64::from(value.f028_bits);
     let f1: u64 = value.f029_i64 as u64;
     let f2: u64 = u64::from(value.f030_f32.to_bits());
@@ -559,19 +513,13 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     stream.serialize_bits(&mut w4, 32)?;
     let mut w5 = (f11 >> 10) as u32;
     stream.serialize_bits(&mut w5, 9)?;
-    if value.f040_fixed < -20480 || value.f040_fixed > 20480 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f040_fixed >= -20480 && value.f040_fixed <= 20480, "f040_fixed raw value out of range [-20480, 20480]");
     {
         let mut fixed_value = value.f040_fixed;
         stream.serialize_fixed(&mut fixed_value, 4, 12, -5, 5)?;
     }
-    if value.f041_int < -55 || value.f041_int > 55 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f042_bits >= 1 << 30 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f041_int >= -55 && value.f041_int <= 55, "f041_int out of range [-55, 55]");
+    debug_assert!(value.f042_bits < 1 << 30, "f042_bits above the bits(30) wire width");
     let f0: u64 = u64::from((value.f041_int as u32).wrapping_sub((-55_i32) as u32));
     let f1: u64 = u64::from(value.f042_bits);
     let f2: u64 = u64::from(value.f043_bool);
@@ -580,15 +528,9 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     let mut w1 = ((f1 >> 25) | (f2 << 5)) as u32;
     stream.serialize_bits(&mut w1, 6)?;
     if value.f043_bool {
-        if value.f045_bits >= 1 << 12 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f046_uint > 76063 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f047_int < -430976 || value.f047_int > 430976 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f045_bits < 1 << 12, "f045_bits above the bits(12) wire width");
+        debug_assert!(value.f046_uint <= 76063, "f046_uint out of range [0, 76063]");
+        debug_assert!(value.f047_int >= -430976 && value.f047_int <= 430976, "f047_int out of range [-430976, 430976]");
         let f0: u64 = u64::from(value.f044_f32.to_bits());
         let f1: u64 = u64::from(value.f045_bits);
         let f2: u64 = u64::from(value.f046_uint);
@@ -604,9 +546,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f048_f64;
         stream.serialize_f64(&mut float_value)?;
     }
-    if value.f049_ufixed > 49152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f049_ufixed <= 49152, "f049_ufixed raw value out of range [0, 49152]");
     {
         let mut fixed_value = value.f049_ufixed;
         stream.serialize_fixed(&mut fixed_value, 2, 14, 0, 3)?;
@@ -616,12 +556,8 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         stream.serialize_bool(&mut bool_value)?;
     }
     if value.f050_bool {
-        if value.f052_int < -57 || value.f052_int > 57 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f054_int < -35 || value.f054_int > 35 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f052_int >= -57 && value.f052_int <= 57, "f052_int out of range [-57, 57]");
+        debug_assert!(value.f054_int >= -35 && value.f054_int <= 35, "f054_int out of range [-35, 35]");
         let f0: u64 = u64::from(value.f051_bool);
         let f1: u64 = u64::from((value.f052_int as u32).wrapping_sub((-57_i32) as u32));
         let f2: u64 = u64::from(value.f053_f32.to_bits());
@@ -631,15 +567,9 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut w1 = ((f2 >> 24) | (f3 << 8)) as u32;
         stream.serialize_bits(&mut w1, 15)?;
     }
-    if value.f056_int < -13 || value.f056_int > 13 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f057_int < -15 || value.f057_int > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f060_bits >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f056_int >= -13 && value.f056_int <= 13, "f056_int out of range [-13, 13]");
+    debug_assert!(value.f057_int >= -15 && value.f057_int <= 15, "f057_int out of range [-15, 15]");
+    debug_assert!(value.f060_bits < 1 << 8, "f060_bits above the bits(8) wire width");
     let f0: u64 = u64::from(value.f055_bool);
     let f1: u64 = u64::from((value.f056_int as u32).wrapping_sub((-13_i32) as u32));
     let f2: u64 = u64::from((value.f057_int as u32).wrapping_sub((-15_i32) as u32));
@@ -658,12 +588,8 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f061_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation
     }
-    if value.f062_uint > 503 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f064_uint > 299 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f062_uint <= 503, "f062_uint out of range [0, 503]");
+    debug_assert!(value.f064_uint <= 299, "f064_uint out of range [0, 299]");
     let f0: u64 = u64::from(value.f062_uint as u32);
     let f1: u64 = value.f063_i64 as u64;
     let f2: u64 = u64::from(value.f064_uint as u32);
@@ -677,9 +603,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f065_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation
     }
-    if value.f066_ufixed > 32768 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f066_ufixed <= 32768, "f066_ufixed raw value out of range [0, 32768]");
     {
         let mut fixed_value = value.f066_ufixed;
         stream.serialize_fixed(&mut fixed_value, 2, 14, 0, 2)?;
@@ -692,12 +616,8 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f068_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation
     }
-    if value.f069_bits >= 1 << 11 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f070_uint > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f069_bits < 1 << 11, "f069_bits above the bits(11) wire width");
+    debug_assert!(value.f070_uint <= 2, "f070_uint out of range [0, 2]");
     let f0: u64 = u64::from(value.f069_bits);
     let f1: u64 = u64::from(value.f070_uint as u32);
     let mut w0 = (f0 | (f1 << 11)) as u32;
@@ -710,26 +630,16 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut compressed_value = value.f072_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation
     }
-    if value.f073_int < -4 || value.f073_int > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f073_int >= -4 && value.f073_int <= 4, "f073_int out of range [-4, 4]");
     let f0: u64 = u64::from((value.f073_int as u32).wrapping_sub((-4_i32) as u32));
     let f1: u64 = u64::from(value.f074_bool);
     let mut w0 = (f0 | (f1 << 4)) as u32;
     stream.serialize_bits(&mut w0, 5)?;
     if value.f074_bool {
-        if value.f076_int < -26218 || value.f076_int > 26218 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f077_int < -17 || value.f077_int > 17 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f078_bits >= 1 << 9 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        if value.f079_uint > 17 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.f076_int >= -26218 && value.f076_int <= 26218, "f076_int out of range [-26218, 26218]");
+        debug_assert!(value.f077_int >= -17 && value.f077_int <= 17, "f077_int out of range [-17, 17]");
+        debug_assert!(value.f078_bits < 1 << 9, "f078_bits above the bits(9) wire width");
+        debug_assert!(value.f079_uint <= 17, "f079_uint out of range [0, 17]");
         let f0: u64 = value.f075_u64;
         let f1: u64 = u64::from((value.f076_int as u32).wrapping_sub((-26218_i32) as u32));
         let f2: u64 = u64::from((value.f077_int as u32).wrapping_sub((-17_i32) as u32));
@@ -744,15 +654,9 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut w3 = (f4 >> 1) as u32;
         stream.serialize_bits(&mut w3, 4)?;
     }
-    if value.f081_bits >= 1 << 29 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f082_bits >= 1 << 25 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f083_enum.0 > 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f081_bits < 1 << 29, "f081_bits above the bits(29) wire width");
+    debug_assert!(value.f082_bits < 1 << 25, "f082_bits above the bits(25) wire width");
+    debug_assert!(value.f083_enum.0 <= 5, "f083_enum above the PacketMode wire range [0, 5]");
     let f0: u64 = u64::from(value.f080_bool);
     let f1: u64 = u64::from(value.f081_bits);
     let f2: u64 = u64::from(value.f082_bits);
@@ -761,32 +665,17 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     stream.serialize_bits(&mut w0, 32)?;
     let mut w1 = ((f2 >> 2) | (f3 << 23)) as u32;
     stream.serialize_bits(&mut w1, 26)?;
-    if value.f084_ufixed > 128 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f084_ufixed <= 128, "f084_ufixed raw value out of range [0, 128]");
     {
         let mut fixed_value = value.f084_ufixed;
         stream.serialize_fixed(&mut fixed_value, 1, 7, 0, 1)?;
     }
-    if value.f085_bits >= 1 << 21 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f086_uint > 399 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f088_int < -694 || value.f088_int > 694 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f089_bits >= 1 << 48 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f090_uint > 214 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f091_flags >= 1 << 5 {
-        // a mask bit above the wire width cannot ride
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f085_bits < 1 << 21, "f085_bits above the bits(21) wire width");
+    debug_assert!(value.f086_uint <= 399, "f086_uint out of range [0, 399]");
+    debug_assert!(value.f088_int >= -694 && value.f088_int <= 694, "f088_int out of range [-694, 694]");
+    debug_assert!(value.f089_bits < 1 << 48, "f089_bits above the bits(48) wire width");
+    debug_assert!(value.f090_uint <= 214, "f090_uint out of range [0, 214]");
+    debug_assert!(value.f091_flags < 1 << 5, "f091_flags has a mask bit above the 5-bit wire width");
     let f0: u64 = u64::from(value.f085_bits);
     let f1: u64 = u64::from(value.f086_uint as u32);
     let f2: u64 = value.f087_f64.to_bits();
@@ -813,19 +702,13 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     stream.serialize_bits(&mut w6, 32)?;
     let mut w7 = ((f8 >> 57) | (f9 << 7)) as u32;
     stream.serialize_bits(&mut w7, 8)?;
-    if value.f095_fixed < -103350272 || value.f095_fixed > 103350272 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f095_fixed >= -103350272 && value.f095_fixed <= 103350272, "f095_fixed raw value out of range [-103350272, 103350272]");
     {
         let mut fixed_value = value.f095_fixed;
         stream.serialize_fixed(&mut fixed_value, 16, 16, -1577, 1577)?;
     }
-    if value.f096_bits >= 1 << 18 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f097_bits >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f096_bits < 1 << 18, "f096_bits above the bits(18) wire width");
+    debug_assert!(value.f097_bits < 1 << 12, "f097_bits above the bits(12) wire width");
     let f0: u64 = u64::from(value.f096_bits);
     let f1: u64 = u64::from(value.f097_bits);
     let mut w0 = (f0 | (f1 << 18)) as u32;

--- a/generated/bench/rust/src/bench.rs
+++ b/generated/bench/rust/src/bench.rs
@@ -79,24 +79,12 @@ pub const BENCH_PACKET_MAX_BYTES: usize = 56;
 
 #[inline(always)]
 pub fn write_bench_packet(stream: &mut WriteStream<'_>, value: &BenchPacket) -> Result {
-    if value.a < -100 || value.a > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b < 0 || value.b > 65535 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.c < -1000000 || value.c > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.bits7 >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.bits13 >= 1 << 13 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.bits23 >= 1 << 23 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a >= -100 && value.a <= 100, "a out of range [-100, 100]");
+    debug_assert!(value.b >= 0 && value.b <= 65535, "b out of range [0, 65535]");
+    debug_assert!(value.c >= -1000000 && value.c <= 1000000, "c out of range [-1000000, 1000000]");
+    debug_assert!(value.bits7 < 1 << 7, "bits7 above the bits(7) wire width");
+    debug_assert!(value.bits13 < 1 << 13, "bits13 above the bits(13) wire width");
+    debug_assert!(value.bits23 < 1 << 23, "bits23 above the bits(23) wire width");
     let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
     let f1: u64 = u64::from(value.b as u32);
     let f2: u64 = u64::from((value.c as u32).wrapping_sub((-1000000_i32) as u32));
@@ -222,36 +210,16 @@ pub const BENCH_INTS_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_bench_ints(stream: &mut WriteStream<'_>, value: &BenchInts) -> Result {
-    if value.f0 < -100 || value.f0 > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f1 < 0 || value.f1 > 65535 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f2 < -1000000 || value.f2 > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f3 < 0 || value.f3 > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f4 < -15 || value.f4 > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f5 < 0 || value.f5 > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f6 < -2048 || value.f6 > 2047 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f7 < 0 || value.f7 > 255 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f8 < -600000 || value.f8 > 600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f9 < 0 || value.f9 > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.f0 >= -100 && value.f0 <= 100, "f0 out of range [-100, 100]");
+    debug_assert!(value.f1 >= 0 && value.f1 <= 65535, "f1 out of range [0, 65535]");
+    debug_assert!(value.f2 >= -1000000 && value.f2 <= 1000000, "f2 out of range [-1000000, 1000000]");
+    debug_assert!(value.f3 >= 0 && value.f3 <= 3, "f3 out of range [0, 3]");
+    debug_assert!(value.f4 >= -15 && value.f4 <= 15, "f4 out of range [-15, 15]");
+    debug_assert!(value.f5 >= 0 && value.f5 <= 1000, "f5 out of range [0, 1000]");
+    debug_assert!(value.f6 >= -2048 && value.f6 <= 2047, "f6 out of range [-2048, 2047]");
+    debug_assert!(value.f7 >= 0 && value.f7 <= 255, "f7 out of range [0, 255]");
+    debug_assert!(value.f8 >= -600000 && value.f8 <= 600000, "f8 out of range [-600000, 600000]");
+    debug_assert!(value.f9 >= 0 && value.f9 <= 100, "f9 out of range [0, 100]");
     let f0: u64 = u64::from((value.f0 as u32).wrapping_sub((-100_i32) as u32));
     let f1: u64 = u64::from(value.f1 as u32);
     let f2: u64 = u64::from((value.f2 as u32).wrapping_sub((-1000000_i32) as u32));
@@ -362,27 +330,13 @@ pub const BENCH_BITS_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_bench_bits(stream: &mut WriteStream<'_>, value: &BenchBits) -> Result {
-    if value.b7 >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b13 >= 1 << 13 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b23 >= 1 << 23 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b3 >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b11 >= 1 << 11 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b19 >= 1 << 19 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b48 >= 1 << 48 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.b7 < 1 << 7, "b7 above the bits(7) wire width");
+    debug_assert!(value.b13 < 1 << 13, "b13 above the bits(13) wire width");
+    debug_assert!(value.b23 < 1 << 23, "b23 above the bits(23) wire width");
+    debug_assert!(value.b3 < 1 << 3, "b3 above the bits(3) wire width");
+    debug_assert!(value.b11 < 1 << 11, "b11 above the bits(11) wire width");
+    debug_assert!(value.b19 < 1 << 19, "b19 above the bits(19) wire width");
+    debug_assert!(value.b48 < 1 << 48, "b48 above the bits(48) wire width");
     let f0: u64 = u64::from(value.b7);
     let f1: u64 = u64::from(value.b13);
     let f2: u64 = u64::from(value.b23);
@@ -628,43 +582,18 @@ pub const MIXED_ENTITY_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_mixed_entity(stream: &mut WriteStream<'_>, value: &MixedEntity) -> Result {
-    if value.entity_id >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pos_x < -16383 || value.pos_x > 16383 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pos_y < -16383 || value.pos_y > 16383 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pos_z < -16383 || value.pos_z > 16383 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.yaw >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pitch >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.vel_x < -2048 || value.vel_x > 2047 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.vel_y < -2048 || value.vel_y > 2047 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.vel_z < -2048 || value.vel_z > 2047 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.health < 0 || value.health > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.weapon.0 > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.damage >= 1 << 8 {
-        // a mask bit above the wire width cannot ride
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.entity_id < 1 << 12, "entity_id above the bits(12) wire width");
+    debug_assert!(value.pos_x >= -16383 && value.pos_x <= 16383, "pos_x out of range [-16383, 16383]");
+    debug_assert!(value.pos_y >= -16383 && value.pos_y <= 16383, "pos_y out of range [-16383, 16383]");
+    debug_assert!(value.pos_z >= -16383 && value.pos_z <= 16383, "pos_z out of range [-16383, 16383]");
+    debug_assert!(value.yaw < 1 << 9, "yaw above the bits(9) wire width");
+    debug_assert!(value.pitch < 1 << 9, "pitch above the bits(9) wire width");
+    debug_assert!(value.vel_x >= -2048 && value.vel_x <= 2047, "vel_x out of range [-2048, 2047]");
+    debug_assert!(value.vel_y >= -2048 && value.vel_y <= 2047, "vel_y out of range [-2048, 2047]");
+    debug_assert!(value.vel_z >= -2048 && value.vel_z <= 2047, "vel_z out of range [-2048, 2047]");
+    debug_assert!(value.health >= 0 && value.health <= 1000, "health out of range [0, 1000]");
+    debug_assert!(value.weapon.0 <= 15, "weapon above the MixedWeapon wire range [0, 15]");
+    debug_assert!(value.damage < 1 << 8, "damage has a mask bit above the 8-bit wire width");
     let f0: u64 = u64::from(value.entity_id);
     let f1: u64 = u64::from((value.pos_x as u32).wrapping_sub((-16383_i32) as u32));
     let f2: u64 = u64::from((value.pos_y as u32).wrapping_sub((-16383_i32) as u32));
@@ -773,12 +702,8 @@ pub const MIXED_STAT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_mixed_stat(stream: &mut WriteStream<'_>, value: &MixedStat) -> Result {
-    if value.stat_id >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.delta < -512 || value.delta > 511 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.stat_id < 1 << 8, "stat_id above the bits(8) wire width");
+    debug_assert!(value.delta >= -512 && value.delta <= 511, "delta out of range [-512, 511]");
     let f0: u64 = u64::from(value.stat_id);
     let f1: u64 = u64::from((value.delta as u32).wrapping_sub((-512_i32) as u32));
     let mut w0 = (f0 | (f1 << 8)) as u32;
@@ -827,15 +752,9 @@ pub const MIXED_HIT_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_mixed_hit_event(stream: &mut WriteStream<'_>, value: &MixedHitEvent) -> Result {
-    if value.target_id >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.damage < 0 || value.damage > 4095 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.hit_kind < 0 || value.hit_kind > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.target_id < 1 << 12, "target_id above the bits(12) wire width");
+    debug_assert!(value.damage >= 0 && value.damage <= 4095, "damage out of range [0, 4095]");
+    debug_assert!(value.hit_kind >= 0 && value.hit_kind <= 7, "hit_kind out of range [0, 7]");
     let f0: u64 = u64::from(value.target_id);
     let f1: u64 = u64::from(value.damage as u32);
     let f2: u64 = u64::from(value.hit_kind as u32);
@@ -886,12 +805,8 @@ pub const MIXED_CHAT_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_mixed_chat_event(stream: &mut WriteStream<'_>, value: &MixedChatEvent) -> Result {
-    if value.channel < 0 || value.channel > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.speaker >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.channel >= 0 && value.channel <= 3, "channel out of range [0, 3]");
+    debug_assert!(value.speaker < 1 << 12, "speaker above the bits(12) wire width");
     let f0: u64 = u64::from(value.channel as u32);
     let f1: u64 = u64::from(value.speaker);
     let mut w0 = (f0 | (f1 << 2)) as u32;
@@ -936,12 +851,8 @@ pub const MIXED_PICKUP_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_mixed_pickup_event(stream: &mut WriteStream<'_>, value: &MixedPickupEvent) -> Result {
-    if value.item_id >= 1 << 10 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.amount < 0 || value.amount > 255 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.item_id < 1 << 10, "item_id above the bits(10) wire width");
+    debug_assert!(value.amount >= 0 && value.amount <= 255, "amount out of range [0, 255]");
     let f0: u64 = u64::from(value.item_id);
     let f1: u64 = u64::from(value.amount as u32);
     let mut w0 = (f0 | (f1 << 10)) as u32;
@@ -1153,12 +1064,8 @@ pub const BENCH_MIXED_MAX_BYTES: usize = 456;
 
 #[inline(always)]
 pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Result {
-    if value.sequence >= 1 << 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.ack_sequence < 0 || value.ack_sequence > 65535 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.sequence < 1 << 16, "sequence above the bits(16) wire width");
+    debug_assert!(value.ack_sequence >= 0 && value.ack_sequence <= 65535, "ack_sequence out of range [0, 65535]");
     let f0: u64 = 49374_u64; // const(49374, 16) — SPEC §4.3
     let f1: u64 = u64::from(value.sequence);
     let f2: u64 = u64::from(value.ack_sequence as u32);
@@ -1182,12 +1089,8 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
     stream.serialize_bits(&mut w6, 32)?;
     let mut w7 = (f6 >> 48) as u32;
     stream.serialize_bits(&mut w7, 16)?;
-    if value.world_time < -1000000000000 || value.world_time > 1000000000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.frame_tick >= 1 << 48 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.world_time >= -1000000000000 && value.world_time <= 1000000000000, "world_time out of range [-1000000000000, 1000000000000]");
+    debug_assert!(value.frame_tick < 1 << 48, "frame_tick above the bits(48) wire width");
     let f0: u64 = (value.world_time as u64).wrapping_sub((-1000000000000_i64) as u64);
     let f1: u64 = value.frame_tick;
     let mut w0 = f0 as u32;
@@ -1196,16 +1099,12 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
     stream.serialize_bits(&mut w1, 32)?;
     let mut w2 = (f1 >> 23) as u32;
     stream.serialize_bits(&mut w2, 25)?;
-    if value.server_time < 0 || value.server_time > 16776960 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.server_time >= 0 && value.server_time <= 16776960, "server_time raw value out of range [0, 16776960]");
     {
         let mut fixed_value = value.server_time;
         stream.serialize_fixed(&mut fixed_value, 24, 8, 0, 65535)?;
     }
-    if value.entities_count < 1 || value.entities_count > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.entities_count >= 1 && value.entities_count <= 8, "entities_count out of range [1, 8]");
     {
         let mut offset_value = (value.entities_count as u32).wrapping_sub((1_i32) as u32);
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -1213,9 +1112,7 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
     for i in 0..value.entities_count as usize {
         write_mixed_entity(stream, &value.entities[i])?;
     }
-    if value.stats_count < 0 || value.stats_count > 80 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.stats_count >= 0 && value.stats_count <= 80, "stats_count out of range [0, 80]");
     {
         let mut offset_value = value.stats_count as u32;
         stream.serialize_bits(&mut offset_value, 7)?; // the count guards the loop (§6.3)
@@ -1230,17 +1127,13 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
             stream.serialize_bits(&mut raw_value, 8)?;
         }
     }
-    if value.player_name_length < 0 || value.player_name_length > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.player_name_length >= 0 && value.player_name_length <= 15, "player_name_length out of range [0, 15]");
     {
         let mut offset_value = value.player_name_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.player_name[..value.player_name_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.payload_length < 0 || value.payload_length > 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.payload_length >= 0 && value.payload_length <= 16, "payload_length out of range [0, 16]");
     {
         let mut offset_value = value.payload_length as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the length guards the slice (§6.3)
@@ -1270,16 +1163,12 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
         let mut raw_value = value.wide_key;
         stream.serialize_u128(&mut raw_value)?;
     }
-    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.flux >= -1267650600228229401496703205376 && value.flux <= 1267650600228229401496703205376, "flux out of range [-1267650600228229401496703205376, 1267650600228229401496703205376]");
     {
         let mut range_value = value.flux;
         stream.serialize_int128(&mut range_value, -1267650600228229401496703205376, 1267650600228229401496703205376)?;
     }
-    if value.ping > 64000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ping <= 64000, "ping raw value out of range [0, 64000]");
     {
         let mut fixed_value = value.ping;
         stream.serialize_fixed(&mut fixed_value, 8, 8, 0, 250)?;
@@ -1289,25 +1178,19 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
         stream.serialize_bits(&mut reserved_value, 4)?; // reserved(4) — zeros on the wire
     }
     stream.serialize_align()?;
-    if value.crc_hint >= 1 << 24 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.crc_hint < 1 << 24, "crc_hint above the bits(24) wire width");
     let f0: u64 = u64::from(value.crc_hint);
     let f1: u64 = u64::from(value.has_extra);
     let mut w0 = (f0 | (f1 << 24)) as u32;
     stream.serialize_bits(&mut w0, 25)?;
     if value.has_extra {
-        if value.extra < 0 || value.extra > 255 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.extra >= 0 && value.extra <= 255, "extra out of range [0, 255]");
         {
             let mut offset_value = value.extra as u32;
             stream.serialize_bits(&mut offset_value, 8)?;
         }
     } else {
-        if value.idle_ticks < 0 || value.idle_ticks > 15 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.idle_ticks >= 0 && value.idle_ticks <= 15, "idle_ticks out of range [0, 15]");
         {
             let mut offset_value = value.idle_ticks as u32;
             stream.serialize_bits(&mut offset_value, 4)?;

--- a/generated/bench/tables/rust/src/benchtable.rs
+++ b/generated/bench/tables/rust/src/benchtable.rs
@@ -206,15 +206,9 @@ pub const TABLE_HIT_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_table_hit_event(stream: &mut WriteStream<'_>, value: &TableHitEvent) -> Result {
-    if value.target_id >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.damage < 0 || value.damage > 4095 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.hit_kind < 0 || value.hit_kind > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.target_id < 1 << 12, "target_id above the bits(12) wire width");
+    debug_assert!(value.damage >= 0 && value.damage <= 4095, "damage out of range [0, 4095]");
+    debug_assert!(value.hit_kind >= 0 && value.hit_kind <= 7, "hit_kind out of range [0, 7]");
     let f0: u64 = u64::from(value.target_id);
     let f1: u64 = u64::from(value.damage as u32);
     let f2: u64 = u64::from(value.hit_kind as u32);
@@ -265,12 +259,8 @@ pub const TABLE_CHAT_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_table_chat_event(stream: &mut WriteStream<'_>, value: &TableChatEvent) -> Result {
-    if value.channel < 0 || value.channel > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.speaker >= 1 << 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.channel >= 0 && value.channel <= 3, "channel out of range [0, 3]");
+    debug_assert!(value.speaker < 1 << 12, "speaker above the bits(12) wire width");
     let f0: u64 = u64::from(value.channel as u32);
     let f1: u64 = u64::from(value.speaker);
     let mut w0 = (f0 | (f1 << 2)) as u32;
@@ -315,12 +305,8 @@ pub const TABLE_PICKUP_EVENT_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_table_pickup_event(stream: &mut WriteStream<'_>, value: &TablePickupEvent) -> Result {
-    if value.item_id >= 1 << 10 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.amount < 0 || value.amount > 255 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.item_id < 1 << 10, "item_id above the bits(10) wire width");
+    debug_assert!(value.amount >= 0 && value.amount <= 255, "amount out of range [0, 255]");
     let f0: u64 = u64::from(value.item_id);
     let f1: u64 = u64::from(value.amount as u32);
     let mut w0 = (f0 | (f1 << 10)) as u32;

--- a/generated/rust-ludicrous/src/ludicrous.rs
+++ b/generated/rust-ludicrous/src/ludicrous.rs
@@ -93,38 +93,28 @@ pub const FIXED_PROBE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Result {
-    if value.angle < -11796480 || value.angle > 11796480 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.angle >= -11796480 && value.angle <= 11796480, "angle raw value out of range [-11796480, 11796480]");
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, -180, 180)?;
     }
-    if value.position < -1966080000 || value.position > 1966080000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.position >= -1966080000 && value.position <= 1966080000, "position raw value out of range [-1966080000, 1966080000]");
     {
         let mut fixed_value = value.position;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -MAX_WORLD_UNITS, MAX_WORLD_UNITS)?;
     }
-    if value.reach < -65536000000 || value.reach > 65536000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.reach >= -65536000000 && value.reach <= 65536000000, "reach raw value out of range [-65536000000, 65536000000]");
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, -1000000, 1000000)?;
     }
-    if value.ticks < 0 || value.ticks > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ticks >= 0 && value.ticks <= 1000000, "ticks raw value out of range [0, 1000000]");
     {
         let mut fixed_value = value.ticks;
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] < -524288 || value.samples[i] > 524288 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.samples[i] >= -524288 && value.samples[i] <= 524288, "samples[i] raw value out of range [-524288, 524288]");
         {
             let mut fixed_value = value.samples[i];
             stream.serialize_fixed(&mut fixed_value, 16, 16, -8, 8)?;
@@ -191,46 +181,34 @@ pub const UNSIGNED_PROBE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe) -> Result {
-    if value.angle > 23592960 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.angle <= 23592960, "angle raw value out of range [0, 23592960]");
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 360)?;
     }
-    if value.span > 18446744073709486080 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.span <= 18446744073709486080, "span raw value out of range [0, 18446744073709486080]");
     {
         let mut fixed_value = value.span;
         stream.serialize_fixed(&mut fixed_value, 48, 16, 0, 281474976710655)?;
     }
-    if value.reach > 131072000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.reach <= 131072000000, "reach raw value out of range [0, 131072000000]");
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, 0, 2000000)?;
     }
-    if value.ticks > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ticks <= 1000000, "ticks raw value out of range [0, 1000000]");
     {
         let mut fixed_value = value.ticks;
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] > 1048576 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.samples[i] <= 1048576, "samples[i] raw value out of range [0, 1048576]");
         {
             let mut fixed_value = value.samples[i];
             stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 16)?;
         }
     }
-    if value.locked < 196608 || value.locked > 196608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.locked >= 196608 && value.locked <= 196608, "locked raw value out of range [196608, 196608]");
     {
         let mut raw_value = value.tail as u32;
         stream.serialize_bits(&mut raw_value, 8)?;
@@ -303,23 +281,17 @@ pub fn write_wide_probe(stream: &mut WriteStream<'_>, value: &WideProbe) -> Resu
         let mut raw_value = value.entity_id;
         stream.serialize_u128(&mut raw_value)?;
     }
-    if value.energy < -5000000000 || value.energy > 5000000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.energy >= -5000000000 && value.energy <= 5000000000, "energy out of range [-5000000000, 5000000000]");
     {
         let mut range_value = value.energy;
         stream.serialize_int128(&mut range_value, -5000000000, 5000000000)?;
     }
-    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.flux >= -1267650600228229401496703205376 && value.flux <= 1267650600228229401496703205376, "flux out of range [-1267650600228229401496703205376, 1267650600228229401496703205376]");
     {
         let mut range_value = value.flux;
         stream.serialize_int128(&mut range_value, -1267650600228229401496703205376, 1267650600228229401496703205376)?;
     }
-    if value.bias < -1000 || value.bias > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.bias >= -1000 && value.bias <= 1000, "bias out of range [-1000, 1000]");
     {
         let mut range_value = value.bias;
         stream.serialize_int128(&mut range_value, -1000, 1000)?;
@@ -390,18 +362,14 @@ pub const LUDICROUS_STATE_MAX_BYTES: usize = 152;
 
 #[inline(always)]
 pub fn write_ludicrous_state(stream: &mut WriteStream<'_>, value: &LudicrousState) -> Result {
-    if value.mode.0 > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.mode.0 <= 3, "mode above the DriveMode wire range [0, 3]");
     {
         let mut offset_value = value.mode.0 as u32;
         stream.serialize_bits(&mut offset_value, 2)?;
     }
     write_fixed_probe(stream, &value.probe)?;
     write_wide_probe(stream, &value.wide)?;
-    if value.keys_count < 0 || value.keys_count > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.keys_count >= 0 && value.keys_count <= 4, "keys_count out of range [0, 4]");
     {
         let mut offset_value = value.keys_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -489,15 +457,9 @@ pub const DEGENERATE_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_degenerate_probe(stream: &mut WriteStream<'_>, value: &DegenerateProbe) -> Result {
-    if value.locked_fixed < -196608 || value.locked_fixed > -196608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.locked_int < 7 || value.locked_int > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.locked_fixed >= -196608 && value.locked_fixed <= -196608, "locked_fixed raw value out of range [-196608, -196608]");
+    debug_assert!(value.locked_int >= 7 && value.locked_int <= 7, "locked_int out of range [7, 7]");
+    debug_assert!(value.locked_wide >= -12345678901234 && value.locked_wide <= -12345678901234, "locked_wide out of range [-12345678901234, -12345678901234]");
     {
         let mut raw_value = value.tail as u32;
         stream.serialize_bits(&mut raw_value, 8)?;
@@ -545,23 +507,17 @@ pub const FIXED_VEC_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_vec(stream: &mut WriteStream<'_>, value: &FixedVec) -> Result {
-    if value.x < -6553600000 || value.x > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -6553600000 && value.x <= 6553600000, "x raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.y < -6553600000 || value.y > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.y >= -6553600000 && value.y <= 6553600000, "y raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.z < -6553600000 || value.z > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.z >= -6553600000 && value.z <= 6553600000, "z raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
@@ -617,30 +573,22 @@ pub const FIXED_QUAT_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_quat(stream: &mut WriteStream<'_>, value: &FixedQuat) -> Result {
-    if value.x < -1073741824 || value.x > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -1073741824 && value.x <= 1073741824, "x raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.y < -1073741824 || value.y > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.y >= -1073741824 && value.y <= 1073741824, "y raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.z < -1073741824 || value.z > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.z >= -1073741824 && value.z <= 1073741824, "z raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.w < -1073741824 || value.w > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.w >= -1073741824 && value.w <= 1073741824, "w raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.w;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;

--- a/generated/rust/src/armdefaults.rs
+++ b/generated/rust/src/armdefaults.rs
@@ -47,9 +47,7 @@ pub const DEFAULT_ARM_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_default_arm(stream: &mut WriteStream<'_>, value: &DefaultArm) -> Result {
-    if value.entries_count < 0 || value.entries_count > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.entries_count >= 0 && value.entries_count <= 2, "entries_count out of range [0, 2]");
     {
         let mut offset_value = value.entries_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -57,9 +55,7 @@ pub fn write_default_arm(stream: &mut WriteStream<'_>, value: &DefaultArm) -> Re
     for i in 0..value.entries_count as usize {
         write_probe_config(stream, &value.entries[i])?;
     }
-    if value.marker > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.marker <= 7, "marker out of range [0, 7]");
     {
         let mut offset_value = value.marker as u32;
         stream.serialize_bits(&mut offset_value, 3)?;
@@ -231,9 +227,7 @@ pub const DEFAULT_BULK_ARM_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_default_bulk_arm(stream: &mut WriteStream<'_>, value: &DefaultBulkArm) -> Result {
     write_default_arm(stream, &value.payload)?;
-    if value.data_length < 0 || value.data_length > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.data_length >= 0 && value.data_length <= 2, "data_length out of range [0, 2]");
     {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the length guards the slice (§6.3)

--- a/generated/rust/src/clauses.rs
+++ b/generated/rust/src/clauses.rs
@@ -32,17 +32,13 @@ pub const W13_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w13(stream: &mut WriteStream<'_>, value: &W13) -> Result {
-    if value.items_count < 0 || value.items_count > 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 12, "items_count out of range [0, 12]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
@@ -89,17 +85,13 @@ pub const W17_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w17(stream: &mut WriteStream<'_>, value: &W17) -> Result {
-    if value.items_count < 0 || value.items_count > 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 9, "items_count out of range [0, 9]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 131071 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 131071, "items[i] out of range [0, 131071]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits(&mut offset_value, 17)?;
@@ -146,17 +138,13 @@ pub const W26_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w26(stream: &mut WriteStream<'_>, value: &W26) -> Result {
-    if value.items_count < 0 || value.items_count > 6 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 6, "items_count out of range [0, 6]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 67108863 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 67108863, "items[i] out of range [0, 67108863]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits(&mut offset_value, 26)?;
@@ -203,17 +191,13 @@ pub const W1_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_w1(stream: &mut WriteStream<'_>, value: &W1) -> Result {
-    if value.items_count < 0 || value.items_count > 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 20, "items_count out of range [0, 20]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 1 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 1, "items[i] out of range [0, 1]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 1)?;
@@ -260,17 +244,13 @@ pub const W52_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w52(stream: &mut WriteStream<'_>, value: &W52) -> Result {
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 4503599627370495 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 4503599627370495, "items[i] out of range [0, 4503599627370495]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits64(&mut offset_value, 52)?;
@@ -317,17 +297,13 @@ pub const W50_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w50(stream: &mut WriteStream<'_>, value: &W50) -> Result {
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 1125899906842623 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 1125899906842623, "items[i] out of range [0, 1125899906842623]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits64(&mut offset_value, 50)?;
@@ -373,9 +349,7 @@ pub const F13_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_f13(stream: &mut WriteStream<'_>, value: &F13) -> Result {
     for i in 0..7 {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
@@ -421,12 +395,8 @@ pub const TRI3_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_tri3(stream: &mut WriteStream<'_>, value: &Tri3) -> Result {
-    if value.a >= 1 << 1 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 1, "a above the bits(1) wire width");
+    debug_assert!(value.b < 1 << 2, "b above the bits(2) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let mut w0 = (f0 | (f1 << 1)) as u32;
@@ -471,9 +441,7 @@ pub const ARR_TRI3_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arr_tri3(stream: &mut WriteStream<'_>, value: &ArrTri3) -> Result {
-    if value.items_count < 0 || value.items_count > 10 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 10, "items_count out of range [0, 10]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
@@ -518,12 +486,8 @@ pub const ELEVEN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_eleven(stream: &mut WriteStream<'_>, value: &Eleven) -> Result {
-    if value.a >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 3, "a above the bits(3) wire width");
+    debug_assert!(value.b < 1 << 8, "b above the bits(8) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let mut w0 = (f0 | (f1 << 3)) as u32;
@@ -743,17 +707,13 @@ pub const HOLDS_EMPTY_UNION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_holds_empty_union(stream: &mut WriteStream<'_>, value: &HoldsEmptyUnion) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
     write_empty_union(stream, &value.u)?;
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -802,32 +762,24 @@ pub const STRS_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_strs(stream: &mut WriteStream<'_>, value: &Strs) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.s_length < 0 || value.s_length > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.s_length >= 0 && value.s_length <= 8, "s_length out of range [0, 8]");
     {
         let mut offset_value = value.s_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.b_length < 0 || value.b_length > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.b_length >= 0 && value.b_length <= 8, "b_length out of range [0, 8]");
     {
         let mut offset_value = value.b_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.b[..value.b_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -883,16 +835,12 @@ pub const ARR_NESTED_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arr_nested(stream: &mut WriteStream<'_>, value: &ArrNested) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 4, "items_count out of range [0, 4]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -900,9 +848,7 @@ pub fn write_arr_nested(stream: &mut WriteStream<'_>, value: &ArrNested) -> Resu
     for i in 0..value.items_count as usize {
         write_eleven(stream, &value.items[i])?;
     }
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -944,9 +890,7 @@ pub const SOLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_sole(stream: &mut WriteStream<'_>, value: &Sole) -> Result {
-    if value.only >= 1 << 13 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.only < 1 << 13, "only above the bits(13) wire width");
     {
         let mut raw_value = value.only;
         stream.serialize_bits(&mut raw_value, 13)?;

--- a/generated/rust/src/degenerate.rs
+++ b/generated/rust/src/degenerate.rs
@@ -396,15 +396,9 @@ pub const TRIO_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_trio(stream: &mut WriteStream<'_>, value: &Trio) -> Result {
-    if value.a >= 1 << 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.c >= 1 << 24 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 20, "a above the bits(20) wire width");
+    debug_assert!(value.b < 1 << 20, "b above the bits(20) wire width");
+    debug_assert!(value.c < 1 << 24, "c above the bits(24) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let f2: u64 = u64::from(value.c);
@@ -490,9 +484,7 @@ pub const TRIO_FIRST_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_trio_first(stream: &mut WriteStream<'_>, value: &TrioFirst) -> Result {
     write_trio(stream, &value.inner)?;
-    if value.trailer >= 1 << 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.trailer < 1 << 16, "trailer above the bits(16) wire width");
     {
         let mut raw_value = value.trailer;
         stream.serialize_bits(&mut raw_value, 16)?;
@@ -562,9 +554,7 @@ pub fn write_trio_straddle(stream: &mut WriteStream<'_>, value: &TrioStraddle) -
     stream.serialize_bits(&mut w6, 32)?;
     let mut w7 = (f3 >> 32) as u32;
     stream.serialize_bits(&mut w7, 32)?;
-    if value.pad5 >= 1 << 24 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.pad5 < 1 << 24, "pad5 above the bits(24) wire width");
     let f0: u64 = value.pad4;
     let f1: u64 = u64::from(value.pad5);
     let mut w0 = f0 as u32;

--- a/generated/rust/src/joins.rs
+++ b/generated/rust/src/joins.rs
@@ -45,33 +45,25 @@ pub const ARMS_AGREE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_agree(stream: &mut WriteStream<'_>, value: &ArmsAgree) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 11, "a above the bits(11) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     } else {
-        if value.b >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 11, "b above the bits(11) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -137,33 +129,25 @@ pub const ARMS_DISAGREE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_disagree(stream: &mut WriteStream<'_>, value: &ArmsDisagree) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 11, "a above the bits(11) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     } else {
-        if value.b >= 1 << 3 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 3, "b above the bits(3) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 3)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -224,25 +208,19 @@ pub const ARM_EMPTY_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_empty(stream: &mut WriteStream<'_>, value: &ArmEmpty) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 19 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 19, "a above the bits(19) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 19)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -316,9 +294,7 @@ pub const ARMS_NESTED_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_nested(stream: &mut WriteStream<'_>, value: &ArmsNested) -> Result {
-    if value.lead >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 3, "lead above the bits(3) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.outer);
     let mut w0 = (f0 | (f1 << 3)) as u32;
@@ -329,34 +305,26 @@ pub fn write_arms_nested(stream: &mut WriteStream<'_>, value: &ArmsNested) -> Re
             stream.serialize_bool(&mut bool_value)?;
         }
         if value.inner {
-            if value.x >= 1 << 29 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.x < 1 << 29, "x above the bits(29) wire width");
             {
                 let mut raw_value = value.x;
                 stream.serialize_bits(&mut raw_value, 29)?;
             }
         } else {
-            if value.y >= 1 << 5 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.y < 1 << 5, "y above the bits(5) wire width");
             {
                 let mut raw_value = value.y;
                 stream.serialize_bits(&mut raw_value, 5)?;
             }
         }
     } else {
-        if value.z >= 1 << 13 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.z < 1 << 13, "z above the bits(13) wire width");
         {
             let mut raw_value = value.z;
             stream.serialize_bits(&mut raw_value, 13)?;
         }
     }
-    if value.tail >= 1 << 6 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 6, "tail above the bits(6) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 6)?;
@@ -433,34 +401,26 @@ pub const ARM_ALIGN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_align(stream: &mut WriteStream<'_>, value: &ArmAlign) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.s_length < 0 || value.s_length > 4 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.s_length >= 0 && value.s_length <= 4, "s_length out of range [0, 4]");
         {
             let mut offset_value = value.s_length as u32;
             stream.serialize_bits(&mut offset_value, 3)?; // the length guards the slice (§6.3)
         }
         stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     } else {
-        if value.b >= 1 << 10 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 10, "b above the bits(10) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 10)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -538,42 +498,32 @@ pub const ARM_ARRAY_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_array(stream: &mut WriteStream<'_>, value: &ArmArray) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.items_count < 0 || value.items_count > 3 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
         {
             let mut offset_value = value.items_count as u32;
             stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
         }
         for i in 0..value.items_count as usize {
-            if value.items[i] > 8191 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
             {
                 let mut offset_value = value.items[i] as u32;
                 stream.serialize_bits(&mut offset_value, 13)?;
             }
         }
     } else {
-        if value.b >= 1 << 9 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 9, "b above the bits(9) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 9)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -632,9 +582,7 @@ pub const NARROW_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_narrow(stream: &mut WriteStream<'_>, value: &Narrow) -> Result {
-    if value.n >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.n < 1 << 3, "n above the bits(3) wire width");
     {
         let mut raw_value = value.n;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -671,9 +619,7 @@ pub const WIDE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_wide(stream: &mut WriteStream<'_>, value: &Wide) -> Result {
-    if value.w >= 1 << 37 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.w < 1 << 37, "w above the bits(37) wire width");
     {
         let mut raw_value = value.w;
         stream.serialize_bits64(&mut raw_value, 37)?;
@@ -792,17 +738,13 @@ pub const HOLDS_UNEVEN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_holds_uneven(stream: &mut WriteStream<'_>, value: &HoldsUneven) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
     write_uneven(stream, &value.u)?;
-    if value.tail >= 1 << 11 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 11, "tail above the bits(11) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 11)?;
@@ -847,16 +789,12 @@ pub const ARR_UNEVEN_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_arr_uneven(stream: &mut WriteStream<'_>, value: &ArrUneven) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -864,9 +802,7 @@ pub fn write_arr_uneven(stream: &mut WriteStream<'_>, value: &ArrUneven) -> Resu
     for i in 0..value.items_count as usize {
         write_uneven(stream, &value.items[i])?;
     }
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -924,46 +860,32 @@ pub const REGAIN_AFTER_ALIGN_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_regain_after_align(stream: &mut WriteStream<'_>, value: &RegainAfterAlign) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
         }
     }
-    if value.s_length < 0 || value.s_length > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.s_length >= 0 && value.s_length <= 4, "s_length out of range [0, 4]");
     {
         let mut offset_value = value.s_length as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.q >= 1 << 29 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.r >= 1 << 19 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.tail >= 1 << 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.q < 1 << 29, "q above the bits(29) wire width");
+    debug_assert!(value.r < 1 << 19, "r above the bits(19) wire width");
+    debug_assert!(value.tail < 1 << 4, "tail above the bits(4) wire width");
     let f0: u64 = u64::from(value.p);
     let f1: u64 = u64::from(value.q);
     let f2: u64 = u64::from(value.r);

--- a/generated/rust/src/render.rs
+++ b/generated/rust/src/render.rs
@@ -40,9 +40,7 @@ pub const RENDER_SPRITE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_render_sprite(stream: &mut WriteStream<'_>, value: &RenderSprite) -> Result {
-    if value.team.0 > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.team.0 <= 2, "team above the Team wire range [0, 2]");
     let f0: u64 = value.sort_key;
     let f1: u64 = u64::from(value.mesh_id);
     let f2: u64 = u64::from(value.material_id);
@@ -125,9 +123,7 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
     stream.serialize_bits(&mut w0, 32)?;
     let mut w1 = f1 as u32;
     stream.serialize_bits(&mut w1, 32)?;
-    if value.sprites_count < 0 || value.sprites_count > 64 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.sprites_count >= 0 && value.sprites_count <= 64, "sprites_count out of range [0, 64]");
     {
         let mut offset_value = value.sprites_count as u32;
         stream.serialize_bits(&mut offset_value, 7)?; // the count guards the loop (§6.3)

--- a/generated/rust/src/types.rs
+++ b/generated/rust/src/types.rs
@@ -183,9 +183,7 @@ pub const HANDLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
-    if value.object_id < 0 || value.object_id > 9999 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.object_id >= 0 && value.object_id <= 9999, "object_id out of range [0, 9999]");
     let f0: u64 = u64::from(value.object_id as u32);
     let f1: u64 = u64::from(value.object_sequence);
     let mut w0 = (f0 | (f1 << 14)) as u32;
@@ -235,15 +233,9 @@ pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
-    if value.x < -8388608 || value.x > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -8388608 || value.y > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -8388608 || value.z > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -8388608 && value.x <= 8388608, "x out of range [-8388608, 8388608]");
+    debug_assert!(value.y >= -8388608 && value.y <= 8388608, "y out of range [-8388608, 8388608]");
+    debug_assert!(value.z >= -8388608 && value.z <= 8388608, "z out of range [-8388608, 8388608]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
@@ -310,15 +302,9 @@ pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
-    if value.x < -2097152 || value.x > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -2097152 || value.y > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -2097152 || value.z > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -2097152 && value.x <= 2097152, "x out of range [-2097152, 2097152]");
+    debug_assert!(value.y >= -2097152 && value.y <= 2097152, "y out of range [-2097152, 2097152]");
+    debug_assert!(value.z >= -2097152 && value.z <= 2097152, "z out of range [-2097152, 2097152]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
@@ -387,18 +373,10 @@ pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
-    if value.x < -1024 || value.x > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -1024 || value.y > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -1024 || value.z > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.w < -1024 || value.w > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -1024 && value.x <= 1024, "x out of range [-1024, 1024]");
+    debug_assert!(value.y >= -1024 && value.y <= 1024, "y out of range [-1024, 1024]");
+    debug_assert!(value.z >= -1024 && value.z <= 1024, "z out of range [-1024, 1024]");
+    debug_assert!(value.w >= -1024 && value.w <= 1024, "w out of range [-1024, 1024]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
@@ -665,9 +643,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
     stream.serialize_bits(&mut w3, 32)?;
     let mut w4 = (f2 >> 48) as u32;
     stream.serialize_bits(&mut w4, 16)?;
-    if value.inputs_count < 0 || value.inputs_count > 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.inputs_count >= 0 && value.inputs_count <= 16, "inputs_count out of range [0, 16]");
     {
         let mut offset_value = value.inputs_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
@@ -749,9 +725,7 @@ pub const SHIP_CREATE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Result {
-    if value.ship_type.0 > 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ship_type.0 <= 5, "ship_type above the ShipType wire range [0, 5]");
     {
         let mut offset_value = value.ship_type.0 as u32;
         stream.serialize_bits(&mut offset_value, 3)?;
@@ -764,27 +738,16 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
         stream.serialize_bool(&mut bool_value)?;
     }
     if value.has_flags {
-        if value.flags >= 1 << 4 {
-            // a mask bit above the wire width cannot ride
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.flags < 1 << 4, "flags has a mask bit above the 4-bit wire width");
         {
             let mut flags_value = value.flags as u32;
             stream.serialize_bits(&mut flags_value, 4)?;
         }
     }
-    if value.team.0 > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.health < 0 || value.health > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.thrust < 0 || value.thrust > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pending.0 > 0 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.team.0 <= 2, "team above the Team wire range [0, 2]");
+    debug_assert!(value.health >= 0 && value.health <= 1000, "health out of range [0, 1000]");
+    debug_assert!(value.thrust >= 0 && value.thrust <= 100, "thrust out of range [0, 100]");
+    debug_assert!(value.pending.0 <= 0, "pending above the Pending wire range [0, 0]");
     let f0: u64 = u64::from(value.team.0);
     let f1: u64 = u64::from(value.health as u32);
     let f2: u64 = u64::from(value.thrust as u32);
@@ -871,12 +834,8 @@ pub const EXPRESSION_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionProbe) -> Result {
-    if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.spin_rate < 1024 || value.spin_rate > 2048 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.hardpoint_index >= 0 && value.hardpoint_index <= 31, "hardpoint_index out of range [0, 31]");
+    debug_assert!(value.spin_rate >= 1024 && value.spin_rate <= 2048, "spin_rate out of range [1024, 2048]");
     let f0: u64 = u64::from(value.hardpoint_index as u32);
     let f1: u64 = u64::from((value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32));
     let mut w0 = (f0 | (f1 << 5)) as u32;
@@ -947,15 +906,9 @@ pub const EXTREME_PROBE_MAX_BYTES: usize = 40;
 
 #[inline(always)]
 pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -> Result {
-    if value.floor_bound > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.doubled_floor > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.ceiling_range < 1 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.floor_bound <= 100, "floor_bound out of range [-9223372036854775808, 100]");
+    debug_assert!(value.doubled_floor <= 100, "doubled_floor out of range [-9223372036854775808, 100]");
+    debug_assert!(value.ceiling_range >= 1, "ceiling_range out of range [1, 18446744073709551615]");
     let f0: u64 = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f1: u64 = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f2: u64 = value.ceiling_range - 1;
@@ -1066,12 +1019,8 @@ pub const EXTREME_ROW_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Result {
-    if value.clamped_floor > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.clamped_ceiling < 1 || value.clamped_ceiling > 18446744073709551614 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.clamped_floor <= 100, "clamped_floor out of range [-9223372036854775808, 100]");
+    debug_assert!(value.clamped_ceiling >= 1 && value.clamped_ceiling <= 18446744073709551614, "clamped_ceiling out of range [1, 18446744073709551614]");
     let f0: u64 = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f1: u64 = value.clamped_ceiling - 1;
     let f2: u64 = value.floor_def as u64;

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -119,9 +119,7 @@ pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
-    if value.version >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.version < 1 << 3, "version above the bits(3) wire width");
     let f0: u64 = 171_u64; // const(171, 8) — SPEC §4.3
     let f1: u64 = u64::from(value.version);
     let f2: u64 = 0; // reserved(5) — zeros on the wire
@@ -188,12 +186,8 @@ pub const PROBE_BITS_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Result {
-    if value.small >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.boundary >= 1 << 33 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.small < 1 << 9, "small above the bits(9) wire width");
+    debug_assert!(value.boundary < 1 << 33, "boundary above the bits(33) wire width");
     let f0: u64 = u64::from(value.small);
     let f1: u64 = value.boundary;
     let f2: u64 = value.wide;
@@ -326,9 +320,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     let mut w2 = (f1 >> 32) as u32;
     stream.serialize_bits(&mut w2, 32)?;
     if value.active {
-        if value.weapon.0 > 15 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.weapon.0 <= 15, "weapon above the Weapon wire range [0, 15]");
         let f0: u64 = u64::from(value.weapon.0);
         let f1: u64 = u64::from(value.has_target);
         let mut w0 = (f0 | (f1 << 4)) as u32;
@@ -345,9 +337,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
             stream.serialize_bits(&mut raw_value, 32)?;
         }
     }
-    if value.samples_count < 1 || value.samples_count > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.samples_count >= 1 && value.samples_count <= 8, "samples_count out of range [1, 8]");
     {
         let mut offset_value = (value.samples_count as u32).wrapping_sub((1_i32) as u32);
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -476,9 +466,7 @@ pub const PROBE_SLAB_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Result {
-    if value.width > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.width <= 100, "width out of range [0, 100]");
     let f0: u64 = u64::from(value.width as u32);
     let f1: u64 = u64::from(value.height);
     let mut w0 = (f0 | (f1 << 7)) as u32;
@@ -616,9 +604,7 @@ pub fn write_probe_collider(stream: &mut WriteStream<'_>, value: &ProbeCollider)
     }
     write_probe_shape(stream, &value.shape)?;
     write_probe_shape(stream, &value.backup)?;
-    if value.extras_count < 0 || value.extras_count > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.extras_count >= 0 && value.extras_count <= 2, "extras_count out of range [0, 2]");
     {
         let mut offset_value = value.extras_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -682,9 +668,7 @@ pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
-    if value.preferred.0 > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.preferred.0 <= 15, "preferred above the Weapon wire range [0, 15]");
     let f0: u64 = u64::from(value.retries as u32);
     let f1: u64 = u64::from(value.preferred.0);
     let mut w0 = f0 as u32;
@@ -821,15 +805,9 @@ pub const TEST_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
-    if value.test_b < 0 || value.test_b > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.test_c < 0 || value.test_c > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.test_d < 0 || value.test_d > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.test_b >= 0 && value.test_b <= 1000, "test_b out of range [0, 1000]");
+    debug_assert!(value.test_c >= 0 && value.test_c <= 1000, "test_c out of range [0, 1000]");
+    debug_assert!(value.test_d >= 0 && value.test_d <= 1000, "test_d out of range [0, 1000]");
     let f0: u64 = u64::from(value.test_a);
     let f1: u64 = u64::from(value.test_b as u32);
     let f2: u64 = u64::from(value.test_c as u32);
@@ -893,9 +871,7 @@ pub const BLOCK_MAX_BYTES: usize = 2008;
 
 #[inline(always)]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
-    if value.data_length < 0 || value.data_length > 2000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.data_length >= 0 && value.data_length <= 2000, "data_length out of range [0, 2000]");
     {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 11)?; // the length guards the slice (§6.3)
@@ -936,9 +912,7 @@ pub const CHAT_MAX_BYTES: usize = 264;
 
 #[inline(always)]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
-    if value.text_length < 0 || value.text_length > 256 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.text_length >= 0 && value.text_length <= 256, "text_length out of range [0, 256]");
     {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 9)?; // the length guards the slice (§6.3)
@@ -990,10 +964,7 @@ pub const PROBE_REPORT_MAX_BYTES: usize = 24;
 #[inline(always)]
 pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> Result {
     write_probe_header(stream, &value.header)?;
-    if value.flags >= 1 << 8 {
-        // a mask bit above the wire width cannot ride
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.flags < 1 << 8, "flags has a mask bit above the 8-bit wire width");
     {
         let mut flags_value = value.flags as u32;
         stream.serialize_bits(&mut flags_value, 8)?;
@@ -1081,24 +1052,12 @@ pub const TEST_DATA_MAX_BYTES: usize = 344;
 
 #[inline(always)]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
-    if value.a < -100 || value.a > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b < -100 || value.b > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.c < -100 || value.c > 150 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.d >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.e >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a >= -100 && value.a <= 100, "a out of range [-100, 100]");
+    debug_assert!(value.b >= -100 && value.b <= 100, "b out of range [-100, 100]");
+    debug_assert!(value.c >= -100 && value.c <= 150, "c out of range [-100, 150]");
+    debug_assert!(value.d < 1 << 8, "d above the bits(8) wire width");
+    debug_assert!(value.e < 1 << 8, "e above the bits(8) wire width");
+    debug_assert!(value.f < 1 << 8, "f above the bits(8) wire width");
     let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
     let f1: u64 = u64::from((value.b as u32).wrapping_sub((-100_i32) as u32));
     let f2: u64 = u64::from((value.c as u32).wrapping_sub((-100_i32) as u32));
@@ -1110,17 +1069,13 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w0, 32)?;
     let mut w1 = (f4 | (f5 << 8) | (f6 << 16)) as u32;
     stream.serialize_bits(&mut w1, 17)?;
-    if value.items_count < 0 || value.items_count > 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 16, "items_count out of range [0, 16]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] < 0 || value.items[i] > 255 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] >= 0 && value.items[i] <= 255, "items[i] out of range [0, 255]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 8)?;
@@ -1155,9 +1110,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w5, 32)?;
     let mut w6 = (f6 >> 48) as u32;
     stream.serialize_bits(&mut w6, 16)?;
-    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.int64_range >= -1000000000000 && value.int64_range <= 1000000000000, "int64_range out of range [-1000000000000, 1000000000000]");
     let f0: u64 = value.int64_full as u64;
     let f1: u64 = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
     let mut w0 = f0 as u32;
@@ -1170,9 +1123,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w3, 9)?;
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
-    if value.text_length < 0 || value.text_length > 255 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.text_length >= 0 && value.text_length <= 255, "text_length out of range [0, 255]");
     {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 8)?; // the length guards the slice (§6.3)

--- a/internal/codegen/golang/flat.go
+++ b/internal/codegen/golang/flat.go
@@ -32,7 +32,9 @@
 //
 //  2. EVERY PIECE IS MASKED TO ITS WIDTH. serialize.go's write path MASKS a
 //     too-wide value to the field width; the Rust runtime only debug_asserts,
-//     so PR #183 had to REFUSE such values to stay faithful. Masking here is
+//     so PR #183 had the Rust backend REFUSE such values to stay faithful —
+//     the 2026-09-07 ruling reversed that and the Rust backend now
+//     debug_asserts them like its runtime. Masking here is
 //     what keeps the Go form observably identical to the per-field form it
 //     replaces, and it doubles as the guarantee that no piece can corrupt its
 //     neighbours in the chunk.

--- a/internal/codegen/rust/flat.go
+++ b/internal/codegen/rust/flat.go
@@ -312,12 +312,11 @@ func (g *gen) flatFieldPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
 		w := int64(f.Type.Width)
 		guard := noGuard
 		if f.Type.Width != 32 && f.Type.Width != 64 {
-			// storage is the wider unsigned type: bits above the wire width
-			// are refused, not wrapped (the runtime's write side only
-			// debug_asserts)
+			// storage is the wider unsigned type: a bit above the wire width
+			// is caller error, asserted in debug and trusted in release
 			guard = func(ind string) {
-				g.pf("%sif %s >= 1 << %d {\n", ind, name, f.Type.Width)
-				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s < 1 << %d", name, f.Type.Width),
+					fmt.Sprintf("%s above the bits(%d) wire width", assertLabel(name), f.Type.Width))
 			}
 		}
 		storage := g.rustFieldType(f.Type)
@@ -364,11 +363,11 @@ func (g *gen) flatFieldPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
 			bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
 			guard := noGuard
 			if ref.Max < (int64(1)<<uint(ref.StorageBits))-1 {
-				// headroom storage can exceed the wire range: refused, not
-				// wrapped (the runtime's write side only debug_asserts)
+				// headroom storage can exceed the wire range: caller error,
+				// asserted in debug and trusted in release
 				guard = func(ind string) {
-					g.pf("%sif %s.0 > %d {\n", ind, name, ref.Max)
-					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s.0 <= %d", name, ref.Max),
+						fmt.Sprintf("%s above the %s wire range [0, %d]", assertLabel(name), f.Type.Name, ref.Max))
 				}
 			}
 			storage := rustUint(ref.StorageBits)
@@ -394,9 +393,8 @@ func (g *gen) flatFieldPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
 			guard := noGuard
 			if ref.WireBits < 64 {
 				guard = func(ind string) {
-					g.pf("%sif %s >= 1 << %d {\n", ind, name, ref.WireBits)
-					g.pf("%s    // a mask bit above the wire width cannot ride\n", ind)
-					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s < 1 << %d", name, ref.WireBits),
+						fmt.Sprintf("%s has a mask bit above the %d-bit wire width", assertLabel(name), ref.WireBits))
 				}
 			}
 			return flatPiece{
@@ -564,20 +562,17 @@ func (g *gen) flatIntPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
 	return flatPiece{
 		item: item, bits: bits,
 		guard: func(ind string) {
-			// Like every bounded write path in this target, the range refusal
-			// is generated: serialize.rs's write side only debug_asserts, so a
-			// misuse value must be refused here or it wraps into valid-looking
-			// wire; vacuous halves are elided.
+			// Like every bounded write path in this target, the range is the
+			// caller's contract: asserted in debug, trusted in release;
+			// vacuous halves are elided.
+			msg := fmt.Sprintf("%s out of range [%s, %s]", assertLabel(name), f.IntMin.String(), f.IntMax.String())
 			switch {
 			case !loVacuous && !hiVacuous:
-				g.pf("%sif %s < %s || %s > %s {\n", ind, name, lo, name, f.IntMax.String())
-				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, lo, name, f.IntMax.String()), msg)
 			case !loVacuous:
-				g.pf("%sif %s < %s {\n", ind, name, lo)
-				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, lo), msg)
 			case !hiVacuous:
-				g.pf("%sif %s > %s {\n", ind, name, f.IntMax.String())
-				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, f.IntMax.String()), msg)
 			}
 		},
 		value: value,

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 
 	"github.com/mas-bandwidth/schema/v2/internal/ast"
 	"github.com/mas-bandwidth/schema/v2/ir"
@@ -483,30 +484,48 @@ func storageMax(t ir.FieldType) *big.Int {
 	return new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(t.Width)), big.NewInt(1))
 }
 
-// emitWriteRangeGuard refuses an out-of-contract caller value BEFORE it
-// reaches the runtime. serialize.rs's write side only debug_asserts — in a
-// release build an out-of-range value wraps and ORs stray bits over
-// NEIGHBORING fields, and the reader can accept the corrupt packet — so the
-// generated code supplies the refusal the Go runtime provides natively.
-// Halves vacuous against the storage domain are elided.
+// assertLabel names a field in an assert message the way a Rust programmer
+// reads it: the field path without the `value.` receiver prefix.
+func assertLabel(name string) string {
+	return strings.TrimPrefix(name, "value.")
+}
+
+// writeAssert emits one write-side contract assertion.
+//
+// THE WRITE SIDE IS THE CALLER'S RESPONSIBILITY (SPEC §5). A value outside its
+// declared bounds is a bug in the calling program, not packet data, and Rust's
+// idiom for a caller contract is `debug_assert!`: it fires loudly in a debug
+// build and compiles out of release, where the caller has taken responsibility
+// for correctness. serialize.rs states the same posture for the runtime half
+// (src/stream.rs, `misuse_check!` — "the caller is responsible for well formed
+// calls; release carries minimal runtime checking"), so the generated code and
+// the runtime it calls now hold ONE contract instead of two.
+//
+// READ-SIDE VALIDATION IS UNTOUCHED AND UNCONDITIONAL: the network is the
+// world, and every read still bounds checks and range validates in every build.
+func (g *gen) writeAssert(ind, cond, msg string) {
+	g.pf("%sdebug_assert!(%s, \"%s\");\n", ind, cond, msg)
+}
+
+// emitWriteRangeGuard states the caller's contract for a ranged field. Halves
+// vacuous against the storage domain are elided, and the message names the
+// declared range whichever half survives.
 func (g *gen) emitWriteRangeGuard(name string, f *ir.Field, ind string) {
 	loVacuous := f.IntMin.Cmp(storageMin(f.Type)) <= 0
 	hiVacuous := f.IntMax.Cmp(storageMax(f.Type)) >= 0
+	msg := fmt.Sprintf("%s out of range [%s, %s]", assertLabel(name), f.IntMin.String(), f.IntMax.String())
 	switch {
 	case !loVacuous && !hiVacuous:
-		g.pf("%sif %s < %s || %s > %s {\n", ind, name, f.IntMin.String(), name, f.IntMax.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, f.IntMin.String(), name, f.IntMax.String()), msg)
 	case !loVacuous:
-		g.pf("%sif %s < %s {\n", ind, name, f.IntMin.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, f.IntMin.String()), msg)
 	case !hiVacuous:
-		g.pf("%sif %s > %s {\n", ind, name, f.IntMax.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, f.IntMax.String()), msg)
 	}
 }
 
 // emitWriteFixedRawGuard is emitWriteRangeGuard for a fixed(I, F) field: the
-// storage holds the RAW (scaled) value, so the refusal compares against the
+// storage holds the RAW (scaled) value, so the assertion compares against the
 // whole-unit bounds shifted into the raw domain — the exact range
 // serialize_fixed debug_asserts on write and rejects on read. Halves vacuous
 // against the I+F-bit signed storage domain are elided.
@@ -526,16 +545,14 @@ func (g *gen) emitWriteFixedRawGuard(name string, f *ir.Field, ind string) {
 	}
 	loVacuous := rawMin.Cmp(smin) <= 0
 	hiVacuous := rawMax.Cmp(smax) >= 0
+	msg := fmt.Sprintf("%s raw value out of range [%s, %s]", assertLabel(name), rawMin.String(), rawMax.String())
 	switch {
 	case !loVacuous && !hiVacuous:
-		g.pf("%sif %s < %s || %s > %s {\n", ind, name, rawMin.String(), name, rawMax.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, rawMin.String(), name, rawMax.String()), msg)
 	case !loVacuous:
-		g.pf("%sif %s < %s {\n", ind, name, rawMin.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, rawMin.String()), msg)
 	case !hiVacuous:
-		g.pf("%sif %s > %s {\n", ind, name, rawMax.String())
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, rawMax.String()), msg)
 	}
 }
 
@@ -552,8 +569,13 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 			return
 		}
 		if f.Array == ir.ArrayCounted {
-			g.pf("%sif %s_count < %d || %s_count > %d {\n", ind, name, f.ArrayMin, name, f.ArrayBound)
-			g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			// the count is the caller's contract like every other bound, and
+			// the maintainer ruled it "debug only" on 2026-09-07 with the rest
+			// of the write side: a count outside [A, B] is a bug in the calling
+			// program. The READ still refuses one in every build (SPEC §4.6).
+			g.writeAssert(ind,
+				fmt.Sprintf("%s_count >= %d && %s_count <= %d", name, f.ArrayMin, name, f.ArrayBound),
+				fmt.Sprintf("%s_count out of range [%d, %d]", assertLabel(name), f.ArrayMin, f.ArrayBound))
 			g.emitWriteRangedFold32(name+"_count", false, fmt.Sprintf("%d_i32", f.ArrayMin), f.ArrayMin == 0,
 				ir.BitsRequired(big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound)), " // the count guards the loop (§6.3)", ind)
 			g.pf("%sfor i in 0..%s_count as usize {\n", ind, name)
@@ -573,18 +595,18 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.emitWriteWString(f, name, ind)
 	case ir.TFixed:
 		if f.IntMin.Cmp(f.IntMax) == 0 {
-			// degenerate range: ZERO bits — the generated raw-domain refusal
-			// and no wire call at all, so no runtime degenerate support is
-			// needed (SPEC §4.6)
+			// degenerate range: ZERO bits — the raw-domain assertion and no
+			// wire call at all, so no runtime degenerate support is needed
+			// (SPEC §4.6)
 			g.emitWriteFixedRawGuard(name, f, ind)
 			return
 		}
 		// the Q format and the whole-unit bounds are compile-time constants
 		// of the call site — part of the wire format, exactly like a ranged
-		// integer's bounds (STANDARD.md, fixed). serialize.rs's write side
-		// only debug_asserts, so the raw-domain refusal is generated, like
-		// every bounded write path in this target; the call goes through a
-		// temp — the write functions borrow value immutably
+		// integer's bounds (STANDARD.md, fixed). The raw-domain contract is
+		// a debug assertion, like every bounded write path in this target;
+		// the call goes through a temp — the write functions borrow value
+		// immutably
 		g.emitWriteFixedRawGuard(name, f, ind)
 		lo, hi := g.rangeArgs(f, "i64")
 		g.pf("%s{\n%s    let mut fixed_value = %s;\n", ind, ind, name)
@@ -594,14 +616,15 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		if f.Type.Width == 128 {
 			if f.HasIntRange {
 				if f.IntMin.Cmp(f.IntMax) == 0 {
-					// degenerate range: ZERO bits — refusal only (SPEC §4.6)
+					// degenerate range: ZERO bits — the assertion only
+					// (SPEC §4.6)
 					g.emitWriteRangeGuard(name, f, ind)
 					return
 				}
 				// int128 is ALWAYS ranged (SPEC §4.3): offset from min —
 				// identical bytes to serialize_int64 wherever the range fits.
-				// The runtime's write side only debug_asserts, so the range
-				// refusal is generated (the target's family rule)
+				// The range is the caller's contract, asserted in debug and
+				// trusted in release (the target's family rule)
 				g.emitWriteRangeGuard(name, f, ind)
 				lo, hi := g.rangeArgs(f, "i128")
 				g.pf("%s{\n%s    let mut range_value = %s;\n", ind, ind, name)
@@ -628,23 +651,19 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			default:
 				// full-range unsigned: raw offset bits (u64 storage only — no
 				// narrower storage can hold a range past i64). Like every
-				// bounded write path in this target, the range refusal is
-				// generated: serialize.rs's write side only debug_asserts,
-				// so a misuse value must be refused here or it wraps into
-				// valid-looking wire; vacuous halves are elided
+				// bounded write path in this target, the range contract is a
+				// debug assertion; vacuous halves are elided
 				lo, _ := g.rangeArgs(f, "u64")
 				loVacuous := f.IntMin.Sign() == 0
 				hiVacuous := f.IntMax.Cmp(maxUint64) == 0
+				msg := fmt.Sprintf("%s out of range [%s, %s]", assertLabel(name), f.IntMin.String(), f.IntMax.String())
 				switch {
 				case !loVacuous && !hiVacuous:
-					g.pf("%sif %s < %s || %s > %s {\n", ind, name, lo, name, f.IntMax.String())
-					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, lo, name, f.IntMax.String()), msg)
 				case !loVacuous:
-					g.pf("%sif %s < %s {\n", ind, name, lo)
-					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, lo), msg)
 				case !hiVacuous:
-					g.pf("%sif %s > %s {\n", ind, name, f.IntMax.String())
-					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, f.IntMax.String()), msg)
 				}
 				if loVacuous {
 					g.pf("%s{\n%s    let mut offset_value = %s;\n", ind, ind, name)
@@ -658,11 +677,10 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.emitWriteBareInt(f, name, ind)
 	case ir.TBits:
 		if f.Type.Width != 32 && f.Type.Width != 64 {
-			// storage is the wider unsigned type: bits above the wire width
-			// are refused, not wrapped (the runtime's write side only
-			// debug_asserts)
-			g.pf("%sif %s >= 1 << %d {\n", ind, name, f.Type.Width)
-			g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			// storage is the wider unsigned type: a bit above the wire width
+			// is caller error, asserted in debug and trusted in release
+			g.writeAssert(ind, fmt.Sprintf("%s < 1 << %d", name, f.Type.Width),
+				fmt.Sprintf("%s above the bits(%d) wire width", assertLabel(name), f.Type.Width))
 		}
 		g.pf("%s{\n%s    let mut raw_value = %s;\n", ind, ind, name)
 		if f.Type.Width <= 32 {
@@ -690,8 +708,8 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		// length in [0, N], align, then the used bytes — the classic
 		// serialize_string framing over a buffer of N + 1 (SPEC §4.7).
 		// Interior nulls are writer misuse; the read side rejects them (§4.7).
-		g.pf("%sif %s_length < 0 || %s_length > %d {\n", ind, name, name, f.Type.Size)
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s_length >= 0 && %s_length <= %d", name, name, f.Type.Size),
+			fmt.Sprintf("%s_length out of range [0, %d]", assertLabel(name), f.Type.Size))
 		g.emitWriteRangedFold32(name+"_length", false, "0", true,
 			ir.BitsRequired(big.NewInt(0), big.NewInt(f.Type.Size)), " // the length guards the slice (§6.3)", ind)
 		// the write side borrows the used bytes in place: WriteStream::write_bytes
@@ -703,10 +721,10 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Enum:
 			if ref.Max < (int64(1)<<uint(ref.StorageBits))-1 {
-				// headroom storage can exceed the wire range: refused, not
-				// wrapped (the runtime's write side only debug_asserts)
-				g.pf("%sif %s.0 > %d {\n", ind, name, ref.Max)
-				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				// headroom storage can exceed the wire range: caller error,
+				// asserted in debug and trusted in release
+				g.writeAssert(ind, fmt.Sprintf("%s.0 <= %d", name, ref.Max),
+					fmt.Sprintf("%s above the %s wire range [0, %d]", assertLabel(name), f.Type.Name, ref.Max))
 			}
 			g.emitWriteRangedFold32(name+".0", ref.StorageBits == 32, "0", true,
 				ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max)), "", ind)
@@ -966,12 +984,11 @@ func (g *gen) emitReadFlags(name, typeName string, wireBits int, ind string) {
 
 // emitWriteFlagsValue is the write half used by emitWriteScalar. Storage is
 // wider than the wire wherever WireBits < 64, so a mask bit above the wire
-// width is refused rather than silently truncated.
+// width is a caller contract: asserted in debug, trusted in release.
 func (g *gen) emitWriteFlagsValue(name string, wireBits int, ind string) {
 	if wireBits < 64 {
-		g.pf("%sif %s >= 1 << %d {\n", ind, name, wireBits)
-		g.pf("%s    // a mask bit above the wire width cannot ride\n", ind)
-		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s < 1 << %d", name, wireBits),
+			fmt.Sprintf("%s has a mask bit above the %d-bit wire width", assertLabel(name), wireBits))
 	}
 	if wireBits <= 32 {
 		g.pf("%s{\n%s    let mut flags_value = %s as u32;\n", ind, ind, name)

--- a/internal/codegen/rust/wstring.go
+++ b/internal/codegen/rust/wstring.go
@@ -1,6 +1,7 @@
 package rust
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/mas-bandwidth/schema/v2/ir"
@@ -9,10 +10,11 @@ import (
 func (g *gen) emitWriteWString(f *ir.Field, name, ind string) {
 	bound := g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "i32")
 	g.pf("%s{\n%s    let mut length = %s_length;\n", ind, ind, name)
-	g.pf("%s    if length < 0 || length > %s {\n%s        return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s    }\n", ind, bound, ind, ind)
+	g.writeAssert(ind+"    ", fmt.Sprintf("length >= 0 && length <= %s", bound),
+		fmt.Sprintf("%s_length out of range [0, %s]", assertLabel(name), bound))
 	g.pf("%s    stream.serialize_int(&mut length, 0, %s)?;\n", ind, bound)
 	g.pf("%s    for &unit in &%s[..length as usize] {\n", ind, name)
-	g.pf("%s        if unit == 0 { return Err(Error::Validation); }\n", ind)
+	g.writeAssert(ind+"        ", "unit != 0", fmt.Sprintf("%s carries an interior null within its used length", assertLabel(name)))
 	g.pf("%s        let mut group = u32::from(unit);\n%s        stream.serialize_bits(&mut group, 32)?;\n%s    }\n%s}\n", ind, ind, ind, ind)
 }
 

--- a/make/rust.mk
+++ b/make/rust.mk
@@ -354,7 +354,8 @@ build/conformance-rust: build/tables-generated-rust/.stamp test/conformance/rust
 
 # THE RUST LEG of `make test`: the walk, clippy and feature gates, the names
 # control, the allocation audit and its control, the big-endian check, the
-# bench crates' compile gates, and the packet tests.
+# bench crates' compile gates, and the packet tests — the corpus binaries in
+# BOTH build modes (see below).
 .PHONY: test-rust
 test-rust: generated/rust/.stamp generated/rust-ludicrous/.stamp generated/bench/rust/.stamp
 	$(MAKE) tables-rust-walk
@@ -369,8 +370,15 @@ test-rust: generated/rust/.stamp generated/rust-ludicrous/.stamp generated/bench
 	$(MAKE) tables-rust-big-endian
 	cd generated/bench/rust && PATH="$(RUSTUP_BIN):$$PATH" cargo build --quiet
 	cd generated/bench/rust-realworld && PATH="$(RUSTUP_BIN):$$PATH" cargo build --quiet
+	# BOTH BUILD MODES. The generated writer holds its caller contracts with
+	# `debug_assert!` (the 2026-09-07 ruling: "checks are *DEBUG ONLY*"), so
+	# the debug run is the one that proves the contracts FIRE and the release
+	# run is the one that proves they are GONE and the corpus still writes the
+	# pinned wire. Java, Dart and the packet-wide Rust leg already run both.
 	cd test/rust && PATH="$(RUSTUP_BIN):$$PATH" cargo run --quiet
+	cd test/rust && PATH="$(RUSTUP_BIN):$$PATH" cargo run --quiet --release
 	cd test/rust-ludicrous && PATH="$(RUSTUP_BIN):$$PATH" cargo run --quiet
+	cd test/rust-ludicrous && PATH="$(RUSTUP_BIN):$$PATH" cargo run --quiet --release
 
 TEST_LEGS         += test-rust
 CONFORMANCE_LEGS  += build/conformance-rust

--- a/test/packet-wide/rust/src/main.rs
+++ b/test/packet-wide/rust/src/main.rs
@@ -80,13 +80,38 @@ mod contracts {
         padded[..bytes.len()].copy_from_slice(bytes);
         decode(&mut ReadStream::new(&padded, bytes.len()), value).expect("read");
     }
+    // The writer's wstring contracts — a used length outside [0, N] and an
+    // interior null among the used units (SPEC §4.12) — are `debug_assert!`,
+    // the Rust idiom serialize.rs itself uses (src/stream.rs, `misuse_check!`).
+    // They panic in a debug build and are compiled out of release, so this
+    // helper skips the cases entirely there rather than weakening them. The
+    // READ side's rejections below run in every build.
+    fn expect_assert(f: impl FnOnce(), what: &str) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // the panic IS the pass
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        std::panic::set_hook(previous);
+        assert!(outcome.is_err(), "{what}");
+    }
+
     #[test]
     fn bounds_null_pairing_and_reused_tail() {
         let mut value = wide::WideSeven::default();
         for length in [-1, 8, 1] {
             value.text_length = length;
-            assert!(
-                wide::write_wide_seven(&mut WriteStream::new(&mut [0u8; 256]), &value).is_err()
+            expect_assert(
+                || {
+                    let mut probe = wide::WideSeven::default();
+                    probe.text_length = length;
+                    let _ = wide::write_wide_seven(
+                        &mut WriteStream::new(&mut [0u8; 256]),
+                        &probe,
+                    );
+                },
+                "an out-of-contract wstring write asserts",
             );
         }
         value.text[0] = 0xd800;

--- a/test/rust-ludicrous/src/main.rs
+++ b/test/rust-ludicrous/src/main.rs
@@ -41,6 +41,27 @@ fn check_err(result: ludicrous::Result, what: &str) {
     }
 }
 
+// asserts on = the debug build (the checked twin); off = the release shape.
+// The generated writer holds its caller contracts with `debug_assert!` — the
+// Rust idiom, and what serialize.rs does for its own API misuse (src/stream.rs,
+// `misuse_check!`) — so a violation panics in debug and is compiled out of
+// release. The same shape as test/rust, test/java and test/dart.
+const ASSERTS_ENABLED: bool = cfg!(debug_assertions);
+
+// expect_assert runs a writer-contract violation and demands the assertion
+// fires (checked twin only — the release writer trusts by design). The panic
+// hook is silenced for the duration: the panic IS the pass.
+fn expect_assert<F: FnOnce()>(f: F, what: &str) {
+    if !ASSERTS_ENABLED {
+        return;
+    }
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    std::panic::set_hook(previous);
+    check(outcome.is_err(), what);
+}
+
 // golden_wire byte-compares written wire against the C++-pinned golden.
 fn golden_wire(name: &str, data: &[u8]) {
     match std::fs::read(format!("../../testdata/wire/{name}.bin")) {
@@ -268,15 +289,18 @@ fn main() {
         check_err(read_unsigned_probe(&mut rs, &mut out), "read UnsignedProbe");
         check(out == input, "UnsignedProbe round-trips — the u64 high half bit-exact");
 
-        // the write-side degenerate refusal: any raw but 3 * 2^16 is refused
-        // before a single bit is written
-        let mut bad = input;
-        bad.locked = 196609;
-        let mut bad_buffer = [0u8; 64];
-        let mut bad_ws = WriteStream::new(&mut bad_buffer);
-        check(
-            write_unsigned_probe(&mut bad_ws, &bad).is_err(),
-            "a wrong degenerate ufixed raw is REFUSED on write",
+        // the write-side degenerate contract: any raw but 3 * 2^16 asserts
+        // before a single bit is written (debug only — the release writer
+        // trusts its caller, SPEC §5)
+        expect_assert(
+            || {
+                let mut bad = input;
+                bad.locked = 196609;
+                let mut bad_buffer = [0u8; 64];
+                let mut bad_ws = WriteStream::new(&mut bad_buffer);
+                let _ = write_unsigned_probe(&mut bad_ws, &bad);
+            },
+            "a wrong degenerate ufixed raw ASSERTS on write",
         );
 
         // hostile: span's 64 offset bits (starting at bit 25) all-ones =

--- a/test/rust/src/main.rs
+++ b/test/rust/src/main.rs
@@ -36,6 +36,29 @@ fn check_err(result: example::Result, what: &str) {
     }
 }
 
+// asserts on = the debug build (the checked twin); off = the release shape.
+// The generated writer holds its caller contracts with `debug_assert!`, the
+// idiom serialize.rs itself uses (src/stream.rs, `misuse_check!`), so a
+// violation PANICS in debug and is compiled out of release — where the caller
+// has taken responsibility for correctness (SPEC §5). This mirrors the Java
+// and Dart tests' `assertsEnabled`.
+const ASSERTS_ENABLED: bool = cfg!(debug_assertions);
+
+// expect_assert runs a writer-contract violation and demands the assertion
+// fires (checked twin only — the release writer trusts by design). The panic
+// hook is silenced for the duration: the panic IS the pass, and its backtrace
+// noise would read like a failure in the log.
+fn expect_assert<F: FnOnce()>(f: F, what: &str) {
+    if !ASSERTS_ENABLED {
+        return;
+    }
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    std::panic::set_hook(previous);
+    check(outcome.is_err(), what);
+}
+
 // golden_wire byte-compares written wire against the C++-pinned golden.
 fn golden_wire(name: &str, data: &[u8]) {
     match std::fs::read(format!("../../testdata/wire/{name}.bin")) {
@@ -582,33 +605,41 @@ fn main() {
         check_err(read_probe_report(&mut rs, &mut out), "read ProbeReport");
         check(out == input, "ProbeReport round-trips — a named type as an ordinary field");
 
-        // a mask bit above the widened 8-bit wire is refused, not truncated
+        // a mask bit above the widened 8-bit wire violates the writer's
+        // contract: the debug build asserts, release trusts the caller
         input.flags = 1 << 9;
-        let mut buffer2 = [0u8; 2048];
-        let mut ws2 = WriteStream::new(&mut buffer2);
-        check(
-            write_probe_report(&mut ws2, &input).is_err(),
-            "a mask bit above the flags wire width is refused",
+        expect_assert(
+            || {
+                let mut buffer2 = [0u8; 2048];
+                let mut ws2 = WriteStream::new(&mut buffer2);
+                let _ = write_probe_report(&mut ws2, &input);
+            },
+            "a mask bit above the flags wire width asserts",
         );
     }
 
-    // ---- write-side refusals: serialize.rs only debug_asserts on write, so
-    // the GENERATED guards are what stand between an out-of-contract caller
-    // value and silently corrupt wire in release builds (the Go target gets
-    // these refusals from its runtime; here they are emitted) ----
+    // ---- write-side contracts: the generated writer holds every caller
+    // contract with `debug_assert!` — the Rust idiom, and what serialize.rs
+    // does for its own API misuse (src/stream.rs, `misuse_check!`). The
+    // maintainer's ruling, 2026-09-07: "No runtime should ever promise to keep
+    // checks in writing packets (asserts) in release build. Removing them is
+    // the whole point... checks are *DEBUG ONLY*". So each violation below
+    // PANICS in this debug build and is compiled out of release, and every one
+    // of these cases is skipped there rather than weakened. The READ side is
+    // untouched: it validates in every build, and its tests are elsewhere in
+    // this file. ----
     {
         // enum headroom: Weapon(200) against wire [0, 15]
-        let mut sample = ProbeSample::new();
-        sample.samples_count = 1;
-        sample.weapon = Weapon(200);
-        let mut buffer = [0u8; 2048];
-        let mut ws = WriteStream::new(&mut buffer);
-        check(
-            matches!(
-                write_probe_sample(&mut ws, &sample),
-                Err(Error::Stream(serialize::Error::ValueOutOfRange))
-            ),
-            "an out-of-set enum value is refused on write",
+        expect_assert(
+            || {
+                let mut sample = ProbeSample::new();
+                sample.samples_count = 1;
+                sample.weapon = Weapon(200);
+                let mut buffer = [0u8; 2048];
+                let mut ws = WriteStream::new(&mut buffer);
+                let _ = write_probe_sample(&mut ws, &sample);
+            },
+            "an out-of-set enum value asserts on write",
         );
 
         // a freshly constructed ProbeSample is WIRE-LEGAL: samples_count is
@@ -626,58 +657,54 @@ fn main() {
             "a freshly constructed value writes cleanly",
         );
 
-        // and a count set below that minimum is still refused loudly, exactly
-        // as Go does, never a corrupt packet with Ok
-        let mut below = ProbeSample::new();
-        below.samples_count = 0;
-        let mut buffer_below = [0u8; 2048];
-        let mut ws_below = WriteStream::new(&mut buffer_below);
-        check(
-            matches!(
-                write_probe_sample(&mut ws_below, &below),
-                Err(Error::Stream(serialize::Error::ValueOutOfRange))
-            ),
-            "a below-minimum array count is refused on write",
+        // and a count set below that minimum asserts: the count is a caller
+        // contract like every other bound, ruled "debug only" with the rest
+        expect_assert(
+            || {
+                let mut below = ProbeSample::new();
+                below.samples_count = 0;
+                let mut buffer_below = [0u8; 2048];
+                let mut ws_below = WriteStream::new(&mut buffer_below);
+                let _ = write_probe_sample(&mut ws_below, &below);
+            },
+            "a below-minimum array count asserts on write",
         );
 
         // ranged int: Test.test_b = 2000 against wire [0, 1000]
-        let mut test = Test::default();
-        test.test_b = 2000;
-        let mut buffer3 = [0u8; 2048];
-        let mut ws3 = WriteStream::new(&mut buffer3);
-        check(
-            matches!(
-                write_test(&mut ws3, &test),
-                Err(Error::Stream(serialize::Error::ValueOutOfRange))
-            ),
-            "an out-of-range int value is refused on write",
+        expect_assert(
+            || {
+                let mut test = Test::default();
+                test.test_b = 2000;
+                let mut buffer3 = [0u8; 2048];
+                let mut ws3 = WriteStream::new(&mut buffer3);
+                let _ = write_test(&mut ws3, &test);
+            },
+            "an out-of-range int value asserts on write",
         );
 
         // bits(9): a tenth bit set
-        let mut bits = ProbeBits::default();
-        bits.small = 512;
-        bits.nonce = 0; // in range
-        let mut buffer4 = [0u8; 2048];
-        let mut ws4 = WriteStream::new(&mut buffer4);
-        check(
-            matches!(
-                write_probe_bits(&mut ws4, &bits),
-                Err(Error::Stream(serialize::Error::ValueOutOfRange))
-            ),
-            "a bit above a bits(N) wire width is refused on write",
+        expect_assert(
+            || {
+                let mut bits = ProbeBits::default();
+                bits.small = 512;
+                bits.nonce = 0; // in range
+                let mut buffer4 = [0u8; 2048];
+                let mut ws4 = WriteStream::new(&mut buffer4);
+                let _ = write_probe_bits(&mut ws4, &bits);
+            },
+            "a bit above a bits(N) wire width asserts on write",
         );
 
-        // string length beyond the buffer bound: refused, never a slice panic
-        let mut chat = Chat::default();
-        chat.text_length = 300;
-        let mut buffer5 = [0u8; 2048];
-        let mut ws5 = WriteStream::new(&mut buffer5);
-        check(
-            matches!(
-                write_chat(&mut ws5, &chat),
-                Err(Error::Stream(serialize::Error::ValueOutOfRange))
-            ),
-            "an over-length string is refused on write, not panicked",
+        // string length beyond the buffer bound
+        expect_assert(
+            || {
+                let mut chat = Chat::default();
+                chat.text_length = 300;
+                let mut buffer5 = [0u8; 2048];
+                let mut ws5 = WriteStream::new(&mut buffer5);
+                let _ = write_chat(&mut ws5, &chat);
+            },
+            "an over-length string asserts on write",
         );
     }
 

--- a/testdata/golden/ludicrous/rust/ludicrous.rs
+++ b/testdata/golden/ludicrous/rust/ludicrous.rs
@@ -93,38 +93,28 @@ pub const FIXED_PROBE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Result {
-    if value.angle < -11796480 || value.angle > 11796480 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.angle >= -11796480 && value.angle <= 11796480, "angle raw value out of range [-11796480, 11796480]");
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, -180, 180)?;
     }
-    if value.position < -1966080000 || value.position > 1966080000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.position >= -1966080000 && value.position <= 1966080000, "position raw value out of range [-1966080000, 1966080000]");
     {
         let mut fixed_value = value.position;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -MAX_WORLD_UNITS, MAX_WORLD_UNITS)?;
     }
-    if value.reach < -65536000000 || value.reach > 65536000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.reach >= -65536000000 && value.reach <= 65536000000, "reach raw value out of range [-65536000000, 65536000000]");
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, -1000000, 1000000)?;
     }
-    if value.ticks < 0 || value.ticks > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ticks >= 0 && value.ticks <= 1000000, "ticks raw value out of range [0, 1000000]");
     {
         let mut fixed_value = value.ticks;
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] < -524288 || value.samples[i] > 524288 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.samples[i] >= -524288 && value.samples[i] <= 524288, "samples[i] raw value out of range [-524288, 524288]");
         {
             let mut fixed_value = value.samples[i];
             stream.serialize_fixed(&mut fixed_value, 16, 16, -8, 8)?;
@@ -191,46 +181,34 @@ pub const UNSIGNED_PROBE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe) -> Result {
-    if value.angle > 23592960 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.angle <= 23592960, "angle raw value out of range [0, 23592960]");
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 360)?;
     }
-    if value.span > 18446744073709486080 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.span <= 18446744073709486080, "span raw value out of range [0, 18446744073709486080]");
     {
         let mut fixed_value = value.span;
         stream.serialize_fixed(&mut fixed_value, 48, 16, 0, 281474976710655)?;
     }
-    if value.reach > 131072000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.reach <= 131072000000, "reach raw value out of range [0, 131072000000]");
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, 0, 2000000)?;
     }
-    if value.ticks > 1000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ticks <= 1000000, "ticks raw value out of range [0, 1000000]");
     {
         let mut fixed_value = value.ticks;
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] > 1048576 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.samples[i] <= 1048576, "samples[i] raw value out of range [0, 1048576]");
         {
             let mut fixed_value = value.samples[i];
             stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 16)?;
         }
     }
-    if value.locked < 196608 || value.locked > 196608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.locked >= 196608 && value.locked <= 196608, "locked raw value out of range [196608, 196608]");
     {
         let mut raw_value = value.tail as u32;
         stream.serialize_bits(&mut raw_value, 8)?;
@@ -303,23 +281,17 @@ pub fn write_wide_probe(stream: &mut WriteStream<'_>, value: &WideProbe) -> Resu
         let mut raw_value = value.entity_id;
         stream.serialize_u128(&mut raw_value)?;
     }
-    if value.energy < -5000000000 || value.energy > 5000000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.energy >= -5000000000 && value.energy <= 5000000000, "energy out of range [-5000000000, 5000000000]");
     {
         let mut range_value = value.energy;
         stream.serialize_int128(&mut range_value, -5000000000, 5000000000)?;
     }
-    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.flux >= -1267650600228229401496703205376 && value.flux <= 1267650600228229401496703205376, "flux out of range [-1267650600228229401496703205376, 1267650600228229401496703205376]");
     {
         let mut range_value = value.flux;
         stream.serialize_int128(&mut range_value, -1267650600228229401496703205376, 1267650600228229401496703205376)?;
     }
-    if value.bias < -1000 || value.bias > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.bias >= -1000 && value.bias <= 1000, "bias out of range [-1000, 1000]");
     {
         let mut range_value = value.bias;
         stream.serialize_int128(&mut range_value, -1000, 1000)?;
@@ -390,18 +362,14 @@ pub const LUDICROUS_STATE_MAX_BYTES: usize = 152;
 
 #[inline(always)]
 pub fn write_ludicrous_state(stream: &mut WriteStream<'_>, value: &LudicrousState) -> Result {
-    if value.mode.0 > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.mode.0 <= 3, "mode above the DriveMode wire range [0, 3]");
     {
         let mut offset_value = value.mode.0 as u32;
         stream.serialize_bits(&mut offset_value, 2)?;
     }
     write_fixed_probe(stream, &value.probe)?;
     write_wide_probe(stream, &value.wide)?;
-    if value.keys_count < 0 || value.keys_count > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.keys_count >= 0 && value.keys_count <= 4, "keys_count out of range [0, 4]");
     {
         let mut offset_value = value.keys_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -489,15 +457,9 @@ pub const DEGENERATE_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_degenerate_probe(stream: &mut WriteStream<'_>, value: &DegenerateProbe) -> Result {
-    if value.locked_fixed < -196608 || value.locked_fixed > -196608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.locked_int < 7 || value.locked_int > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.locked_fixed >= -196608 && value.locked_fixed <= -196608, "locked_fixed raw value out of range [-196608, -196608]");
+    debug_assert!(value.locked_int >= 7 && value.locked_int <= 7, "locked_int out of range [7, 7]");
+    debug_assert!(value.locked_wide >= -12345678901234 && value.locked_wide <= -12345678901234, "locked_wide out of range [-12345678901234, -12345678901234]");
     {
         let mut raw_value = value.tail as u32;
         stream.serialize_bits(&mut raw_value, 8)?;
@@ -545,23 +507,17 @@ pub const FIXED_VEC_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_vec(stream: &mut WriteStream<'_>, value: &FixedVec) -> Result {
-    if value.x < -6553600000 || value.x > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -6553600000 && value.x <= 6553600000, "x raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.y < -6553600000 || value.y > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.y >= -6553600000 && value.y <= 6553600000, "y raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.z < -6553600000 || value.z > 6553600000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.z >= -6553600000 && value.z <= 6553600000, "z raw value out of range [-6553600000, 6553600000]");
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
@@ -617,30 +573,22 @@ pub const FIXED_QUAT_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_quat(stream: &mut WriteStream<'_>, value: &FixedQuat) -> Result {
-    if value.x < -1073741824 || value.x > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -1073741824 && value.x <= 1073741824, "x raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.y < -1073741824 || value.y > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.y >= -1073741824 && value.y <= 1073741824, "y raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.z < -1073741824 || value.z > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.z >= -1073741824 && value.z <= 1073741824, "z raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.w < -1073741824 || value.w > 1073741824 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.w >= -1073741824 && value.w <= 1073741824, "w raw value out of range [-1073741824, 1073741824]");
     {
         let mut fixed_value = value.w;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;

--- a/testdata/golden/packet-wide/rust/widetext.rs
+++ b/testdata/golden/packet-wide/rust/widetext.rs
@@ -61,12 +61,10 @@ pub const WIDE_SEVEN_MAX_BYTES: usize = 32;
 pub fn write_wide_seven(stream: &mut WriteStream<'_>, value: &WideSeven) -> Result {
     {
         let mut length = value.text_length;
-        if length < 0 || length > 7 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(length >= 0 && length <= 7, "text_length out of range [0, 7]");
         stream.serialize_int(&mut length, 0, 7)?;
         for &unit in &value.text[..length as usize] {
-            if unit == 0 { return Err(Error::Validation); }
+            debug_assert!(unit != 0, "text carries an interior null within its used length");
             let mut group = u32::from(unit);
             stream.serialize_bits(&mut group, 32)?;
         }
@@ -121,12 +119,10 @@ pub const WIDE_FOUR_MAX_BYTES: usize = 24;
 pub fn write_wide_four(stream: &mut WriteStream<'_>, value: &WideFour) -> Result {
     {
         let mut length = value.text_length;
-        if length < 0 || length > 4 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(length >= 0 && length <= 4, "text_length out of range [0, 4]");
         stream.serialize_int(&mut length, 0, 4)?;
         for &unit in &value.text[..length as usize] {
-            if unit == 0 { return Err(Error::Validation); }
+            debug_assert!(unit != 0, "text carries an interior null within its used length");
             let mut group = u32::from(unit);
             stream.serialize_bits(&mut group, 32)?;
         }
@@ -179,9 +175,7 @@ pub const NARROW_FIFTEEN_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_narrow_fifteen(stream: &mut WriteStream<'_>, value: &NarrowFifteen) -> Result {
-    if value.text_length < 0 || value.text_length > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.text_length >= 0 && value.text_length <= 15, "text_length out of range [0, 15]");
     {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
@@ -232,12 +226,10 @@ pub const WIDE_INTEROP_MAX_BYTES: usize = 32;
 pub fn write_wide_interop(stream: &mut WriteStream<'_>, value: &WideInterop) -> Result {
     {
         let mut length = value.caption_length;
-        if length < 0 || length > 7 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(length >= 0 && length <= 7, "caption_length out of range [0, 7]");
         stream.serialize_int(&mut length, 0, 7)?;
         for &unit in &value.caption[..length as usize] {
-            if unit == 0 { return Err(Error::Validation); }
+            debug_assert!(unit != 0, "caption carries an interior null within its used length");
             let mut group = u32::from(unit);
             stream.serialize_bits(&mut group, 32)?;
         }

--- a/testdata/golden/rust/armdefaults.rs
+++ b/testdata/golden/rust/armdefaults.rs
@@ -47,9 +47,7 @@ pub const DEFAULT_ARM_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_default_arm(stream: &mut WriteStream<'_>, value: &DefaultArm) -> Result {
-    if value.entries_count < 0 || value.entries_count > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.entries_count >= 0 && value.entries_count <= 2, "entries_count out of range [0, 2]");
     {
         let mut offset_value = value.entries_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -57,9 +55,7 @@ pub fn write_default_arm(stream: &mut WriteStream<'_>, value: &DefaultArm) -> Re
     for i in 0..value.entries_count as usize {
         write_probe_config(stream, &value.entries[i])?;
     }
-    if value.marker > 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.marker <= 7, "marker out of range [0, 7]");
     {
         let mut offset_value = value.marker as u32;
         stream.serialize_bits(&mut offset_value, 3)?;
@@ -231,9 +227,7 @@ pub const DEFAULT_BULK_ARM_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_default_bulk_arm(stream: &mut WriteStream<'_>, value: &DefaultBulkArm) -> Result {
     write_default_arm(stream, &value.payload)?;
-    if value.data_length < 0 || value.data_length > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.data_length >= 0 && value.data_length <= 2, "data_length out of range [0, 2]");
     {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the length guards the slice (§6.3)

--- a/testdata/golden/rust/clauses.rs
+++ b/testdata/golden/rust/clauses.rs
@@ -32,17 +32,13 @@ pub const W13_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w13(stream: &mut WriteStream<'_>, value: &W13) -> Result {
-    if value.items_count < 0 || value.items_count > 12 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 12, "items_count out of range [0, 12]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
@@ -89,17 +85,13 @@ pub const W17_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w17(stream: &mut WriteStream<'_>, value: &W17) -> Result {
-    if value.items_count < 0 || value.items_count > 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 9, "items_count out of range [0, 9]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 131071 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 131071, "items[i] out of range [0, 131071]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits(&mut offset_value, 17)?;
@@ -146,17 +138,13 @@ pub const W26_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w26(stream: &mut WriteStream<'_>, value: &W26) -> Result {
-    if value.items_count < 0 || value.items_count > 6 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 6, "items_count out of range [0, 6]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 67108863 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 67108863, "items[i] out of range [0, 67108863]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits(&mut offset_value, 26)?;
@@ -203,17 +191,13 @@ pub const W1_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_w1(stream: &mut WriteStream<'_>, value: &W1) -> Result {
-    if value.items_count < 0 || value.items_count > 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 20, "items_count out of range [0, 20]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 1 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 1, "items[i] out of range [0, 1]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 1)?;
@@ -260,17 +244,13 @@ pub const W52_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w52(stream: &mut WriteStream<'_>, value: &W52) -> Result {
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 4503599627370495 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 4503599627370495, "items[i] out of range [0, 4503599627370495]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits64(&mut offset_value, 52)?;
@@ -317,17 +297,13 @@ pub const W50_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_w50(stream: &mut WriteStream<'_>, value: &W50) -> Result {
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 1125899906842623 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 1125899906842623, "items[i] out of range [0, 1125899906842623]");
         {
             let mut offset_value = value.items[i];
             stream.serialize_bits64(&mut offset_value, 50)?;
@@ -373,9 +349,7 @@ pub const F13_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_f13(stream: &mut WriteStream<'_>, value: &F13) -> Result {
     for i in 0..7 {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
@@ -421,12 +395,8 @@ pub const TRI3_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_tri3(stream: &mut WriteStream<'_>, value: &Tri3) -> Result {
-    if value.a >= 1 << 1 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 1, "a above the bits(1) wire width");
+    debug_assert!(value.b < 1 << 2, "b above the bits(2) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let mut w0 = (f0 | (f1 << 1)) as u32;
@@ -471,9 +441,7 @@ pub const ARR_TRI3_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arr_tri3(stream: &mut WriteStream<'_>, value: &ArrTri3) -> Result {
-    if value.items_count < 0 || value.items_count > 10 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 10, "items_count out of range [0, 10]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the count guards the loop (§6.3)
@@ -518,12 +486,8 @@ pub const ELEVEN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_eleven(stream: &mut WriteStream<'_>, value: &Eleven) -> Result {
-    if value.a >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 3, "a above the bits(3) wire width");
+    debug_assert!(value.b < 1 << 8, "b above the bits(8) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let mut w0 = (f0 | (f1 << 3)) as u32;
@@ -743,17 +707,13 @@ pub const HOLDS_EMPTY_UNION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_holds_empty_union(stream: &mut WriteStream<'_>, value: &HoldsEmptyUnion) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
     write_empty_union(stream, &value.u)?;
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -802,32 +762,24 @@ pub const STRS_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_strs(stream: &mut WriteStream<'_>, value: &Strs) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.s_length < 0 || value.s_length > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.s_length >= 0 && value.s_length <= 8, "s_length out of range [0, 8]");
     {
         let mut offset_value = value.s_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.b_length < 0 || value.b_length > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.b_length >= 0 && value.b_length <= 8, "b_length out of range [0, 8]");
     {
         let mut offset_value = value.b_length as u32;
         stream.serialize_bits(&mut offset_value, 4)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.b[..value.b_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -883,16 +835,12 @@ pub const ARR_NESTED_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arr_nested(stream: &mut WriteStream<'_>, value: &ArrNested) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 4, "items_count out of range [0, 4]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -900,9 +848,7 @@ pub fn write_arr_nested(stream: &mut WriteStream<'_>, value: &ArrNested) -> Resu
     for i in 0..value.items_count as usize {
         write_eleven(stream, &value.items[i])?;
     }
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -944,9 +890,7 @@ pub const SOLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_sole(stream: &mut WriteStream<'_>, value: &Sole) -> Result {
-    if value.only >= 1 << 13 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.only < 1 << 13, "only above the bits(13) wire width");
     {
         let mut raw_value = value.only;
         stream.serialize_bits(&mut raw_value, 13)?;

--- a/testdata/golden/rust/degenerate.rs
+++ b/testdata/golden/rust/degenerate.rs
@@ -396,15 +396,9 @@ pub const TRIO_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_trio(stream: &mut WriteStream<'_>, value: &Trio) -> Result {
-    if value.a >= 1 << 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b >= 1 << 20 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.c >= 1 << 24 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a < 1 << 20, "a above the bits(20) wire width");
+    debug_assert!(value.b < 1 << 20, "b above the bits(20) wire width");
+    debug_assert!(value.c < 1 << 24, "c above the bits(24) wire width");
     let f0: u64 = u64::from(value.a);
     let f1: u64 = u64::from(value.b);
     let f2: u64 = u64::from(value.c);
@@ -490,9 +484,7 @@ pub const TRIO_FIRST_MAX_BYTES: usize = 16;
 #[inline(always)]
 pub fn write_trio_first(stream: &mut WriteStream<'_>, value: &TrioFirst) -> Result {
     write_trio(stream, &value.inner)?;
-    if value.trailer >= 1 << 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.trailer < 1 << 16, "trailer above the bits(16) wire width");
     {
         let mut raw_value = value.trailer;
         stream.serialize_bits(&mut raw_value, 16)?;
@@ -562,9 +554,7 @@ pub fn write_trio_straddle(stream: &mut WriteStream<'_>, value: &TrioStraddle) -
     stream.serialize_bits(&mut w6, 32)?;
     let mut w7 = (f3 >> 32) as u32;
     stream.serialize_bits(&mut w7, 32)?;
-    if value.pad5 >= 1 << 24 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.pad5 < 1 << 24, "pad5 above the bits(24) wire width");
     let f0: u64 = value.pad4;
     let f1: u64 = u64::from(value.pad5);
     let mut w0 = f0 as u32;

--- a/testdata/golden/rust/joins.rs
+++ b/testdata/golden/rust/joins.rs
@@ -45,33 +45,25 @@ pub const ARMS_AGREE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_agree(stream: &mut WriteStream<'_>, value: &ArmsAgree) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 11, "a above the bits(11) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     } else {
-        if value.b >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 11, "b above the bits(11) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -137,33 +129,25 @@ pub const ARMS_DISAGREE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_disagree(stream: &mut WriteStream<'_>, value: &ArmsDisagree) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 11 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 11, "a above the bits(11) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 11)?;
         }
     } else {
-        if value.b >= 1 << 3 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 3, "b above the bits(3) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 3)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -224,25 +208,19 @@ pub const ARM_EMPTY_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_empty(stream: &mut WriteStream<'_>, value: &ArmEmpty) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.a >= 1 << 19 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.a < 1 << 19, "a above the bits(19) wire width");
         {
             let mut raw_value = value.a;
             stream.serialize_bits(&mut raw_value, 19)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -316,9 +294,7 @@ pub const ARMS_NESTED_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arms_nested(stream: &mut WriteStream<'_>, value: &ArmsNested) -> Result {
-    if value.lead >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 3, "lead above the bits(3) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.outer);
     let mut w0 = (f0 | (f1 << 3)) as u32;
@@ -329,34 +305,26 @@ pub fn write_arms_nested(stream: &mut WriteStream<'_>, value: &ArmsNested) -> Re
             stream.serialize_bool(&mut bool_value)?;
         }
         if value.inner {
-            if value.x >= 1 << 29 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.x < 1 << 29, "x above the bits(29) wire width");
             {
                 let mut raw_value = value.x;
                 stream.serialize_bits(&mut raw_value, 29)?;
             }
         } else {
-            if value.y >= 1 << 5 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.y < 1 << 5, "y above the bits(5) wire width");
             {
                 let mut raw_value = value.y;
                 stream.serialize_bits(&mut raw_value, 5)?;
             }
         }
     } else {
-        if value.z >= 1 << 13 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.z < 1 << 13, "z above the bits(13) wire width");
         {
             let mut raw_value = value.z;
             stream.serialize_bits(&mut raw_value, 13)?;
         }
     }
-    if value.tail >= 1 << 6 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 6, "tail above the bits(6) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 6)?;
@@ -433,34 +401,26 @@ pub const ARM_ALIGN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_align(stream: &mut WriteStream<'_>, value: &ArmAlign) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.s_length < 0 || value.s_length > 4 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.s_length >= 0 && value.s_length <= 4, "s_length out of range [0, 4]");
         {
             let mut offset_value = value.s_length as u32;
             stream.serialize_bits(&mut offset_value, 3)?; // the length guards the slice (§6.3)
         }
         stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     } else {
-        if value.b >= 1 << 10 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 10, "b above the bits(10) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 10)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -538,42 +498,32 @@ pub const ARM_ARRAY_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_arm_array(stream: &mut WriteStream<'_>, value: &ArmArray) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     let f0: u64 = u64::from(value.lead);
     let f1: u64 = u64::from(value.flag);
     let mut w0 = (f0 | (f1 << 5)) as u32;
     stream.serialize_bits(&mut w0, 6)?;
     if value.flag {
-        if value.items_count < 0 || value.items_count > 3 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
         {
             let mut offset_value = value.items_count as u32;
             stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
         }
         for i in 0..value.items_count as usize {
-            if value.items[i] > 8191 {
-                return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-            }
+            debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
             {
                 let mut offset_value = value.items[i] as u32;
                 stream.serialize_bits(&mut offset_value, 13)?;
             }
         }
     } else {
-        if value.b >= 1 << 9 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.b < 1 << 9, "b above the bits(9) wire width");
         {
             let mut raw_value = value.b;
             stream.serialize_bits(&mut raw_value, 9)?;
         }
     }
-    if value.tail >= 1 << 7 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 7, "tail above the bits(7) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 7)?;
@@ -632,9 +582,7 @@ pub const NARROW_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_narrow(stream: &mut WriteStream<'_>, value: &Narrow) -> Result {
-    if value.n >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.n < 1 << 3, "n above the bits(3) wire width");
     {
         let mut raw_value = value.n;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -671,9 +619,7 @@ pub const WIDE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_wide(stream: &mut WriteStream<'_>, value: &Wide) -> Result {
-    if value.w >= 1 << 37 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.w < 1 << 37, "w above the bits(37) wire width");
     {
         let mut raw_value = value.w;
         stream.serialize_bits64(&mut raw_value, 37)?;
@@ -792,17 +738,13 @@ pub const HOLDS_UNEVEN_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_holds_uneven(stream: &mut WriteStream<'_>, value: &HoldsUneven) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
     write_uneven(stream, &value.u)?;
-    if value.tail >= 1 << 11 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 11, "tail above the bits(11) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 11)?;
@@ -847,16 +789,12 @@ pub const ARR_UNEVEN_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_arr_uneven(stream: &mut WriteStream<'_>, value: &ArrUneven) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -864,9 +802,7 @@ pub fn write_arr_uneven(stream: &mut WriteStream<'_>, value: &ArrUneven) -> Resu
     for i in 0..value.items_count as usize {
         write_uneven(stream, &value.items[i])?;
     }
-    if value.tail >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.tail < 1 << 3, "tail above the bits(3) wire width");
     {
         let mut raw_value = value.tail;
         stream.serialize_bits(&mut raw_value, 3)?;
@@ -924,46 +860,32 @@ pub const REGAIN_AFTER_ALIGN_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_regain_after_align(stream: &mut WriteStream<'_>, value: &RegainAfterAlign) -> Result {
-    if value.lead >= 1 << 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.lead < 1 << 5, "lead above the bits(5) wire width");
     {
         let mut raw_value = value.lead;
         stream.serialize_bits(&mut raw_value, 5)?;
     }
-    if value.items_count < 0 || value.items_count > 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 3, "items_count out of range [0, 3]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] > 8191 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] <= 8191, "items[i] out of range [0, 8191]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 13)?;
         }
     }
-    if value.s_length < 0 || value.s_length > 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.s_length >= 0 && value.s_length <= 4, "s_length out of range [0, 4]");
     {
         let mut offset_value = value.s_length as u32;
         stream.serialize_bits(&mut offset_value, 3)?; // the length guards the slice (§6.3)
     }
     stream.write_bytes(&value.s[..value.s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
-    if value.q >= 1 << 29 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.r >= 1 << 19 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.tail >= 1 << 4 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.q < 1 << 29, "q above the bits(29) wire width");
+    debug_assert!(value.r < 1 << 19, "r above the bits(19) wire width");
+    debug_assert!(value.tail < 1 << 4, "tail above the bits(4) wire width");
     let f0: u64 = u64::from(value.p);
     let f1: u64 = u64::from(value.q);
     let f2: u64 = u64::from(value.r);

--- a/testdata/golden/rust/render.rs
+++ b/testdata/golden/rust/render.rs
@@ -40,9 +40,7 @@ pub const RENDER_SPRITE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_render_sprite(stream: &mut WriteStream<'_>, value: &RenderSprite) -> Result {
-    if value.team.0 > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.team.0 <= 2, "team above the Team wire range [0, 2]");
     let f0: u64 = value.sort_key;
     let f1: u64 = u64::from(value.mesh_id);
     let f2: u64 = u64::from(value.material_id);
@@ -125,9 +123,7 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
     stream.serialize_bits(&mut w0, 32)?;
     let mut w1 = f1 as u32;
     stream.serialize_bits(&mut w1, 32)?;
-    if value.sprites_count < 0 || value.sprites_count > 64 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.sprites_count >= 0 && value.sprites_count <= 64, "sprites_count out of range [0, 64]");
     {
         let mut offset_value = value.sprites_count as u32;
         stream.serialize_bits(&mut offset_value, 7)?; // the count guards the loop (§6.3)

--- a/testdata/golden/rust/types.rs
+++ b/testdata/golden/rust/types.rs
@@ -183,9 +183,7 @@ pub const HANDLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
-    if value.object_id < 0 || value.object_id > 9999 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.object_id >= 0 && value.object_id <= 9999, "object_id out of range [0, 9999]");
     let f0: u64 = u64::from(value.object_id as u32);
     let f1: u64 = u64::from(value.object_sequence);
     let mut w0 = (f0 | (f1 << 14)) as u32;
@@ -235,15 +233,9 @@ pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
-    if value.x < -8388608 || value.x > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -8388608 || value.y > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -8388608 || value.z > 8388608 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -8388608 && value.x <= 8388608, "x out of range [-8388608, 8388608]");
+    debug_assert!(value.y >= -8388608 && value.y <= 8388608, "y out of range [-8388608, 8388608]");
+    debug_assert!(value.z >= -8388608 && value.z <= 8388608, "z out of range [-8388608, 8388608]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
@@ -310,15 +302,9 @@ pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
-    if value.x < -2097152 || value.x > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -2097152 || value.y > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -2097152 || value.z > 2097152 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -2097152 && value.x <= 2097152, "x out of range [-2097152, 2097152]");
+    debug_assert!(value.y >= -2097152 && value.y <= 2097152, "y out of range [-2097152, 2097152]");
+    debug_assert!(value.z >= -2097152 && value.z <= 2097152, "z out of range [-2097152, 2097152]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
@@ -387,18 +373,10 @@ pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
-    if value.x < -1024 || value.x > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.y < -1024 || value.y > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.z < -1024 || value.z > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.w < -1024 || value.w > 1024 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.x >= -1024 && value.x <= 1024, "x out of range [-1024, 1024]");
+    debug_assert!(value.y >= -1024 && value.y <= 1024, "y out of range [-1024, 1024]");
+    debug_assert!(value.z >= -1024 && value.z <= 1024, "z out of range [-1024, 1024]");
+    debug_assert!(value.w >= -1024 && value.w <= 1024, "w out of range [-1024, 1024]");
     let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
     let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
     let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
@@ -665,9 +643,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
     stream.serialize_bits(&mut w3, 32)?;
     let mut w4 = (f2 >> 48) as u32;
     stream.serialize_bits(&mut w4, 16)?;
-    if value.inputs_count < 0 || value.inputs_count > 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.inputs_count >= 0 && value.inputs_count <= 16, "inputs_count out of range [0, 16]");
     {
         let mut offset_value = value.inputs_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
@@ -749,9 +725,7 @@ pub const SHIP_CREATE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Result {
-    if value.ship_type.0 > 5 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.ship_type.0 <= 5, "ship_type above the ShipType wire range [0, 5]");
     {
         let mut offset_value = value.ship_type.0 as u32;
         stream.serialize_bits(&mut offset_value, 3)?;
@@ -764,27 +738,16 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
         stream.serialize_bool(&mut bool_value)?;
     }
     if value.has_flags {
-        if value.flags >= 1 << 4 {
-            // a mask bit above the wire width cannot ride
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.flags < 1 << 4, "flags has a mask bit above the 4-bit wire width");
         {
             let mut flags_value = value.flags as u32;
             stream.serialize_bits(&mut flags_value, 4)?;
         }
     }
-    if value.team.0 > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.health < 0 || value.health > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.thrust < 0 || value.thrust > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.pending.0 > 0 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.team.0 <= 2, "team above the Team wire range [0, 2]");
+    debug_assert!(value.health >= 0 && value.health <= 1000, "health out of range [0, 1000]");
+    debug_assert!(value.thrust >= 0 && value.thrust <= 100, "thrust out of range [0, 100]");
+    debug_assert!(value.pending.0 <= 0, "pending above the Pending wire range [0, 0]");
     let f0: u64 = u64::from(value.team.0);
     let f1: u64 = u64::from(value.health as u32);
     let f2: u64 = u64::from(value.thrust as u32);
@@ -871,12 +834,8 @@ pub const EXPRESSION_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionProbe) -> Result {
-    if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.spin_rate < 1024 || value.spin_rate > 2048 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.hardpoint_index >= 0 && value.hardpoint_index <= 31, "hardpoint_index out of range [0, 31]");
+    debug_assert!(value.spin_rate >= 1024 && value.spin_rate <= 2048, "spin_rate out of range [1024, 2048]");
     let f0: u64 = u64::from(value.hardpoint_index as u32);
     let f1: u64 = u64::from((value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32));
     let mut w0 = (f0 | (f1 << 5)) as u32;
@@ -947,15 +906,9 @@ pub const EXTREME_PROBE_MAX_BYTES: usize = 40;
 
 #[inline(always)]
 pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -> Result {
-    if value.floor_bound > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.doubled_floor > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.ceiling_range < 1 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.floor_bound <= 100, "floor_bound out of range [-9223372036854775808, 100]");
+    debug_assert!(value.doubled_floor <= 100, "doubled_floor out of range [-9223372036854775808, 100]");
+    debug_assert!(value.ceiling_range >= 1, "ceiling_range out of range [1, 18446744073709551615]");
     let f0: u64 = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f1: u64 = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f2: u64 = value.ceiling_range - 1;
@@ -1066,12 +1019,8 @@ pub const EXTREME_ROW_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Result {
-    if value.clamped_floor > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.clamped_ceiling < 1 || value.clamped_ceiling > 18446744073709551614 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.clamped_floor <= 100, "clamped_floor out of range [-9223372036854775808, 100]");
+    debug_assert!(value.clamped_ceiling >= 1 && value.clamped_ceiling <= 18446744073709551614, "clamped_ceiling out of range [1, 18446744073709551614]");
     let f0: u64 = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
     let f1: u64 = value.clamped_ceiling - 1;
     let f2: u64 = value.floor_def as u64;

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -119,9 +119,7 @@ pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
-    if value.version >= 1 << 3 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.version < 1 << 3, "version above the bits(3) wire width");
     let f0: u64 = 171_u64; // const(171, 8) — SPEC §4.3
     let f1: u64 = u64::from(value.version);
     let f2: u64 = 0; // reserved(5) — zeros on the wire
@@ -188,12 +186,8 @@ pub const PROBE_BITS_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Result {
-    if value.small >= 1 << 9 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.boundary >= 1 << 33 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.small < 1 << 9, "small above the bits(9) wire width");
+    debug_assert!(value.boundary < 1 << 33, "boundary above the bits(33) wire width");
     let f0: u64 = u64::from(value.small);
     let f1: u64 = value.boundary;
     let f2: u64 = value.wide;
@@ -326,9 +320,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     let mut w2 = (f1 >> 32) as u32;
     stream.serialize_bits(&mut w2, 32)?;
     if value.active {
-        if value.weapon.0 > 15 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.weapon.0 <= 15, "weapon above the Weapon wire range [0, 15]");
         let f0: u64 = u64::from(value.weapon.0);
         let f1: u64 = u64::from(value.has_target);
         let mut w0 = (f0 | (f1 << 4)) as u32;
@@ -345,9 +337,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
             stream.serialize_bits(&mut raw_value, 32)?;
         }
     }
-    if value.samples_count < 1 || value.samples_count > 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.samples_count >= 1 && value.samples_count <= 8, "samples_count out of range [1, 8]");
     {
         let mut offset_value = (value.samples_count as u32).wrapping_sub((1_i32) as u32);
         stream.serialize_bits(&mut offset_value, 3)?; // the count guards the loop (§6.3)
@@ -476,9 +466,7 @@ pub const PROBE_SLAB_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Result {
-    if value.width > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.width <= 100, "width out of range [0, 100]");
     let f0: u64 = u64::from(value.width as u32);
     let f1: u64 = u64::from(value.height);
     let mut w0 = (f0 | (f1 << 7)) as u32;
@@ -616,9 +604,7 @@ pub fn write_probe_collider(stream: &mut WriteStream<'_>, value: &ProbeCollider)
     }
     write_probe_shape(stream, &value.shape)?;
     write_probe_shape(stream, &value.backup)?;
-    if value.extras_count < 0 || value.extras_count > 2 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.extras_count >= 0 && value.extras_count <= 2, "extras_count out of range [0, 2]");
     {
         let mut offset_value = value.extras_count as u32;
         stream.serialize_bits(&mut offset_value, 2)?; // the count guards the loop (§6.3)
@@ -682,9 +668,7 @@ pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
-    if value.preferred.0 > 15 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.preferred.0 <= 15, "preferred above the Weapon wire range [0, 15]");
     let f0: u64 = u64::from(value.retries as u32);
     let f1: u64 = u64::from(value.preferred.0);
     let mut w0 = f0 as u32;
@@ -821,15 +805,9 @@ pub const TEST_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
-    if value.test_b < 0 || value.test_b > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.test_c < 0 || value.test_c > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.test_d < 0 || value.test_d > 1000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.test_b >= 0 && value.test_b <= 1000, "test_b out of range [0, 1000]");
+    debug_assert!(value.test_c >= 0 && value.test_c <= 1000, "test_c out of range [0, 1000]");
+    debug_assert!(value.test_d >= 0 && value.test_d <= 1000, "test_d out of range [0, 1000]");
     let f0: u64 = u64::from(value.test_a);
     let f1: u64 = u64::from(value.test_b as u32);
     let f2: u64 = u64::from(value.test_c as u32);
@@ -893,9 +871,7 @@ pub const BLOCK_MAX_BYTES: usize = 2008;
 
 #[inline(always)]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
-    if value.data_length < 0 || value.data_length > 2000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.data_length >= 0 && value.data_length <= 2000, "data_length out of range [0, 2000]");
     {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 11)?; // the length guards the slice (§6.3)
@@ -936,9 +912,7 @@ pub const CHAT_MAX_BYTES: usize = 264;
 
 #[inline(always)]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
-    if value.text_length < 0 || value.text_length > 256 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.text_length >= 0 && value.text_length <= 256, "text_length out of range [0, 256]");
     {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 9)?; // the length guards the slice (§6.3)
@@ -990,10 +964,7 @@ pub const PROBE_REPORT_MAX_BYTES: usize = 24;
 #[inline(always)]
 pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> Result {
     write_probe_header(stream, &value.header)?;
-    if value.flags >= 1 << 8 {
-        // a mask bit above the wire width cannot ride
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.flags < 1 << 8, "flags has a mask bit above the 8-bit wire width");
     {
         let mut flags_value = value.flags as u32;
         stream.serialize_bits(&mut flags_value, 8)?;
@@ -1081,24 +1052,12 @@ pub const TEST_DATA_MAX_BYTES: usize = 344;
 
 #[inline(always)]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
-    if value.a < -100 || value.a > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.b < -100 || value.b > 100 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.c < -100 || value.c > 150 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.d >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.e >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    if value.f >= 1 << 8 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.a >= -100 && value.a <= 100, "a out of range [-100, 100]");
+    debug_assert!(value.b >= -100 && value.b <= 100, "b out of range [-100, 100]");
+    debug_assert!(value.c >= -100 && value.c <= 150, "c out of range [-100, 150]");
+    debug_assert!(value.d < 1 << 8, "d above the bits(8) wire width");
+    debug_assert!(value.e < 1 << 8, "e above the bits(8) wire width");
+    debug_assert!(value.f < 1 << 8, "f above the bits(8) wire width");
     let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
     let f1: u64 = u64::from((value.b as u32).wrapping_sub((-100_i32) as u32));
     let f2: u64 = u64::from((value.c as u32).wrapping_sub((-100_i32) as u32));
@@ -1110,17 +1069,13 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w0, 32)?;
     let mut w1 = (f4 | (f5 << 8) | (f6 << 16)) as u32;
     stream.serialize_bits(&mut w1, 17)?;
-    if value.items_count < 0 || value.items_count > 16 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.items_count >= 0 && value.items_count <= 16, "items_count out of range [0, 16]");
     {
         let mut offset_value = value.items_count as u32;
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] < 0 || value.items[i] > 255 {
-            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
+        debug_assert!(value.items[i] >= 0 && value.items[i] <= 255, "items[i] out of range [0, 255]");
         {
             let mut offset_value = value.items[i] as u32;
             stream.serialize_bits(&mut offset_value, 8)?;
@@ -1155,9 +1110,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w5, 32)?;
     let mut w6 = (f6 >> 48) as u32;
     stream.serialize_bits(&mut w6, 16)?;
-    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.int64_range >= -1000000000000 && value.int64_range <= 1000000000000, "int64_range out of range [-1000000000000, 1000000000000]");
     let f0: u64 = value.int64_full as u64;
     let f1: u64 = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
     let mut w0 = f0 as u32;
@@ -1170,9 +1123,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     stream.serialize_bits(&mut w3, 9)?;
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
-    if value.text_length < 0 || value.text_length > 255 {
-        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
+    debug_assert!(value.text_length >= 0 && value.text_length <= 255, "text_length out of range [0, 255]");
     {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 8)?; // the length guards the slice (§6.3)


### PR DESCRIPTION
Glenn's rulings, verbatim, today: "No runtime should ever promise to keep checks in writing packets (asserts) in release build. Removing them is the whole point. ... checks are *DEBUG ONLY*"; "Of course, on read side we MUST always do the checks!"; on the counted array's count: "debug only."; "consistency matters. writing packets correctness is the caller's responsibility, and it is our duty to catch it with asserts in debug."; "The bottom line is that a user of schema/serialize in that languages should feel that the implementation is native to their language and how it is used in best practice."

**What was wrong.** serialize.rs already does this right: its `misuse_check!` is `debug_assert!`, compiled out in release. The Rust emitter then re-added every write-side refusal as unconditional generated code, `if cond { return Err(ValueOutOfRange) }`, to compensate (the note in internal/codegen/golang/flat.go said so). In generated/bench/rust that was 75 `return Err` sites, 58 of them caller-error checks on the write.

**What changes.** Every write-side caller-error check in the Rust emitter is `debug_assert!(cond, "field out of range [lo, hi]")`: integer ranges (151 sites across the regenerated corpus), bits(N) raw width (149), fixed and ufixed raw domain (48), the counted array's count (38), string, bytes and wstring used length (22), enum headroom (17), flags mask width (6), wstring interior null (3). Unchanged: every read-side check; capacity and overflow (a runtime condition); union tags (type-checked). The wire files did not move: a check that never fired wrote no bits. compiler/countedbirth_test.go's gate is restructured so Rust's count expectation is the assert form and the other eight targets' sweep is untouched (a stray assert on C's count still fails). Tests that asserted a release refusal move to the debug idiom with an `expect_assert` shape gated on `cfg!(debug_assertions)`: test/rust, test/rust-ludicrous, test/packet-wide/rust. The Rust bench leg records `checks=removed`; its runner comment and BENCH-STANDARD's two rows name the one residual the column does not price, safe Rust's slice bounds checks, which no release profile removes.

**Sequencing, done.** Rebased onto #700 (the count and the spec for all nine): countedbirth_test.go takes #700's shape with Rust moved into assertsInDebug and goneFromRelease (the `if` predicate only; `return Err(` still legitimately appears on the capacity path), FAQ.md falls out of the diff (main already carries the final roll call), USAGE.md merged to the union, SPEC.md is main's with the dated #696/#697 note that #697 removes. A cold read confirmed every removed check is write-side, the wire is unchanged, a violated contract panics in debug and passes in release, and named one release behaviour worth knowing, now in USAGE.md: a length or count past its array end panics on the slice in a Rust release, the language's own bounds check, where it returned Err before. The union tag is type-checked in Rust and has no check to move.

**Receipts.** make test-rust (debug and release, both negative controls, walk, clippy, features, names, alloc gates) exit 0; cargo run in test/rust and test/rust-ludicrous, debug and release, OK; release builds of generated/rust, rust-ludicrous, bench/rust, generated/bench/rust-realworld, bench/tables/rust warning-free; go test ./... ok; make shape-gate clean; gofmt, go vet clean; make update-goldens exit 0. 33 files, 776 insertions, 1494 deletions.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)