### PR TITLE
cs: every write-side check becomes Debug.Assert, the idiom the runtime already uses

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -1043,9 +1043,16 @@ That is as far as matching goes, and the standard says so out loud:
 >
 > | value | meaning |
 > |---|---|
-> | `removed` | the build compiles its debug asserts AND its bounds/range checks away (C++ with `NDEBUG`/`SERIALIZE_RELEASE`; C with `-DNDEBUG` since serialize.c ruling #20; Rust with `debug-assertions = false` since the 2026-09-07 ruling made the generated write side `debug_assert!` — safe Rust's own slice bounds checks remain, a LANGUAGE residual this column does not price) |
-> | `always` | the library keeps bounds checks, range validation and the sticky error check in **every** build by contract (Go by design; C# by its runtime's nature) |
+> | `removed` | the build compiles its debug asserts AND its bounds/range checks away (C++ with `NDEBUG`/`SERIALIZE_RELEASE`; C with `-DNDEBUG` since serialize.c ruling #20; Rust with `debug-assertions = false` and C# with `DEBUG` undefined, since the 2026-09-07 ruling made both generated write sides `debug_assert!` and `Debug.Assert`) |
+> | `always` | the library keeps bounds checks, range validation and the sticky error check in **every** build by contract (Go by design, and Go alone: it has no debug-only idiom to compile out) |
 > | `contract` | the library's debug asserts compile out like `removed`, **but** validation that is part of the wire/API contract stays in every build. Its exemplar was serialize.c's write path until ruling #20 (2026-08-17) moved C to `removed`; no leg records it today, and the value stays defined for a runtime that makes that promise. |
+>
+> The column names the checks the LIBRARY and the GENERATED code perform. A
+> language's own memory-safety checks (safe Rust's slice bounds, the CLR's and
+> the JVM's array bounds, Dart's) are not the library's, no profile removes
+> them, and the column does not price them; a runner whose language carries
+> them says so in its comment (2026-09-07, when Rust and C# moved to
+> `removed`).
 >
 > `contract` was added 2026-08-15 because the two-value column could not
 > express serialize.c at all, and the hybrid it could not express was the

--- a/bench/cs/src/Program.cs
+++ b/bench/cs/src/Program.cs
@@ -42,17 +42,28 @@ static partial class Program
     // for each file in sorted basename order, the basename bytes, a 0x00
     // byte, the contents. The per-runner constants: family gen (these are
     // the generated-code benchmarks), linkage asm (the serialize.cs runtime
-    // is a separate assembly the JIT inlines across), checks ALWAYS —
-    // serialize.cs has no Debug.Assert and no conditional compilation of
-    // its checks: bounds checks, range validation and the sticky error
-    // latch are unconditional in every build, §3.4's definition of
-    // `always` word for word (this row previously claimed `removed`, which
-    // was wrong — there is no NDEBUG-equivalent build of serialize.cs) —
+    // is a separate assembly the JIT inlines across), checks REMOVED —
+    // §3.4: this project sets no DefineConstants, so `dotnet run -c Release`
+    // leaves DEBUG undefined and every Debug.Assert is gone, the call and
+    // its arguments both ([Conditional("DEBUG")]). That is true of the
+    // serialize.cs runtime's whole write path — WriteStream documents
+    // values, capacity, lengths and float finiteness as "checked by
+    // Debug.Assert in debug builds and not at all in release builds" — and,
+    // from 2026-09-07, of the generated code beside it: the schema
+    // compiler's C# backend emits its write-side caller-error checks as
+    // Debug.Assert too ("checks are *DEBUG ONLY*"). An earlier version of
+    // this comment claimed `always` and justified it with "serialize.cs has
+    // no Debug.Assert and no conditional compilation of its checks", which
+    // was never true of the write path — the runtime carries ~90 of them.
+    // What the label does not price is the CLR's own array bounds checks,
+    // which no build removes; §3.4 says the column names the library's and
+    // the generated code's checks, not the language's, and every managed
+    // runner is in the same position —
     // opt default (the JIT has no operator-visible optimization levels),
     // inline unknown until the verdict pass (§4.2) backfills it.
     // family is per ROW now (gen | bits — §5.1); linkage/checks/opt/
     // inline stay per-runner constants
-    const string CsvSuffix = "asm,always,default,unknown";
+    const string CsvSuffix = "asm,removed,default,unknown";
 
     static readonly List<(string Row, string Family)> gCsvRows = new List<(string, string)>();
     static readonly SortedDictionary<string, byte[]> gGoldensLoaded =

--- a/compiler/countedbirth_test.go
+++ b/compiler/countedbirth_test.go
@@ -73,11 +73,10 @@ var bornAtMinimum = map[string]string{
 // targets that still hold the count that way. Go and Elixir are here by the
 // ruling — "For each language, do not force this in. If the language simply
 // doesn't have this concept (Golang) then it is not something we can do" — an
-// error-returning runtime in Go, an always-on raise in Elixir. C# is here only
-// until its own emitter change lands; it moves to assertsInDebug then,
-// alongside every other write check in that backend.
+// error-returning runtime in Go, an always-on raise in Elixir. They are the
+// only two: every other target has a build-removable idiom and is held to it
+// by assertsInDebug.
 var refusesEveryBuild = map[string][]string{
-	"cs":     {"if (value.WindowCount < 2 || value.WindowCount > 8)"},
 	"elixir": {"if n < 2 do", "if n > 8 do", "raise ArgumentError"},
 	"go":     {"if value.WindowCount < 2 || value.WindowCount > 8 {", "return serialize.ErrValueOutOfRange"},
 }
@@ -87,6 +86,7 @@ var refusesEveryBuild = map[string][]string{
 var assertsInDebug = map[string][]string{
 	"c":    {"serialize_assert( value->window_count >= 2 && value->window_count <= 8 );"},
 	"cpp":  {"serialize_assert( int32_t( value.window_count ) >= int32_t( 2 ) && int32_t( value.window_count ) <= int32_t( 8 ) );"},
+	"cs":   {`Debug.Assert(value.WindowCount >= 2 && value.WindowCount <= 8, "value.WindowCount out of range [2, 8]");`},
 	"dart": {"assert(value.windowCount >= 2);", "assert(value.windowCount <= 8);"},
 	"java": {"assert value.windowCount >= 2;", "assert value.windowCount <= 8;"},
 	// js is not here: its debug-only idiom is not an assert statement but the
@@ -101,6 +101,7 @@ var goneFromRelease = map[string][]string{
 	"cpp": {
 		"if ( int32_t( value.window_count ) < int32_t( 2 ) || int32_t( value.window_count ) > int32_t( 8 ) )",
 	},
+	"cs":   {"if (value.WindowCount < 2 || value.WindowCount > 8)"},
 	"dart": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
 	"java": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
 	"rust": {"if value.window_count < 2 || value.window_count > 8 {"},
@@ -110,7 +111,6 @@ var goneFromRelease = map[string][]string{
 // contracts with. For a refusesEveryBuild target, none of them may reach the
 // count.
 var assertToken = map[string][]string{
-	"cs":     {"Debug.Assert"},
 	"elixir": nil, // the BEAM has no compile-out assert, so the raise is always on
 	"go":     nil, // the runtime returns an error, in every build
 }

--- a/compiler/uniontagwrite_test.go
+++ b/compiler/uniontagwrite_test.go
@@ -51,26 +51,27 @@ type Volley
 var tagAssertsInDebug = map[string][]string{
 	"c":    {"serialize_assert( value->type <= SHOT_TYPE_MAX );"},
 	"cpp":  {"serialize_assert( value.type <= ShotType::Max );"},
+	"cs":   {`Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]");`},
 	"dart": {"assert(value.type >= 0);", "assert(value.type <= 2);"},
 	"java": {"assert (value.type & 0xffL) >= 0;", "assert (value.type & 0xffL) <= 2;"},
 	// js is not here: its debug-only idiom is the PRODUCTION/checked fork of
 	// the flat writer, not a statement. Checked separately below.
 }
 
-// tagGoneFromRelease is the every-build refusal C and C++ used to carry. An
-// assert BESIDE a live refusal removes nothing, so none of it may survive.
+// tagGoneFromRelease is the every-build refusal each assert target used to
+// carry. An assert BESIDE a live refusal removes nothing, so none of it may
+// survive.
 var tagGoneFromRelease = map[string][]string{
 	"c":   {"if ( value->type > SHOT_TYPE_MAX )", "not a ShotType value; nothing was written"},
 	"cpp": {"not a ShotType value; nothing was written"},
+	"cs":  {"if (tagValue > 2)"},
 }
 
 // tagRefusesEveryBuild is the write's UNCONDITIONAL tag refusal, for the
 // targets that still hold it that way. Go and Elixir are here by the ruling —
-// a language with no dormant-assert idiom keeps the form native to it. C# is
-// here only until PR #697's emitter change lands on this tree; it moves to
-// tagAssertsInDebug then, with every other write check in that backend.
+// a language with no dormant-assert idiom keeps the form native to it. They
+// are the only two left.
 var tagRefusesEveryBuild = map[string][]string{
-	"cs":     {"if (tagValue > 2)"},
 	"elixir": {`raise ArgumentError, "value.type is above the wire maximum"`},
 	"go":     {"if tagValue < 0 || tagValue > 2 {"},
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -282,13 +282,11 @@ no dormant assert at all, so Elixir raises `ArgumentError` in every build.
 Those two are the only every-build write side of the nine. The other seven
 are debug-only: C# through `Debug.Assert`, Rust through `debug_assert!`,
 Dart and Java through the language's own `assert`, and JavaScript through
-the checked/production fork its flat writers take at load. (Implementation
-note, 2026-09-07: Rust and C# reach that form in the two changes landing the
-same day, schema#696 and schema#697; until they merge, their emitters still
-refuse on the write in every build.) A language should verify correctness
-the way that language verifies correctness — which means the write side is
-not uniform across targets, and you should not build on it. Keep values inside
-their declared bounds when you write them — your code already knows they are,
+the checked/production fork its flat writers take at load. A language should
+verify correctness the way that language verifies correctness — which means
+the write side is not uniform across targets, and you should not build on it.
+Keep values inside their declared bounds when you write them — your code
+already knows they are,
 and in a game shipping at 60 Hz re-checking every field on the write path is a
 cost with no buyer. See
 [USAGE.md](USAGE.md#writes-are-the-callers-responsibility).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -160,9 +160,17 @@ union tag outside its variant set (§4.8) was the last structural holdout — it
 to be dispatch rather than a guard — and it too is a `serialize_assert` now, so a C or C++
 release build performs no write-side validation whatsoever. Every
 read-side check stays in every build everywhere, by the other half of the same ruling: "Of
-course, on read side we MUST always do the checks!" Rust, C# and Go carry bounds, range and
-sticky-error checks in every build by contract, Rust's and C#'s pending their own change. A
-ratio between two of those columns includes the price of a different promise.
+course, on read side we MUST always do the checks!" **Rust moved the same day**, every
+write-side check becoming a `debug_assert!` that a release profile drops, and its bench runner
+records `checks=removed` from 2026-09-07; safe Rust's own slice bounds checks survive release
+and are a language residual that column does not price. **C# moved the same day too**: every
+write-side caller-error check the C# backend emits is a `Debug.Assert`, gone from a release
+build along with the call, beside a serialize.cs runtime whose write path was already
+`Debug.Assert` only, and the C# bench runner records `checks=removed` from 2026-09-07 (it
+recorded `always` before, on a justification that was never true of the write path). Go alone
+carries bounds, range and sticky-error checks in every build by contract, because it has no
+debug-only idiom to compile out. A ratio between two of those columns includes the price of a
+different promise.
 
 **Measured the same day, the C change bought nothing the instrument can see.** A twins pass on
 the C and C++ legs with the asserts in place

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2200,11 +2200,6 @@ language and how it is used in best practice." (2026-09-07). **No target
 panics and none throws**: Elixir's raise is the only unwinding path in the
 nine, and it is the BEAM's own.
 
-**Implementation note, 2026-09-07.** The Rust and C# backends reach the form
-stated above in the two changes landing the same day (schema#696 for Rust,
-schema#697 for C#); until they merge, their emitters still refuse on the
-write in every build. This note is removed by the second of them.
-
 **There is no exception to the tier split.** Settled 2026-09-07: "No runtime
 should ever promise to keep checks in writing packets (asserts) in release
 build. Removing them is the whole point. ... checks are *DEBUG ONLY*". A

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1142,9 +1142,7 @@ assert (`serialize_assert` in C++ and C, `debug_assert!` in Rust,
 `Debug.Assert` in C#, `assert` in Java and Dart, the checked writer in
 JavaScript); Go returns `ErrValueOutOfRange` and Elixir raises an
 `ArgumentError` in every build, because neither language has a debug-only
-idiom worth faking. (Implementation note, 2026-09-07: Rust and C# reach that
-form in the two changes landing the same day, schema#696 and schema#697;
-until they merge, their emitters still refuse on the write in every build.)
+idiom worth faking.
 And the READ refuses a bad count in every build, in all nine — that side is
 never trusted.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -645,9 +645,7 @@ than zero without a declared default, and `[..N]` is born at 0 as usual.
 Writing a count outside its bound is **caller error**, and it is a write-side
 contract like every other (SPEC.md §5): it asserts in DEBUG in each target
 whose language has that idiom, and is refused in every build only in Go and
-Elixir, which have none. (Implementation note, 2026-09-07: Rust and C# reach
-that form in the two changes landing the same day, schema#696 and schema#697;
-until they merge, their emitters still refuse on the write in every build.)
+Elixir, which have none.
 The count guards the element loop and the pack subtracts the low bound, so
 an out-of-range count wraps and a release build will happily write bytes no
 reader takes — which is why the debug assert is worth having, and why
@@ -819,9 +817,12 @@ Rust has `debug_assert!`, compiled out of release, and serialize.rs itself
 holds its API-misuse contracts with it (`src/stream.rs`, `misuse_check!`), so
 the Rust backend `debug_assert!`s (2026-09-07: "No runtime should ever promise
 to keep checks in writing packets (asserts) in release build. Removing them is
-the whole point... checks are *DEBUG ONLY*").
+the whole point... checks are *DEBUG ONLY*"). C# has `Debug.Assert` and
+`[Conditional("DEBUG")]`, which remove the check AND the call from a release
+build, so the C# backend asserts too — the same idiom the serialize.cs runtime
+it calls has always used for its own write path.
 Go has no assert idiom, so it returns
-`ErrValueOutOfRange`; C# and JavaScript likewise return failure
+`ErrValueOutOfRange`; JavaScript likewise returns failure
 rather than invent an assert. Dart has `assert` — active under
 `--enable-asserts`, compiled out of release and AOT builds — so the Dart
 writer asserts, exactly like C++; Java's `assert` is active under `-ea` and
@@ -833,12 +834,12 @@ correctness the way that language verifies correctness — not that every
 target behaves identically here.
 
 So writing `health = 2000` into a field declared `| min = 0, max = 1000`
-asserts in a C++, C, debug-Rust, checked-Dart or `-ea` Java build, raises in
-Elixir, silently writes the truncated low bits in a C++ or C release
-(`NDEBUG`), a Rust release (`debug-assertions = false`; a length or count
-past its array's end panics there on the slice instead, the language's own
-bounds check, which no profile removes), Dart AOT or default-JVM build, and
-returns failure in the others.
+asserts in a C++, C, C# `DEBUG`, debug-Rust, checked-Dart or `-ea` Java build,
+raises in Elixir, silently writes the truncated low bits in a C++ or C release
+(`NDEBUG`), a C# release, a Rust release (`debug-assertions = false`; a length
+or count past its array's end panics there on the slice instead, the
+language's own bounds check, which no profile removes), Dart AOT or
+default-JVM build, and returns failure in the others.
 
 Do not build on any of it. **Keep your values inside their declared bounds on
 the write side** — your simulation already knows they are, and that is the only

--- a/generated/bench/cs/Bench.cs
+++ b/generated/bench/cs/Bench.cs
@@ -4,13 +4,22 @@
 // AGPL-3.0, its output is not.
 // package bench — protocol id 0x8d12c3149393f40f
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -265,18 +274,9 @@ namespace Bench
         {
             {
                 // flat run: 89 bits in 2 chunk(s) — the field placement is folded
-                if (value.A < -100 || value.A > 100)
-                {
-                    return false;
-                }
-                if (value.B < 0 || value.B > 65535)
-                {
-                    return false;
-                }
-                if (value.C < -1000000 || value.C > 1000000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.A >= -100 && value.A <= 100, "value.A out of range [-100, 100]");
+                Debug.Assert(value.B >= 0 && value.B <= 65535, "value.B out of range [0, 65535]");
+                Debug.Assert(value.C >= -1000000 && value.C <= 1000000, "value.C out of range [-1000000, 1000000]");
                 ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f1 = ((ulong)((uint)(value.B))) & 0xffffUL;
                 ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-1000000)))) & 0x1fffffUL;
@@ -432,46 +432,16 @@ namespace Bench
         {
             {
                 // flat run: 110 bits in 2 chunk(s) — the field placement is folded
-                if (value.F0 < -100 || value.F0 > 100)
-                {
-                    return false;
-                }
-                if (value.F1 < 0 || value.F1 > 65535)
-                {
-                    return false;
-                }
-                if (value.F2 < -1000000 || value.F2 > 1000000)
-                {
-                    return false;
-                }
-                if (value.F3 < 0 || value.F3 > 3)
-                {
-                    return false;
-                }
-                if (value.F4 < -15 || value.F4 > 15)
-                {
-                    return false;
-                }
-                if (value.F5 < 0 || value.F5 > 1000)
-                {
-                    return false;
-                }
-                if (value.F6 < -2048 || value.F6 > 2047)
-                {
-                    return false;
-                }
-                if (value.F7 < 0 || value.F7 > 255)
-                {
-                    return false;
-                }
-                if (value.F8 < -600000 || value.F8 > 600000)
-                {
-                    return false;
-                }
-                if (value.F9 < 0 || value.F9 > 100)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F0 >= -100 && value.F0 <= 100, "value.F0 out of range [-100, 100]");
+                Debug.Assert(value.F1 >= 0 && value.F1 <= 65535, "value.F1 out of range [0, 65535]");
+                Debug.Assert(value.F2 >= -1000000 && value.F2 <= 1000000, "value.F2 out of range [-1000000, 1000000]");
+                Debug.Assert(value.F3 >= 0 && value.F3 <= 3, "value.F3 out of range [0, 3]");
+                Debug.Assert(value.F4 >= -15 && value.F4 <= 15, "value.F4 out of range [-15, 15]");
+                Debug.Assert(value.F5 >= 0 && value.F5 <= 1000, "value.F5 out of range [0, 1000]");
+                Debug.Assert(value.F6 >= -2048 && value.F6 <= 2047, "value.F6 out of range [-2048, 2047]");
+                Debug.Assert(value.F7 >= 0 && value.F7 <= 255, "value.F7 out of range [0, 255]");
+                Debug.Assert(value.F8 >= -600000 && value.F8 <= 600000, "value.F8 out of range [-600000, 600000]");
+                Debug.Assert(value.F9 >= 0 && value.F9 <= 100, "value.F9 out of range [0, 100]");
                 ulong f0 = ((ulong)((uint)(value.F0) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f1 = ((ulong)((uint)(value.F1))) & 0xffffUL;
                 ulong f2 = ((ulong)((uint)(value.F2) - unchecked((uint)(-1000000)))) & 0x1fffffUL;
@@ -853,42 +823,15 @@ namespace Bench
         {
             {
                 // flat run: 135 bits in 3 chunk(s) — the field placement is folded
-                if (value.PosX < -16383 || value.PosX > 16383)
-                {
-                    return false;
-                }
-                if (value.PosY < -16383 || value.PosY > 16383)
-                {
-                    return false;
-                }
-                if (value.PosZ < -16383 || value.PosZ > 16383)
-                {
-                    return false;
-                }
-                if (value.VelX < -2048 || value.VelX > 2047)
-                {
-                    return false;
-                }
-                if (value.VelY < -2048 || value.VelY > 2047)
-                {
-                    return false;
-                }
-                if (value.VelZ < -2048 || value.VelZ > 2047)
-                {
-                    return false;
-                }
-                if (value.Health < 0 || value.Health > 1000)
-                {
-                    return false;
-                }
-                if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
-                if (value.Damage >= 1ul << 8) // a mask bit above the wire width cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(value.PosX >= -16383 && value.PosX <= 16383, "value.PosX out of range [-16383, 16383]");
+                Debug.Assert(value.PosY >= -16383 && value.PosY <= 16383, "value.PosY out of range [-16383, 16383]");
+                Debug.Assert(value.PosZ >= -16383 && value.PosZ <= 16383, "value.PosZ out of range [-16383, 16383]");
+                Debug.Assert(value.VelX >= -2048 && value.VelX <= 2047, "value.VelX out of range [-2048, 2047]");
+                Debug.Assert(value.VelY >= -2048 && value.VelY <= 2047, "value.VelY out of range [-2048, 2047]");
+                Debug.Assert(value.VelZ >= -2048 && value.VelZ <= 2047, "value.VelZ out of range [-2048, 2047]");
+                Debug.Assert(value.Health >= 0 && value.Health <= 1000, "value.Health out of range [0, 1000]");
+                Debug.Assert((uint)value.Weapon <= 15, "value.Weapon above the enum wire range [0, 15]"); // headroom above the wire range cannot ride
+                Debug.Assert(value.Damage < 1ul << 8, "value.Damage has a mask bit above the 8-bit wire width"); // a mask bit above the wire width cannot ride
                 ulong f0 = ((ulong)value.EntityId) & 0xfffUL;
                 ulong f1 = ((ulong)((uint)(value.PosX) - unchecked((uint)(-16383)))) & 0x7fffUL;
                 ulong f2 = ((ulong)((uint)(value.PosY) - unchecked((uint)(-16383)))) & 0x7fffUL;
@@ -1030,10 +973,7 @@ namespace Bench
         {
             {
                 // flat run: 18 bits in 1 chunk(s) — the field placement is folded
-                if (value.Delta < -512 || value.Delta > 511)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Delta >= -512 && value.Delta <= 511, "value.Delta out of range [-512, 511]");
                 ulong f0 = ((ulong)value.StatId) & 0xffUL;
                 ulong f1 = ((ulong)((uint)(value.Delta) - unchecked((uint)(-512)))) & 0x3ffUL;
                 uint w0 = (uint)(f0 | (f1 << 8));
@@ -1113,14 +1053,8 @@ namespace Bench
         {
             {
                 // flat run: 28 bits in 1 chunk(s) — the field placement is folded
-                if (value.Damage < 0 || value.Damage > 4095)
-                {
-                    return false;
-                }
-                if (value.HitKind < 0 || value.HitKind > 7)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Damage >= 0 && value.Damage <= 4095, "value.Damage out of range [0, 4095]");
+                Debug.Assert(value.HitKind >= 0 && value.HitKind <= 7, "value.HitKind out of range [0, 7]");
                 ulong f0 = ((ulong)value.TargetId) & 0xfffUL;
                 ulong f1 = ((ulong)((uint)(value.Damage))) & 0xfffUL;
                 ulong f2 = ((ulong)((uint)(value.HitKind))) & 0x7UL;
@@ -1202,10 +1136,7 @@ namespace Bench
         {
             {
                 // flat run: 14 bits in 1 chunk(s) — the field placement is folded
-                if (value.Channel < 0 || value.Channel > 3)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Channel >= 0 && value.Channel <= 3, "value.Channel out of range [0, 3]");
                 ulong f0 = ((ulong)((uint)(value.Channel))) & 0x3UL;
                 ulong f1 = ((ulong)value.Speaker) & 0xfffUL;
                 uint w0 = (uint)(f0 | (f1 << 2));
@@ -1281,10 +1212,7 @@ namespace Bench
         {
             {
                 // flat run: 18 bits in 1 chunk(s) — the field placement is folded
-                if (value.Amount < 0 || value.Amount > 255)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Amount >= 0 && value.Amount <= 255, "value.Amount out of range [0, 255]");
                 ulong f0 = ((ulong)value.ItemId) & 0x3ffUL;
                 ulong f1 = ((ulong)((uint)(value.Amount))) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 10));
@@ -1372,10 +1300,7 @@ namespace Bench
         private static bool WriteMixedEventBatch(ref WriteBatch batch, MixedEvent value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 3) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 3, "the union tag is outside the variant set [0, 3]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1518,14 +1443,8 @@ namespace Bench
         {
             {
                 // flat run: 329 bits in 6 chunk(s) — the field placement is folded
-                if (value.AckSequence < 0 || value.AckSequence > 65535)
-                {
-                    return false;
-                }
-                if (value.WorldTime < -1000000000000 || value.WorldTime > 1000000000000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.AckSequence >= 0 && value.AckSequence <= 65535, "value.AckSequence out of range [0, 65535]");
+                Debug.Assert(value.WorldTime >= -1000000000000 && value.WorldTime <= 1000000000000, "value.WorldTime out of range [-1000000000000, 1000000000000]");
                 ulong f0 = (49374UL) & 0xffffUL;
                 ulong f1 = ((ulong)value.Sequence) & 0xffffUL;
                 ulong f2 = ((ulong)((uint)(value.AckSequence))) & 0xffffUL;
@@ -1570,10 +1489,7 @@ namespace Bench
             {
                 return false;
             }
-            if (value.EntitiesCount < 1 || value.EntitiesCount > 8) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.EntitiesCount >= 1 && value.EntitiesCount <= 8, "value.EntitiesCount out of range [1, 8]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.EntitiesCount) - (uint)(1);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -1599,10 +1515,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.StatsCount < 0 || value.StatsCount > 80) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.StatsCount >= 0 && value.StatsCount <= 80, "value.StatsCount out of range [0, 80]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.StatsCount);
                 if (!stream.SerializeBits(ref offsetValue, 7))
@@ -1648,10 +1561,7 @@ namespace Bench
                     }
                 }
             }
-            if (value.PlayerNameLength < 0 || value.PlayerNameLength > 15) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.PlayerNameLength >= 0 && value.PlayerNameLength <= 15, "value.PlayerNameLength out of range [0, 15]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.PlayerNameLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -1663,10 +1573,7 @@ namespace Bench
             {
                 return false;
             }
-            if (value.PayloadLength < 0 || value.PayloadLength > 16) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.PayloadLength >= 0 && value.PayloadLength <= 16, "value.PayloadLength out of range [0, 16]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.PayloadLength);
                 if (!stream.SerializeBits(ref offsetValue, 5))
@@ -1742,10 +1649,7 @@ namespace Bench
             }
             if (value.HasExtra)
             {
-                if (value.Extra < 0 || value.Extra > 255)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Extra >= 0 && value.Extra <= 255, "value.Extra out of range [0, 255]");
                 {
                     uint offsetValue = (uint)(value.Extra);
                     if (!stream.SerializeBits(ref offsetValue, 8))
@@ -1756,10 +1660,7 @@ namespace Bench
             }
             else
             {
-                if (value.IdleTicks < 0 || value.IdleTicks > 15)
-                {
-                    return false;
-                }
+                Debug.Assert(value.IdleTicks >= 0 && value.IdleTicks <= 15, "value.IdleTicks out of range [0, 15]");
                 {
                     uint offsetValue = (uint)(value.IdleTicks);
                     if (!stream.SerializeBits(ref offsetValue, 4))

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -4,12 +4,21 @@
 // AGPL-3.0, its output is not.
 // package realworld — protocol id 0x1922430092518648
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
+using System.Diagnostics;
 using Serialize;
 
 namespace Realworld
@@ -448,10 +457,7 @@ namespace Realworld
 
         public static bool WriteRealPacket(WriteStream stream, RealPacket value)
         {
-            if (value.F001Int < -805495 || value.F001Int > 805495)
-            {
-                return false;
-            }
+            Debug.Assert(value.F001Int >= -805495 && value.F001Int <= 805495, "value.F001Int out of range [-805495, 805495]");
             {
                 uint offsetValue = (uint)(value.F001Int) - unchecked((uint)(-805495));
                 if (!stream.SerializeBits(ref offsetValue, 21))
@@ -463,10 +469,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F003Int < -835897 || value.F003Int > 835897)
-            {
-                return false;
-            }
+            Debug.Assert(value.F003Int >= -835897 && value.F003Int <= 835897, "value.F003Int out of range [-835897, 835897]");
             {
                 uint offsetValue = (uint)(value.F003Int) - unchecked((uint)(-835897));
                 if (!stream.SerializeBits(ref offsetValue, 21))
@@ -483,14 +486,8 @@ namespace Realworld
             }
             {
                 // flat run: 25 bits in 1 chunk(s) — the field placement is folded
-                if (value.F005Uint > 7316)
-                {
-                    return false;
-                }
-                if (value.F006Int < -1513 || value.F006Int > 1513)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F005Uint <= 7316, "value.F005Uint out of range [0, 7316]");
+                Debug.Assert(value.F006Int >= -1513 && value.F006Int <= 1513, "value.F006Int out of range [-1513, 1513]");
                 ulong f0 = ((ulong)((uint)(value.F005Uint))) & 0x1fffUL;
                 ulong f1 = ((ulong)((uint)(value.F006Int) - unchecked((uint)(-1513)))) & 0xfffUL;
                 uint w0 = (uint)(f0 | (f1 << 13));
@@ -507,10 +504,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F009Int < -22 || value.F009Int > 22)
-            {
-                return false;
-            }
+            Debug.Assert(value.F009Int >= -22 && value.F009Int <= 22, "value.F009Int out of range [-22, 22]");
             {
                 uint offsetValue = (uint)(value.F009Int) - unchecked((uint)(-22));
                 if (!stream.SerializeBits(ref offsetValue, 6))
@@ -540,14 +534,8 @@ namespace Realworld
                 }
                 {
                     // flat run: 16 bits in 1 chunk(s) — the field placement is folded
-                    if (value.F014Uint > 775)
-                    {
-                        return false;
-                    }
-                    if (value.F015Int < -21 || value.F015Int > 21)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.F014Uint <= 775, "value.F014Uint out of range [0, 775]");
+                    Debug.Assert(value.F015Int >= -21 && value.F015Int <= 21, "value.F015Int out of range [-21, 21]");
                     ulong f0 = ((ulong)((uint)(value.F014Uint))) & 0x3ffUL;
                     ulong f1 = ((ulong)((uint)(value.F015Int) - unchecked((uint)(-21)))) & 0x3fUL;
                     uint w0 = (uint)(f0 | (f1 << 10));
@@ -560,10 +548,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F017Uint > 4606)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F017Uint <= 4606, "value.F017Uint out of range [0, 4606]");
                 {
                     uint offsetValue = (uint)(value.F017Uint);
                     if (!stream.SerializeBits(ref offsetValue, 13))
@@ -572,10 +557,7 @@ namespace Realworld
                     }
                 }
             }
-            if (value.F018Int < -834 || value.F018Int > 834)
-            {
-                return false;
-            }
+            Debug.Assert(value.F018Int >= -834 && value.F018Int <= 834, "value.F018Int out of range [-834, 834]");
             {
                 uint offsetValue = (uint)(value.F018Int) - unchecked((uint)(-834));
                 if (!stream.SerializeBits(ref offsetValue, 11))
@@ -639,22 +621,10 @@ namespace Realworld
             }
             {
                 // flat run: 69 bits in 2 chunk(s) — the field placement is folded
-                if (value.F032Int < -3 || value.F032Int > 3)
-                {
-                    return false;
-                }
-                if (value.F033Uint > 142780)
-                {
-                    return false;
-                }
-                if (value.F034Uint > 14149)
-                {
-                    return false;
-                }
-                if ((uint)value.F036Enum > 5) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(value.F032Int >= -3 && value.F032Int <= 3, "value.F032Int out of range [-3, 3]");
+                Debug.Assert(value.F033Uint <= 142780, "value.F033Uint out of range [0, 142780]");
+                Debug.Assert(value.F034Uint <= 14149, "value.F034Uint out of range [0, 14149]");
+                Debug.Assert((uint)value.F036Enum <= 5, "value.F036Enum above the enum wire range [0, 5]"); // headroom above the wire range cannot ride
                 ulong f0 = ((ulong)value.F031Bits) & 0x1UL;
                 ulong f1 = ((ulong)((uint)(value.F032Int) - unchecked((uint)(-3)))) & 0x7UL;
                 ulong f2 = ((ulong)((uint)(value.F033Uint))) & 0x3ffffUL;
@@ -681,10 +651,7 @@ namespace Realworld
             }
             {
                 // flat run: 38 bits in 1 chunk(s) — the field placement is folded
-                if (value.F041Int < -55 || value.F041Int > 55)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F041Int >= -55 && value.F041Int <= 55, "value.F041Int out of range [-55, 55]");
                 ulong f0 = ((ulong)((uint)(value.F041Int) - unchecked((uint)(-55)))) & 0x7fUL;
                 ulong f1 = ((ulong)value.F042Bits) & 0x3fffffffUL;
                 ulong f2 = value.F043Bool ? 1UL : 0UL;
@@ -702,14 +669,8 @@ namespace Realworld
                 }
                 {
                     // flat run: 49 bits in 1 chunk(s) — the field placement is folded
-                    if (value.F046Uint > 76063)
-                    {
-                        return false;
-                    }
-                    if (value.F047Int < -430976 || value.F047Int > 430976)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.F046Uint <= 76063, "value.F046Uint out of range [0, 76063]");
+                    Debug.Assert(value.F047Int >= -430976 && value.F047Int <= 430976, "value.F047Int out of range [-430976, 430976]");
                     ulong f0 = ((ulong)value.F045Bits) & 0xfffUL;
                     ulong f1 = ((ulong)((uint)(value.F046Uint))) & 0x1ffffUL;
                     ulong f2 = ((ulong)((uint)(value.F047Int) - unchecked((uint)(-430976)))) & 0xfffffUL;
@@ -736,10 +697,7 @@ namespace Realworld
             {
                 {
                     // flat run: 8 bits in 1 chunk(s) — the field placement is folded
-                    if (value.F052Int < -57 || value.F052Int > 57)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.F052Int >= -57 && value.F052Int <= 57, "value.F052Int out of range [-57, 57]");
                     ulong f0 = value.F051Bool ? 1UL : 0UL;
                     ulong f1 = ((ulong)((uint)(value.F052Int) - unchecked((uint)(-57)))) & 0x7fUL;
                     uint w0 = (uint)(f0 | (f1 << 1));
@@ -752,10 +710,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F054Int < -35 || value.F054Int > 35)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F054Int >= -35 && value.F054Int <= 35, "value.F054Int out of range [-35, 35]");
                 {
                     uint offsetValue = (uint)(value.F054Int) - unchecked((uint)(-35));
                     if (!stream.SerializeBits(ref offsetValue, 7))
@@ -766,14 +721,8 @@ namespace Realworld
             }
             {
                 // flat run: 11 bits in 1 chunk(s) — the field placement is folded
-                if (value.F056Int < -13 || value.F056Int > 13)
-                {
-                    return false;
-                }
-                if (value.F057Int < -15 || value.F057Int > 15)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F056Int >= -13 && value.F056Int <= 13, "value.F056Int out of range [-13, 13]");
+                Debug.Assert(value.F057Int >= -15 && value.F057Int <= 15, "value.F057Int out of range [-15, 15]");
                 ulong f0 = value.F055Bool ? 1UL : 0UL;
                 ulong f1 = ((ulong)((uint)(value.F056Int) - unchecked((uint)(-13)))) & 0x1fUL;
                 ulong f2 = ((ulong)((uint)(value.F057Int) - unchecked((uint)(-15)))) & 0x1fUL;
@@ -804,14 +753,8 @@ namespace Realworld
             }
             {
                 // flat run: 82 bits in 2 chunk(s) — the field placement is folded
-                if (value.F062Uint > 503)
-                {
-                    return false;
-                }
-                if (value.F064Uint > 299)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F062Uint <= 503, "value.F062Uint out of range [0, 503]");
+                Debug.Assert(value.F064Uint <= 299, "value.F064Uint out of range [0, 299]");
                 ulong f0 = ((ulong)((uint)(value.F062Uint))) & 0x1ffUL;
                 ulong f1 = (ulong)value.F063I64;
                 ulong f2 = ((ulong)((uint)(value.F064Uint))) & 0x1ffUL;
@@ -853,10 +796,7 @@ namespace Realworld
             }
             {
                 // flat run: 13 bits in 1 chunk(s) — the field placement is folded
-                if (value.F070Uint > 2)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F070Uint <= 2, "value.F070Uint out of range [0, 2]");
                 ulong f0 = ((ulong)value.F069Bits) & 0x7ffUL;
                 ulong f1 = ((ulong)((uint)(value.F070Uint))) & 0x3UL;
                 uint w0 = (uint)(f0 | (f1 << 11));
@@ -881,10 +821,7 @@ namespace Realworld
             }
             {
                 // flat run: 5 bits in 1 chunk(s) — the field placement is folded
-                if (value.F073Int < -4 || value.F073Int > 4)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F073Int >= -4 && value.F073Int <= 4, "value.F073Int out of range [-4, 4]");
                 ulong f0 = ((ulong)((uint)(value.F073Int) - unchecked((uint)(-4)))) & 0xfUL;
                 ulong f1 = value.F074Bool ? 1UL : 0UL;
                 uint w0 = (uint)(f0 | (f1 << 4));
@@ -897,18 +834,9 @@ namespace Realworld
             {
                 {
                     // flat run: 100 bits in 2 chunk(s) — the field placement is folded
-                    if (value.F076Int < -26218 || value.F076Int > 26218)
-                    {
-                        return false;
-                    }
-                    if (value.F077Int < -17 || value.F077Int > 17)
-                    {
-                        return false;
-                    }
-                    if (value.F079Uint > 17)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.F076Int >= -26218 && value.F076Int <= 26218, "value.F076Int out of range [-26218, 26218]");
+                    Debug.Assert(value.F077Int >= -17 && value.F077Int <= 17, "value.F077Int out of range [-17, 17]");
+                    Debug.Assert(value.F079Uint <= 17, "value.F079Uint out of range [0, 17]");
                     ulong f0 = (ulong)value.F075U64;
                     ulong f1 = ((ulong)((uint)(value.F076Int) - unchecked((uint)(-26218)))) & 0xffffUL;
                     ulong f2 = ((ulong)((uint)(value.F077Int) - unchecked((uint)(-17)))) & 0x3fUL;
@@ -928,10 +856,7 @@ namespace Realworld
             }
             {
                 // flat run: 58 bits in 1 chunk(s) — the field placement is folded
-                if ((uint)value.F083Enum > 5) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.F083Enum <= 5, "value.F083Enum above the enum wire range [0, 5]"); // headroom above the wire range cannot ride
                 ulong f0 = value.F080Bool ? 1UL : 0UL;
                 ulong f1 = ((ulong)value.F081Bits) & 0x1fffffffUL;
                 ulong f2 = ((ulong)value.F082Bits) & 0x1ffffffUL;
@@ -951,10 +876,7 @@ namespace Realworld
             }
             {
                 // flat run: 30 bits in 1 chunk(s) — the field placement is folded
-                if (value.F086Uint > 399)
-                {
-                    return false;
-                }
+                Debug.Assert(value.F086Uint <= 399, "value.F086Uint out of range [0, 399]");
                 ulong f0 = ((ulong)value.F085Bits) & 0x1fffffUL;
                 ulong f1 = ((ulong)((uint)(value.F086Uint))) & 0x1ffUL;
                 uint w0 = (uint)(f0 | (f1 << 21));
@@ -969,18 +891,9 @@ namespace Realworld
             }
             {
                 // flat run: 138 bits in 3 chunk(s) — the field placement is folded
-                if (value.F088Int < -694 || value.F088Int > 694)
-                {
-                    return false;
-                }
-                if (value.F090Uint > 214)
-                {
-                    return false;
-                }
-                if (value.F091Flags >= 1ul << 5) // a mask bit above the wire width cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(value.F088Int >= -694 && value.F088Int <= 694, "value.F088Int out of range [-694, 694]");
+                Debug.Assert(value.F090Uint <= 214, "value.F090Uint out of range [0, 214]");
+                Debug.Assert(value.F091Flags < 1ul << 5, "value.F091Flags has a mask bit above the 5-bit wire width"); // a mask bit above the wire width cannot ride
                 ulong f0 = ((ulong)((uint)(value.F088Int) - unchecked((uint)(-694)))) & 0x7ffUL;
                 ulong f1 = ((ulong)value.F089Bits) & 0xffffffffffffUL;
                 ulong f2 = ((ulong)((uint)(value.F090Uint))) & 0xffUL;

--- a/generated/bench/tables/cs/BenchTable.cs
+++ b/generated/bench/tables/cs/BenchTable.cs
@@ -4,12 +4,21 @@
 // AGPL-3.0, its output is not.
 // package benchtable — protocol id 0x0926221bcb6f475f
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -253,14 +262,8 @@ namespace Benchtable
         {
             {
                 // flat run: 28 bits in 1 chunk(s) — the field placement is folded
-                if (value.Damage < 0 || value.Damage > 4095)
-                {
-                    return false;
-                }
-                if (value.HitKind < 0 || value.HitKind > 7)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Damage >= 0 && value.Damage <= 4095, "value.Damage out of range [0, 4095]");
+                Debug.Assert(value.HitKind >= 0 && value.HitKind <= 7, "value.HitKind out of range [0, 7]");
                 ulong f0 = ((ulong)value.TargetId) & 0xfffUL;
                 ulong f1 = ((ulong)((uint)(value.Damage))) & 0xfffUL;
                 ulong f2 = ((ulong)((uint)(value.HitKind))) & 0x7UL;
@@ -342,10 +345,7 @@ namespace Benchtable
         {
             {
                 // flat run: 14 bits in 1 chunk(s) — the field placement is folded
-                if (value.Channel < 0 || value.Channel > 3)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Channel >= 0 && value.Channel <= 3, "value.Channel out of range [0, 3]");
                 ulong f0 = ((ulong)((uint)(value.Channel))) & 0x3UL;
                 ulong f1 = ((ulong)value.Speaker) & 0xfffUL;
                 uint w0 = (uint)(f0 | (f1 << 2));
@@ -421,10 +421,7 @@ namespace Benchtable
         {
             {
                 // flat run: 18 bits in 1 chunk(s) — the field placement is folded
-                if (value.Amount < 0 || value.Amount > 255)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Amount >= 0 && value.Amount <= 255, "value.Amount out of range [0, 255]");
                 ulong f0 = ((ulong)value.ItemId) & 0x3ffUL;
                 ulong f1 = ((ulong)((uint)(value.Amount))) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 10));
@@ -512,10 +509,7 @@ namespace Benchtable
         private static bool WriteTableEventBatch(ref WriteBatch batch, TableEvent value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 3) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 3, "the union tag is outside the variant set [0, 3]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;

--- a/generated/cs-ludicrous/Ludicrous.cs
+++ b/generated/cs-ludicrous/Ludicrous.cs
@@ -4,13 +4,22 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xf4a226f4166d919b
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 using System;
+using System.Diagnostics;
 using Serialize;
 
 namespace Ludicrous
@@ -267,10 +276,7 @@ namespace Ludicrous
                     return false;
                 }
             }
-            if ((ulong)value.Locked != 196608UL)
-            {
-                return false;
-            }
+            Debug.Assert((ulong)value.Locked == 196608UL, "value.Locked is not 196608, the one legal raw of a degenerate fixed range");
             {
                 uint rawValue = value.Tail;
                 if (!stream.SerializeBits(ref rawValue, 8))
@@ -426,10 +432,7 @@ namespace Ludicrous
         {
             {
                 uint enumValue = (uint)value.Mode;
-                if (enumValue > 3) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(enumValue <= 3, "value.Mode above the enum wire range [0, 3]"); // headroom above the wire range cannot ride
                 if (!stream.SerializeBits(ref enumValue, 2))
                 {
                     return false;
@@ -443,10 +446,7 @@ namespace Ludicrous
             {
                 return false;
             }
-            if (value.KeysCount < 0 || value.KeysCount > 4) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.KeysCount >= 0 && value.KeysCount <= 4, "value.KeysCount out of range [0, 4]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.KeysCount);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -547,18 +547,9 @@ namespace Ludicrous
 
         public static bool WriteDegenerateProbe(WriteStream stream, DegenerateProbe value)
         {
-            if ((long)value.LockedFixed != -196608L)
-            {
-                return false;
-            }
-            if (value.LockedInt < 7 || value.LockedInt > 7)
-            {
-                return false;
-            }
-            if (value.LockedWide != (Int128Value)(-12345678901234L))
-            {
-                return false;
-            }
+            Debug.Assert((long)value.LockedFixed == -196608L, "value.LockedFixed is not -196608, the one legal raw of a degenerate fixed range");
+            Debug.Assert(value.LockedInt >= 7 && value.LockedInt <= 7, "value.LockedInt out of range [7, 7]");
+            Debug.Assert(value.LockedWide == (Int128Value)(-12345678901234L), "value.LockedWide is not the one legal value of a degenerate int128 range");
             {
                 uint rawValue = value.Tail;
                 if (!stream.SerializeBits(ref rawValue, 8))

--- a/generated/cs/ArmDefaults.cs
+++ b/generated/cs/ArmDefaults.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -129,10 +130,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDefaultArmBatch(ref WriteBatch batch, DefaultArm value)
         {
-            if (value.EntriesCount < 0 || value.EntriesCount > 2) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.EntriesCount >= 0 && value.EntriesCount <= 2, "value.EntriesCount out of range [0, 2]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.EntriesCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -147,10 +145,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Marker > 7)
-            {
-                return false;
-            }
+            Debug.Assert(value.Marker <= 7, "value.Marker out of range [0, 7]");
             {
                 uint offsetValue = (uint)(value.Marker);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -240,10 +235,7 @@ namespace Example
         private static bool WriteDefaultChoiceBatch(ref WriteBatch batch, DefaultChoice value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -378,10 +370,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DataLength < 0 || value.DataLength > 2) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.DataLength >= 0 && value.DataLength <= 2, "value.DataLength out of range [0, 2]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.DataLength);
                 if (!stream.SerializeBits(ref offsetValue, 2))
@@ -452,10 +441,7 @@ namespace Example
         public static bool WriteDefaultBulkChoice(WriteStream stream, DefaultBulkChoice value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!stream.SerializeBits(ref tagValue, 2))
             {
                 return false;

--- a/generated/cs/Clauses.cs
+++ b/generated/cs/Clauses.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -213,10 +214,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW13Batch(ref WriteBatch batch, W13 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 12) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 12, "value.ItemsCount out of range [0, 12]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -226,10 +224,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 13))
@@ -304,10 +299,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW17Batch(ref WriteBatch batch, W17 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 9) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 9, "value.ItemsCount out of range [0, 9]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -317,10 +309,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 131071)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 131071, "value.Items[i] out of range [0, 131071]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 17))
@@ -395,10 +384,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW26Batch(ref WriteBatch batch, W26 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 6) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 6, "value.ItemsCount out of range [0, 6]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -408,10 +394,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 67108863)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 67108863, "value.Items[i] out of range [0, 67108863]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 26))
@@ -486,10 +469,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW1Batch(ref WriteBatch batch, W1 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 20) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 20, "value.ItemsCount out of range [0, 20]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 5))
@@ -499,10 +479,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 1)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 1, "value.Items[i] out of range [0, 1]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 1))
@@ -577,10 +554,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW52Batch(ref WriteBatch batch, W52 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -590,10 +564,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 4503599627370495)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 4503599627370495, "value.Items[i] out of range [0, 4503599627370495]");
                 {
                     ulong offsetValue = (ulong)(value.Items[i]);
                     if (!batch.SerializeBits64(ref offsetValue, 52))
@@ -668,10 +639,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW50Batch(ref WriteBatch batch, W50 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -681,10 +649,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 1125899906842623)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 1125899906842623, "value.Items[i] out of range [0, 1125899906842623]");
                 {
                     ulong offsetValue = (ulong)(value.Items[i]);
                     if (!batch.SerializeBits64(ref offsetValue, 50))
@@ -759,10 +724,7 @@ namespace Example
         {
             for (int i = 0; i < 7; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 13))
@@ -914,10 +876,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArrTri3Batch(ref WriteBatch batch, ArrTri3 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 10) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 10, "value.ItemsCount out of range [0, 10]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -1224,10 +1183,7 @@ namespace Example
         public static bool WriteEmptyUnion(WriteStream stream, EmptyUnion value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!stream.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1247,10 +1203,7 @@ namespace Example
         private static bool WriteEmptyUnionBatch(ref WriteBatch batch, EmptyUnion value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1417,10 +1370,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.SLength < 0 || value.SLength > 8) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SLength >= 0 && value.SLength <= 8, "value.SLength out of range [0, 8]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.SLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -1432,10 +1382,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.BLength < 0 || value.BLength > 8) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.BLength >= 0 && value.BLength <= 8, "value.BLength out of range [0, 8]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.BLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -1557,10 +1504,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 4) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 4, "value.ItemsCount out of range [0, 4]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 3))

--- a/generated/cs/Constants.cs
+++ b/generated/cs/Constants.cs
@@ -4,11 +4,19 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 namespace Example
 {

--- a/generated/cs/Joins.cs
+++ b/generated/cs/Joins.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -735,10 +736,7 @@ namespace Example
             }
             if (value.Flag)
             {
-                if (value.SLength < 0 || value.SLength > 4) // the length guards the slice (§6.3); out-of-contract writes are refused
-                {
-                    return false;
-                }
+                Debug.Assert(value.SLength >= 0 && value.SLength <= 4, "value.SLength out of range [0, 4]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
                 {
                     uint offsetValue = (uint)(value.SLength);
                     if (!stream.SerializeBits(ref offsetValue, 3))
@@ -889,10 +887,7 @@ namespace Example
             }
             if (value.Flag)
             {
-                if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-                {
-                    return false;
-                }
+                Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
                 {
                     uint offsetValue = (uint)(value.ItemsCount);
                     if (!batch.SerializeBits(ref offsetValue, 2))
@@ -902,10 +897,7 @@ namespace Example
                 }
                 for (int i = 0; i < value.ItemsCount; i++)
                 {
-                    if (value.Items[i] > 8191)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                     {
                         uint offsetValue = (uint)(value.Items[i]);
                         if (!batch.SerializeBits(ref offsetValue, 13))
@@ -1149,10 +1141,7 @@ namespace Example
         private static bool WriteUnevenBatch(ref WriteBatch batch, Uneven value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1321,10 +1310,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -1419,10 +1405,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!stream.SerializeBits(ref offsetValue, 2))
@@ -1432,10 +1415,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!stream.SerializeBits(ref offsetValue, 13))
@@ -1444,10 +1424,7 @@ namespace Example
                     }
                 }
             }
-            if (value.SLength < 0 || value.SLength > 4) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SLength >= 0 && value.SLength <= 4, "value.SLength out of range [0, 4]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.SLength);
                 if (!stream.SerializeBits(ref offsetValue, 3))

--- a/generated/cs/Render.cs
+++ b/generated/cs/Render.cs
@@ -4,6 +4,7 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -85,10 +86,7 @@ namespace Example
         {
             {
                 // flat run: 138 bits in 3 chunk(s) — the field placement is folded
-                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Team <= 2, "value.Team above the enum wire range [0, 2]"); // headroom above the wire range cannot ride
                 ulong f0 = (ulong)value.SortKey;
                 ulong f1 = ((ulong)(value.MeshId)) & 0xffffffffUL;
                 ulong f2 = ((ulong)(value.MaterialId)) & 0xffffffffUL;
@@ -211,10 +209,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SpritesCount < 0 || value.SpritesCount > (int)RenderBlockMaxSprites) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SpritesCount >= 0 && value.SpritesCount <= (int)RenderBlockMaxSprites, "value.SpritesCount out of range [0, (int)RenderBlockMaxSprites]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.SpritesCount);
                 if (!batch.SerializeBits(ref offsetValue, 7))

--- a/generated/cs/Types.cs
+++ b/generated/cs/Types.cs
@@ -4,6 +4,7 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -357,10 +358,7 @@ namespace Example
         {
             {
                 // flat run: 22 bits in 1 chunk(s) — the field placement is folded
-                if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
-                {
-                    return false;
-                }
+                Debug.Assert(value.ObjectId >= 0 && value.ObjectId <= (int)(MaxObjects - 1), "value.ObjectId out of range [0, (int)(MaxObjects - 1)]");
                 ulong f0 = ((ulong)((uint)(value.ObjectId))) & 0x3fffUL;
                 ulong f1 = ((ulong)(value.ObjectSequence)) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 14));
@@ -436,18 +434,9 @@ namespace Example
         {
             {
                 // flat run: 75 bits in 2 chunk(s) — the field placement is folded
-                if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-MaxPositionUnits) && value.X <= (int)MaxPositionUnits, "value.X out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
+                Debug.Assert(value.Y >= (int)(-MaxPositionUnits) && value.Y <= (int)MaxPositionUnits, "value.Y out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
+                Debug.Assert(value.Z >= (int)(-MaxPositionUnits) && value.Z <= (int)MaxPositionUnits, "value.Z out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
@@ -529,18 +518,9 @@ namespace Example
         {
             {
                 // flat run: 69 bits in 2 chunk(s) — the field placement is folded
-                if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-MaxVelocityUnits) && value.X <= (int)MaxVelocityUnits, "value.X out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
+                Debug.Assert(value.Y >= (int)(-MaxVelocityUnits) && value.Y <= (int)MaxVelocityUnits, "value.Y out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
+                Debug.Assert(value.Z >= (int)(-MaxVelocityUnits) && value.Z <= (int)MaxVelocityUnits, "value.Z out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
@@ -624,22 +604,10 @@ namespace Example
         {
             {
                 // flat run: 48 bits in 1 chunk(s) — the field placement is folded
-                if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-RotationUnits) && value.X <= (int)RotationUnits, "value.X out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.Y >= (int)(-RotationUnits) && value.Y <= (int)RotationUnits, "value.Y out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.Z >= (int)(-RotationUnits) && value.Z <= (int)RotationUnits, "value.Z out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.W >= (int)(-RotationUnits) && value.W <= (int)RotationUnits, "value.W out of range [(int)(-RotationUnits), (int)RotationUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
@@ -1023,10 +991,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.InputsCount < 0 || value.InputsCount > (int)MaxInputsPerPacket) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.InputsCount >= 0 && value.InputsCount <= (int)MaxInputsPerPacket, "value.InputsCount out of range [0, (int)MaxInputsPerPacket]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.InputsCount);
                 if (!batch.SerializeBits(ref offsetValue, 5))
@@ -1137,10 +1102,7 @@ namespace Example
         {
             {
                 uint enumValue = (uint)value.ShipType;
-                if (enumValue > 5) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(enumValue <= 5, "value.ShipType above the enum wire range [0, 5]"); // headroom above the wire range cannot ride
                 if (!batch.SerializeBits(ref enumValue, 3))
                 {
                     return false;
@@ -1164,10 +1126,7 @@ namespace Example
             }
             if (value.HasFlags)
             {
-                if (value.Flags >= 1ul << 4) // a mask bit above the wire width cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(value.Flags < 1ul << 4, "value.Flags has a mask bit above the 4-bit wire width"); // a mask bit above the wire width cannot ride
                 {
                     uint flagsValue = (uint)value.Flags;
                     if (!batch.SerializeBits(ref flagsValue, 4))
@@ -1178,22 +1137,10 @@ namespace Example
             }
             {
                 // flat run: 19 bits in 1 chunk(s) — the field placement is folded
-                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
-                if (value.Health < 0 || value.Health > (int)MaxHealth)
-                {
-                    return false;
-                }
-                if (value.Thrust < 0 || value.Thrust > 100)
-                {
-                    return false;
-                }
-                if ((uint)value.Pending > 0) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Team <= 2, "value.Team above the enum wire range [0, 2]"); // headroom above the wire range cannot ride
+                Debug.Assert(value.Health >= 0 && value.Health <= (int)MaxHealth, "value.Health out of range [0, (int)MaxHealth]");
+                Debug.Assert(value.Thrust >= 0 && value.Thrust <= 100, "value.Thrust out of range [0, 100]");
+                Debug.Assert((uint)value.Pending <= 0, "value.Pending above the enum wire range [0, 0]"); // headroom above the wire range cannot ride
                 ulong f0 = ((ulong)(uint)value.Team) & 0x3UL;
                 ulong f1 = ((ulong)((uint)(value.Health))) & 0x3ffUL;
                 ulong f2 = ((ulong)((uint)(value.Thrust))) & 0x7fUL;
@@ -1327,14 +1274,8 @@ namespace Example
         {
             {
                 // flat run: 16 bits in 1 chunk(s) — the field placement is folded
-                if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
-                {
-                    return false;
-                }
-                if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
-                {
-                    return false;
-                }
+                Debug.Assert(value.HardpointIndex >= 0 && value.HardpointIndex <= (int)((ShipMaxLasers + ShipMaxMissiles) - 1), "value.HardpointIndex out of range [0, (int)((ShipMaxLasers + ShipMaxMissiles) - 1)]");
+                Debug.Assert(value.SpinRate >= (int)(-(-RotationUnits)) && value.SpinRate <= (int)(RotationUnits * 2), "value.SpinRate out of range [(int)(-(-RotationUnits)), (int)(RotationUnits * 2)]");
                 ulong f0 = ((ulong)((uint)(value.HardpointIndex))) & 0x1fUL;
                 ulong f1 = ((ulong)((uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits))))) & 0x7ffUL;
                 uint w0 = (uint)(f0 | (f1 << 5));
@@ -1412,10 +1353,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeProbeBatch(ref WriteBatch batch, ExtremeProbe value)
         {
-            if (value.FloorBound > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.FloorBound <= 100, "value.FloorBound out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.FloorBound) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1423,10 +1361,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DoubledFloor > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.DoubledFloor <= 100, "value.DoubledFloor out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.DoubledFloor) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1434,10 +1369,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.CeilingRange < 1)
-            {
-                return false;
-            }
+            Debug.Assert(value.CeilingRange >= 1, "value.CeilingRange out of range [1, 18446744073709551615]");
             {
                 ulong offsetValue = value.CeilingRange - 1;
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1543,10 +1475,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeRowBatch(ref WriteBatch batch, ExtremeRow value)
         {
-            if (value.ClampedFloor > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.ClampedFloor <= 100, "value.ClampedFloor out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.ClampedFloor) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1554,10 +1483,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614)
-            {
-                return false;
-            }
+            Debug.Assert(value.ClampedCeiling >= 1 && value.ClampedCeiling <= 18446744073709551614, "value.ClampedCeiling out of range [1, 18446744073709551614]");
             {
                 ulong offsetValue = value.ClampedCeiling - 1;
                 if (!batch.SerializeBits64(ref offsetValue, 64))

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -577,10 +578,7 @@ namespace Example
             {
                 {
                     // flat run: 5 bits in 1 chunk(s) — the field placement is folded
-                    if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
-                    {
-                        return false;
-                    }
+                    Debug.Assert((uint)value.Weapon <= 15, "value.Weapon above the enum wire range [0, 15]"); // headroom above the wire range cannot ride
                     ulong f0 = ((ulong)(uint)value.Weapon) & 0xfUL;
                     ulong f1 = value.HasTarget ? 1UL : 0UL;
                     uint w0 = (uint)(f0 | (f1 << 4));
@@ -607,10 +605,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SamplesCount < 1 || value.SamplesCount > 8) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SamplesCount >= 1 && value.SamplesCount <= 8, "value.SamplesCount out of range [1, 8]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.SamplesCount) - (uint)(1);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -834,10 +829,7 @@ namespace Example
         {
             {
                 // flat run: 15 bits in 1 chunk(s) — the field placement is folded
-                if (value.Width > 100)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Width <= 100, "value.Width out of range [0, 100]");
                 ulong f0 = ((ulong)((uint)(value.Width))) & 0x7fUL;
                 ulong f1 = ((ulong)(value.Height)) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 7));
@@ -925,10 +917,7 @@ namespace Example
         private static bool WriteProbeShapeBatch(ref WriteBatch batch, ProbeShape value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1033,10 +1022,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ExtrasCount < 0 || value.ExtrasCount > 2) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ExtrasCount >= 0 && value.ExtrasCount <= 2, "value.ExtrasCount out of range [0, 2]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ExtrasCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -1131,10 +1117,7 @@ namespace Example
         {
             {
                 // flat run: 36 bits in 1 chunk(s) — the field placement is folded
-                if ((uint)value.Preferred > 15) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Preferred <= 15, "value.Preferred above the enum wire range [0, 15]"); // headroom above the wire range cannot ride
                 ulong f0 = ((ulong)((uint)value.Retries)) & 0xffffffffUL;
                 ulong f1 = ((ulong)(uint)value.Preferred) & 0xfUL;
                 ulong w0 = f0 | (f1 << 32);
@@ -1321,18 +1304,9 @@ namespace Example
         {
             {
                 // flat run: 46 bits in 1 chunk(s) — the field placement is folded
-                if (value.TestB < 0 || value.TestB > 1000)
-                {
-                    return false;
-                }
-                if (value.TestC < 0 || value.TestC > 1000)
-                {
-                    return false;
-                }
-                if (value.TestD < 0 || value.TestD > 1000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.TestB >= 0 && value.TestB <= 1000, "value.TestB out of range [0, 1000]");
+                Debug.Assert(value.TestC >= 0 && value.TestC <= 1000, "value.TestC out of range [0, 1000]");
+                Debug.Assert(value.TestD >= 0 && value.TestD <= 1000, "value.TestD out of range [0, 1000]");
                 ulong f0 = ((ulong)(value.TestA)) & 0xffffUL;
                 ulong f1 = ((ulong)((uint)(value.TestB))) & 0x3ffUL;
                 ulong f2 = ((ulong)((uint)(value.TestC))) & 0x3ffUL;
@@ -1414,10 +1388,7 @@ namespace Example
 
         public static bool WriteBlock(WriteStream stream, Block value)
         {
-            if (value.DataLength < 0 || value.DataLength > (int)MaxBlockSize) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.DataLength >= 0 && value.DataLength <= (int)MaxBlockSize, "value.DataLength out of range [0, (int)MaxBlockSize]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.DataLength);
                 if (!stream.SerializeBits(ref offsetValue, 11))
@@ -1466,10 +1437,7 @@ namespace Example
 
         public static bool WriteChat(WriteStream stream, Chat value)
         {
-            if (value.TextLength < 0 || value.TextLength > (int)MaxChatLength) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= (int)MaxChatLength, "value.TextLength out of range [0, (int)MaxChatLength]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 9))
@@ -1563,10 +1531,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.Flags >= 1ul << 8) // a mask bit above the wire width cannot ride
-            {
-                return false;
-            }
+            Debug.Assert(value.Flags < 1ul << 8, "value.Flags has a mask bit above the 8-bit wire width"); // a mask bit above the wire width cannot ride
             {
                 uint flagsValue = (uint)value.Flags;
                 if (!batch.SerializeBits(ref flagsValue, 8))
@@ -1677,18 +1642,9 @@ namespace Example
         {
             {
                 // flat run: 49 bits in 1 chunk(s) — the field placement is folded
-                if (value.A < -100 || value.A > 100)
-                {
-                    return false;
-                }
-                if (value.B < -100 || value.B > 100)
-                {
-                    return false;
-                }
-                if (value.C < -100 || value.C > 150)
-                {
-                    return false;
-                }
+                Debug.Assert(value.A >= -100 && value.A <= 100, "value.A out of range [-100, 100]");
+                Debug.Assert(value.B >= -100 && value.B <= 100, "value.B out of range [-100, 100]");
+                Debug.Assert(value.C >= -100 && value.C <= 150, "value.C out of range [-100, 150]");
                 ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f1 = ((ulong)((uint)(value.B) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-100)))) & 0xffUL;
@@ -1702,10 +1658,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 16) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 16, "value.ItemsCount out of range [0, 16]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!stream.SerializeBits(ref offsetValue, 5))
@@ -1715,10 +1668,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] < 0 || value.Items[i] > 255)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] >= 0 && value.Items[i] <= 255, "value.Items[i] out of range [0, 255]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!stream.SerializeBits(ref offsetValue, 8))
@@ -1744,10 +1694,7 @@ namespace Example
             }
             {
                 // flat run: 249 bits in 4 chunk(s) — the field placement is folded
-                if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Int64Range >= -1000000000000 && value.Int64Range <= 1000000000000, "value.Int64Range out of range [-1000000000000, 1000000000000]");
                 ulong f0 = ((ulong)((byte)value.Int8Value)) & 0xffUL;
                 ulong f1 = ((ulong)((ushort)value.Int16Value)) & 0xffffUL;
                 ulong f2 = ((ulong)(value.Uint8Value)) & 0xffUL;
@@ -1785,10 +1732,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TextLength < 0 || value.TextLength > 255) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= 255, "value.TextLength out of range [0, 255]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 8))

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -83,6 +83,7 @@ type gen struct {
 	needsSerialize bool            // the file emits wire functions -> using Serialize;
 	needsSystem    bool            // the file references System (Array, Math, AsSpan)
 	needsCompiler  bool            // the file emits [MethodImpl] -> using System.Runtime.CompilerServices;
+	needsDiag      bool            // the file emits Debug.Assert -> using System.Diagnostics;
 }
 
 // rv is the serialize receiver of the function being emitted: the stream, or
@@ -129,15 +130,26 @@ func (g *gen) assemble() []byte {
 		// the unit-level target notes ride the home file only — said once
 		// per unit, not once per file
 		h.WriteString("//\n")
-		h.WriteString("// Wire functions return bool — the C++-style early-out. A schema validation\n")
-		h.WriteString("// failure (a wrong wire constant, nonzero reserved bits, an interior null)\n")
-		h.WriteString("// returns false WITHOUT latching; stream failures latch on stream.Error —\n")
-		h.WriteString("// the runtime's own sticky latch. Callers get bool always; Error tells the\n")
-		h.WriteString("// two apart.\n")
+		h.WriteString("// Wire functions return bool — the C++-style early-out. A READ-side schema\n")
+		h.WriteString("// validation failure (a wrong wire constant, nonzero reserved bits, an\n")
+		h.WriteString("// interior null) returns false WITHOUT latching; stream failures latch on\n")
+		h.WriteString("// stream.Error — the runtime's own sticky latch. Callers get bool always;\n")
+		h.WriteString("// Error tells the two apart.\n")
+		h.WriteString("//\n")
+		h.WriteString("// WRITE-side contracts — a value outside its declared range, a count or a\n")
+		h.WriteString("// length outside its bound, a mask bit above the wire width, an interior\n")
+		h.WriteString("// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so\n")
+		h.WriteString("// they compile out of a release build along with the call, exactly as\n")
+		h.WriteString("// serialize.cs's own WriteStream does. In a shipping release build it is\n")
+		h.WriteString("// the caller's responsibility to be correct on the write side; every check\n")
+		h.WriteString("// the reader needs is on the read side and runs in every build.\n")
 	}
 	h.WriteString("\n")
 	if g.needsSystem {
 		h.WriteString("using System;\n")
+	}
+	if g.needsDiag {
+		h.WriteString("using System.Diagnostics;\n")
 	}
 	if g.needsCompiler {
 		h.WriteString("using System.Runtime.CompilerServices;\n")
@@ -145,7 +157,7 @@ func (g *gen) assemble() []byte {
 	if g.needsSerialize {
 		h.WriteString("using Serialize;\n")
 	}
-	if g.needsSystem || g.needsCompiler || g.needsSerialize {
+	if g.needsSystem || g.needsDiag || g.needsCompiler || g.needsSerialize {
 		h.WriteString("\n")
 	}
 	// block namespace, not file-scoped: Unity's compiler is C# 9 and

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -285,8 +285,9 @@ func (g *gen) flatWriteFieldPiece(item *ir.FieldItem) (flatPiece, bool) {
 			}
 			return flatPiece{item: item, bits: w,
 				guard: func(ind string) {
-					g.sf("%sif (%s >= 1ul << %d) // a mask bit above the wire width cannot ride\n", ind, name, w)
-					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s < 1ul << %d", name, w),
+						fmt.Sprintf("%s has a mask bit above the %d-bit wire width", name, w),
+						" // a mask bit above the wire width cannot ride")
 				},
 				expr: flatMasked(name, w)}, true
 		}
@@ -313,9 +314,8 @@ func (g *gen) flatWriteBarePiece(item *ir.FieldItem, name string) (flatPiece, bo
 }
 
 // flatWriteRangedPiece is a ranged integer: the offset from min in a
-// generation-time bit count, with the same refusal emitWriteFoldedRange
-// emits — the same guard, the same vacuous halves elided, the same
-// non-latching false.
+// generation-time bit count, with the same contract emitWriteFoldedRange
+// emits — the same debug assertion, the same vacuous halves elided.
 func (g *gen) flatWriteRangedPiece(item *ir.FieldItem, name string) (flatPiece, bool) {
 	f := item.F
 	bits := ir.BitsRequired(f.IntMin, f.IntMax)
@@ -345,14 +345,15 @@ func (g *gen) flatWriteRangedPiece(item *ir.FieldItem, name string) (flatPiece, 
 		}
 		lo, hi = g.rangeArgs(f, typ)
 	}
+	msg := fmt.Sprintf("%s out of range [%s, %s]", name, lo, hi)
 	guard := func(ind string) {
 		switch {
 		case guardLo && guardHi:
-			g.sf("%sif (%s < %s || %s > %s)\n%s{\n%s    return false;\n%s}\n", ind, name, lo, name, hi, ind, ind, ind)
+			g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, lo, name, hi), msg, "")
 		case guardLo:
-			g.sf("%sif (%s < %s)\n%s{\n%s    return false;\n%s}\n", ind, name, lo, ind, ind, ind)
+			g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, lo), msg, "")
 		case guardHi:
-			g.sf("%sif (%s > %s)\n%s{\n%s    return false;\n%s}\n", ind, name, hi, ind, ind, ind)
+			g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, hi), msg, "")
 		}
 	}
 	if bits == 0 {
@@ -372,7 +373,8 @@ func (g *gen) flatWriteRangedPiece(item *ir.FieldItem, name string) (flatPiece, 
 }
 
 // flatWriteEnumPiece is an enum in [0, Max] with a generation-time bit count,
-// carrying the headroom guard the per-field form carries.
+// carrying the headroom contract the per-field form carries, in the same
+// debug-only form.
 func (g *gen) flatWriteEnumPiece(item *ir.FieldItem, ref *ir.Enum, name string) (flatPiece, bool) {
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
 	if bits > 64 {
@@ -385,8 +387,9 @@ func (g *gen) flatWriteEnumPiece(item *ir.FieldItem, ref *ir.Enum, name string) 
 	var guard func(ind string)
 	if big.NewInt(ref.Max).Cmp(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(ref.StorageBits)), big.NewInt(1))) < 0 {
 		guard = func(ind string) {
-			g.sf("%sif ((%s)%s > %d) // headroom above the wire range cannot ride\n", ind, typ, name, ref.Max)
-			g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+			g.writeAssert(ind, fmt.Sprintf("(%s)%s <= %d", typ, name, ref.Max),
+				fmt.Sprintf("%s above the enum wire range [0, %d]", name, ref.Max),
+				" // headroom above the wire range cannot ride")
 		}
 	}
 	if bits == 0 {

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -3,17 +3,32 @@
 // API — every call's bool is checked and early-outs, the C++ twin's shape
 // (§6.3 C# row), so counts and lengths are validated before the loop or slice
 // they guard. The runtime's error latch (stream.Error) rides beneath the bool
-// for callers; generated validation refusals return false without latching.
+// for callers; generated READ-side validation refusals return false without
+// latching.
 // The wire is byte-identical to the C++ target's, construct by construct.
 //
-// Write-side guards: serialize.cs's WriteStream refuses out-of-range values
-// on the ranged calls (SerializeInt/SerializeInt64 latch ValueOutOfRange and
-// return false — Serialize.cs:866-884, 887-917), exactly like serialize.go,
-// and its raw bit writer masks silently (WriteBitsUnchecked, Serialize.cs:439)
-// exactly like serialize.go's — so this emitter carries the Go target's
-// leaner guard set: generated refusals exist only where the generated code
-// bypasses the ranged calls (the flags wire-width guard and the full-range
-// unsigned raw-offset path).
+// Write-side contracts are DEBUG ONLY. The maintainer's ruling, verbatim
+// (2026-09-07): "No runtime should ever promise to keep checks in writing
+// packets (asserts) in release build. Removing them is the whole point. The
+// documented posture of the serialize and schema libraries is that it is
+// *your responsibility* in shipping release builds on the write side to be
+// correct. checks are *DEBUG ONLY*" — and, in the same breath, "Of course, on
+// read side we MUST always do the checks!"
+//
+// So every caller-error check this emitter puts on the write path — a ranged
+// integer, an enum's headroom, a flags mask above the wire width, a union
+// tag, a counted array's count, a string/bytes/wstring length, a wide
+// string's interior null, a degenerate fixed or int128 raw — is a
+// Debug.Assert, which is [Conditional("DEBUG")] and therefore gone from a
+// release build, call and arguments both. That is the idiom of the runtime
+// this code calls: serialize.cs's WriteStream documents values, capacity,
+// lengths and float finiteness as "checked by Debug.Assert in debug builds
+// and not at all in release builds", and its raw bit writer masks silently
+// (WriteBitsUnchecked, Serialize.cs:439).
+//
+// What still returns false in every build: the READ path's whole validation
+// set, and the stream's own runtime conditions (capacity, a latched error) —
+// neither is caller error.
 package csharp
 
 import (
@@ -167,7 +182,7 @@ func (g *gen) emitBatchScope(writing bool, f *ir.Field, child, ind string) {
 		if writing {
 			g.emitWriteFoldedRange(count, fmt.Sprintf("%d", f.ArrayMin), bound,
 				big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), false, true, true,
-				" // the count guards the loop (§6.3); out-of-contract writes are refused", ind)
+				" // the count guards the loop (§6.3); an out-of-contract count is caller error", ind)
 		} else {
 			g.call(ind, fmt.Sprintf("stream.SerializeInt(ref %s, %d, %s)", count, f.ArrayMin, bound),
 				" // the count guards the loop (§6.3)")
@@ -383,12 +398,19 @@ func (g *gen) emitUnionFunctions(d *ir.Union) {
 			if d.Max == 0 {
 				g.sf("    // an empty union holds only None; its degenerate tag range [0, 0]\n")
 				g.sf("    // costs zero bits (SPEC §4.8)\n")
-				g.sf("    return value.Type == %sType.None;\n", d.Name)
+				g.writeAssert("    ", fmt.Sprintf("value.Type == %sType.None", d.Name),
+					"an empty union can only hold None", "")
+				g.sf("    return true;\n")
 				return
 			}
 			g.sf("    uint tagValue = (uint)value.Type;\n")
-			g.sf("    if (tagValue > %d) // the tag validates BEFORE it rides (SPEC §4.8)\n", d.Max)
-			g.sf("    {\n        return false;\n    }\n")
+			// A C# enum variable holds any value of its underlying type — a
+			// tag outside the variant set is reachable, by an explicit cast,
+			// and it is CALLER ERROR, so the contract is a debug assertion
+			// (§5). The read side still refuses such a tag in every build.
+			g.writeAssert("    ", fmt.Sprintf("tagValue <= %d", d.Max),
+				fmt.Sprintf("the union tag is outside the variant set [0, %d]", d.Max),
+				" // the tag contract holds BEFORE it rides (SPEC §4.8)")
 			g.call("    ", fmt.Sprintf("%s.SerializeBits(ref tagValue, %d)", g.rv(), bits), "")
 			g.sf("    switch (value.Type)\n    {\n")
 			for _, v := range d.Variants {
@@ -437,6 +459,30 @@ func (g *gen) armCall(dir string, v ir.UnionVariant) string {
 
 func (g *gen) call(ind, expr, comment string) {
 	g.sf("%sif (!%s)%s\n%s{\n%s    return false;\n%s}\n", ind, expr, comment, ind, ind, ind)
+}
+
+// writeAssert emits ONE write-side contract check. cond is the CONTRACT — the
+// positive form — and message names what the caller broke.
+//
+// The maintainer's ruling, verbatim (2026-09-07): "No runtime should ever
+// promise to keep checks in writing packets (asserts) in release build.
+// Removing them is the whole point. The documented posture of the serialize
+// and schema libraries is that it is *your responsibility* in shipping release
+// builds on the write side to be correct. checks are *DEBUG ONLY*" — and "Of
+// course, on read side we MUST always do the checks!"
+//
+// Debug.Assert is itself [Conditional("DEBUG")], so in a release build the
+// call AND the evaluation of its arguments are gone from the IL: the write
+// body the JIT sees is the pack alone, which is what a separate
+// [Conditional("DEBUG")] CheckWriteX predicate would also buy, without a
+// second walk of the type. It is also the idiom the C# runtime this code calls
+// already uses — serialize.cs carries ~90 Debug.Assert and three
+// [Conditional("DEBUG")] validators, and its WriteStream doc says values,
+// capacity, lengths and float finiteness are "checked by Debug.Assert in debug
+// builds and not at all in release builds".
+func (g *gen) writeAssert(ind, cond, message, comment string) {
+	g.needsDiag = true
+	g.sf("%sDebug.Assert(%s, \"%s\");%s\n", ind, cond, message, comment)
 }
 
 // emitConstItem writes const(value, bits) on the wire; a read rejects any
@@ -606,22 +652,24 @@ func storageBounds(t ir.FieldType) (*big.Int, *big.Int) {
 // offset-from-min in a generation-time bit count. lo/hi are the rendered
 // bound expressions (typed so they compare against expr legally); wide picks
 // the 64-bit call family; guardLo/guardHi say whether each half of the range
-// refusal is non-vacuous for expr's storage type. Byte-identical to the
-// runtime SerializeInt/SerializeInt64 forms.
+// contract is non-vacuous for expr's storage type. The contract rides on
+// Debug.Assert — write-side checks are caller error and DEBUG ONLY (§5).
+// Byte-identical to the runtime SerializeInt/SerializeInt64 forms.
 func (g *gen) emitWriteFoldedRange(expr, lo, hi string, min, max *big.Int, wide, guardLo, guardHi bool, comment, ind string) {
+	msg := fmt.Sprintf("%s out of range [%s, %s]", expr, lo, hi)
 	switch {
 	case guardLo && guardHi:
-		g.sf("%sif (%s < %s || %s > %s)%s\n%s{\n%s    return false;\n%s}\n", ind, expr, lo, expr, hi, comment, ind, ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", expr, lo, expr, hi), msg, comment)
 	case guardLo:
-		g.sf("%sif (%s < %s)%s\n%s{\n%s    return false;\n%s}\n", ind, expr, lo, comment, ind, ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s >= %s", expr, lo), msg, comment)
 	case guardHi:
-		g.sf("%sif (%s > %s)%s\n%s{\n%s    return false;\n%s}\n", ind, expr, hi, comment, ind, ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s <= %s", expr, hi), msg, comment)
 	}
 	bits := ir.BitsRequired(min, max)
 	if bits == 0 {
 		// A degenerate range costs ZERO BITS — the value is known from the
-		// range alone; the refusal above is the whole write (SPEC §4.6,
-		// decided deliberately)
+		// range alone; the debug assertion above is the whole write (SPEC
+		// §4.6, decided deliberately)
 		return
 	}
 	typ, fn := "uint", "SerializeBits"
@@ -709,7 +757,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 			count := "value." + g.m(base+"Count")
 			g.emitWriteFoldedRange(count, fmt.Sprintf("%d", f.ArrayMin), bound,
 				big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), false, true, true,
-				" // the count guards the loop (§6.3); out-of-contract writes are refused", ind)
+				" // the count guards the loop (§6.3); an out-of-contract count is caller error", ind)
 			g.sf("%sfor (int i = 0; i < %s; i++)\n%s{\n", ind, count, ind)
 		} else {
 			// the SCHEMA bound, never the storage's Length: reassigned-short
@@ -727,25 +775,22 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 	switch f.Type.Kind {
 	case ir.TFixed:
 		if f.IntMin.Cmp(f.IntMax) == 0 {
-			// degenerate range: ZERO bits — the folded range refusal and no
+			// degenerate range: ZERO bits — the folded range contract and no
 			// wire call at all, so no runtime degenerate support is needed
 			// (SPEC §4.6). The one legal raw is min << F,
 			// compared in the storage's own signedness (a wide ufixed raw can
 			// live above long.MaxValue).
 			rawMin := new(big.Int).Lsh(f.IntMin, uint(f.Type.FracBits))
+			msg := fmt.Sprintf("%s is not %s, the one legal raw of a degenerate fixed range", name, rawMin.String())
 			switch {
 			case f.Type.Width == 128 && f.Type.Signed:
-				g.sf("%sif (%s != (Int128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
-					ind, name, csRender128(rawMin), ind, ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s == (Int128Value)(%s)", name, csRender128(rawMin)), msg, "")
 			case f.Type.Width == 128:
-				g.sf("%sif (%s != (UInt128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
-					ind, name, csRenderU128(rawMin), ind, ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("%s == (UInt128Value)(%s)", name, csRenderU128(rawMin)), msg, "")
 			case f.Type.Signed:
-				g.sf("%sif ((long)%s != %sL)\n%s{\n%s    return false;\n%s}\n",
-					ind, name, rawMin.String(), ind, ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("(long)%s == %sL", name, rawMin.String()), msg, "")
 			default:
-				g.sf("%sif ((ulong)%s != %sUL)\n%s{\n%s    return false;\n%s}\n",
-					ind, name, rawMin.String(), ind, ind, ind)
+				g.writeAssert(ind, fmt.Sprintf("(ulong)%s == %sUL", name, rawMin.String()), msg, "")
 			}
 			return
 		}
@@ -767,9 +812,10 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		if f.Type.Width == 128 {
 			if f.HasIntRange {
 				if f.IntMin.Cmp(f.IntMax) == 0 {
-					// degenerate range: ZERO bits — refusal only (SPEC §4.6)
-					g.sf("%sif (%s != (Int128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
-						ind, name, csRender128(f.IntMin), ind, ind, ind)
+					// degenerate range: ZERO bits — the contract is the whole
+					// write, and it is DEBUG ONLY (SPEC §4.6, §5)
+					g.writeAssert(ind, fmt.Sprintf("%s == (Int128Value)(%s)", name, csRender128(f.IntMin)),
+						fmt.Sprintf("%s is not the one legal value of a degenerate int128 range", name), "")
 					return
 				}
 				// int128 is ALWAYS ranged (SPEC §4.3): offset from min —
@@ -790,22 +836,19 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 				// full-range unsigned: raw offset bits (ulong storage only —
 				// no narrower storage can hold a range past long). This path
 				// bypasses the runtime's ranged calls, so it supplies their
-				// write-side range refusal (a misuse value must not wrap into
-				// valid-looking wire); vacuous halves are elided. Nothing
-				// latches — bool is the whole verdict here.
+				// write-side range CONTRACT — and the runtime's own is a
+				// Debug.Assert, so this one is too; vacuous halves are elided.
 				lo, _ := g.rangeArgs(f, "ulong")
 				loVacuous := f.IntMin.Sign() == 0
 				hiVacuous := f.IntMax.Cmp(maxUint64) == 0
+				msg := fmt.Sprintf("%s out of range [%s, %s]", name, lo, f.IntMax.String())
 				switch {
 				case !loVacuous && !hiVacuous:
-					g.sf("%sif (%s < %s || %s > %s)\n", ind, name, lo, name, f.IntMax.String())
-					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s >= %s && %s <= %s", name, lo, name, f.IntMax.String()), msg, "")
 				case !loVacuous:
-					g.sf("%sif (%s < %s)\n", ind, name, lo)
-					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s >= %s", name, lo), msg, "")
 				case !hiVacuous:
-					g.sf("%sif (%s > %s)\n", ind, name, f.IntMax.String())
-					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+					g.writeAssert(ind, fmt.Sprintf("%s <= %s", name, f.IntMax.String()), msg, "")
 				}
 				if loVacuous {
 					g.sf("%s{\n%s    ulong offsetValue = %s;\n", ind, ind, name)
@@ -853,7 +896,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		length := "value." + g.m(g.fieldBase(f)+"Length")
 		g.emitWriteFoldedRange(length, "0", g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "int", false),
 			big.NewInt(0), big.NewInt(f.Type.Size), false, true, true,
-			" // the length guards the slice (§6.3); out-of-contract writes are refused", ind)
+			" // the length guards the slice (§6.3); an out-of-contract length is caller error", ind)
 		g.call(ind, fmt.Sprintf("%s.SerializeBytes(%s.AsSpan(0, %s))", g.rv(), name, length), "")
 	case ir.TNamed:
 		switch ref := f.Type.Ref.(type) {
@@ -891,13 +934,14 @@ func (g *gen) emitWriteFoldedEnum(ref *ir.Enum, name, ind string) {
 	g.sf("%s{\n%s    %s enumValue = (%s)%s;\n", ind, ind, typ, typ, name)
 	// the guard is vacuous only when the wire range fills the backing type
 	if big.NewInt(ref.Max).Cmp(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(ref.StorageBits)), big.NewInt(1))) < 0 {
-		g.sf("%s    if (enumValue > %d) // headroom above the wire range cannot ride\n", ind, ref.Max)
-		g.sf("%s    {\n%s        return false;\n%s    }\n", ind, ind, ind)
+		g.writeAssert(ind+"    ", fmt.Sprintf("enumValue <= %d", ref.Max),
+			fmt.Sprintf("%s above the enum wire range [0, %d]", name, ref.Max),
+			" // headroom above the wire range cannot ride")
 	}
 	// A degenerate range (an enum with only the implicit None) costs ZERO BITS
 	// -- the value is known from the range alone. The bit packer requires at
-	// least one bit, so the call is skipped entirely; the headroom guard above
-	// still rides, because a value above the range must still be refused.
+	// least one bit, so the call is skipped entirely; the headroom contract
+	// above still rides, in a debug build.
 	if bits > 0 {
 		g.call(ind+"    ", fmt.Sprintf("%s.%s(ref enumValue, %d)", g.rv(), fn, bits), "")
 	}
@@ -1186,12 +1230,14 @@ func (g *gen) emitReadFlags(name string, wireBits int, ind string) {
 
 // emitWriteFlagsValue is the write half used by emitWriteScalar. Storage is
 // wider than the wire wherever WireBits < 64, so a mask bit above the wire
-// width is refused rather than silently truncated — the raw bit calls mask,
-// so this refusal is generated (nothing latches; bool is the verdict).
+// width breaks the writer's contract rather than being silently truncated —
+// the raw bit calls mask, so the contract is generated here, as a debug
+// assertion (§5: write-side checks are caller error, DEBUG ONLY).
 func (g *gen) emitWriteFlagsValue(name string, wireBits int, ind string) {
 	if wireBits < 64 {
-		g.sf("%sif (%s >= 1ul << %d) // a mask bit above the wire width cannot ride\n", ind, name, wireBits)
-		g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+		g.writeAssert(ind, fmt.Sprintf("%s < 1ul << %d", name, wireBits),
+			fmt.Sprintf("%s has a mask bit above the %d-bit wire width", name, wireBits),
+			" // a mask bit above the wire width cannot ride")
 	}
 	if wireBits <= 32 {
 		g.sf("%s{\n%s    uint flagsValue = (uint)%s;\n", ind, ind, name)

--- a/internal/codegen/csharp/wstring.go
+++ b/internal/codegen/csharp/wstring.go
@@ -12,7 +12,11 @@ func (g *gen) emitWriteWString(f *ir.Field, name, ind string) {
 	g.emitWriteFoldedRange(length, "0", g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "int", false), big.NewInt(0), big.NewInt(f.Type.Size), false, true, true, "", ind)
 	g.sf("%sfor (int wideIndex = 0; wideIndex < %s; wideIndex++)\n%s{\n", ind, length, ind)
 	g.sf("%s    uint wideGroup = %s[wideIndex];\n", ind, name)
-	g.sf("%s    if (wideGroup == 0) return false;\n", ind)
+	// SPEC §4.12's write-side rules — the used length in [0, N] above, and no
+	// zero code unit among the used units — are the WRITER's contract, "in
+	// that target's own idiom (§5)": in C# that idiom is Debug.Assert, gone
+	// from a release build. The read side refuses both in every build.
+	g.writeAssert(ind+"    ", "wideGroup != 0", "a wide string's used units carry an interior null", "")
 	g.call(ind+"    ", fmt.Sprintf("%s.SerializeBits(ref wideGroup, 32)", g.rv()), "")
 	g.sf("%s}\n", ind)
 }

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -386,6 +386,7 @@ test-cs: toolchain-cs build/tables-generated-cs/.stamp generated/bench/tables/cs
 	$(DOTNET) build bench/tables/cs -c Release --nologo -v quiet
 	cd bench/cs && $(DOTNET) build -c Release --nologo -v quiet
 	cd test/cs && $(DOTNET) run
+	cd test/cs && $(DOTNET) run -c Release
 	cd test/cs-ludicrous && $(DOTNET) run
 
 TEST_LEGS         += test-cs

--- a/test/cs-ludicrous/src/Program.cs
+++ b/test/cs-ludicrous/src/Program.cs
@@ -283,14 +283,10 @@ static class Program
             Check(output.Locked == 196608, "the degenerate ufixed materializes from the range alone");
             Check(output.Tail == 0xA5, "the tail rides after zero degenerate bits");
 
-            // the write-side degenerate refusal: any raw but 3 * 2^16 is
-            // refused before a single bit is written
-            UnsignedProbe bad = new UnsignedProbe();
-            bad.Angle = input.Angle; bad.Span = input.Span; bad.Reach = input.Reach;
-            bad.Ticks = input.Ticks; bad.Samples[0] = input.Samples[0]; bad.Samples[1] = input.Samples[1];
-            bad.Locked = 196609; bad.Tail = input.Tail;
-            WriteStream badWs = NewWriteStream();
-            Check(!WriteUnsignedProbe(badWs, bad), "a wrong degenerate ufixed raw is REFUSED on write");
+            // the write-side degenerate contract — any raw but 3 * 2^16 —
+            // is a Debug.Assert (SPEC §5): caller error, compiled out of a
+            // release build, exactly as the C++ leg (test/ludicrous_main.cpp)
+            // has always had it. Nothing to probe here in either build.
 
             // hostile: span's 64 offset bits (starting at bit 25) all-ones =
             // 2^64 - 1, above the raw range 0xFFFFFFFFFFFF0000 — the

--- a/test/cs/src/Program.cs
+++ b/test/cs/src/Program.cs
@@ -661,11 +661,10 @@ static class Program
             Check(!ReadProbeCollider(new ReadStream(corrupt), bad),
                   "a corrupt union arm payload is refused (SPEC §4.8)");
 
-            // the write side validates the tag BEFORE it rides
-            ProbeShape rogue = new ProbeShape();
-            rogue.Type = (ProbeShapeType) 3;
-            WriteStream ws2 = NewWriteStream();
-            Check(!WriteProbeShape(ws2, rogue), "an out-of-set union tag writes nothing (SPEC §4.8)");
+            // the write side's tag contract is a Debug.Assert (SPEC §5): a tag
+            // outside the variant set is caller error, and the check is gone
+            // from a release build. The READ side above still refuses one in
+            // every build, which is the check that faces untrusted bytes.
         }
 
         // ---- TestData and InputPacket against their C++ pins ----
@@ -783,13 +782,20 @@ static class Program
             Check(ReadProbeReport(rs, output), "read ProbeReport");
             Check(EqProbeReport(output, input), "ProbeReport round-trips — a named type as an ordinary field");
 
-            // a mask bit above the widened 8-bit wire is refused, not truncated —
-            // this refusal is a GENERATED guard (the runtime's raw bit calls mask
-            // silently), so bool is the whole verdict: nothing latches
+            // a mask bit above the widened 8-bit wire breaks the WRITER's
+            // contract. That contract is a Debug.Assert in the generated code —
+            // write-side checks are caller error and DEBUG ONLY (SPEC §5), the
+            // idiom serialize.cs's own WriteStream uses — so it is gone from a
+            // release build along with the call. This leg runs Debug (`dotnet
+            // run`, no -c), where the assertion would FailFast the process, so
+            // the violation is only exercised in a release build.
             input.Flags = 1ul << 9;
+#if !DEBUG
             WriteStream ws2 = NewWriteStream();
-            Check(!WriteProbeReport(ws2, input), "a mask bit above the flags wire width is refused");
-            Check(ws2.Error == SerializeError.None, "the generated guard refuses via bool alone — nothing latches");
+            Check(WriteProbeReport(ws2, input), "release: the flags contract is compiled out — the write is not refused");
+            Check(ws2.Error == SerializeError.None, "release: nothing latches on the write side");
+#endif
+            input.Flags = ProbeFlagsArmed; // back inside the contract for anything after
         }
 
         // ---- Block: the bytes(N) framing ----

--- a/test/packet-wide/cs/Program.cs
+++ b/test/packet-wide/cs/Program.cs
@@ -30,7 +30,12 @@ static class Program
     static void Contracts()
     {
         WideSeven v = new WideSeven();
-        foreach(int n in new[]{-1,8,1}) { v.TextLength=n; Check(!Schema.WriteWideSeven(new WriteStream(new byte[256]),v),"writer bounds/null"); }
+        // SPEC §4.12's two WRITE-side rules — the used length in [0, N], and no
+        // zero code unit among the used units — are the caller's contract and
+        // ride on Debug.Assert (SPEC §5), so they are gone from the release
+        // build this file is also compiled into. There is nothing to probe in
+        // either configuration; the READ-side rules below run in both.
+        v.TextLength=1;
         v.Text[0]=(char)0xd800;
         var (wire,_) = Encode(v, Schema.WriteWideSeven);
         Check(!Schema.ReadWideSeven(new ReadStream(wire),v),"unpaired high");

--- a/testdata/golden/cs/ArmDefaults.cs
+++ b/testdata/golden/cs/ArmDefaults.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -129,10 +130,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDefaultArmBatch(ref WriteBatch batch, DefaultArm value)
         {
-            if (value.EntriesCount < 0 || value.EntriesCount > 2) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.EntriesCount >= 0 && value.EntriesCount <= 2, "value.EntriesCount out of range [0, 2]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.EntriesCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -147,10 +145,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Marker > 7)
-            {
-                return false;
-            }
+            Debug.Assert(value.Marker <= 7, "value.Marker out of range [0, 7]");
             {
                 uint offsetValue = (uint)(value.Marker);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -240,10 +235,7 @@ namespace Example
         private static bool WriteDefaultChoiceBatch(ref WriteBatch batch, DefaultChoice value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -378,10 +370,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DataLength < 0 || value.DataLength > 2) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.DataLength >= 0 && value.DataLength <= 2, "value.DataLength out of range [0, 2]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.DataLength);
                 if (!stream.SerializeBits(ref offsetValue, 2))
@@ -452,10 +441,7 @@ namespace Example
         public static bool WriteDefaultBulkChoice(WriteStream stream, DefaultBulkChoice value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!stream.SerializeBits(ref tagValue, 2))
             {
                 return false;

--- a/testdata/golden/cs/Clauses.cs
+++ b/testdata/golden/cs/Clauses.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -213,10 +214,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW13Batch(ref WriteBatch batch, W13 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 12) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 12, "value.ItemsCount out of range [0, 12]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -226,10 +224,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 13))
@@ -304,10 +299,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW17Batch(ref WriteBatch batch, W17 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 9) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 9, "value.ItemsCount out of range [0, 9]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -317,10 +309,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 131071)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 131071, "value.Items[i] out of range [0, 131071]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 17))
@@ -395,10 +384,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW26Batch(ref WriteBatch batch, W26 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 6) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 6, "value.ItemsCount out of range [0, 6]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -408,10 +394,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 67108863)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 67108863, "value.Items[i] out of range [0, 67108863]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 26))
@@ -486,10 +469,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW1Batch(ref WriteBatch batch, W1 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 20) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 20, "value.ItemsCount out of range [0, 20]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 5))
@@ -499,10 +479,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 1)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 1, "value.Items[i] out of range [0, 1]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 1))
@@ -577,10 +554,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW52Batch(ref WriteBatch batch, W52 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -590,10 +564,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 4503599627370495)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 4503599627370495, "value.Items[i] out of range [0, 4503599627370495]");
                 {
                     ulong offsetValue = (ulong)(value.Items[i]);
                     if (!batch.SerializeBits64(ref offsetValue, 52))
@@ -668,10 +639,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteW50Batch(ref WriteBatch batch, W50 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -681,10 +649,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 1125899906842623)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 1125899906842623, "value.Items[i] out of range [0, 1125899906842623]");
                 {
                     ulong offsetValue = (ulong)(value.Items[i]);
                     if (!batch.SerializeBits64(ref offsetValue, 50))
@@ -759,10 +724,7 @@ namespace Example
         {
             for (int i = 0; i < 7; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!batch.SerializeBits(ref offsetValue, 13))
@@ -914,10 +876,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArrTri3Batch(ref WriteBatch batch, ArrTri3 value)
         {
-            if (value.ItemsCount < 0 || value.ItemsCount > 10) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 10, "value.ItemsCount out of range [0, 10]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 4))
@@ -1224,10 +1183,7 @@ namespace Example
         public static bool WriteEmptyUnion(WriteStream stream, EmptyUnion value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!stream.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1247,10 +1203,7 @@ namespace Example
         private static bool WriteEmptyUnionBatch(ref WriteBatch batch, EmptyUnion value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1417,10 +1370,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.SLength < 0 || value.SLength > 8) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SLength >= 0 && value.SLength <= 8, "value.SLength out of range [0, 8]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.SLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -1432,10 +1382,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.BLength < 0 || value.BLength > 8) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.BLength >= 0 && value.BLength <= 8, "value.BLength out of range [0, 8]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.BLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -1557,10 +1504,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 4) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 4, "value.ItemsCount out of range [0, 4]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 3))

--- a/testdata/golden/cs/Constants.cs
+++ b/testdata/golden/cs/Constants.cs
@@ -4,11 +4,19 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 namespace Example
 {

--- a/testdata/golden/cs/Joins.cs
+++ b/testdata/golden/cs/Joins.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -735,10 +736,7 @@ namespace Example
             }
             if (value.Flag)
             {
-                if (value.SLength < 0 || value.SLength > 4) // the length guards the slice (§6.3); out-of-contract writes are refused
-                {
-                    return false;
-                }
+                Debug.Assert(value.SLength >= 0 && value.SLength <= 4, "value.SLength out of range [0, 4]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
                 {
                     uint offsetValue = (uint)(value.SLength);
                     if (!stream.SerializeBits(ref offsetValue, 3))
@@ -889,10 +887,7 @@ namespace Example
             }
             if (value.Flag)
             {
-                if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-                {
-                    return false;
-                }
+                Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
                 {
                     uint offsetValue = (uint)(value.ItemsCount);
                     if (!batch.SerializeBits(ref offsetValue, 2))
@@ -902,10 +897,7 @@ namespace Example
                 }
                 for (int i = 0; i < value.ItemsCount; i++)
                 {
-                    if (value.Items[i] > 8191)
-                    {
-                        return false;
-                    }
+                    Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                     {
                         uint offsetValue = (uint)(value.Items[i]);
                         if (!batch.SerializeBits(ref offsetValue, 13))
@@ -1149,10 +1141,7 @@ namespace Example
         private static bool WriteUnevenBatch(ref WriteBatch batch, Uneven value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1321,10 +1310,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -1419,10 +1405,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 3) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 3, "value.ItemsCount out of range [0, 3]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!stream.SerializeBits(ref offsetValue, 2))
@@ -1432,10 +1415,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] > 8191)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] <= 8191, "value.Items[i] out of range [0, 8191]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!stream.SerializeBits(ref offsetValue, 13))
@@ -1444,10 +1424,7 @@ namespace Example
                     }
                 }
             }
-            if (value.SLength < 0 || value.SLength > 4) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SLength >= 0 && value.SLength <= 4, "value.SLength out of range [0, 4]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.SLength);
                 if (!stream.SerializeBits(ref offsetValue, 3))

--- a/testdata/golden/cs/Render.cs
+++ b/testdata/golden/cs/Render.cs
@@ -4,6 +4,7 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -85,10 +86,7 @@ namespace Example
         {
             {
                 // flat run: 138 bits in 3 chunk(s) — the field placement is folded
-                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Team <= 2, "value.Team above the enum wire range [0, 2]"); // headroom above the wire range cannot ride
                 ulong f0 = (ulong)value.SortKey;
                 ulong f1 = ((ulong)(value.MeshId)) & 0xffffffffUL;
                 ulong f2 = ((ulong)(value.MaterialId)) & 0xffffffffUL;
@@ -211,10 +209,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SpritesCount < 0 || value.SpritesCount > (int)RenderBlockMaxSprites) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SpritesCount >= 0 && value.SpritesCount <= (int)RenderBlockMaxSprites, "value.SpritesCount out of range [0, (int)RenderBlockMaxSprites]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.SpritesCount);
                 if (!batch.SerializeBits(ref offsetValue, 7))

--- a/testdata/golden/cs/Types.cs
+++ b/testdata/golden/cs/Types.cs
@@ -4,6 +4,7 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0x8656ae68c06b97a7
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -357,10 +358,7 @@ namespace Example
         {
             {
                 // flat run: 22 bits in 1 chunk(s) — the field placement is folded
-                if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
-                {
-                    return false;
-                }
+                Debug.Assert(value.ObjectId >= 0 && value.ObjectId <= (int)(MaxObjects - 1), "value.ObjectId out of range [0, (int)(MaxObjects - 1)]");
                 ulong f0 = ((ulong)((uint)(value.ObjectId))) & 0x3fffUL;
                 ulong f1 = ((ulong)(value.ObjectSequence)) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 14));
@@ -436,18 +434,9 @@ namespace Example
         {
             {
                 // flat run: 75 bits in 2 chunk(s) — the field placement is folded
-                if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-MaxPositionUnits) && value.X <= (int)MaxPositionUnits, "value.X out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
+                Debug.Assert(value.Y >= (int)(-MaxPositionUnits) && value.Y <= (int)MaxPositionUnits, "value.Y out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
+                Debug.Assert(value.Z >= (int)(-MaxPositionUnits) && value.Z <= (int)MaxPositionUnits, "value.Z out of range [(int)(-MaxPositionUnits), (int)MaxPositionUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
@@ -529,18 +518,9 @@ namespace Example
         {
             {
                 // flat run: 69 bits in 2 chunk(s) — the field placement is folded
-                if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-MaxVelocityUnits) && value.X <= (int)MaxVelocityUnits, "value.X out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
+                Debug.Assert(value.Y >= (int)(-MaxVelocityUnits) && value.Y <= (int)MaxVelocityUnits, "value.Y out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
+                Debug.Assert(value.Z >= (int)(-MaxVelocityUnits) && value.Z <= (int)MaxVelocityUnits, "value.Z out of range [(int)(-MaxVelocityUnits), (int)MaxVelocityUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
@@ -624,22 +604,10 @@ namespace Example
         {
             {
                 // flat run: 48 bits in 1 chunk(s) — the field placement is folded
-                if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
-                {
-                    return false;
-                }
-                if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
-                {
-                    return false;
-                }
+                Debug.Assert(value.X >= (int)(-RotationUnits) && value.X <= (int)RotationUnits, "value.X out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.Y >= (int)(-RotationUnits) && value.Y <= (int)RotationUnits, "value.Y out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.Z >= (int)(-RotationUnits) && value.Z <= (int)RotationUnits, "value.Z out of range [(int)(-RotationUnits), (int)RotationUnits]");
+                Debug.Assert(value.W >= (int)(-RotationUnits) && value.W <= (int)RotationUnits, "value.W out of range [(int)(-RotationUnits), (int)RotationUnits]");
                 ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
                 ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
                 ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
@@ -1023,10 +991,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.InputsCount < 0 || value.InputsCount > (int)MaxInputsPerPacket) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.InputsCount >= 0 && value.InputsCount <= (int)MaxInputsPerPacket, "value.InputsCount out of range [0, (int)MaxInputsPerPacket]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.InputsCount);
                 if (!batch.SerializeBits(ref offsetValue, 5))
@@ -1137,10 +1102,7 @@ namespace Example
         {
             {
                 uint enumValue = (uint)value.ShipType;
-                if (enumValue > 5) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(enumValue <= 5, "value.ShipType above the enum wire range [0, 5]"); // headroom above the wire range cannot ride
                 if (!batch.SerializeBits(ref enumValue, 3))
                 {
                     return false;
@@ -1164,10 +1126,7 @@ namespace Example
             }
             if (value.HasFlags)
             {
-                if (value.Flags >= 1ul << 4) // a mask bit above the wire width cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(value.Flags < 1ul << 4, "value.Flags has a mask bit above the 4-bit wire width"); // a mask bit above the wire width cannot ride
                 {
                     uint flagsValue = (uint)value.Flags;
                     if (!batch.SerializeBits(ref flagsValue, 4))
@@ -1178,22 +1137,10 @@ namespace Example
             }
             {
                 // flat run: 19 bits in 1 chunk(s) — the field placement is folded
-                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
-                if (value.Health < 0 || value.Health > (int)MaxHealth)
-                {
-                    return false;
-                }
-                if (value.Thrust < 0 || value.Thrust > 100)
-                {
-                    return false;
-                }
-                if ((uint)value.Pending > 0) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Team <= 2, "value.Team above the enum wire range [0, 2]"); // headroom above the wire range cannot ride
+                Debug.Assert(value.Health >= 0 && value.Health <= (int)MaxHealth, "value.Health out of range [0, (int)MaxHealth]");
+                Debug.Assert(value.Thrust >= 0 && value.Thrust <= 100, "value.Thrust out of range [0, 100]");
+                Debug.Assert((uint)value.Pending <= 0, "value.Pending above the enum wire range [0, 0]"); // headroom above the wire range cannot ride
                 ulong f0 = ((ulong)(uint)value.Team) & 0x3UL;
                 ulong f1 = ((ulong)((uint)(value.Health))) & 0x3ffUL;
                 ulong f2 = ((ulong)((uint)(value.Thrust))) & 0x7fUL;
@@ -1327,14 +1274,8 @@ namespace Example
         {
             {
                 // flat run: 16 bits in 1 chunk(s) — the field placement is folded
-                if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
-                {
-                    return false;
-                }
-                if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
-                {
-                    return false;
-                }
+                Debug.Assert(value.HardpointIndex >= 0 && value.HardpointIndex <= (int)((ShipMaxLasers + ShipMaxMissiles) - 1), "value.HardpointIndex out of range [0, (int)((ShipMaxLasers + ShipMaxMissiles) - 1)]");
+                Debug.Assert(value.SpinRate >= (int)(-(-RotationUnits)) && value.SpinRate <= (int)(RotationUnits * 2), "value.SpinRate out of range [(int)(-(-RotationUnits)), (int)(RotationUnits * 2)]");
                 ulong f0 = ((ulong)((uint)(value.HardpointIndex))) & 0x1fUL;
                 ulong f1 = ((ulong)((uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits))))) & 0x7ffUL;
                 uint w0 = (uint)(f0 | (f1 << 5));
@@ -1412,10 +1353,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeProbeBatch(ref WriteBatch batch, ExtremeProbe value)
         {
-            if (value.FloorBound > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.FloorBound <= 100, "value.FloorBound out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.FloorBound) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1423,10 +1361,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DoubledFloor > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.DoubledFloor <= 100, "value.DoubledFloor out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.DoubledFloor) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1434,10 +1369,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.CeilingRange < 1)
-            {
-                return false;
-            }
+            Debug.Assert(value.CeilingRange >= 1, "value.CeilingRange out of range [1, 18446744073709551615]");
             {
                 ulong offsetValue = value.CeilingRange - 1;
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1543,10 +1475,7 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeRowBatch(ref WriteBatch batch, ExtremeRow value)
         {
-            if (value.ClampedFloor > 100)
-            {
-                return false;
-            }
+            Debug.Assert(value.ClampedFloor <= 100, "value.ClampedFloor out of range [-9223372036854775808, 100]");
             {
                 ulong offsetValue = (ulong)(value.ClampedFloor) - unchecked((ulong)(-9223372036854775808));
                 if (!batch.SerializeBits64(ref offsetValue, 64))
@@ -1554,10 +1483,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614)
-            {
-                return false;
-            }
+            Debug.Assert(value.ClampedCeiling >= 1 && value.ClampedCeiling <= 18446744073709551614, "value.ClampedCeiling out of range [1, 18446744073709551614]");
             {
                 ulong offsetValue = value.ClampedCeiling - 1;
                 if (!batch.SerializeBits64(ref offsetValue, 64))

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -5,6 +5,7 @@
 // package example — protocol id 0x8656ae68c06b97a7
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Serialize;
 
@@ -577,10 +578,7 @@ namespace Example
             {
                 {
                     // flat run: 5 bits in 1 chunk(s) — the field placement is folded
-                    if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
-                    {
-                        return false;
-                    }
+                    Debug.Assert((uint)value.Weapon <= 15, "value.Weapon above the enum wire range [0, 15]"); // headroom above the wire range cannot ride
                     ulong f0 = ((ulong)(uint)value.Weapon) & 0xfUL;
                     ulong f1 = value.HasTarget ? 1UL : 0UL;
                     uint w0 = (uint)(f0 | (f1 << 4));
@@ -607,10 +605,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SamplesCount < 1 || value.SamplesCount > 8) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.SamplesCount >= 1 && value.SamplesCount <= 8, "value.SamplesCount out of range [1, 8]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.SamplesCount) - (uint)(1);
                 if (!batch.SerializeBits(ref offsetValue, 3))
@@ -834,10 +829,7 @@ namespace Example
         {
             {
                 // flat run: 15 bits in 1 chunk(s) — the field placement is folded
-                if (value.Width > 100)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Width <= 100, "value.Width out of range [0, 100]");
                 ulong f0 = ((ulong)((uint)(value.Width))) & 0x7fUL;
                 ulong f1 = ((ulong)(value.Height)) & 0xffUL;
                 uint w0 = (uint)(f0 | (f1 << 7));
@@ -925,10 +917,7 @@ namespace Example
         private static bool WriteProbeShapeBatch(ref WriteBatch batch, ProbeShape value)
         {
             uint tagValue = (uint)value.Type;
-            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
-            {
-                return false;
-            }
+            Debug.Assert(tagValue <= 2, "the union tag is outside the variant set [0, 2]"); // the tag contract holds BEFORE it rides (SPEC §4.8)
             if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
@@ -1033,10 +1022,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.ExtrasCount < 0 || value.ExtrasCount > 2) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ExtrasCount >= 0 && value.ExtrasCount <= 2, "value.ExtrasCount out of range [0, 2]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ExtrasCount);
                 if (!batch.SerializeBits(ref offsetValue, 2))
@@ -1131,10 +1117,7 @@ namespace Example
         {
             {
                 // flat run: 36 bits in 1 chunk(s) — the field placement is folded
-                if ((uint)value.Preferred > 15) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert((uint)value.Preferred <= 15, "value.Preferred above the enum wire range [0, 15]"); // headroom above the wire range cannot ride
                 ulong f0 = ((ulong)((uint)value.Retries)) & 0xffffffffUL;
                 ulong f1 = ((ulong)(uint)value.Preferred) & 0xfUL;
                 ulong w0 = f0 | (f1 << 32);
@@ -1321,18 +1304,9 @@ namespace Example
         {
             {
                 // flat run: 46 bits in 1 chunk(s) — the field placement is folded
-                if (value.TestB < 0 || value.TestB > 1000)
-                {
-                    return false;
-                }
-                if (value.TestC < 0 || value.TestC > 1000)
-                {
-                    return false;
-                }
-                if (value.TestD < 0 || value.TestD > 1000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.TestB >= 0 && value.TestB <= 1000, "value.TestB out of range [0, 1000]");
+                Debug.Assert(value.TestC >= 0 && value.TestC <= 1000, "value.TestC out of range [0, 1000]");
+                Debug.Assert(value.TestD >= 0 && value.TestD <= 1000, "value.TestD out of range [0, 1000]");
                 ulong f0 = ((ulong)(value.TestA)) & 0xffffUL;
                 ulong f1 = ((ulong)((uint)(value.TestB))) & 0x3ffUL;
                 ulong f2 = ((ulong)((uint)(value.TestC))) & 0x3ffUL;
@@ -1414,10 +1388,7 @@ namespace Example
 
         public static bool WriteBlock(WriteStream stream, Block value)
         {
-            if (value.DataLength < 0 || value.DataLength > (int)MaxBlockSize) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.DataLength >= 0 && value.DataLength <= (int)MaxBlockSize, "value.DataLength out of range [0, (int)MaxBlockSize]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.DataLength);
                 if (!stream.SerializeBits(ref offsetValue, 11))
@@ -1466,10 +1437,7 @@ namespace Example
 
         public static bool WriteChat(WriteStream stream, Chat value)
         {
-            if (value.TextLength < 0 || value.TextLength > (int)MaxChatLength) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= (int)MaxChatLength, "value.TextLength out of range [0, (int)MaxChatLength]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 9))
@@ -1563,10 +1531,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.Flags >= 1ul << 8) // a mask bit above the wire width cannot ride
-            {
-                return false;
-            }
+            Debug.Assert(value.Flags < 1ul << 8, "value.Flags has a mask bit above the 8-bit wire width"); // a mask bit above the wire width cannot ride
             {
                 uint flagsValue = (uint)value.Flags;
                 if (!batch.SerializeBits(ref flagsValue, 8))
@@ -1677,18 +1642,9 @@ namespace Example
         {
             {
                 // flat run: 49 bits in 1 chunk(s) — the field placement is folded
-                if (value.A < -100 || value.A > 100)
-                {
-                    return false;
-                }
-                if (value.B < -100 || value.B > 100)
-                {
-                    return false;
-                }
-                if (value.C < -100 || value.C > 150)
-                {
-                    return false;
-                }
+                Debug.Assert(value.A >= -100 && value.A <= 100, "value.A out of range [-100, 100]");
+                Debug.Assert(value.B >= -100 && value.B <= 100, "value.B out of range [-100, 100]");
+                Debug.Assert(value.C >= -100 && value.C <= 150, "value.C out of range [-100, 150]");
                 ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f1 = ((ulong)((uint)(value.B) - unchecked((uint)(-100)))) & 0xffUL;
                 ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-100)))) & 0xffUL;
@@ -1702,10 +1658,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ItemsCount < 0 || value.ItemsCount > 16) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.ItemsCount >= 0 && value.ItemsCount <= 16, "value.ItemsCount out of range [0, 16]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.ItemsCount);
                 if (!stream.SerializeBits(ref offsetValue, 5))
@@ -1715,10 +1668,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] < 0 || value.Items[i] > 255)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Items[i] >= 0 && value.Items[i] <= 255, "value.Items[i] out of range [0, 255]");
                 {
                     uint offsetValue = (uint)(value.Items[i]);
                     if (!stream.SerializeBits(ref offsetValue, 8))
@@ -1744,10 +1694,7 @@ namespace Example
             }
             {
                 // flat run: 249 bits in 4 chunk(s) — the field placement is folded
-                if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
-                {
-                    return false;
-                }
+                Debug.Assert(value.Int64Range >= -1000000000000 && value.Int64Range <= 1000000000000, "value.Int64Range out of range [-1000000000000, 1000000000000]");
                 ulong f0 = ((ulong)((byte)value.Int8Value)) & 0xffUL;
                 ulong f1 = ((ulong)((ushort)value.Int16Value)) & 0xffffUL;
                 ulong f2 = ((ulong)(value.Uint8Value)) & 0xffUL;
@@ -1785,10 +1732,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TextLength < 0 || value.TextLength > 255) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= 255, "value.TextLength out of range [0, 255]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 8))

--- a/testdata/golden/ludicrous/cs/Ludicrous.cs
+++ b/testdata/golden/ludicrous/cs/Ludicrous.cs
@@ -4,13 +4,22 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xf4a226f4166d919b
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 using System;
+using System.Diagnostics;
 using Serialize;
 
 namespace Ludicrous
@@ -267,10 +276,7 @@ namespace Ludicrous
                     return false;
                 }
             }
-            if ((ulong)value.Locked != 196608UL)
-            {
-                return false;
-            }
+            Debug.Assert((ulong)value.Locked == 196608UL, "value.Locked is not 196608, the one legal raw of a degenerate fixed range");
             {
                 uint rawValue = value.Tail;
                 if (!stream.SerializeBits(ref rawValue, 8))
@@ -426,10 +432,7 @@ namespace Ludicrous
         {
             {
                 uint enumValue = (uint)value.Mode;
-                if (enumValue > 3) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
+                Debug.Assert(enumValue <= 3, "value.Mode above the enum wire range [0, 3]"); // headroom above the wire range cannot ride
                 if (!stream.SerializeBits(ref enumValue, 2))
                 {
                     return false;
@@ -443,10 +446,7 @@ namespace Ludicrous
             {
                 return false;
             }
-            if (value.KeysCount < 0 || value.KeysCount > 4) // the count guards the loop (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.KeysCount >= 0 && value.KeysCount <= 4, "value.KeysCount out of range [0, 4]"); // the count guards the loop (§6.3); an out-of-contract count is caller error
             {
                 uint offsetValue = (uint)(value.KeysCount);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -547,18 +547,9 @@ namespace Ludicrous
 
         public static bool WriteDegenerateProbe(WriteStream stream, DegenerateProbe value)
         {
-            if ((long)value.LockedFixed != -196608L)
-            {
-                return false;
-            }
-            if (value.LockedInt < 7 || value.LockedInt > 7)
-            {
-                return false;
-            }
-            if (value.LockedWide != (Int128Value)(-12345678901234L))
-            {
-                return false;
-            }
+            Debug.Assert((long)value.LockedFixed == -196608L, "value.LockedFixed is not -196608, the one legal raw of a degenerate fixed range");
+            Debug.Assert(value.LockedInt >= 7 && value.LockedInt <= 7, "value.LockedInt out of range [7, 7]");
+            Debug.Assert(value.LockedWide == (Int128Value)(-12345678901234L), "value.LockedWide is not the one legal value of a degenerate int128 range");
             {
                 uint rawValue = value.Tail;
                 if (!stream.SerializeBits(ref rawValue, 8))

--- a/testdata/golden/packet-wide/cs/WideText.cs
+++ b/testdata/golden/packet-wide/cs/WideText.cs
@@ -4,13 +4,22 @@
 // AGPL-3.0, its output is not.
 // package wide — protocol id 0x53835dbf9f05e4d9
 //
-// Wire functions return bool — the C++-style early-out. A schema validation
-// failure (a wrong wire constant, nonzero reserved bits, an interior null)
-// returns false WITHOUT latching; stream failures latch on stream.Error —
-// the runtime's own sticky latch. Callers get bool always; Error tells the
-// two apart.
+// Wire functions return bool — the C++-style early-out. A READ-side schema
+// validation failure (a wrong wire constant, nonzero reserved bits, an
+// interior null) returns false WITHOUT latching; stream failures latch on
+// stream.Error — the runtime's own sticky latch. Callers get bool always;
+// Error tells the two apart.
+//
+// WRITE-side contracts — a value outside its declared range, a count or a
+// length outside its bound, a mask bit above the wire width, an interior
+// null in a wide string — are CALLER ERROR and ride on Debug.Assert, so
+// they compile out of a release build along with the call, exactly as
+// serialize.cs's own WriteStream does. In a shipping release build it is
+// the caller's responsibility to be correct on the write side; every check
+// the reader needs is on the read side and runs in every build.
 
 using System;
+using System.Diagnostics;
 using Serialize;
 
 namespace Wide
@@ -74,10 +83,7 @@ namespace Wide
 
         public static bool WriteWideSeven(WriteStream stream, WideSeven value)
         {
-            if (value.TextLength < 0 || value.TextLength > 7)
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= 7, "value.TextLength out of range [0, 7]");
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -88,7 +94,7 @@ namespace Wide
             for (int wideIndex = 0; wideIndex < value.TextLength; wideIndex++)
             {
                 uint wideGroup = value.Text[wideIndex];
-                if (wideGroup == 0) return false;
+                Debug.Assert(wideGroup != 0, "a wide string's used units carry an interior null");
                 if (!stream.SerializeBits(ref wideGroup, 32))
                 {
                     return false;
@@ -145,10 +151,7 @@ namespace Wide
 
         public static bool WriteWideFour(WriteStream stream, WideFour value)
         {
-            if (value.TextLength < 0 || value.TextLength > 4)
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= 4, "value.TextLength out of range [0, 4]");
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -159,7 +162,7 @@ namespace Wide
             for (int wideIndex = 0; wideIndex < value.TextLength; wideIndex++)
             {
                 uint wideGroup = value.Text[wideIndex];
-                if (wideGroup == 0) return false;
+                Debug.Assert(wideGroup != 0, "a wide string's used units carry an interior null");
                 if (!stream.SerializeBits(ref wideGroup, 32))
                 {
                     return false;
@@ -216,10 +219,7 @@ namespace Wide
 
         public static bool WriteNarrowFifteen(WriteStream stream, NarrowFifteen value)
         {
-            if (value.TextLength < 0 || value.TextLength > 15) // the length guards the slice (§6.3); out-of-contract writes are refused
-            {
-                return false;
-            }
+            Debug.Assert(value.TextLength >= 0 && value.TextLength <= 15, "value.TextLength out of range [0, 15]"); // the length guards the slice (§6.3); an out-of-contract length is caller error
             {
                 uint offsetValue = (uint)(value.TextLength);
                 if (!stream.SerializeBits(ref offsetValue, 4))
@@ -295,10 +295,7 @@ namespace Wide
 
         public static bool WriteWideInterop(WriteStream stream, WideInterop value)
         {
-            if (value.CaptionLength < 0 || value.CaptionLength > 7)
-            {
-                return false;
-            }
+            Debug.Assert(value.CaptionLength >= 0 && value.CaptionLength <= 7, "value.CaptionLength out of range [0, 7]");
             {
                 uint offsetValue = (uint)(value.CaptionLength);
                 if (!stream.SerializeBits(ref offsetValue, 3))
@@ -309,7 +306,7 @@ namespace Wide
             for (int wideIndex = 0; wideIndex < value.CaptionLength; wideIndex++)
             {
                 uint wideGroup = value.Caption[wideIndex];
-                if (wideGroup == 0) return false;
+                Debug.Assert(wideGroup != 0, "a wide string's used units carry an interior null");
                 if (!stream.SerializeBits(ref wideGroup, 32))
                 {
                     return false;


### PR DESCRIPTION
Glenn's rulings, verbatim, today: "No runtime should ever promise to keep checks in writing packets (asserts) in release build. Removing them is the whole point. ... checks are *DEBUG ONLY*"; "Of course, on read side we MUST always do the checks!"; on the counted array's count: "debug only."; "consistency matters. writing packets correctness is the caller's responsibility, and it is our duty to catch it with asserts in debug."; "The bottom line is that a user of schema/serialize in that languages should feel that the implementation is native to their language and how it is used in best practice."

**What was wrong.** serialize.cs already does this right: 97 `Debug.Assert` and three `[Conditional(\"DEBUG\")]` validators, and its WriteStream doc says values, capacity, lengths and float finiteness are checked in debug builds and not at all in release. The C# emitter then emitted every write-side check as `return false;` in every build: 36 of the 155 return-false sites in generated/bench/cs/Bench.cs are such checks; the rest propagate runtime failures or validate on read. (The emitter's header also claimed the runtime latches ValueOutOfRange and returns false on the write; in v1.9.1 it asserts. Corrected.)

**What changes.** Every write-side caller-error check is `Debug.Assert(contract, \"what the caller broke\")`, inline rather than a per-type check method: Debug.Assert is itself [Conditional(\"DEBUG\")], so in Release both the call and its arguments leave the IL, which is what the predicate form buys Java, whose assert is a runtime -ea test. Across the C# corpus: ranged ints 78 sites, counts 40, string/bytes/wstring length 14, enum headroom 10, union tag 8, flags above wire width 4, wstring interior null 3, degenerate fixed 2, degenerate int128 1; `return false;` 933 to 776, the remainder all runtime-call propagation. Unchanged: every read-side check; capacity, latch and batch propagation. Return types stay bool; the wire and protocol ids do not move. One judgment named: the union tag on write is converted (an out-of-set tag in a C# enum variable is reachable only by an explicit cast, caller error), where the C backend kept its §4.8 refusal an hour earlier; the count PR being written now decides that one for every target, and a single writeAssert call reverts it if the answer is keep. compiler/countedbirth_test.go: the cs row moves to an assertsTheCount map with a claim that the assertion is present with the generated spelling and has not quietly become a return; no other target's entry moved. Tests: the Debug leg cannot probe a firing Debug.Assert (FailFast), so test/cs asserts the Release behaviour under #if !DEBUG and test/packet-wide/cs drops its three write probes, which compile into both configurations; read-side tests untouched. The C# bench leg records `checks=removed`, with the CLR's own bounds checks named as what the column cannot price. USAGE, FAQ and PERFORMANCE move C# out of the return-failure list; SPEC §4.6 and §5 are left for the cross-language spec edit and the six sentences that move are listed in the worker's report.

**After the read.** test/cs now also runs in Release under make test-cs, so its #if !DEBUG assertion is gated, not by hand; BENCH-STANDARD §3.4 says the checks column names the library's and the generated code's checks and not a language's own bounds checks, which is why Rust and C# both record removed with the residual named; the C# mention leaves the always row. SPEC §4.6, §4.8 and §5 still describe C# as returning failure: the count PR rewrites them for all nine and lands first; this PR rebases onto it and onto #696's countedbirth_test shape.

**Rebased onto #700 and #696.** countedbirth_test.go takes #700's shape with C# in assertsInDebug and goneFromRelease; uniontagwrite_test.go moves C# to the assert form; the dated implementation note leaves SPEC §5, FAQ, USAGE and TUTORIAL, this being the second of the two; PERFORMANCE.md and BENCH-STANDARD §3.4 are the union (C# joins C, C++ and Rust under removed; always is Go alone). Only C# files move relative to the Rust branch.

**Receipts.** make test-cs rc=0 twice (packet-defaults, packet-utf8 and packet-wide in Debug and Release with their negative controls, the tables and cook batteries with four negative controls, bench builds, test/cs, test/cs-ludicrous); test/cs by hand in Release, OK; go test ./... ok; make shape-gate clean; gofmt, go vet clean. 32 files, +622 -1134.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)