### PR TITLE
bench: the C++ bitpacker read leg goes through the checked reader, as the C leg does

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -289,6 +289,41 @@ run is 24576 passes (6 × the historical constant), identical in every
 language, recorded in the `iters` column. The workload itself — the width
 table and the 65536-byte buffer — is unchanged.
 
+**Note, 2026-09-07 — which API layer the legs call.** This section says "the raw
+bit packer", and that phrase is about the WORKLOAD (no message shape, a width
+table specified here) rather than about an API tier. It does not license the
+legs to call different tiers, and until today they did: the C leg's read called
+`serialize_read_bits`, whose past-end test is a real branch in every build,
+while the C++ leg's read called `BitReader::ReadBits`, whose past-end test is a
+debug assert and is gone under `-DNDEBUG` — C++'s read-side check lives in
+`ReadStream`, one layer up, which that leg never entered. The row divided a
+checked reader by an unchecked one, which §5.3 forbids dividing.
+
+**The bitpacker read leg MUST call its language's checked bit read** — the
+entry point that performs a past-end test per read and whose refusal is
+terminal — in both of its §3.2 call sites. There is no common raw tier to
+choose instead: serialize.c exposes no unchecked bit read, so the checked layer
+is the only layer both languages have. The bitpacker WRITE leg calls its
+language's bit writer, whose capacity and range guards are debug asserts in
+C and C++ (issue #52; verified by disassembly, 2026-09-07), and is therefore
+already the same work on those two sides; the other legs' writers are
+unaudited on this point, like their readers below.
+
+This is a fairness rule about what the harness ASKS FOR, not a promise about
+emitted code: a compiler that can prove a leg's checks dead may still delete
+them, and one runtime's failure-latch representation can make that proof
+possible where another's does not. Such a difference is a property of the
+runtime and belongs in the row; a difference in which function the harness
+called does not.
+
+The C and C++ legs comply as of this note. The go, rust, cs and js bitpacker
+read legs call their runtimes' `BitReader` and have NOT been audited against
+this rule — each of those runtimes has to be read to say whether its raw
+reader keeps the past-end test in a release build. Named as debt here rather
+than assumed either way; until that audit lands, a bitpacker/read ratio that
+crosses one of those legs carries the same unstated risk this note just closed
+for C-vs-C++.
+
 `serialize.go/bench_test.go`'s `i % 32 + 1` workload and `serialize.rs`'s extra
 `read_bits_group` row are **removed** from cross-language reporting. They may survive
 as in-repo diagnostics under a `local` family, which the tool never ratios.

--- a/bench/README.md
+++ b/bench/README.md
@@ -157,7 +157,7 @@ its iteration count is fixed and identical across all nine languages.
 | bench        | family | pinned to golden | shape                                              |
 |--------------|--------|------------------|----------------------------------------------------|
 | bench_mixed  | gen    | bench_mixed      | **THE canonical benchmark** (#184): every construct the schema language expresses, in one representative game message, integers carrying 91.87% of the wire bits (438 B) |
-| bitpacker    | bits   | — (read-back verified in setup) | 16-width table over a 64 KiB buffer, 24576 passes/run (§1.4) |
+| bitpacker    | bits   | — (read-back verified in setup) | 16-width table over a 64 KiB buffer, 24576 passes/run (§1.4). **write:** the language's bit writer, unchecked under NDEBUG in every language (capacity and range are debug asserts). **read:** the language's CHECKED bit read — one past-end test per read, refusal terminal |
 
 **bench_mixed is THE Bench-corpus shape** (owner's ruling, issue #184: *"I'd
 rather we just have ONE good benchmark we can apply to all serialize and
@@ -194,6 +194,57 @@ The `bits` timed loops live in noinline symbols (`bitpacker_*_loop`) so the
 §4.1 inline verdict counts the emitted body of the timed loop directly, and
 every benched op has exactly two call sites (§3.2): its untimed
 oracle/setup helper and its timed loop.
+
+**Which layer the bitpacker rows call, and why (2026-09-07).** Until today the
+C and C++ read legs did not measure the same work. The C leg called
+`serialize_read_bits`, serialize.c's only bit-read entry point, whose past-end
+test is a real branch in every build and whose refusal is terminal through a
+poisoned limit. The C++ leg called `BitReader::ReadBits`, whose past-end test
+is a `serialize_assert` and therefore absent under `-DNDEBUG`; C++'s read-side
+check lives one layer up, in `ReadStream` (`WouldReadPastEnd`, then `Fail()`),
+which that leg never touched. Measured at `-O3 -DNDEBUG` on arm64 clang, per
+16-read group (instructions in the emitted noinline body, conditional
+branches): C++ 135 / 2, C 270 / 33, and C with its check forced off 135 / 2 — in emitted code, the published C-vs-C++ read gap
+was the check. The row was comparing a checked reader with an unchecked one.
+
+The C++ read leg now goes through `ReadStream::SerializeBits` — same width
+asserts, one past-end test per read, refusal terminal — in both its call
+sites, the untimed verify gate and the timed loop. That is
+`serialize_read_bits`' exact counterpart, and it is the ONLY layer the two
+languages share: serialize.c ships no unchecked raw reader to meet C++'s
+`BitReader` at. The maintainer's posture decides which way the row resolves:
+*"on read side we MUST always do the checks!"* (2026-09-07).
+
+The **write** legs were already fair and are untouched: `serialize_write_bits`'
+capacity and range guards are `serialize_assert` (issue #52's ruling, *"C
+should match C++ and have no checks on write at all (except assert)"*), so C's
+stream writer and C++'s `BitWriter` are the same unchecked work under NDEBUG.
+The receipt is mechanical — `bitpacker_write_loop` compiles to **317
+instructions and 36 conditional branches in both languages**, unchanged by
+this commit.
+
+What the read row means now, precisely: **both legs ask their runtime for a
+checked bit read.** The emitted code still differs, and the reason is a
+runtime property rather than a harness one. C++'s failure latch poisons
+`m_bitsRead`, the same counter the group's entry condition tests, so clang
+proves all sixteen past-end tests dead and emits 135 / 2. C's latch poisons
+`bits_limit`, a *second* field, while the entry condition reads `num_bits`, so
+the proof does not go through and clang emits 270 / 33. Two probes pin that down. Give the C++ leg
+a buffer length the compiler cannot fold and the same source emits 261 / 33 —
+C's shape — so the C++ check is genuinely
+compiled in, not absent. Point C's past-end test at `num_bits` instead of
+`bits_limit` (a scratch probe against a copied header; the runtime is NOT
+changed) and the C leg emits 135 / 2 — C++'s shape exactly. That pins the residual
+C-vs-C++ bitpacker/read gap to one field indirection in serialize.c's failure
+latch, in emitted code; the probe's rate was not measured, and the probe
+breaks the sticky-failure contract, so it is a diagnosis and not a fix.
+
+So the read row now reports how well each runtime's CHECKED read optimizes,
+which is a real difference between the runtimes — not a difference in what the
+harness asked them to do. No number in this pass moved: the change is to what
+the row means, and the receipt is that the C++ leg's emitted loop is
+identical in shape before and after (the same 135 instructions and 2 branches;
+register allocation differs).
 
 Two further rows — `bench_string` and `bench_wstring` — are DEFINED in
 BENCH-STANDARD §1.8 (measure-first, issue #64) and not yet implemented in

--- a/bench/cpp/bench_main.cpp
+++ b/bench/cpp/bench_main.cpp
@@ -466,16 +466,23 @@ int64_t bits_write_pass( uint8_t * buffer, const uint32_t * values )
     return writer.GetBytesWritten();
 }
 
-// the single untimed ReadBits call site (§3.2): verifies a buffer reads back
-// exactly the values written into it — the bits family's refuse-to-bench gate
+// the single untimed SerializeBits call site (§3.2): verifies a buffer reads
+// back exactly the values written into it — the bits family's refuse-to-bench
+// gate. Reads through ReadStream, the CHECKED reader, exactly as the timed
+// loop below does, and exactly as the C leg's serialize_read_bits does.
 bool bits_read_verify( const uint8_t * buffer, const uint32_t * values )
 {
-    serialize::BitReader reader( buffer, BitsBufferSize );
-    while ( reader.GetBitsRemaining() >= 256 )
+    serialize::ReadStream reader( buffer, BitsBufferSize );
+    // C's serialize_read_bits_remaining is num_bits - bits_read; ReadStream
+    // exposes no GetBitsRemaining, and its m_numBits IS BitsBufferSize * 8
+    while ( int64_t( BitsBufferSize ) * 8 - reader.GetBitsProcessed() >= 256 )
     {
         for ( int i = 0; i < BitsNumWidths; i++ )
         {
-            if ( reader.ReadBits( bits_widths[i] ) != values[i] )
+            uint32_t value = 0;
+            if ( !reader.SerializeBits( value, bits_widths[i] ) )
+                return false;
+            if ( value != values[i] )
                 return false;
         }
     }
@@ -503,16 +510,50 @@ BENCH_NOINLINE bool bitpacker_write_loop( long passes, int64_t bytes_per_pass, u
     return true;
 }
 
+/*
+    The timed read leg goes through ReadStream::SerializeBits — the CHECKED
+    reader — and not through BitReader::ReadBits (2026-09-07).
+
+    BitReader::ReadBits performs its past-end test as serialize_assert, so
+    under -DNDEBUG the raw reader has no bounds check at all; C++'s check for
+    the read path lives one layer up, in ReadStream (WouldReadPastEnd, then
+    Fail(), which poisons the position and makes the refusal terminal). The C
+    leg has no such split: serialize.c ships ONE bit-reading entry point,
+    serialize_read_bits, whose past-end test is a real branch in every build
+    and whose refusal is terminal through the poisoned limit. So this leg used
+    to compare a checked reader against an unchecked one, and the whole
+    published C-vs-C++ read gap was the check: the instruction and branch
+    counts, before and after, are in bench/README.md under "Which layer the
+    bitpacker rows call".
+
+    The two legs can only meet at the checked layer, because the raw layer
+    does not exist in C. ReadStream::SerializeBits is serialize_read_bits'
+    exact counterpart: same width asserts, one past-end test per read,
+    refusal terminal. "On read side we MUST always do the checks!" — the
+    maintainer, 2026-09-07.
+
+    The WRITE legs are untouched: serialize_write_bits' capacity and range
+    guards are already serialize_assert (issue #52), so C's writer and C++'s
+    BitWriter are the same unchecked work under NDEBUG — bitpacker_write_loop
+    compiles to the identical instruction and branch count in both languages,
+    before and after this change.
+*/
+
 BENCH_NOINLINE bool bitpacker_read_loop( long passes )
 {
     for ( long pass = 0; pass < passes; pass++ )
     {
-        serialize::BitReader reader( g_bits_variants[pass & ( NumVariants - 1 )], BitsBufferSize );
+        serialize::ReadStream reader( g_bits_variants[pass & ( NumVariants - 1 )], BitsBufferSize );
         uint64_t sum = 0;
-        while ( reader.GetBitsRemaining() >= 256 )
+        // num_bits - bits_read, exactly C's serialize_read_bits_remaining
+        while ( int64_t( BitsBufferSize ) * 8 - reader.GetBitsProcessed() >= 256 )
         {
             for ( int i = 0; i < BitsNumWidths; i++ )
-                sum += reader.ReadBits( bits_widths[i] );
+            {
+                uint32_t value = 0;
+                reader.SerializeBits( value, bits_widths[i] );
+                sum += value;
+            }
         }
         g_sink = g_sink + sum;
     }

--- a/bench/results/2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv
@@ -1,0 +1,45 @@
+# schema bench results
+# date: 2026-09-07T16:54:52Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 6cc9ae6b-dirty (bitpacker-legs-measure-the-same-work)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c
+# load_start: 4.57 5.25 5.49
+# load_end: 10.32 7.62 6.53
+# load_max: 10.34
+# core_busy_pct: n/a
+# foreign_procs: 29
+# control_start_median: 6638016   control_end_median: 6517670
+# control_delta_pct: 1.8   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8469350,8329169,8676300,3537.73,4.10,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4214796,4114299,4279494,1760.56,3.92,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,91266,88475,92304,5702.59,4.20,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,75323,73501,76492,4706.39,3.97,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8448668,8222870,8668363,3529.09,5.27,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4464078,4345346,4540420,1864.69,4.37,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,90930,88415,91994,5681.53,3.94,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,121998,116622,123487,7622.78,5.63,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown


### PR DESCRIPTION
**What was wrong.** The two bitpacker read legs did not measure the same work. bench/c calls `serialize_read_bits`, the C runtime's one bit-read entry point, whose past-end test is a real branch in every build. bench/cpp called `BitReader::ReadBits`, whose four asserts vanish under NDEBUG; C++'s check lives one layer up in `ReadStream`, which the leg never touched. Per 16-read group at -O3 -DNDEBUG on arm64: C++ 135 instructions and 2 conditional branches, C 270 and 33. The published bitpacker/read row (C at 158% of C++ this morning) compared a checked reader with an unchecked one. The maintainer's rule, today: "on read side we MUST always do the checks!", so the checked layer is the representative one, and it is the only layer the two runtimes share.

**What changes.** bench/cpp's bitpacker read, both the untimed verify gate and the timed loop, goes through `ReadStream::SerializeBits`, the exact counterpart of `serialize_read_bits` (same width asserts, one past-end test per read, terminal refusal). Group structure, widths, buffer, variant rotation, accumulation and loop entry are unchanged and identical between the legs. The write legs were already the same work (C's stream writer's guards are asserts; 317 instructions and 36 branches in both languages, before and after) and are untouched. BENCH-STANDARD §1.4 gets a dated note making the layer rule explicit and naming the go, rust, cs and js read legs as unaudited on this point; bench/README.md's row description carries the receipts.

**The measurement.** A twins pass (7 rounds, window OK, control delta 1.8%): bitpacker/read C at 161% of C++ (61.9% the other way), bench_mixed round trip 106.1%, every row inside the two same-day baselines' noise. No number moved, and that is the finding: the C++ leg now calls the checked read and clang proves the check dead (a group needs 256 bits remaining and reads 227). Two diagnostic probes, not committed, pin the residual to one thing in serialize.c: the per-read test compares against `bits_limit`, which the failure latch poisons, while the group's entry condition reads `num_bits`, so the compiler cannot close the proof across two fields; C++ latches on the read cursor, the same counter the entry condition tests, so it can. Give C++ a length the compiler cannot fold and it emits C's 261/33; point C's test at `num_bits` (breaking the sticky-failure contract, diagnostic only) and it emits C++'s 135/2. That is a serialize.c change, being tried next.

**What the row means now.** Both legs ask their runtime for a checked bit read, and the row reports how well each runtime's checked read optimizes.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)