### PR TITLE
bench: C and C++ are locked together by the record; the ledger gate gets two teeth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,7 +526,13 @@ jobs:
         run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.23.0 ./...
       - name: bench scripts parse
         run: bash -n bench/run.sh
-      - name: absolute ledger — the cpp curve holds or goes red
+      # Both locked legs (cpp and c) hold their curve on their own machine,
+      # and on every (machine, corpus_id) axis the NEWEST certified pass that
+      # publishes a figure keeps c inside §2.8's tie band of cpp. Older
+      # certified passes on the axis are history: they print, one line each,
+      # and gate nothing.
+      # stdout is the series; the verdicts are on stderr and stay visible.
+      - name: absolute ledger — the cpp and c curves hold, and the pair stays locked
         run: go run ./bench/tools ledger --check > /dev/null
       - name: render smoke — the headline table renders from a committed CSV
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4174,6 +4174,39 @@ update-goldens: build/schema_test_retain build/schema_test build/schema_test_lud
 bench:
 	bench/run.sh
 
+# LOCKING C AND C++ TOGETHER (owner, 2026-09-07: "So we should now be able to
+# lock C and C++ together now in perf and make sure we don't regress").
+# The maintainer's pass: a cpp,c A/A twins pass, seven rounds, into
+# bench/results/<date>-<arch>-<host>-lock-pass.csv, then the ledger check over
+# the whole committed record. Two teeth fire from that one file — the §2.8 tie
+# band between the legs, and each leg's own curve against the BEST of the
+# previous three points on the SAME machine (absolute rates do not compare
+# across machines, §2), so run it on the box those points came from: the
+# Studio. Only files carrying BOTH legs are points on that axis.
+#
+# `--twins` is not optional here. The lock is a claim about two binaries
+# measured in one window, and §2.6.1's A/A legs are what rules out
+# state-selective interference dressing up as a separation.
+#
+# WHAT THE LOCK COVERS: bench_mixed / family gen / round_trip / best rate —
+# the headline statistic §2.8 rules on, and the whole of the lock. The
+# bitpacker rows and the write path are OUTSIDE it. Not an oversight: in
+# bench/results/2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv, a
+# `window: OK` pass this lock calls green at 106.1%, bitpacker/read has c at
+# 161.4% of cpp. A band over that row is a ruling about a different statistic
+# and is not invented here — it would need its own §2.8-style paragraph in
+# bench/BENCH-STANDARD.md first.
+#
+# CI does not run this — it reads the committed CSV. A GitHub-hosted runner is
+# too noisy for a window the standard would accept (§2.6, §7), so the lock
+# lives in the record a maintainer commits, and the gate reads the record.
+# bench/README.md, "Locking C and C++ together".
+.PHONY: bench-lock
+bench-lock:
+	bench/tools/pass-driver.sh --twins --rounds 7 --langs cpp,c \
+	  --out "bench/results/$$(date +%F)-$$(uname -m)-$$(hostname -s)-lock-pass.csv"
+	go run ./bench/tools ledger --check
+
 # The bench_mixed variant data (issue #191): 64 wire buffers the data-driven
 # drivers bench, regenerated from bench/corpus/Bench.schema's generated Go
 # codec. Deterministic — a regeneration that changes the committed file means

--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -809,6 +809,65 @@ figure. Display rule only — the CSV always carries the raw rates — and the
 ruling carries its own exit: a sitting that separates the pair beyond the
 combined spread prints the real figure, and that separation is a finding.
 
+**The pair is LOCKED by the record (owner, 2026-09-07: "So we should now be
+able to lock C and C++ together now in perf and make sure we don't
+regress").** Reporting two legs as one figure is only honest while something
+holds them together, so from this date `go run ./bench/tools ledger --check`
+— the gate CI runs on every pull request — carries both teeth:
+
+- **the pair axis is this section's band, on the newest certified pass.** On
+  each `(machine, corpus_id)` axis, the NEWEST committed pass with both legs'
+  `bench_mixed` `round_trip` rows has c's percentage of cpp computed on the
+  best rate and held to the tie band above (the two `spread_pct` values
+  summed, floored at 3.0 points), computed exactly as `bench/render.awk`
+  computes it — the table and the gate must agree about a sitting, or the
+  record would say two things at once. §2.3 rules first: a leg over the 40%
+  INVALID line yields NO verdict, because `render.awk` prints `—` for that row
+  and a row that does not publish as a number cannot be one side of a ratio.
+  **THAT PASS outside the band is RED**: it ran control legs and carries
+  `window: OK` (§2.6), which is the certificate that a ratio may be published
+  from it, so its separation is real and it is where the pair stands now.
+  **Older passes on the axis are HISTORY**, printed one line each and gating
+  nothing: the lock is a claim about the pair's CURRENT state, so a pass that
+  recorded a separation which a later certified pass closed stays in the
+  record without redding the tree forever — a gate that reds on a fixed
+  finding is a gate people learn to ignore — while a regression away from
+  parity reds the moment the pass that shows it is committed, being then the
+  newest on its axis. **A SITTING outside the band WARNS and exits 0**, every
+  one of them: with no control legs and no window verdict it cannot
+  distinguish a separation from a drifting box, and §2.6 does not let a ratio
+  publish from it in the first place. A pass stamped `window: INVALID` locks
+  nothing, for the same reason.
+- **the time axis is the ledger's gate.** `c` joins `cpp` as a LOCKED LEG: on
+  every `(machine, corpus_id)` axis the newest `round_trip` point of each
+  locked leg must not sit above **the best (lowest ns/msg) of the previous
+  three points** by more than
+  `max(2 × the two sittings' summed spread, 5%)`. One gate definition, one
+  list of locked legs — the check is generic over the list, never forked per
+  language. Absolute rates do not compare across machines (§2), so the pass
+  that renews the lock runs on the same box as the point before it. A point
+  enters the axis only from a CSV carrying BOTH legs' rows — the lock is a
+  claim about the pair, so a single-leg experiment file is not a like
+  measurement of it. Against the best of a window rather than the neighbour, a
+  regression cannot be laundered by landing two regressed files together;
+  plainly, a commit landing four or more points on one axis can still reset
+  the baseline, which is why plain `ledger` prints the whole series to read.
+
+**What the lock covers, and what it does not.** Exactly `bench_mixed`, family
+`gen`, path `round_trip`, best rate: the headline statistic this section rules
+on. The `bitpacker` rows and the `write` path are OUTSIDE the lock. On the
+committed record of 2026-09-07,
+`bench/results/2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv` is a
+`window: OK` pass the pair lock calls green at 106.1% while its
+`bitpacker`/`read` rows have c at 161.4% of cpp — so the scope is a real
+boundary, not a formality. A band over the bitpacker rows would be a ruling
+about a different statistic and IS NOT MADE HERE; it would need its own
+paragraph in this section, with its own derivation and its own exit.
+
+Neither tooth changes what publishes: the exit clause above stands, and a
+separation beyond the combined spread is a finding to investigate, not a
+number to publish or a band to widen.
+
 `run.sh --quick` is the ITERATION instrument, never the certification
 instrument, and every leg's stderr says so. It exists so a nine-language
 comparison costs minutes, not an evening; nothing it prints publishes.

--- a/bench/README.md
+++ b/bench/README.md
@@ -149,6 +149,143 @@ rules; there is no `--force`. `--label-checks` / `--cross-linkage` print a
 ratio across a contract/packaging difference with the caption that names
 it. Human-readable tables live beside the CSVs in `bench/results/`.
 
+## Locking C and C++ together
+
+*(Added 2026-09-07, on the owner's word: "So we should now be able to lock C
+and C++ together now in perf and make sure we don't regress.")*
+
+The C and C++ legs compile the same word-codec shape with the same clang
+backend at the same flags, and BENCH-STANDARD §2.8 reports them as one figure
+when they sit inside the pair's own spread. Two legs reported as one number
+have to be held together, or the tie becomes a place a regression can hide:
+either leg could slide while the headline still printed 100%.
+
+**The lock lives in the committed record and in CI's ledger check** — not in a
+CI benchmark. `go run ./bench/tools ledger --check` walks every CSV under
+`bench/results/` and applies two gates:
+
+- **The time axis.** For each *locked leg* — `cpp` and `c`, one list in
+  `bench/tools/ledger.go`, not two code paths — the newest `bench_mixed`
+  `round_trip` point on a `(machine, corpus_id)` axis must not sit above **the
+  best (lowest ns/msg) of the previous three points** on that axis by more
+  than the noise gate: `max(2 × the two sittings' summed spread, 5%)`. Beyond
+  it, `LEDGER RED` and exit 1. **The machine leads the key because absolute
+  rates do not compare across machines (§2)** — a Studio point is never gated
+  against a laptop point, so the pass that renews the lock has to run on the
+  same box as the point before it.
+- **The pair axis.** On each `(machine, corpus_id)` axis, **the newest
+  certified pass** carrying *both* legs' `bench_mixed` `round_trip` rows has
+  C's percentage of C++ computed on the best rate and held to §2.8's tie band
+  — the two within-sitting `spread_pct` values summed, floored at 3.0 points —
+  computed exactly as `bench/render.awk` computes it for the headline table.
+  Outside the band, the check names the CSV, the percentage, the band, both
+  spreads and the axis. That pass is named in the output even when it is
+  green (`pair lock: … inside`), because the gate has to say which pass it is
+  holding. A leg whose spread is over §2.3's 40% INVALID line yields **no
+  verdict at all**: `render.awk` prints `—` for such a row and refuses a
+  number, so no ratio is defined from it and the gate prints a skip line
+  instead of a ruling — and, publishing no figure, such a pass is not the one
+  the lock holds either; the newest pass that does publish one keeps the axis
+  locked. A test runs the committed `render.awk` and the gate over the same
+  fixture and requires their verdicts to match, because the 3.0-point floor is
+  written out once in each language.
+
+**The lock holds the newest certified pass on the axis, and only that one.**
+Older passes on the axis print as history — one line each, `pair history:
+<file> <pct> against <band>: inside|outside` — and gate nothing. The lock is a
+claim about where the pair stands *now* (the owner's word was "land parity
+between C and C++ and then lock"), and the record is a record: it keeps the
+passes that FOUND things, not only the clean ones.
+`bench/results/2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv` is exactly
+that — a `window: OK` pass measuring C at 107.4% of C++ against a 5.8-point
+band, and that measurement *is* the finding, a 7% read-path gap, which the
+next pass, `2026-09-07-arm64-studio-c-read-guard-pass.csv`, closed at 98.2%
+inside 6.5. Holding every historical pass forever would leave CI red on a
+finding that is already fixed, and **a gate that reds on something already
+fixed teaches people to ignore the gate**. Holding the newest certified pass
+keeps both teeth: the separation that was found stays readable in the record
+and in the check's own output, and a regression away from parity goes red the
+moment the pass that shows it is committed — because that pass is then the
+newest one on its axis.
+
+**Why the best of the previous three, and what that still does not stop.**
+Comparing the newest point against its immediate neighbour was defeated by a
+single commit: land two CSVs that are each ~50% slower, and the newest is
+measured against the *other regressed file*, so the step between them is ~0%,
+the check exits 0, and the axis has quietly reset at the worse level. Measured
+against the best of the previous three, a regression has to beat the recent
+best, which two files landing together cannot arrange. Plainly, though: **a
+commit that lands four or more points on one axis can still reset the
+baseline**, because the fourth point pushes the last pre-commit point out of
+the window. Three is a depth, not a proof. The answer to a suspicious series
+is to read it, and plain `ledger` (no `--check`) prints the whole series.
+
+**The time axis is built from both-leg files only.** A point enters a locked
+leg's series only from a CSV that carries *both* legs' `bench_mixed` `gen`
+`round_trip` rows. The lock is a claim about the pair, so a single-leg
+experiment file is by construction not a like measurement of it — and the
+record already showed what that costs: the Studio `c` axis was interleaved
+with four single-leg C experiments (`packet-void-c-studio`,
+`c-defaults-c-studio`, `c-utf8-c-studio`, `c-wide-c-studio`, 228–242 ns/msg)
+among passes at 224–233, and the `c-defaults` → `c-utf8` step alone is +5.35%
+against a 5.00% gate, so the next single-leg C experiment committed last would
+have red CI for something that is not a regression of the locked pair at all.
+This **also narrows the pre-existing `cpp` gate** to both-leg files: one rule,
+both legs, no special case. After the narrowing, each Studio axis gates eleven
+points (the eight twins/pair passes and the three nine-language sittings) and
+each macbook axis twelve; the `x86_64 spacegame` axes are down to one point
+each and gate nothing, and the laptop axis disappears entirely — both its
+files carried one leg.
+
+**What the lock covers, exactly.** `bench_mixed`, family `gen`, path
+`round_trip`, best rate. That is the headline statistic §2.8 rules on, and it
+is the whole of the lock. **The `bitpacker` rows and the `write` path are
+outside it**, and knowing that matters: in
+`bench/results/2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv` — a
+`window: OK` pass this lock calls green at 106.1% — `bitpacker`/`read` has C
+at 161.4% of C++. Locking that row would be a ruling about a different
+statistic against a different band, and it is **not** invented here; it would
+need its own §2.8-style paragraph in `BENCH-STANDARD.md` first.
+
+**A pass reds; a sitting warns.** A pass runs control legs at both ends and
+the driver stamps `# window: OK` (§2.6), which is precisely the certificate
+that says a ratio may be published from it — so a separation in the axis's
+newest such pass is a real separation and exits 1. A sitting has no control
+legs and no window verdict; it cannot tell a separation from a drifting box,
+so it prints `LEDGER WARN` and exits 0 — every sitting, not just the newest
+one, since they are informational and there is nothing to single out. That is
+not leniency, it is what the record already says: measured on the tree of
+2026-09-07, five committed sittings sit outside the band (three Studio
+nine-language sittings at 106.6–109.2%, the x86_64 spacegame sitting at
+111.3%, one macbook quick sitting at 112.6%) while every
+twins pass of the same era holds inside it — 99.1–106.7% against bands of
+4.0–27.2 points, the C-asserts twins pass landing at 105.2% inside 8.6. A pass
+whose window is stamped `INVALID` locks nothing either: §2.6 already refuses
+to publish ratios from it.
+
+Either way the message ends with the same line, because it is the ruling's own
+exit clause: **a separation beyond the combined spread is a finding to
+investigate, not a number to publish.** The response to a red is to find out
+what moved, not to widen the band.
+
+**Renewing the lock — `make bench-lock`.** On the Studio:
+
+    make bench-lock
+
+which is a `cpp,c` A/A twins pass, seven rounds, into
+`bench/results/<date>-<arch>-<host>-lock-pass.csv`, followed by
+`ledger --check`. `--twins` is not optional: the lock is a claim about two
+binaries measured in one window, and §2.6.1's A/A legs are what rules out
+state-selective interference dressing up as a separation. Run it on the same
+machine as the previous point — the Studio — commit the CSV, and CI's ledger
+step reads it from then on. The intent is a scheduled pass on the Studio,
+committed by whoever runs it.
+
+There is deliberately **no GitHub-hosted-runner benchmark**: a shared hosted
+runner cannot hold a window the standard would accept (§2.6, §7), and a gate
+built on windows the standard refuses would red on the weather. CI reads the
+record; the maintainer makes it.
+
 ## The benchmark set
 
 One shape, plus the raw bitpacker. Family `gen` is oracle-gated per §1.5;

--- a/bench/tools/ledger.go
+++ b/bench/tools/ledger.go
@@ -10,16 +10,45 @@
 // and the box are part of the question, so the key leads with them.
 //
 //	go run ./bench/tools ledger            # the series, CSV on stdout
-//	go run ./bench/tools ledger --check    # exit 1 if the newest cpp point
-//	                                       # regressed beyond the noise gate
-//	                                       # against the previous sitting on
-//	                                       # the same (machine, corpus) axis
+//	go run ./bench/tools ledger --check    # exit 1 if a LOCKED leg's newest
+//	                                       # point regressed beyond the noise
+//	                                       # gate against the previous sitting
+//	                                       # on the same (machine, corpus)
+//	                                       # axis, or if the NEWEST certified
+//	                                       # PASS on such an axis separates c
+//	                                       # from cpp beyond the §2.8 tie band
 //
-// The check is the anti-churn instrument's teeth: a cpp regression goes RED,
-// it does not drift (BENCH-STANDARD's own law, given its time axis). The gate
-// is max(2 * the two sittings' summed spread, 5%) — generous, because a
-// same-box cross-sitting rerun of frozen code has measured ~3 points of TU
-// layout and thermal noise; a real regression clears it.
+// The check is the anti-churn instrument's teeth: a regression on a locked leg
+// goes RED, it does not drift (BENCH-STANDARD's own law, given its time axis).
+// The gate is max(2 * the two sittings' summed spread, 5%) — generous, because
+// a same-box cross-sitting rerun of frozen code has measured ~3 points of TU
+// layout and thermal noise; a real regression clears it. ONE gate definition,
+// in noiseGate below; the locked legs are a list, not a fork of the logic.
+//
+// LOCKING C AND C++ TOGETHER (owner, 2026-09-07: "So we should now be able to
+// lock C and C++ together now in perf and make sure we don't regress"). Two
+// teeth, not one:
+//
+//  1. the time axis — c gets the same per-axis regression gate cpp has, so a
+//     C regression on the same machine goes RED too; and
+//  2. the pair axis — the NEWEST certified pass carrying both legs' bench_mixed
+//     round_trip rows on each (machine, corpus) axis is held to §2.8's tie
+//     band, so the two legs cannot drift apart while each separately holds its
+//     own curve. Older passes on the axis are printed as history, not gated:
+//     the lock is about the pair's CURRENT state (owner, 2026-09-07: "land
+//     parity between C and C++ and then lock"), so a pass that RECORDED a
+//     separation which a later pass CLOSED stays in the record without redding
+//     CI forever, and a regression from parity reds the moment the pass that
+//     shows it is committed.
+//
+// WHAT THE LOCK COVERS, EXACTLY: bench_mixed, family gen, path round_trip,
+// best rate. That is the headline statistic §2.8 rules on, and it is the whole
+// of the lock. The bitpacker rows and the write path are OUTSIDE it, and not
+// by oversight: in 2026-09-07-arm64-studio-bitpacker-checked-read-pass.csv —
+// a `window: OK` pass this pair lock calls green at 106.1% — bitpacker/read
+// has c at 161.4% of cpp. A band over that row would be a new ruling about a
+// different statistic, and it is NOT invented here; it would need its own
+// §2.8-style paragraph in BENCH-STANDARD.md first.
 package main
 
 import (
@@ -31,6 +60,45 @@ import (
 	"strings"
 )
 
+// lockedLegs are the languages whose curve the ledger gates. cpp is the
+// reference the whole table normalizes on; c was added 2026-09-07 when the two
+// legs were locked together — same clang backend, same word codec, and §2.8
+// reports them as one figure, so one of them silently regressing while the
+// other holds is exactly the churn this instrument exists to catch. Adding a
+// leg here is the whole change: the check below is generic over the list.
+var lockedLegs = []string{"cpp", "c"}
+
+// tieBandFloor is §2.8's floor on the c/cpp tie band, in percentage points,
+// and it is render.awk's constant — the two must agree or the table and the
+// gate would disagree about the same sitting.
+const tieBandFloor = 3.0
+
+// invalidSpread is §2.3's INVALID line, in percentage points, and it is also
+// render.awk's constant: a row whose spread exceeds it prints "—" in the
+// headline table and never yields a figure at all. The pair lock refuses the
+// same row for the same reason, so the table and the gate agree by
+// construction and not by luck — before this, render.awk would print no
+// number for a leg the Go lock was busy ruling on.
+const invalidSpread = 40.0
+
+// lookback is how many earlier points on an axis the newest one is measured
+// against. The newest point is compared to the BEST (lowest ns/msg) of them,
+// not to its immediate neighbour.
+//
+// Neighbour-only comparison was defeated by one commit: land two CSVs that are
+// each ~50% slower than the record, and the newest is compared against the
+// other regressed file, so the pair exits 0 and the axis has quietly reset at
+// the worse level. Against the best of the previous three, a regression has to
+// beat the recent best, which two files landing together cannot arrange.
+//
+// PLAINLY, THE HOLE THAT REMAINS: a single commit landing FOUR OR MORE points
+// on one axis can still reset the baseline, because the fourth point pushes
+// the last pre-commit point out of the window. Three is a depth, not a proof.
+// The instrument's answer to a suspicious series is to read it, and plain
+// `ledger` prints the whole series for exactly that. bench/README.md,
+// "Locking C and C++ together", says the same thing.
+const lookback = 3
+
 type point struct {
 	file    string
 	date    string // preamble date, the sitting's stamp
@@ -40,6 +108,7 @@ type point struct {
 	path    string  // write | round_trip
 	nsMsg   float64 // 1e9 / max rate (§2.2: max is the contract statistic)
 	spread  float64 // spread_pct column
+	window  string  // preamble `window:` verdict: OK | INVALID | "" (a sitting)
 }
 
 func ledger(args []string) {
@@ -96,7 +165,11 @@ func ledger(args []string) {
 	}
 
 	if check {
-		os.Exit(checkCpp(pts))
+		code := checkLockedLegs(pts)
+		if c := checkPairLock(pts); c != 0 {
+			code = c
+		}
+		os.Exit(code)
 	}
 }
 
@@ -109,7 +182,7 @@ func parse(file string) []point {
 		fmt.Fprintf(os.Stderr, "ledger: %s: %v\n", file, err)
 		os.Exit(1)
 	}
-	date, host, arch := "", "", ""
+	date, host, arch, window := "", "", "", ""
 	var pts []point
 	for line := range strings.SplitSeq(string(data), "\n") {
 		if after, ok := strings.CutPrefix(line, "# date: "); ok {
@@ -126,11 +199,30 @@ func parse(file string) []point {
 			}
 			continue
 		}
+		// §2.6's window verdict. The driver stamps it on the same preamble
+		// line as control_delta_pct; a sitting has no control legs and so
+		// carries no verdict at all.
+		if strings.HasPrefix(line, "# ") {
+			if fields := strings.Fields(line); len(fields) > 0 {
+				for i, f := range fields {
+					if f == "window:" && i+1 < len(fields) {
+						window = fields[i+1]
+					}
+				}
+			}
+			continue
+		}
 		c := strings.Split(line, ",")
 		if len(c) < 13 || c[1] != "bench_mixed" || c[12] != "gen" {
 			continue
 		}
 		if c[2] != "write" && c[2] != "round_trip" {
+			continue
+		}
+		// render.awk's codec guard, kept identical: js emits two gen tiers
+		// and only the flat tier is THE js path. Files written before the
+		// column existed have no field 18 and are unaffected.
+		if len(c) >= 18 && c[17] == "runtime" {
 			continue
 		}
 		maxRate, err1 := strconv.ParseFloat(c[8], 64)
@@ -141,40 +233,299 @@ func parse(file string) []point {
 		pts = append(pts, point{
 			file: file, date: date, machine: arch + " " + host, corpus: c[11],
 			lang: c[0], path: c[2], nsMsg: 1e9 / maxRate, spread: spread,
+			window: window,
 		})
+	}
+	// The window stamp usually precedes the rows, but the preamble order is
+	// not normative, so stamp every row once the whole file has been read.
+	for i := range pts {
+		pts[i].window = window
 	}
 	return pts
 }
 
-// checkCpp gates the reference: on every (machine, corpus) axis with at least
-// two sittings, the newest cpp round_trip point must not sit above the
-// previous one by more than the gate.
-func checkCpp(pts []point) int {
-	type axis struct{ machine, corpus string }
+// noiseGate is THE gate, in percentage points: 2x the two sittings' summed
+// spread, floored at 5%. One definition, used by every locked leg — a gate
+// that differed per language would be a gate nobody could reason about.
+func noiseGate(prevSpread, lastSpread float64) float64 {
+	gate := 2 * (prevSpread + lastSpread)
+	if gate < 5.0 {
+		gate = 5.0
+	}
+	return gate
+}
+
+// checkLockedLegs gates the time axis: on every (machine, corpus) axis with at
+// least two points, each locked leg's newest round_trip point must not sit
+// above the BEST of the previous `lookback` points by more than the gate.
+// Absolute rates do not compare across machines (§2), which is why the machine
+// leads the key.
+//
+// THE AXIS IS BUILT FROM BOTH-LEG FILES ONLY. A point enters a locked leg's
+// series only from a CSV that carries EVERY locked leg's bench_mixed gen
+// round_trip row. The lock is a claim about the pair, so a single-leg
+// experiment file is by construction not a like measurement of it: the Studio
+// c axis was interleaved with four single-leg C experiments
+// (packet-void-c-studio, c-defaults-c-studio, c-utf8-c-studio, c-wide-c-studio,
+// 228-242 ns/msg) among passes at 224-233, and the c-defaults -> c-utf8 step
+// alone is +5.35% against a 5.00% gate — so the next single-leg C experiment
+// committed last would have red CI for something that is not a regression of
+// the locked pair at all. This also narrows the pre-existing cpp gate the same
+// way, deliberately: one rule, both legs.
+func checkLockedLegs(pts []point) int {
+	type axis struct{ lang, machine, corpus string }
+	locked := map[string]bool{}
+	for _, l := range lockedLegs {
+		locked[l] = true
+	}
+	legsInFile := map[string]map[string]bool{}
+	for _, p := range pts {
+		if locked[p.lang] && p.path == "round_trip" {
+			if legsInFile[p.file] == nil {
+				legsInFile[p.file] = map[string]bool{}
+			}
+			legsInFile[p.file][p.lang] = true
+		}
+	}
+	bothLegs := func(file string) bool {
+		for _, l := range lockedLegs {
+			if !legsInFile[file][l] {
+				return false
+			}
+		}
+		return true
+	}
 	series := map[axis][]point{}
 	for _, p := range pts {
-		if p.lang == "cpp" && p.path == "round_trip" {
-			k := axis{p.machine, p.corpus}
+		if locked[p.lang] && p.path == "round_trip" && bothLegs(p.file) {
+			k := axis{p.lang, p.machine, p.corpus}
 			series[k] = append(series[k], p)
 		}
 	}
+	keys := make([]axis, 0, len(series))
+	for k := range series {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.machine != b.machine {
+			return a.machine < b.machine
+		}
+		if a.corpus != b.corpus {
+			return a.corpus < b.corpus
+		}
+		return a.lang < b.lang
+	})
 	code := 0
-	for k, s := range series {
+	for _, k := range keys {
+		s := series[k]
 		if len(s) < 2 {
 			continue
 		}
-		prev, last := s[len(s)-2], s[len(s)-1]
-		gate := 2 * (prev.spread + last.spread)
-		if gate < 5.0 {
-			gate = 5.0
+		last := s[len(s)-1]
+		lo := max(len(s)-1-lookback, 0)
+		// The BEST of the window, not the neighbour: see lookback.
+		best := s[lo]
+		for _, p := range s[lo : len(s)-1] {
+			if p.nsMsg < best.nsMsg {
+				best = p
+			}
 		}
-		regression := (last.nsMsg - prev.nsMsg) / prev.nsMsg * 100.0
+		gate := noiseGate(best.spread, last.spread)
+		regression := (last.nsMsg - best.nsMsg) / best.nsMsg * 100.0
 		if regression > gate {
 			fmt.Fprintf(os.Stderr,
-				"LEDGER RED: cpp round_trip regressed %.1f%% on [%s %s] (%.1f -> %.1f ns/msg, %s -> %s), gate %.1f%% — a perf regression goes red, it does not drift\n",
-				regression, k.machine, k.corpus, prev.nsMsg, last.nsMsg,
-				filepath.Base(prev.file), filepath.Base(last.file), gate)
+				"LEDGER RED: %s round_trip regressed %.1f%% on [%s %s] against the axis's recent best (%.1f -> %.1f ns/msg, %s -> %s), gate %.1f%% — a perf regression goes red, it does not drift\n",
+				k.lang, regression, k.machine, k.corpus, best.nsMsg, last.nsMsg,
+				filepath.Base(best.file), filepath.Base(last.file), gate)
 			code = 1
+		}
+	}
+	return code
+}
+
+// checkPairLock gates the pair axis. For a committed CSV carrying both legs'
+// bench_mixed round_trip rows, c's percentage of cpp is computed on the best
+// rate and held to §2.8's tie band — the two within-sitting spreads summed,
+// floored at 3.0 points — exactly as render.awk computes it for the headline
+// table. The table and the gate must agree about a sitting or the record would
+// say two things at once.
+//
+// THE LOCK HOLDS THE NEWEST CERTIFIED PASS ON EACH (MACHINE, CORPUS) AXIS, AND
+// ONLY THAT ONE. Older passes on the axis print as history and gate nothing.
+// The lock is a claim about the pair's CURRENT state — the maintainer's intent
+// was "land parity between C and C++ and then lock" — and the record is a
+// record: it keeps the passes that FOUND things, not only the ones that were
+// clean. 2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv is exactly that,
+// a `window: OK` pass measuring c at 107.4% of cpp against a 5.8-point band,
+// and that measurement is the finding — a 7% read-path gap — which the next
+// pass, 2026-09-07-arm64-studio-c-read-guard-pass.csv, closed at 98.2% inside
+// 6.5. Holding every historical pass forever would leave CI red on a fixed
+// finding, and a gate that reds on something already fixed teaches people to
+// ignore the gate. Holding the newest certified pass keeps both teeth: the
+// record still carries the separation that was found, and a regression from
+// parity goes red the moment the pass that shows it is committed — because
+// that pass is then the newest one on its axis.
+//
+// PASSES LOCK HARD, SITTINGS WARN. A pass certifies its window: it ran control
+// legs at both ends and the driver stamped `window: OK` (§2.6), so the numbers
+// in it are the ones the standard lets you publish a ratio from, and a
+// separation there is a real separation. A sitting has no control legs and no
+// window verdict — it cannot tell a separation from a drifting box, so reding
+// it would be gating on evidence the standard itself refuses to publish
+// ratios from. Sittings therefore print and exit 0, every one of them: they
+// are informational, so there is no "newest sitting" to single out. This is
+// not leniency: measured 2026-09-07, FIVE committed sittings (three Studio
+// ninelang at 106.6-109.2%, the x86_64 spacegame at 111.3%, and one macbook
+// quick sitting just past a 12.3-point band) sit outside their bands, which is
+// exactly the difference a window verdict is there to record. A window stamped
+// INVALID does not lock either — §2.6 already refuses to publish ratios from
+// it.
+//
+// §2.3 REFUSES BEFORE §2.8 RULES. A leg whose spread_pct exceeds §2.3's
+// INVALID line yields NO verdict here, because render.awk yields no figure for
+// it either — it prints "—" and a §2.3 note, and a row that does not publish
+// as a number cannot be the c in a c/cpp ratio. Without this the two would
+// disagree by construction: the table refusing to print while the gate red on
+// the number the table refused. Such a pass is not the axis's newest certified
+// pass either, for the same reason: it publishes no figure, so it cannot be
+// the figure the lock holds, and the newest pass that DOES publish one keeps
+// the axis locked rather than a noisy sitting silently disarming it.
+//
+// SCOPE, said once: bench_mixed / gen / round_trip / best rate, and nothing
+// else. bitpacker and the write path are outside this lock (see the package
+// comment for the committed receipt that shows why that matters).
+func checkPairLock(pts []point) int {
+	type sitting struct {
+		file, machine, corpus, date, window string
+		c, cpp                              *point
+	}
+	byFile := map[string]*sitting{}
+	for i, p := range pts {
+		if p.path != "round_trip" || (p.lang != "c" && p.lang != "cpp") {
+			continue
+		}
+		s, ok := byFile[p.file]
+		if !ok {
+			s = &sitting{file: p.file, machine: p.machine, corpus: p.corpus, date: p.date, window: p.window}
+			byFile[p.file] = s
+		}
+		// Last row of a language wins, as render.awk's gt[$1] assignment
+		// does. NOTE, inert on today's record: "last" is not the same
+		// "last" in the two tools. pts is sorted (machine, corpus, date,
+		// lang, path) before this loop, so a Go last-row-wins is the last
+		// row of the LAST CORPUS in a file; render.awk's is the last row
+		// in FILE ORDER. No committed results file carries two corpus_ids
+		// among its family-gen rows, so today the two pick the same row.
+		// A file that ever did would need one rule chosen and both tools
+		// moved to it.
+		if p.lang == "c" {
+			s.c = &pts[i]
+		} else {
+			s.cpp = &pts[i]
+		}
+	}
+
+	var all []*sitting
+	for _, s := range byFile {
+		if s.c != nil && s.cpp != nil {
+			all = append(all, s)
+		}
+	}
+	// Axis order, oldest first: the history of an axis reads down the page and
+	// the pass the lock holds is the last of its axis.
+	sort.Slice(all, func(i, j int) bool {
+		a, b := all[i], all[j]
+		if a.machine != b.machine {
+			return a.machine < b.machine
+		}
+		if a.corpus != b.corpus {
+			return a.corpus < b.corpus
+		}
+		if a.date != b.date {
+			return a.date < b.date
+		}
+		return a.file < b.file
+	})
+
+	// refused is §2.3's line: neither leg publishes as a number, so no ratio
+	// is defined and nothing here can rule on it.
+	refused := func(s *sitting) bool {
+		return s.c.spread > invalidSpread || s.cpp.spread > invalidSpread
+	}
+	axisKey := func(s *sitting) string { return s.machine + "\x00" + s.corpus }
+
+	// The pass the lock holds on each axis: the newest certified pass that
+	// publishes a figure. `all` is oldest-first, so the last write wins.
+	held := map[string]*sitting{}
+	for _, s := range all {
+		if s.window == "OK" && !refused(s) {
+			held[axisKey(s)] = s
+		}
+	}
+
+	code := 0
+	for _, s := range all {
+		// §2.3 first: a leg over the INVALID line does not publish as a
+		// number, so no ratio is defined from it and the lock yields no
+		// verdict — exactly what render.awk does with the same row.
+		if refused(s) {
+			fmt.Fprintf(os.Stderr,
+				"ledger: pair-lock skipped — %s: a leg's spread is over §2.3's %.0f%% INVALID line (spread c %.2f, spread cpp %.2f), so the row does not publish as a number and no c/cpp figure is defined; render.awk prints — for it too\n",
+				filepath.Base(s.file), invalidSpread, s.c.spread, s.cpp.spread)
+			continue
+		}
+		// §2.8's figure: ns/msg of c over ns/msg of cpp, cpp the denominator
+		// at 100%, so a c above 100% is the slower leg.
+		pct := s.c.nsMsg / s.cpp.nsMsg * 100.0
+		band := s.c.spread + s.cpp.spread
+		if band < tieBandFloor {
+			band = tieBandFloor
+		}
+		delta := pct - 100.0
+		if delta < 0 {
+			delta = -delta
+		}
+		inside := delta <= band
+
+		// An older certified pass on the axis: history, not a verdict. It is
+		// printed either way — a pass that recorded a separation is part of
+		// how the pair got here, and hiding it would make the closed finding
+		// unreadable in the same output that shows the pass which closed it.
+		if s.window == "OK" && held[axisKey(s)] != s {
+			where := "inside"
+			tail := ""
+			if !inside {
+				where = "outside"
+				tail = " — a separation this pass recorded; the lock holds this axis's newest certified pass instead"
+			}
+			fmt.Fprintf(os.Stderr, "pair history: %s %.1f%% against %.1f points: %s%s\n",
+				filepath.Base(s.file), pct, band, where, tail)
+			continue
+		}
+
+		if inside {
+			// The pass the lock holds says so even when it is green: the
+			// output has to name WHICH pass is under the gate, or "history"
+			// lines above it would read as findings nobody is acting on.
+			if s.window == "OK" {
+				fmt.Fprintf(os.Stderr, "pair lock: %s %.1f%% against %.1f points: inside — the newest certified pass that publishes a figure on [%s %s], and the one the lock holds\n",
+					filepath.Base(s.file), pct, band, s.machine, s.corpus)
+			}
+			continue
+		}
+		what := fmt.Sprintf("c measured %.1f%% of cpp in %s, outside the §2.8 tie band of %.1f points (spread c %.2f + spread cpp %.2f, floor %.1f)",
+			pct, filepath.Base(s.file), band, s.c.spread, s.cpp.spread, tieBandFloor)
+		const finding = "a separation beyond the combined spread is a finding to investigate, not a number to publish"
+		switch s.window {
+		case "OK":
+			fmt.Fprintf(os.Stderr, "LEDGER RED: %s — the pass certifies its window (§2.6) and is the newest certified pass that publishes a figure on [%s %s], so this is where the pair stands now: %s\n",
+				what, s.machine, s.corpus, finding)
+			code = 1
+		case "INVALID":
+			fmt.Fprintf(os.Stderr, "ledger: pair-lock skipped — %s, but the pass is `window: INVALID` and §2.6 refuses to publish ratios from it\n", what)
+		default:
+			fmt.Fprintf(os.Stderr, "LEDGER WARN: %s — a sitting has no control legs and no window verdict, so it warns rather than reds (§2.6); %s\n", what, finding)
 		}
 	}
 	return code

--- a/bench/tools/ledger_test.go
+++ b/bench/tools/ledger_test.go
@@ -1,0 +1,468 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A committed results file as the driver writes one: the §5.2 preamble stamps
+// the ledger reads (date, host/arch, and — for a PASS — §2.6's window verdict)
+// and the CSV rows. `window` empty writes no verdict line at all, which is what
+// a sitting looks like: no control legs, nothing certified.
+func writeResults(t *testing.T, dir, name, date, host, arch, window string, rows ...string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("# schema bench results\n")
+	b.WriteString("# date: " + date + "\n")
+	b.WriteString("# host: " + host + "  arch: " + arch + "  os: Darwin 25.6.0\n")
+	b.WriteString("# rounds: 7   interleaved: yes\n")
+	if window != "" {
+		b.WriteString("# control_delta_pct: 1.0   window: " + window + "\n")
+	}
+	b.WriteString("# corpus_id: 6b213fbfa1a03a99\n")
+	b.WriteString("lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline\n")
+	b.WriteString(strings.Join(rows, "\n") + "\n")
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// rt is one family-gen bench_mixed round_trip row at a given best rate and
+// spread — the only row the lock and the gate read.
+func rt(lang string, maxRate int, spread string) string {
+	return lang + ",bench_mixed,round_trip,4000000,100," +
+		"14,4000000," + strconv.Itoa(maxRate) + "," + strconv.Itoa(maxRate) + ",1800.00," + spread +
+		",6b213fbfa1a03a99,gen,hdr,removed,O3,unknown"
+}
+
+// The pair lock, green side: a PASS whose c sits inside §2.8's band is the
+// normal committed state and must not red. 4,400,000 vs 4,500,000 msg/s is
+// c at 102.3% of cpp, inside the 3.0-point floor.
+func TestPairLockPassInsideTheBandIsGreen(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "in-band-pass.csv", "2026-09-07T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("the lock red a pass inside the band (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if strings.Contains(errOut, "LEDGER") {
+		t.Errorf("a pass inside the band printed a verdict at all:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "pair lock: in-band-pass.csv 102.3% against 3.0 points: inside") {
+		t.Errorf("the lock did not name the pass it holds:\n%s", errOut)
+	}
+}
+
+// The pair lock, red side: the axis's newest certified PASS, whose c leaves
+// the band, goes RED, and the message names the CSV, the percentage, the band,
+// both spreads, the axis it is the newest pass on, and the finding line.
+// 4,200,000 vs 4,500,000 is c at 107.1% of cpp against a 3.0-point band.
+func TestPairLockPassOutsideTheBandIsRed(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "out-of-band-pass.csv", "2026-09-07T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4200000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("a pass outside the band did not red (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	want := "LEDGER RED: c measured 107.1% of cpp in out-of-band-pass.csv, outside the §2.8 tie band of 3.0 points (spread c 1.00 + spread cpp 1.00, floor 3.0) — the pass certifies its window (§2.6) and is the newest certified pass that publishes a figure on [arm64 studio 6b213fbfa1a03a99], so this is where the pair stands now: a separation beyond the combined spread is a finding to investigate, not a number to publish"
+	if !strings.Contains(errOut, want) {
+		t.Errorf("the pair lock's message is not the one the record promises\nwant: %s\ngot:  %s", want, errOut)
+	}
+}
+
+// The band is the two spreads summed, not the floor, once the spreads clear
+// it: the same 107.1% separation sits INSIDE a band built from two 4-point
+// spreads, so a noisy pass does not red on noise.
+func TestPairLockBandWidensWithTheSpreads(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "noisy-pass.csv", "2026-09-07T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "4.00"), rt("c", 4200000, "4.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("the lock red a separation inside the summed spreads (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+}
+
+// THE LOCK IS ABOUT THE PAIR'S CURRENT STATE. An older certified pass on the
+// axis is outside the band, the newest is inside: GREEN, because the older
+// pass is the record of a finding that the newer one closed — which is exactly
+// what happened on the Studio between the serialize-c-1.10.0 pin pass (c at
+// 107.4% of cpp, the 7% read-path gap) and the c-read-guard pass that closed
+// it at 98.2%. The older pass still PRINTS, as history, so the closed finding
+// stays readable in the same output that shows the pass which closed it. The
+// time axis is silent here by construction: c gets faster (238.1 -> 227.3
+// ns/msg) and cpp does not move.
+func TestPairLockGatesOnlyTheNewestCertifiedPassOnTheAxis(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-finding-pass.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4200000, "1.00"))
+	writeResults(t, dir, "b-fix-pass.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("a historical pass whose finding a later pass closed still red the tree (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if strings.Contains(errOut, "LEDGER RED") {
+		t.Errorf("the lock red on a pass it no longer holds:\n%s", errOut)
+	}
+	want := "pair history: a-finding-pass.csv 107.1% against 3.0 points: outside"
+	if !strings.Contains(errOut, want) {
+		t.Errorf("the closed finding is not in the output as history\nwant: %s\ngot:  %s", want, errOut)
+	}
+	// And the output names the pass the lock DOES hold, green though it is:
+	// history lines are only readable next to the pass under the gate.
+	held := "pair lock: b-fix-pass.csv 102.3% against 3.0 points: inside — the newest certified pass that publishes a figure on [arm64 studio 6b213fbfa1a03a99], and the one the lock holds"
+	if !strings.Contains(errOut, held) {
+		t.Errorf("the output does not name the pass the lock holds\nwant: %s\ngot:  %s", held, errOut)
+	}
+}
+
+// The other side of the same rule: when the NEWEST certified pass on the axis
+// is the one outside the band, that is a regression from parity and it reds
+// the moment it is committed — with the older, inside pass printed as history
+// so the output shows what the pair moved away from. cpp moves too (222.2 ->
+// 200.0 ns/msg) and c improves in absolute terms (227.3 -> 217.4), so nothing
+// here is the time axis's doing: this is the pair separating.
+func TestPairLockRedsWhenTheNewestCertifiedPassLeavesTheBand(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-parity-pass.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	writeResults(t, dir, "b-regressed-pass.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 5000000, "1.00"), rt("c", 4600000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("the newest pass left the band and the lock did not red (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	for _, want := range []string{
+		"LEDGER RED: c measured 108.7% of cpp in b-regressed-pass.csv",
+		"outside the §2.8 tie band of 3.0 points",
+		"is the newest certified pass that publishes a figure on [arm64 studio 6b213fbfa1a03a99]",
+		"pair history: a-parity-pass.csv 102.3% against 3.0 points: inside",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("the red on the newest pass lacks %q:\n%s", want, errOut)
+		}
+	}
+}
+
+// A NEWER pass §2.3 refuses does not disarm the axis. A leg whose spread is
+// over the INVALID line publishes no figure, so that pass cannot be the figure
+// the lock holds — the newest pass that DOES publish one stays under the gate
+// and its separation still reds. Without this, one noisy sitting-shaped pass
+// committed after a regression would silently unlock the axis. Both files
+// carry cpp at the same rate and c faster in the newer one, so the time axis
+// says nothing here: this is the pair lock alone.
+func TestANewerPassRefusedByRuleTwoThreeDoesNotDisarmTheAxis(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-separated-pass.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4200000, "1.00"))
+	writeResults(t, dir, "b-noisy-pass.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "41.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("a §2.3-refused newer pass disarmed the axis (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	for _, want := range []string{
+		"LEDGER RED: c measured 107.1% of cpp in a-separated-pass.csv",
+		"outside the §2.8 tie band of 3.0 points",
+		"is the newest certified pass that publishes a figure on [arm64 studio 6b213fbfa1a03a99]",
+		"ledger: pair-lock skipped — b-noisy-pass.csv",
+		"a leg's spread is over §2.3's 40% INVALID line (spread c 41.00, spread cpp 1.00)",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("the output lacks %q:\n%s", want, errOut)
+		}
+	}
+	// The refused pass yields no verdict at all — not a red, not history.
+	if strings.Contains(errOut, "b-noisy-pass.csv 97") || strings.Contains(errOut, "pair history: b-noisy-pass.csv") {
+		t.Errorf("the refused pass published a figure anyway:\n%s", errOut)
+	}
+}
+
+// A SITTING outside the band warns and exits 0. A sitting has no control legs
+// and no window verdict, so §2.6 does not let a ratio publish from it — the
+// separation is printed as the finding it is, not enforced as a verdict.
+func TestPairLockSittingOutsideTheBandWarnsAndExitsZero(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "out-of-band-sitting.csv", "2026-09-07T10:00:00Z", "studio", "arm64", "",
+		rt("cpp", 4500000, "1.00"), rt("c", 4200000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("a sitting outside the band red instead of warning (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	for _, want := range []string{
+		"LEDGER WARN: c measured 107.1% of cpp in out-of-band-sitting.csv",
+		"outside the §2.8 tie band of 3.0 points (spread c 1.00 + spread cpp 1.00, floor 3.0)",
+		"a sitting has no control legs and no window verdict, so it warns rather than reds (§2.6)",
+		"a separation beyond the combined spread is a finding to investigate, not a number to publish",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("the sitting warning lacks %q:\n%s", want, errOut)
+		}
+	}
+}
+
+// A pass whose window is stamped INVALID locks nothing: §2.6 already refuses
+// to publish ratios from it, so gating on it would gate on evidence the
+// standard threw away.
+func TestPairLockDoesNotLockAnInvalidWindow(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "invalid-window-pass.csv", "2026-09-07T10:00:00Z", "studio", "arm64", "INVALID",
+		rt("cpp", 4500000, "1.00"), rt("c", 4200000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("an INVALID window locked (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if !strings.Contains(errOut, "pair-lock skipped") || !strings.Contains(errOut, "window: INVALID") {
+		t.Errorf("the skip did not name itself and its reason:\n%s", errOut)
+	}
+}
+
+// The time axis, C leg (the 2026-09-07 lock): a C regression beyond the noise
+// gate on the same machine goes RED, exactly as the cpp leg's has since #194.
+// Both files carry both legs, because the axis is built from both-leg files
+// only; cpp holds its rate, so only the c curve moves.
+func TestCLegRegressionOnTheSameMachineIsRed(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-before.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	writeResults(t, dir, "b-after.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "",
+		rt("cpp", 4500000, "1.00"), rt("c", 3000000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("a C regression did not red (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	for _, want := range []string{
+		"LEDGER RED: c round_trip regressed 46.7% on [arm64 studio 6b213fbfa1a03a99]",
+		"against the axis's recent best",
+		"(227.3 -> 333.3 ns/msg, a-before.csv -> b-after.csv), gate 5.0%",
+		"a perf regression goes red, it does not drift",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("the C regression message lacks %q:\n%s", want, errOut)
+		}
+	}
+}
+
+// The time axis, cpp leg: the check the ledger has always had must survive
+// being generalized over the locked-leg list and over the both-leg filter.
+func TestCppLegRegressionIsStillRed(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-before.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	writeResults(t, dir, "b-after.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "",
+		rt("cpp", 3000000, "1.00"), rt("c", 4400000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("a cpp regression did not red (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if !strings.Contains(errOut, "LEDGER RED: cpp round_trip regressed 50.0% on [arm64 studio 6b213fbfa1a03a99]") {
+		t.Errorf("the cpp regression message changed shape:\n%s", errOut)
+	}
+}
+
+// THE HOLE THE COLD READ FOUND, closed. Comparing only the newest two points
+// on an axis let ONE COMMIT defeat the time axis: land two ~50%-regressed
+// CSVs together and the newest is measured against the other regressed file,
+// so the step between them is ~0% and the gate exits 0 with the axis quietly
+// reset at the worse level. Against the BEST of the previous three points the
+// second file cannot launder the first: both legs go RED. The two later files
+// hold the pair's own ratio exactly (102.3%, inside the 3.0-point floor), so
+// nothing here is the pair lock's doing — this is the time axis alone.
+func TestTwoRegressedFilesInOneCommitCannotResetTheAxis(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-baseline.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	writeResults(t, dir, "b-regressed.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 3000000, "1.00"), rt("c", 2933333, "1.00"))
+	writeResults(t, dir, "c-regressed.csv", "2026-09-02T11:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 3000000, "1.00"), rt("c", 2933333, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 1 {
+		t.Fatalf("two files landing together laundered a 50%% regression (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	for _, want := range []string{
+		"LEDGER RED: c round_trip regressed 50.0% on [arm64 studio 6b213fbfa1a03a99] against the axis's recent best",
+		"a-baseline.csv -> c-regressed.csv",
+		"LEDGER RED: cpp round_trip regressed 50.0% on [arm64 studio 6b213fbfa1a03a99] against the axis's recent best",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("the best-of-window gate did not name what it compared: want %q\n%s", want, errOut)
+		}
+	}
+}
+
+// The time axis is built from BOTH-LEG files only, and this is why: on the
+// Studio the c axis was interleaved with single-leg C experiment CSVs
+// (packet-void-c, c-defaults-c, c-utf8-c, c-wide-c) whose 228 -> 240 ns/msg
+// step is +5.35% against a 5.00% floor gate — so the next single-leg C
+// experiment committed last would have red CI for a difference that is not a
+// regression of the locked pair at all. The lock is a claim about the pair;
+// a file with one leg in it is by construction not a like measurement of it.
+func TestASingleLegExperimentFileIsNotAPointOnTheAxis(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-pass.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	// The committed Studio pair: 228.17 -> 240.38 ns/msg, +5.35% on a 5.0%
+	// gate, and the second file carries the c leg alone.
+	writeResults(t, dir, "b-c-defaults-c.csv", "2026-09-02T10:00:00Z", "studio", "arm64", "",
+		rt("c", 4382609, "1.08"))
+	writeResults(t, dir, "c-c-utf8-c.csv", "2026-09-02T11:00:00Z", "studio", "arm64", "",
+		rt("c", 4160000, "0.88"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("a single-leg C experiment gated the locked pair's axis (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if strings.Contains(errOut, "LEDGER RED") {
+		t.Errorf("a single-leg experiment red the time axis:\n%s", errOut)
+	}
+	// It still appears in the printed series — the ledger prints the record,
+	// it only gates the like-for-like part of it.
+	if !strings.Contains(out, "b-c-defaults-c.csv") || !strings.Contains(out, "c-c-utf8-c.csv") {
+		t.Errorf("the excluded experiments vanished from the printed series:\n%s", out)
+	}
+}
+
+// Absolute rates do not compare across machines (§2), so the same regression
+// split across two hosts is not a regression at all — the axis leads with the
+// machine and each host has one point.
+func TestARegressionAcrossMachinesIsNotAnAxis(t *testing.T) {
+	dir := t.TempDir()
+	writeResults(t, dir, "a-studio.csv", "2026-09-01T10:00:00Z", "studio", "arm64", "OK",
+		rt("cpp", 4500000, "1.00"), rt("c", 4400000, "1.00"))
+	writeResults(t, dir, "b-laptop.csv", "2026-09-02T10:00:00Z", "laptop", "arm64", "OK",
+		rt("cpp", 3000000, "1.00"), rt("c", 2950000, "1.00"))
+	out, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+	if code != 0 {
+		t.Fatalf("the gate compared two machines (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+}
+
+// renderAwk runs the COMMITTED bench/render.awk over one results CSV exactly
+// as the --quick sweep tail and --render invoke it, and returns its table and
+// notes. Nothing is reimplemented here: the point of the test below is that
+// the awk the record is printed with and the Go the record is gated with rule
+// the same way on the same bytes.
+func renderAwk(t *testing.T, file string) string {
+	t.Helper()
+	cmd := exec.Command("awk", "-F,", "-v", "skips=", "-f", "../render.awk", file)
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("render.awk on %s: %v\n%s", file, err, errb.String())
+	}
+	return out.String()
+}
+
+var (
+	awkTie    = regexp.MustCompile(`§2\.8 TIE: c measured ([0-9.]+)% of cpp`)
+	awkRow    = regexp.MustCompile(`(?m)^\s+c\s+([0-9]+)%\s*$`)
+	awkNoFig  = regexp.MustCompile(`§2\.3 INVALID: c spread`)
+	ledgerFig = regexp.MustCompile(`c measured ([0-9.]+)% of cpp in `)
+)
+
+// awkVerdict reads render.awk's ruling on the c row out of its own output:
+// "tie" when §2.8's note fired (c printed 100% and the note carries the
+// measured figure), "refused" when §2.3 made the row print no number at all,
+// and "figure" with the printed percentage otherwise.
+func awkVerdict(t *testing.T, out string) (string, float64) {
+	t.Helper()
+	if awkNoFig.MatchString(out) {
+		return "refused", 0
+	}
+	if m := awkTie.FindStringSubmatch(out); m != nil {
+		return "tie", mustFloat(t, m[1])
+	}
+	if m := awkRow.FindStringSubmatch(out); m != nil {
+		return "figure", mustFloat(t, m[1])
+	}
+	t.Fatalf("render.awk printed no c row at all:\n%s", out)
+	return "", 0
+}
+
+// ledgerVerdict reads the pair lock's ruling on the same sitting out of the
+// check's stderr: silence is "tie" (inside the band, nothing to say), the
+// §2.3 skip is "refused", and a RED or WARN carries the figure.
+func ledgerVerdict(t *testing.T, errOut, base string) (string, float64) {
+	t.Helper()
+	for line := range strings.SplitSeq(errOut, "\n") {
+		if !strings.Contains(line, base) {
+			continue
+		}
+		if strings.Contains(line, "pair-lock skipped") && strings.Contains(line, "§2.3") {
+			return "refused", 0
+		}
+		if m := ledgerFig.FindStringSubmatch(line); m != nil {
+			return "figure", mustFloat(t, m[1])
+		}
+	}
+	return "tie", 0
+}
+
+func mustFloat(t *testing.T, s string) float64 {
+	t.Helper()
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// THE TABLE AND THE GATE MUST AGREE, and the only way to know they do is to
+// run both over the same bytes. render.awk prints the record; the ledger gates
+// it; the 3.0-point tie floor is written out TWICE, once in each language, and
+// §2.3's refusal was written in only one of them until this test was added.
+// So: one sitting inside the band, one outside, one refused by §2.3, and the
+// verdicts have to match on every one.
+func TestRenderAwkAndThePairLockAgreeOnTheSameSitting(t *testing.T) {
+	for _, tc := range []struct {
+		name, file string
+		cpp, c     int
+		cppSp, cSp string
+		want       string // the verdict both tools must reach
+	}{
+		// 102.3% of cpp against the 3.0-point floor: a tie both ways.
+		{"inside the band", "inside.csv", 4500000, 4400000, "1.00", "1.00", "tie"},
+		// 107.1% against the same floor: a real figure both ways.
+		{"outside the band", "outside.csv", 4500000, 4200000, "1.00", "1.00", "figure"},
+		// c's spread is over §2.3's 40% INVALID line. render.awk prints "—"
+		// and refuses a number. The separation is 150% of cpp against a band
+		// of 46.0 points, so a pair lock WITHOUT the §2.3 rule would have gone
+		// RED here on a figure the table declines to print — the exact
+		// disagreement this clause removes.
+		{"refused by §2.3", "invalid-spread.csv", 4500000, 3000000, "1.00", "45.00", "refused"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeResults(t, dir, tc.file, "2026-09-07T10:00:00Z", "studio", "arm64", "OK",
+				rt("cpp", tc.cpp, tc.cppSp), rt("c", tc.c, tc.cSp))
+			aKind, aPct := awkVerdict(t, renderAwk(t, filepath.Join(dir, tc.file)))
+			_, errOut, code := runTool(t, "ledger", "--check", "--dir", dir)
+			lKind, lPct := ledgerVerdict(t, errOut, tc.file)
+			if aKind != tc.want || lKind != tc.want {
+				t.Fatalf("the table and the gate disagree (want %q): render.awk says %q, the ledger says %q\n--- ledger stderr ---\n%s",
+					tc.want, aKind, lKind, errOut)
+			}
+			if tc.want == "figure" {
+				// awk prints the row rounded to whole points, the ledger to
+				// one place; they must name the same measurement.
+				if d := aPct - lPct; d > 0.5 || d < -0.5 {
+					t.Errorf("same sitting, two figures: render.awk %.1f%%, ledger %.1f%%", aPct, lPct)
+				}
+				if code != 1 {
+					t.Errorf("a PASS outside the band did not red (exit %d):\n%s", code, errOut)
+				}
+			}
+			if tc.want != "figure" && code != 0 {
+				t.Errorf("exit %d on a sitting the table publishes no separation for:\n%s", code, errOut)
+			}
+		})
+	}
+}

--- a/bench/tools/relative.go
+++ b/bench/tools/relative.go
@@ -752,7 +752,8 @@ func usage() {
   relative controlmedian control.csv                    corpus-median headline of a control leg (§2.6)
   relative twingate      twin-a.csv twin-b.csv          §2.6.1 A/A twin-leg gate (state-suspect rows exit 4)
   relative bands         current.csv prior.csv [...]    §2.6.1 per-row historical bands (band-break rows exit 5)
-  relative ledger [--check] [--dir DIR]                 the absolute ledger series (#194); --check reds a cpp regression
+  relative ledger [--check] [--dir DIR]                 the absolute ledger series (#194); --check reds a cpp or c
+                                                        regression and a pass that breaks the c/cpp lock (§2.8)
 
 flags (the only escapes; each prints its §3.4/§3.1 caption with the ratio):
   --label-checks    allow ratios across differing checks columns, captioned


### PR DESCRIPTION
Glenn, today: "So we should now be able to lock C and C++ together now in perf and make sure we don't regress."

**What exists.** `go run ./bench/tools ledger --check`, which CI runs, walks the committed CSVs and goes RED when the newest C++ round-trip point on a (machine, corpus) axis regressed beyond the noise gate (max(2 x the two sittings' summed spread, 5%)) against the previous point.

**What changes.** Two teeth. The time axis: `c` joins `cpp` as a locked leg, the check is generic over a list, one gate definition (`noiseGate`), machine-keyed because absolute rates do not compare across machines (§2). The pair axis: every committed CSV carrying both legs' bench_mixed round-trip rows is held to §2.8's tie band, C's percentage of C++ on the best rate against the two spreads summed with the 3.0 floor, computed exactly as render.awk does (the codec guard ported too). A PASS outside the band goes RED: it certifies its window with control legs (§2.6), so the separation is real. A SITTING outside the band WARNS and exits 0: no control legs, no window verdict, so it cannot tell a separation from a drifting box. A pass stamped window INVALID locks nothing, as §2.6 already refuses ratios from it. The tree as it stands is GREEN: every twins pass is inside its band (today's C-asserts pass 105.2% against 8.6 points; the bitpacker pass 106.1% against 8.3; the four-legs passes 99.2 to 106.7), five sittings are outside and warn (three of today's Studio sittings at 106.6 to 109.2%, the x86_64 spacegame at 111.3%, an Air quick sitting at 112.6%), neither leg regressed on the Studio axis. Nothing was tuned to make that true. `make bench-lock` runs a cpp,c twins pass named the driver's way and then the check; bench/README.md's "Locking C and C++ together" says the lock lives in the committed record, the renewing pass must run on the same machine as the previous point, twins are not optional, and there is deliberately no GitHub-hosted-runner benchmark because a shared runner cannot hold a window the standard accepts. BENCH-STANDARD §2.8 gains the dated paragraph. Eight new tests in bench/tools (green inside the band; RED outside with the exact message; the band widening with spreads; a sitting warning; an INVALID window skipped; a C regression RED; a C++ regression still RED; a drop split across two machines not an axis).

**After the read.** The time axis now gates the newest point against the best of the previous three on the axis, so two regressed CSVs landing in one commit cannot reset the baseline (four or more still can, said plainly); the axis is built from files carrying both legs only, which drops the Studio's single-leg C experiment files (a +5.35% step against a 5% gate sat among them) and narrows the pre-existing cpp gate the same way; the pair lock applies §2.3 first (a leg over 40% spread yields no figure, as render.awk prints none); a test runs the committed render.awk over fixtures and requires the same verdict as the ledger, pinning the duplicated 3.0 floor; the scope is stated where the heading is loud: bench_mixed gen round trip on the best rate, bitpacker and write outside it, a bitpacker band not invented here; the README's low end is 99.1.

**Narrowed to the newest certified pass per axis.** The pair lock holds the newest window-OK pass on each (machine, corpus) axis and only that one; older passes print as history, so a pass that recorded a since-fixed finding stays in the record without redding it forever, and a regression from parity reds the moment the pass that shows it is committed. On the tree with #702's read-guard pass present the check is GREEN (the pin pass prints as history outside, the read-guard pass as the held pass inside, 98.2% against 6.5); on the tree as it stands it is RED on the pin pass, which is the instrument working.

**Parity landed (#702), so this lands.** The re-read's four fixes are in: the ci.yml comment, the README's point count (eleven on the Studio), the held-pass wording when a newer pass was refused by §2.3, and a test for that fallback; nineteen tests in bench/tools.

**Named, not hidden.** A `--quick` sitting can show a real C regression as a warning nobody reads; a regression that survives into a pass reds on both teeth. The 3.0 floor lives in awk and Go with nothing enforcing they agree beyond a comment. Who runs the periodic pass on the Studio is the maintainer's call.

**Receipts.** gofmt, go vet, go test ./... (34 packages), modernize, make shape-gate clean; `ledger --check` on the tree exit 0 with the five warnings above.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)