### PR TITLE
The count and the union tag on write become debug asserts; no write-side exception is left, and the spec says so for all nine

### DIFF
--- a/compiler/countedbirth_test.go
+++ b/compiler/countedbirth_test.go
@@ -8,18 +8,20 @@
 // the one wire-legal count a fresh value can carry and an array takes no
 // specified default to name another.
 //
-// The write refuses a count outside the bound in every build. The count guards
-// the element loop and the pack subtracts the low bound, so a count below A
-// wraps and an unchecked write would report success on bytes no reader
-// accepts. It is the one write-side contract that is never a debug-only
-// assert.
+// What the write does with a count outside the bound is a §5 tier question,
+// settled 2026-09-07: "No runtime should ever promise to keep checks in
+// writing packets (asserts) in release build. Removing them is the whole
+// point. ... checks are *DEBUG ONLY*". The count is a writer contract like any
+// other scalar range — it is caught by an assert in debug and gone in release,
+// in every target whose language HAS that idiom. Go and Elixir have none, so
+// they keep the every-build refusal their languages make native.
 //
 // Two claims are pinned here, one per test, so a regression in either is named
 // on its own:
 //
 //  1. the constructed form is born at the declared minimum, in all nine
-//  2. the write path refuses a count outside the bound in EVERY build mode, in
-//     all nine, never through an assert the build can remove
+//  2. the write path holds the count in its target's own debug-only idiom
+//     where the language has one, and refuses in every build where it does not
 package compiler
 
 import (
@@ -67,36 +69,49 @@ var bornAtMinimum = map[string]string{
 	"rust":   "value.window_count = 2;",
 }
 
-// refusesEveryBuild is the write path's unconditional range refusal in each
-// target's own spelling. Every target refuses through its own convention, an
-// error-returning runtime in Go, Rust and C#, an always-on raise in Elixir,
-// and a plain failure return in C, C++, Dart, Java and JavaScript.
+// refusesEveryBuild is the write path's UNCONDITIONAL range refusal, for the
+// targets that still hold the count that way. Go and Elixir are here by the
+// ruling — "For each language, do not force this in. If the language simply
+// doesn't have this concept (Golang) then it is not something we can do" — an
+// error-returning runtime in Go, an always-on raise in Elixir. Rust and C# are
+// here only until their own emitter changes land; they move to
+// assertsInDebug then, alongside every other write check in those backends.
 var refusesEveryBuild = map[string][]string{
-	"c": {"if ( value->window_count < 2 || value->window_count > 8 )", "return 0;"},
-	"cpp": {
-		"if ( int32_t( value.window_count ) < int32_t( 2 ) || int32_t( value.window_count ) > int32_t( 8 ) )",
-		"return false;",
-	},
 	"cs":     {"if (value.WindowCount < 2 || value.WindowCount > 8)"},
-	"dart":   {"if (value.windowCount < 2 || value.windowCount > 8) {", "return -1;"},
 	"elixir": {"if n < 2 do", "if n > 8 do", "raise ArgumentError"},
 	"go":     {"if value.WindowCount < 2 || value.WindowCount > 8 {", "return serialize.ErrValueOutOfRange"},
-	"java":   {"if (value.windowCount < 2 || value.windowCount > 8) {", "return -1;"},
-	"js":     {"if (value.WindowCount < 2 || value.WindowCount > 8) {", "return -1;"},
 	"rust":   {"if value.window_count < 2 || value.window_count > 8 {", "return Err("},
 }
 
+// assertsInDebug is the count's DEBUG-ONLY form in each target that has one:
+// the exact text the writer emits, in that target's own assert idiom.
+var assertsInDebug = map[string][]string{
+	"c":    {"serialize_assert( value->window_count >= 2 && value->window_count <= 8 );"},
+	"cpp":  {"serialize_assert( int32_t( value.window_count ) >= int32_t( 2 ) && int32_t( value.window_count ) <= int32_t( 8 ) );"},
+	"dart": {"assert(value.windowCount >= 2);", "assert(value.windowCount <= 8);"},
+	"java": {"assert value.windowCount >= 2;", "assert value.windowCount <= 8;"},
+	// js is not here: its debug-only idiom is not an assert statement but the
+	// PRODUCTION/checked fork of the flat writer, checked separately below.
+}
+
+// goneFromRelease is the every-build refusal each assert target used to carry.
+// None of it may survive: an assert BESIDE a live refusal removes nothing.
+var goneFromRelease = map[string][]string{
+	"c": {"if ( value->window_count < 2 || value->window_count > 8 )"},
+	"cpp": {
+		"if ( int32_t( value.window_count ) < int32_t( 2 ) || int32_t( value.window_count ) > int32_t( 8 ) )",
+	},
+	"dart": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
+	"java": {"if (value.windowCount < 2 || value.windowCount > 8) {"},
+}
+
 // assertToken is the build-removable predicate each target spells its writer
-// contracts with. None of them may reach the count.
+// contracts with. For a refusesEveryBuild target, none of them may reach the
+// count.
 var assertToken = map[string][]string{
-	"c":      {"serialize_assert"},
-	"cpp":    {"serialize_assert"},
 	"cs":     {"Debug.Assert"},
-	"dart":   {"assert("},
 	"elixir": nil, // the BEAM has no compile-out assert, so the raise is always on
 	"go":     nil, // the runtime returns an error, in every build
-	"java":   {"assert "},
-	"js":     {"assert("},
 	"rust":   {"debug_assert", "assert!"},
 }
 
@@ -116,6 +131,23 @@ func generatedText(t *testing.T, src, target string) string {
 	return all.String()
 }
 
+// jsFlatWriter slices one named function out of the JavaScript flat codec.
+// JavaScript's debug-only idiom is the emitted fork, not a statement: the
+// checked writer holds the contract and the production writer holds none, and
+// `PRODUCTION ? production : checked` picks between them at import time.
+func jsFlatWriter(t *testing.T, text, fn string) string {
+	t.Helper()
+	i := strings.Index(text, "function "+fn+"(")
+	if i < 0 {
+		t.Fatalf("js: %s is not emitted; the flat writer fork is gone", fn)
+	}
+	rest := text[i+1:]
+	if before, _, ok := strings.Cut(rest, "\nfunction "); ok {
+		return before
+	}
+	return rest
+}
+
 // CLAIM 1. A [A..B] count is born at A in every target: the one wire-legal
 // count a fresh value can carry, since an array takes no specified default to
 // name another one.
@@ -132,18 +164,46 @@ func TestCountedArrayIsBornAtItsDeclaredMinimum(t *testing.T) {
 	}
 }
 
-// CLAIM 2. The write path refuses a count outside its bound in every build
-// mode. The count guards the element loop and the pack subtracts the low
-// bound, so a count below the minimum wraps, and a build that drops the check
-// would write bytes no reader accepts and report success.
-func TestCountOutsideItsWireRangeIsRefusedInEveryBuild(t *testing.T) {
+// CLAIM 2. The count is a write-side contract and nothing more. Where the
+// language has a debug-only idiom the writer holds it there and release
+// carries nothing; where the language has none the writer refuses in every
+// build, because forcing an idiom the language lacks would not be native.
+func TestCountOnWriteIsDebugOnlyWhereTheLanguageHasThatIdiom(t *testing.T) {
 	for _, target := range New().Targets() {
-		wants, known := refusesEveryBuild[target]
-		if !known {
-			t.Errorf("target %q has no refusal claim here. A new backend landed and this gate was not told", target)
+		text := generatedText(t, countedAboveZero, target)
+
+		if target == "js" {
+			// the fork, not a statement: the contract lives in the checked
+			// writer and the production writer is free of it
+			const want = "value.WindowCount < 2 || value.WindowCount > 8"
+			if got := jsFlatWriter(t, text, "writeTFlatChecked"); !strings.Contains(got, want) {
+				t.Errorf("js: the checked flat writer does not hold the count, %q absent", want)
+			}
+			if got := jsFlatWriter(t, text, "writeTFlatProduction"); strings.Contains(got, want) {
+				t.Errorf("js: the PRODUCTION flat writer still holds the count: %q survives release", want)
+			}
 			continue
 		}
-		text := generatedText(t, countedAboveZero, target)
+
+		if wants, ok := assertsInDebug[target]; ok {
+			for _, want := range wants {
+				if !strings.Contains(text, want) {
+					t.Errorf("%s: the count is not held by a debug assert, %q not emitted", target, want)
+				}
+			}
+			for _, gone := range goneFromRelease[target] {
+				if strings.Contains(text, gone) {
+					t.Errorf("%s: the count still carries an every-build refusal that release cannot drop: %s", target, gone)
+				}
+			}
+			continue
+		}
+
+		wants, known := refusesEveryBuild[target]
+		if !known {
+			t.Errorf("target %q has no count claim here. A new backend landed and this gate was not told", target)
+			continue
+		}
 		for _, want := range wants {
 			if !strings.Contains(text, want) {
 				t.Errorf("%s: the count's range refusal is absent, %q not emitted", target, want)

--- a/compiler/uniontagwrite_test.go
+++ b/compiler/uniontagwrite_test.go
@@ -1,0 +1,145 @@
+// A UNION TAG ON WRITE (SPEC §4.8): what each target does when the tag in
+// storage names no arm.
+//
+// It had been argued that the tag is DISPATCH rather than a guard — an
+// out-of-set tag selects no arm, so the switch's own `default` may refuse in
+// every build without breaking §5's tiers. That argument is retired
+// (2026-09-07): "consistency matters. writing packets correctness is the
+// caller's responsibility, and it is our duty to catch it with asserts in
+// debug." The tag in storage is a value the CALLER put there, exactly like a
+// count past its bound, so it takes §5's tiers whole — debug-only wherever
+// the language has the idiom, every-build only where it has none.
+//
+// The claim pinned here is the WRITE side. The read's refusal of a tag above
+// the count is every-build in all nine and is not this gate's subject.
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// unionTagUnit is the smallest unit that reaches the case: one union, and one
+// struct holding it so the inlining backends (JavaScript's flat tier, Dart,
+// Java) emit their field form too.
+const unionTagUnit = `package tagunit
+
+type Laser
+{
+    power [0..7]uint32
+}
+
+type Missile
+{
+    fuel [0..7]uint32
+}
+
+union Shot
+{
+    laser Laser
+    missile Missile
+}
+
+type Volley
+{
+    shot Shot
+}
+`
+
+// tagAssertsInDebug is the tag's DEBUG-ONLY form in each target that has one:
+// the exact text the writer emits, in that target's own assert idiom.
+var tagAssertsInDebug = map[string][]string{
+	"c":    {"serialize_assert( value->type <= SHOT_TYPE_MAX );"},
+	"cpp":  {"serialize_assert( value.type <= ShotType::Max );"},
+	"dart": {"assert(value.type >= 0);", "assert(value.type <= 2);"},
+	"java": {"assert (value.type & 0xffL) >= 0;", "assert (value.type & 0xffL) <= 2;"},
+	// js is not here: its debug-only idiom is the PRODUCTION/checked fork of
+	// the flat writer, not a statement. Checked separately below.
+}
+
+// tagGoneFromRelease is the every-build refusal C and C++ used to carry. An
+// assert BESIDE a live refusal removes nothing, so none of it may survive.
+var tagGoneFromRelease = map[string][]string{
+	"c":   {"if ( value->type > SHOT_TYPE_MAX )", "not a ShotType value; nothing was written"},
+	"cpp": {"not a ShotType value; nothing was written"},
+}
+
+// tagRefusesEveryBuild is the write's UNCONDITIONAL tag refusal, for the
+// targets that still hold it that way. Go and Elixir are here by the ruling —
+// a language with no dormant-assert idiom keeps the form native to it. C# is
+// here only until PR #697's emitter change lands on this tree; it moves to
+// tagAssertsInDebug then, with every other write check in that backend.
+var tagRefusesEveryBuild = map[string][]string{
+	"cs":     {"if (tagValue > 2)"},
+	"elixir": {`raise ArgumentError, "value.type is above the wire maximum"`},
+	"go":     {"if tagValue < 0 || tagValue > 2 {"},
+}
+
+// CLAIM. The union tag is a write-side contract and nothing more: held by the
+// target's own debug-only idiom where the language has one, refused in every
+// build only where it has none, and needing no check at all in Rust, whose
+// tag IS the enum discriminant.
+func TestUnionTagOnWriteIsDebugOnlyWhereTheLanguageHasThatIdiom(t *testing.T) {
+	for _, target := range New().Targets() {
+		text := generatedText(t, unionTagUnit, target)
+
+		switch {
+		case target == "js":
+			// the fork, not a statement: the contract lives in the checked
+			// flat writer and the production writer is free of it
+			const want = "value.Shot.Type < 0 || value.Shot.Type > 2"
+			if got := jsFlatWriter(t, text, "writeVolleyFlatChecked"); !strings.Contains(got, want) {
+				t.Errorf("js: the checked flat writer does not hold the tag, %q absent", want)
+			}
+			if got := jsFlatWriter(t, text, "writeVolleyFlatProduction"); strings.Contains(got, want) {
+				t.Errorf("js: the PRODUCTION flat writer still holds the tag: %q survives release", want)
+			}
+
+		case target == "rust":
+			// an out-of-set tag cannot be BUILT: Shot is a Rust enum and the
+			// tag is its discriminant, so write_shot is a total match with
+			// nothing to assert
+			body := rustFn(t, text, "write_shot")
+			if strings.Contains(body, "assert") {
+				t.Errorf("rust: write_shot carries a tag assert, and the enum already makes an out-of-set tag unrepresentable:\n%s", body)
+			}
+
+		case tagAssertsInDebug[target] != nil:
+			for _, want := range tagAssertsInDebug[target] {
+				if !strings.Contains(text, want) {
+					t.Errorf("%s: the tag is not held by a debug assert, %q not emitted", target, want)
+				}
+			}
+			for _, gone := range tagGoneFromRelease[target] {
+				if strings.Contains(text, gone) {
+					t.Errorf("%s: the tag still carries an every-build refusal that release cannot drop: %s", target, gone)
+				}
+			}
+
+		case tagRefusesEveryBuild[target] != nil:
+			for _, want := range tagRefusesEveryBuild[target] {
+				if !strings.Contains(text, want) {
+					t.Errorf("%s: the tag's every-build refusal is gone, %q not emitted. If that backend moved to an assert, move it here", target, want)
+				}
+			}
+
+		default:
+			t.Errorf("target %q has no union-tag claim here. A new backend landed and this gate was not told", target)
+		}
+	}
+}
+
+// rustFn slices one named Rust function out of the generated text, so a claim
+// about write_shot is not answered by an assert somewhere else in the file.
+func rustFn(t *testing.T, text, fn string) string {
+	t.Helper()
+	i := strings.Index(text, "pub fn "+fn+"(")
+	if i < 0 {
+		t.Fatalf("rust: %s is not emitted", fn)
+	}
+	rest := text[i+1:]
+	if before, _, ok := strings.Cut(rest, "\npub fn "); ok {
+		return before
+	}
+	return rest
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -277,13 +277,17 @@ it holds in all nine languages.
 On the write side each language uses its own correctness idiom: C++ and C
 have `assert`/`NDEBUG`, a check that disappears in release, so that is what
 they use;
-Go has no assert idiom, so it returns `ErrValueOutOfRange`, and C#, Rust
-and JavaScript likewise return failure rather than invent an assert; Dart
-and Java have `assert`, so like C++ they assert; and the BEAM has no dormant
-assert at all, so Elixir raises `ArgumentError` in every build. A
-language should verify correctness the way that language verifies
-correctness — which means the write side is not uniform across targets, and you
-should not build on it. Keep values inside
+Go has no assert idiom, so it returns `ErrValueOutOfRange`, and the BEAM has
+no dormant assert at all, so Elixir raises `ArgumentError` in every build.
+Those two are the only every-build write side of the nine. The other seven
+are debug-only: C# through `Debug.Assert`, Rust through `debug_assert!`,
+Dart and Java through the language's own `assert`, and JavaScript through
+the checked/production fork its flat writers take at load. (Implementation
+note, 2026-09-07: Rust and C# reach that form in the two changes landing the
+same day, schema#696 and schema#697; until they merge, their emitters still
+refuse on the write in every build.) A language should verify correctness
+the way that language verifies correctness — which means the write side is
+not uniform across targets, and you should not build on it. Keep values inside
 their declared bounds when you write them — your code already knows they are,
 and in a game shipping at 60 Hz re-checking every field on the write path is a
 cost with no buyer. See

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -149,14 +149,20 @@ construction. The Rust `-O2` leg is a named harness gap.
 it.** C++ compiles its debug asserts and bounds checks out; **so does C, from 2026-09-07** —
 the ruling was "Every language, by design, compiles out asserts/checks in release build. This
 is the whole point!", and the C backend's per-field write-side range and bounds refusals
-became `serialize_assert`s that vanish under `NDEBUG`, the tier C++'s are in (C still asserts
-less than C++ in two places, a flags value wider than its wire width and interior nulls in a
-`string(N)` on write; those are the next change). Two write-side checks stay in every build in
-both, because the spec mandates them in all nine targets: a counted array's count outside
-`[A, B]` (SPEC §4.6) and a union tag outside its variant set (§4.8); every read-side check
-stays in every build everywhere, by the other half of the same ruling. Rust, C# and Go carry bounds,
-range and sticky-error checks in every build by contract. A ratio between two of those columns
-includes the price of a different promise.
+became `serialize_assert`s that vanish under `NDEBUG`, the tier C++'s are in. The same day the
+last exception went with them: a counted array's count outside `[A, B]` (SPEC §4.6) had been
+refused in every build in all nine targets, and is now a debug assert wherever the language
+has that idiom — "checks are *DEBUG ONLY*" — so a C or C++ release build now holds NO
+write-side range check at all. C's two remaining gaps closed in the same change, a flags value
+wider than its wire width and interior nulls in a `string(N)` on write, so the C and C++
+write-side check sets are identical. NO write-side check stays in every build in either: the
+union tag outside its variant set (§4.8) was the last structural holdout — it had been argued
+to be dispatch rather than a guard — and it too is a `serialize_assert` now, so a C or C++
+release build performs no write-side validation whatsoever. Every
+read-side check stays in every build everywhere, by the other half of the same ruling: "Of
+course, on read side we MUST always do the checks!" Rust, C# and Go carry bounds, range and
+sticky-error checks in every build by contract, Rust's and C#'s pending their own change. A
+ratio between two of those columns includes the price of a different promise.
 
 **Measured the same day, the C change bought nothing the instrument can see.** A twins pass on
 the C and C++ legs with the asserts in place

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1358,18 +1358,32 @@ All compile errors with positions:
   own range at rest. The element range above is a different bound and still
   must reach zero.
 
-  **A count outside [A, B] is refused by the WRITE in every build, in all
-  nine targets.** That is not a compile error but the other half of the same
-  rule, and it is stated here because it is the rule generated code cites. It is the one write-side
-  contract that is never a debug-only
-  assert (§5). The count guards the element loop and the pack subtracts the
-  low bound, so a count below A wraps to a large unsigned value and the write
-  would otherwise report success on bytes no reader accepts. Each target
-  refuses in its own convention: C `0`, C++ and C# `false`, Dart and Java
-  `-1`, Go `serialize.ErrValueOutOfRange`, Rust
-  `Err(serialize::Error::ValueOutOfRange)`, Elixir `ArgumentError`, and
-  JavaScript `false` from the stream writer and `-1` from BOTH tiers of the
-  flat writer, the production tier included.
+  **A count outside [A, B] on the WRITE is caller error, and it is a
+  write-side contract like every other (§5).** That is not a compile error
+  but the other half of the same rule, and it is stated here because it is
+  the rule generated code cites. The count guards the element loop and the
+  pack subtracts the low bound, so a count below A wraps to a large unsigned
+  value, and a release build then drives the element loop over a
+  fixed-capacity array with nothing left to stop it: a bad count is an
+  out-of-bounds READ of the caller's array and an out-of-bounds WRITE of the
+  stream buffer, whose capacity serialize.h makes the writer's contract
+  (issue #52). That is the same exposure a `string(N)` or a `bytes(N)` length
+  past its bound already carries, and it is the ruling's intent rather than
+  an oversight of it — the debug build's assert is where a bad count is meant
+  to be caught, which is why every target catches it there and why no target
+  catches it in release. What such a write leaves on the wire, where it
+  completes at all, is DEFINED BUT UNSPECIFIED: a reader may refuse it, or
+  may accept some other message.
+  Settled 2026-09-07: "consistency matters. writing packets
+  correctness is the caller's responsibility, and it is our duty to catch it
+  with asserts in debug." So the count asserts in DEBUG ONLY in each target
+  whose language has that idiom — `serialize_assert` in C++ and C,
+  `debug_assert!` in Rust, `Debug.Assert` in C#, `assert` in Java and Dart,
+  and the checked side of JavaScript's checked/production fork — and is
+  refused in every build only where the language has no such idiom: Go
+  returns `serialize.ErrValueOutOfRange` and Elixir raises `ArgumentError`.
+  The READ is untouched: a decoded count outside [A, B] fails the read in
+  every build, in all nine.
 - **Attribute discipline:** an unknown attribute key, a key repeated, an
   attribute on a type that does not take it, `min` without `max` (or vice
   versa), and `resolution` without both bounds are compile errors, each
@@ -1691,8 +1705,20 @@ union Value
   **rejects a tag above the count** — refusal, never clamping, the ranged-
   integer rule. MaxBits = tag bits + the largest payload's MaxBits; a union
   no arm of which carries a payload has MaxBits equal to its tag bits.
-  `Write<Union>` validates the tag BEFORE it rides — an out-of-set tag
-  value in storage writes nothing and fails, it never desyncs the stream.
+  `Write<Union>` ASSERTS the tag before it rides. An out-of-set tag value in
+  storage is caller error like every other write-side value, and it follows
+  §5's tiers exactly: a debug-only assert wherever the language has the
+  idiom (C++, C, C#, Java, Dart, and JavaScript's flat fork), unrepresentable
+  in Rust because the tag IS the enum discriminant, and an every-build
+  refusal only in Go and Elixir, where every write contract is every-build.
+  What a release build handed an out-of-set tag writes is DEFINED BUT
+  UNSPECIFIED, and not bytes every reader is guaranteed to refuse: no arm is
+  selected, so the payload the tag names never rides, but C++ writes no tag
+  bits at all while C writes the tag unmasked — a 2-bit tag holding 4 rides
+  as `00`, a legal `None`, with the spilled bit landing in whatever follows.
+  A shifted-but-legal parse is reachable from either. That is the caller's
+  responsibility, not the writer's to check. The READ rejects a tag above the
+  count in EVERY build, in all nine.
 - **Selection uses ordinary construction (§4.2).** Selecting an arm with a
   payload constructs it with the declared defaults, recursively. Application
   code initializes the payload before populating it and setting its tag;
@@ -2155,37 +2181,75 @@ readers face untrusted data and keep every mandated check above.
 
 Within that doctrine, misuse surfaces by each target's own convention — a
 language verifies correctness the way that language verifies correctness —
-and the list is exhaustive at all nine. **Four debug-assert**, unchecked in
-release: C++ and C through `serialize_assert`, Dart and Java through the
-language's own `assert`, live under `--enable-asserts` and `-ea` (Java's
-contracts ride one `check<Name>` predicate call, so a dormant assert costs
-the JIT one inlining slot rather than a body). C's generated writes asserted
-from 2026-09-07, on the ruling "Every language, by design, compiles out
-asserts/checks in release build. This is the whole point!" — C has `assert`
-and `NDEBUG`, so the tier it belongs in is the one C++ is in. **One raises in every
-build**: Elixir's `ArgumentError`, the BEAM having no dormant assert to
-compile out. **Four return failure from the write** rather than invent an
-assert their language does not have: C# and JavaScript `false`, Go
-`serialize.ErrValueOutOfRange`, Rust `Err(serialize::Error::ValueOutOfRange)`
-— and JavaScript's flat tier, which forks checked/production at module load
-(§6.1), refuses with `-1` on the checked side and trusts the caller on the
-production one. **No target panics and none throws**: Elixir's raise is the
-only unwinding path in the nine, and it is the BEAM's own.
+and the list is exhaustive at all nine. **Seven are DEBUG ONLY**, gone from
+release: C++ and C through `serialize_assert` under `NDEBUG`, Rust through
+`debug_assert!`, C# through `Debug.Assert` and `[Conditional("DEBUG")]`, Java
+and Dart through the language's own `assert` under `-ea` and
+`--enable-asserts` (Java's contracts ride one `checkWrite<Name>` predicate
+call, so a dormant assert costs the JIT one inlining slot rather than a
+body), and JavaScript through the checked/production fork its flat writers
+take at module load (§6.1) — the checked writer refuses with `-1`, the
+production writer holds nothing. **Two hold in EVERY BUILD**, because their
+languages have no debug-only idiom to compile out: Go returns
+`serialize.ErrValueOutOfRange` and Elixir raises `ArgumentError`. That is
+deliberate, not an oversight — "For each language, do not force this in. If
+the language simply doesn't have this concept (Golang) then it is not
+something we can do. ... The bottom line is that a user of schema/serialize
+in that languages should feel that the implementation is native to their
+language and how it is used in best practice." (2026-09-07). **No target
+panics and none throws**: Elixir's raise is the only unwinding path in the
+nine, and it is the BEAM's own.
 
-**The tier split has exactly one stated exception, and it is a counted
-array's COUNT.** A count outside its declared `[A, B]` is refused by the
-write IN EVERY BUILD in all nine targets, so C++, C, Dart and Java refuse it
-from the write rather than through the assert their other contracts ride,
-and JavaScript's flat production tier refuses it rather than trusting the
-caller. The count is not a diagnostic: it guards the element loop and the
-pack subtracts the low bound, so a count below A wraps and an unchecked
-write reports success on bytes no reader accepts (§4.6). Every other
-write-side contract in this section keeps the tiers above.
+**Implementation note, 2026-09-07.** The Rust and C# backends reach the form
+stated above in the two changes landing the same day (schema#696 for Rust,
+schema#697 for C#); until they merge, their emitters still refuse on the
+write in every build. This note is removed by the second of them.
+
+**There is no exception to the tier split.** Settled 2026-09-07: "No runtime
+should ever promise to keep checks in writing packets (asserts) in release
+build. Removing them is the whole point. ... checks are *DEBUG ONLY*". A
+counted array's COUNT (§4.6) and a union's TAG (§4.8) were the last two
+write-side checks this section held outside the tiers — one by contract, one
+by structure — and neither is one now. Both are writer contracts like every
+other range, asserted in debug and gone in release wherever the language has
+the idiom, and every-build only in Go and Elixir, where every other write
+contract is every-build too. What a release build writes is the
+caller's responsibility, in all nine. (One implementation note, not a rule:
+JavaScript's STREAM tier still refuses from the write in both modes for
+every contract it holds, the count included; the fork the flat tier already
+takes lands there with that tier's own change.)
+
+**A union tag outside its variant set is one of these contracts too, and it
+takes the same tiers.** It had been argued the other way — that dispatch is
+not a guard, so the `switch`'s own `default` may refuse in every build — and
+that argument is retired: the rule has no structural exception any more than
+it has a per-contract one. An out-of-set tag in storage is a value the
+CALLER put there, exactly like a count past its bound or an int outside its
+range, so the write ASSERTS it in debug wherever the language has the idiom
+(C++ and C through `serialize_assert`, C# through `Debug.Assert`, Java and
+Dart through `assert`, JavaScript's flat writers through the checked/
+production fork) and does not check it in release. Rust needs no check at
+all: its tag IS the enum discriminant, so an out-of-set tag cannot be built.
+Go and Elixir keep the every-build refusal, for the same reason they keep
+every other one. What a release build does with an out-of-set tag is defined
+but unspecified — no arm is selected, so the arm's payload never rides, but
+C++ writes no tag bits at all and C writes the tag unmasked, so a reader may
+refuse the result or may accept some other message (§4.8). The READ refuses
+an out-of-set tag in EVERY build, in all nine, and that is the half that
+faces untrusted bytes.
+
+**None of this reaches the read side.** "Of course, on read side we MUST
+always do the checks!" (2026-09-07). Every read-side refusal §4 and this
+section name — ranges, counts, bounds, wire constants, reserved bits, enum
+values, union tags, UTF-8 in `string(N)` and UTF-16 in `wstring(N)` — runs
+in EVERY BUILD MODE in all nine targets, and a refusal is terminal. Readers
+face untrusted bytes; writers do not.
 
 The generated
 write code's job is to
-make misuse impossible by construction — bounds come from the schema. Costlier contracts
-assert in DEBUG ONLY, and only where a target carries one at all. Text
+make misuse impossible by construction — bounds come from the schema. Every
+write-side contract
+asserts in DEBUG ONLY, and only where a target carries the idiom at all. Text
 well-formedness is not one of them. UTF-8 in `string(N)` and UTF-16 in
 `wstring(N)` are READ-side refusals in every target (§4.7, §4.12), so the
 guarantee rests on the reader rather than on a write-side check some

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1118,10 +1118,7 @@ struct T {
 ```cpp
 SCHEMA_WRITE_INLINE bool WriteT( serialize::WriteStream & stream, const T & value )
 {
-    if ( int32_t( value.window_count ) < int32_t( 2 ) || int32_t( value.window_count ) > int32_t( 8 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.window_count ) >= int32_t( 2 ) && int32_t( value.window_count ) <= int32_t( 8 ) );
     write_bits( stream, uint32_t( value.window_count ) - uint32_t( 2 ), 3 );
 ```
 
@@ -1134,14 +1131,22 @@ name a birth value another way. The bound names it instead. This is the one
 place in the language where storage starts at something other than zero without
 a declaration saying so, and `[..8]` is born at 0 like everything else.
 
-The write refuses an out-of-range count in **every build**, release included.
-It is not an assert and there is no build flag that removes it. The reason is
-the line under it: the pack subtracts the low bound, so `window_count = 0`
-would wrap `0 - 2` to a large unsigned value, and the loop below writes
-`window_count` elements. An unchecked write would report success on bytes no
-reader takes. Every one of the nine targets refuses it, each in its own
-convention, among them `false` here, `0` in C, `-1` in Dart and Java,
-`ErrValueOutOfRange` in Go, an `ArgumentError` in Elixir.
+The write **asserts** the count in debug and carries nothing in release, the
+same tier every other writer contract rides (SPEC.md §5). Look at the line
+under it for why the assert is worth having: the pack subtracts the low
+bound, so `window_count = 0` wraps `0 - 2` to a large unsigned value, and the
+loop below reads that many elements past the caller's array and writes them
+into the stream: defined, unspecified, and the caller's bug. Writing correctly is the caller's job, and
+the assert is there to catch you in debug before you ship it. Seven targets
+assert (`serialize_assert` in C++ and C, `debug_assert!` in Rust,
+`Debug.Assert` in C#, `assert` in Java and Dart, the checked writer in
+JavaScript); Go returns `ErrValueOutOfRange` and Elixir raises an
+`ArgumentError` in every build, because neither language has a debug-only
+idiom worth faking. (Implementation note, 2026-09-07: Rust and C# reach that
+form in the two changes landing the same day, schema#696 and schema#697;
+until they merge, their emitters still refuse on the write in every build.)
+And the READ refuses a bad count in every build, in all nine — that side is
+never trusted.
 
 Reach for `[A..B]` with A above zero wherever the count genuinely has a floor.
 The tool holds both ends of it for you.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -541,9 +541,8 @@ int32_t name_length = 0;
 ```
 
 The write holds embedded NULs and any length past the maximum in its
-target's own §5 idiom (C++ asserts both, dormant under `NDEBUG`; C's
-runtime asserts the length and C does not yet scan for the NUL), and the
-read validates both in every build. In C and C++ a successful read also writes the zero
+target's own §5 idiom (C++ and C both assert both, dormant under `NDEBUG`),
+and the read validates both in every build. In C and C++ a successful read also writes the zero
 byte at `name[name_length]`, so `name` is a valid C string every time the
 read succeeds, which is what the `+ 1` in the array is for. The other seven
 targets carry the buffer and the used length with nothing written past it.
@@ -643,11 +642,17 @@ outside that count's own wire range, so a fresh value would otherwise carry a
 count no reader accepts. It is the one place storage starts at something other
 than zero without a declared default, and `[..N]` is born at 0 as usual.
 
-Writing a count outside its bound is **refused in every build**, in all nine
-targets, and it is the one write-side contract that is never a debug-only
-assert. The count guards the element loop and the pack subtracts the low
-bound, so an unchecked out-of-range count would wrap and report a successful
-write of bytes no reader takes.
+Writing a count outside its bound is **caller error**, and it is a write-side
+contract like every other (SPEC.md §5): it asserts in DEBUG in each target
+whose language has that idiom, and is refused in every build only in Go and
+Elixir, which have none. (Implementation note, 2026-09-07: Rust and C# reach
+that form in the two changes landing the same day, schema#696 and schema#697;
+until they merge, their emitters still refuse on the write in every build.)
+The count guards the element loop and the pack subtracts the low bound, so
+an out-of-range count wraps and a release build will happily write bytes no
+reader takes — which is why the debug assert is worth having, and why
+keeping the count in range is your job. The READ refuses an out-of-range
+count in every build, in all nine.
 
 ### Composition
 

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -704,6 +705,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_entity( serialize_wri
     {
         return 0;
     }
+    serialize_assert( value->damage < ( 1ULL << 8 ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->damage, 8 ) )
     {
         return 0;
@@ -1077,10 +1079,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_pickup_event( serialize
 /* Writes MixedEvent. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_event( serialize_write_stream_t * stream, const MixedEvent * value )
 {
-    if ( value->type > MIXED_EVENT_TYPE_MAX )
-    {
-        return 0; /* not a MixedEventType value; nothing was written */
-    }
+    serialize_assert( value->type <= MIXED_EVENT_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -1198,10 +1197,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
             return 0;
         }
     }
-    if ( value->entities_count < 1 || value->entities_count > 8 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->entities_count >= 1 && value->entities_count <= 8 );
     if ( !serialize_write_int( stream, value->entities_count, 1, 8 ) )
     {
         return 0;
@@ -1216,10 +1212,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
             }
         }
     }
-    if ( value->stats_count < 0 || value->stats_count > 80 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->stats_count >= 0 && value->stats_count <= 80 );
     if ( !serialize_write_int( stream, value->stats_count, 0, 80 ) )
     {
         return 0;
@@ -1246,6 +1239,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
             {
                 return 0;
             }
+        }
+    }
+    {
+        int32_t i;
+        for ( i = 0; i < value->player_name_length; i++ )
+        {
+            serialize_assert( value->player_name[i] != 0 ); /* interior null on write (SPEC §4.7) */
         }
     }
     if ( !serialize_write_int( stream, value->player_name_length, 0, 15 ) )

--- a/generated/bench/c/RealWorldWire.h
+++ b/generated/bench/c/RealWorldWire.h
@@ -24,9 +24,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -484,6 +485,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
+    serialize_assert( value->f091_flags < ( 1ULL << 5 ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->f091_flags, 5 ) )
     {
         return 0;

--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -387,6 +387,7 @@ SCHEMA_READ_INLINE bool ReadMixedPickupEvent( serialize::ReadStream & stream, Mi
 
 SCHEMA_WRITE_INLINE bool WriteMixedEvent( serialize::WriteStream & stream, const MixedEvent & value )
 {
+    serialize_assert( value.type <= MixedEventType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case MixedEventType::None:
@@ -404,7 +405,7 @@ SCHEMA_WRITE_INLINE bool WriteMixedEvent( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a MixedEventType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadMixedEvent( serialize::ReadStream & stream, MixedEvent & value )
@@ -446,10 +447,7 @@ SCHEMA_WRITE_INLINE bool WriteBenchMixed( serialize::WriteStream & stream, const
         int32_t fixed_value = value.server_time;
         write_fixed( stream, fixed_value, 24, 8, 0, 65535 );
     }
-    if ( int32_t( value.entities_count ) < int32_t( 1 ) || int32_t( value.entities_count ) > int32_t( 8 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.entities_count ) >= int32_t( 1 ) && int32_t( value.entities_count ) <= int32_t( 8 ) );
     write_bits( stream, uint32_t( value.entities_count ) - uint32_t( 1 ), 3 );
     for ( int32_t i = 0; i < value.entities_count; i++ )
     {
@@ -458,10 +456,7 @@ SCHEMA_WRITE_INLINE bool WriteBenchMixed( serialize::WriteStream & stream, const
             return false;
         }
     }
-    if ( int32_t( value.stats_count ) < int32_t( 0 ) || int32_t( value.stats_count ) > int32_t( 80 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.stats_count ) >= int32_t( 0 ) && int32_t( value.stats_count ) <= int32_t( 80 ) );
     write_bits( stream, uint32_t( value.stats_count ), 7 );
     for ( int32_t i = 0; i < value.stats_count; i++ )
     {

--- a/generated/bench/dart/Bench.dart
+++ b/generated/bench/dart/Bench.dart
@@ -196,8 +196,7 @@ void initBenchPacket(BenchPacket value) {
 
 // writeBenchPacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// benchPacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// benchPacketMaxBytes. Returns the bytes written.
 int writeBenchPacket(BenchPacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= benchPacketMaxBytes);
@@ -510,8 +509,7 @@ void initBenchInts(BenchInts value) {
 
 // writeBenchInts packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// benchIntsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// benchIntsMaxBytes. Returns the bytes written.
 int writeBenchInts(BenchInts value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= benchIntsMaxBytes);
@@ -712,8 +710,7 @@ void initBenchBits(BenchBits value) {
 
 // writeBenchBits packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// benchBitsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// benchBitsMaxBytes. Returns the bytes written.
 int writeBenchBits(BenchBits value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= benchBitsMaxBytes);
@@ -1047,8 +1044,7 @@ void initMixedEntity(MixedEntity value) {
 
 // writeMixedEntity packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedEntityMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedEntityMaxBytes. Returns the bytes written.
 int writeMixedEntity(MixedEntity value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedEntityMaxBytes);
@@ -1248,8 +1244,7 @@ void initMixedStat(MixedStat value) {
 
 // writeMixedStat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedStatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedStatMaxBytes. Returns the bytes written.
 int writeMixedStat(MixedStat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedStatMaxBytes);
@@ -1351,8 +1346,7 @@ void initMixedHitEvent(MixedHitEvent value) {
 
 // writeMixedHitEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedHitEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedHitEventMaxBytes. Returns the bytes written.
 int writeMixedHitEvent(MixedHitEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedHitEventMaxBytes);
@@ -1459,8 +1453,7 @@ void initMixedChatEvent(MixedChatEvent value) {
 
 // writeMixedChatEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedChatEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedChatEventMaxBytes. Returns the bytes written.
 int writeMixedChatEvent(MixedChatEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedChatEventMaxBytes);
@@ -1555,8 +1548,7 @@ void initMixedPickupEvent(MixedPickupEvent value) {
 
 // writeMixedPickupEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedPickupEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedPickupEventMaxBytes. Returns the bytes written.
 int writeMixedPickupEvent(MixedPickupEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedPickupEventMaxBytes);
@@ -1676,8 +1668,7 @@ void zeroMixedEvent(MixedEvent value) {
 
 // writeMixedEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// mixedEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// mixedEventMaxBytes. Returns the bytes written.
 int writeMixedEvent(MixedEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= mixedEventMaxBytes);
@@ -2005,8 +1996,7 @@ void initBenchMixed(BenchMixed value) {
 
 // writeBenchMixed packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// benchMixedMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// benchMixedMaxBytes. Returns the bytes written.
 int writeBenchMixed(BenchMixed value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= benchMixedMaxBytes);
@@ -2086,9 +2076,8 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (48 - scratchBits);
   }
-  if (value.entitiesCount < 1 || value.entitiesCount > 8) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.entitiesCount >= 1);
+  assert(value.entitiesCount <= 8);
   v =
       ((value.serverTime) & 0xffffff) |
       (((value.entitiesCount - 1) & 0x7) << 24);
@@ -2161,9 +2150,8 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
       scratch = v >>> (14 - scratchBits);
     }
   }
-  if (value.statsCount < 0 || value.statsCount > 80) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.statsCount >= 0);
+  assert(value.statsCount <= 80);
   v = ((value.statsCount) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;

--- a/generated/bench/dart/realworld/RealWorld.dart
+++ b/generated/bench/dart/realworld/RealWorld.dart
@@ -566,8 +566,7 @@ void initRealPacket(RealPacket value) {
 
 // writeRealPacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// realPacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// realPacketMaxBytes. Returns the bytes written.
 int writeRealPacket(RealPacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= realPacketMaxBytes);

--- a/generated/bench/java/Bench.java
+++ b/generated/bench/java/Bench.java
@@ -2735,6 +2735,8 @@ public final class Bench {
         assert value.worldTime <= 1000000000000L;
         assert value.serverTime >= 0;
         assert value.serverTime <= 16776960;
+        assert value.entitiesCount >= 1;
+        assert value.entitiesCount <= 8;
         for (int i0 = 0; i0 < value.entitiesCount; i0++) {
             final MixedEntity e0 = value.entities[i0];
             assert e0.posX >= -16383;
@@ -2755,6 +2757,8 @@ public final class Bench {
             assert (e0.weapon & 0xffL) <= 15;
             assert e0.damage >>> 8 == 0;
         }
+        assert value.statsCount >= 0;
+        assert value.statsCount <= 80;
         for (int i0 = 0; i0 < value.statsCount; i0++) {
             final MixedStat e0 = value.stats[i0];
             assert e0.delta >= -512;
@@ -2941,9 +2945,6 @@ public final class Bench {
             scratchBits -= 64;
             scratch = v >>> (24 - scratchBits);
         }
-        if (value.entitiesCount < 1 || value.entitiesCount > 8) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.entitiesCount - 1) & 0x7L;
         scratch |= v << scratchBits;
         scratchBits += 3;
@@ -3081,9 +3082,6 @@ public final class Bench {
                 scratchBits -= 64;
                 scratch = v >>> (1 - scratchBits);
             }
-        }
-        if (value.statsCount < 0 || value.statsCount > 80) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.statsCount) & 0x7fL;
         scratch |= v << scratchBits;

--- a/generated/bench/js/BenchFlat.js
+++ b/generated/bench/js/BenchFlat.js
@@ -333,9 +333,9 @@ function writeBenchPacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBenchPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BenchPacketMaxBytes.
+// WriteBenchPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BenchPacketMaxBytes.
 export const WriteBenchPacketFlat = PRODUCTION ? writeBenchPacketFlatProduction : writeBenchPacketFlatChecked;
 
 // ReadBenchPacketFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -599,9 +599,9 @@ function writeBenchIntsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBenchIntsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BenchIntsMaxBytes.
+// WriteBenchIntsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BenchIntsMaxBytes.
 export const WriteBenchIntsFlat = PRODUCTION ? writeBenchIntsFlatProduction : writeBenchIntsFlatChecked;
 
 // ReadBenchIntsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -806,9 +806,9 @@ function writeBenchBitsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBenchBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BenchBitsMaxBytes.
+// WriteBenchBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BenchBitsMaxBytes.
 export const WriteBenchBitsFlat = PRODUCTION ? writeBenchBitsFlatProduction : writeBenchBitsFlatChecked;
 
 // ReadBenchBitsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1053,9 +1053,9 @@ function writeMixedEntityFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteMixedEntityFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold MixedEntityMaxBytes.
+// WriteMixedEntityFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold MixedEntityMaxBytes.
 export const WriteMixedEntityFlat = PRODUCTION ? writeMixedEntityFlatProduction : writeMixedEntityFlatChecked;
 
 // ReadMixedEntityFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1179,9 +1179,9 @@ function writeMixedStatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteMixedStatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold MixedStatMaxBytes.
+// WriteMixedStatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold MixedStatMaxBytes.
 export const WriteMixedStatFlat = PRODUCTION ? writeMixedStatFlatProduction : writeMixedStatFlatChecked;
 
 // ReadMixedStatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1248,9 +1248,9 @@ function writeMixedHitEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteMixedHitEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold MixedHitEventMaxBytes.
+// WriteMixedHitEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold MixedHitEventMaxBytes.
 export const WriteMixedHitEventFlat = PRODUCTION ? writeMixedHitEventFlatProduction : writeMixedHitEventFlatChecked;
 
 // ReadMixedHitEventFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1318,9 +1318,9 @@ function writeMixedChatEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteMixedChatEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold MixedChatEventMaxBytes.
+// WriteMixedChatEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold MixedChatEventMaxBytes.
 export const WriteMixedChatEventFlat = PRODUCTION ? writeMixedChatEventFlatProduction : writeMixedChatEventFlatChecked;
 
 // ReadMixedChatEventFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1384,9 +1384,9 @@ function writeMixedPickupEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteMixedPickupEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold MixedPickupEventMaxBytes.
+// WriteMixedPickupEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold MixedPickupEventMaxBytes.
 export const WriteMixedPickupEventFlat = PRODUCTION ? writeMixedPickupEventFlatProduction : writeMixedPickupEventFlatChecked;
 
 // ReadMixedPickupEventFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1527,9 +1527,6 @@ function writeBenchMixedFlatProduction(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (16 - sb);
   }
-  if (value.EntitiesCount < 1 || value.EntitiesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ServerTime) & 0xffffff) | (((((value.EntitiesCount >>> 0) - 1) >>> 0) & 0x7) << 24)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 27;
@@ -1605,9 +1602,6 @@ function writeBenchMixedFlatProduction(value, view) {
       sb -= 32;
       lo = sb === 0 ? 0 : v >>> (2 - sb);
     }
-  }
-  if (value.StatsCount < 0 || value.StatsCount > 80) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.StatsCount) & 0x7f)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -2100,7 +2094,7 @@ function writeBenchMixedFlatChecked(value, view) {
   if (!Number.isInteger(value.ServerTime) || value.ServerTime < 0 || value.ServerTime > 16776960) {
     return -1;
   }
-  if (!Number.isInteger(value.EntitiesCount) || value.EntitiesCount < 1 || value.EntitiesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.EntitiesCount) || value.EntitiesCount < 1 || value.EntitiesCount > 8) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ServerTime) & 0xffffff) | (((((value.EntitiesCount >>> 0) - 1) >>> 0) & 0x7) << 24)) >>> 0;
@@ -2206,7 +2200,7 @@ function writeBenchMixedFlatChecked(value, view) {
       lo = sb === 0 ? 0 : v >>> (2 - sb);
     }
   }
-  if (!Number.isInteger(value.StatsCount) || value.StatsCount < 0 || value.StatsCount > 80) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.StatsCount) || value.StatsCount < 0 || value.StatsCount > 80) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.StatsCount) & 0x7f)) >>> 0;
@@ -2620,9 +2614,9 @@ function writeBenchMixedFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBenchMixedFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BenchMixedMaxBytes.
+// WriteBenchMixedFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BenchMixedMaxBytes.
 export const WriteBenchMixedFlat = PRODUCTION ? writeBenchMixedFlatProduction : writeBenchMixedFlatChecked;
 
 // ReadBenchMixedFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/bench/js/realworld/RealWorldFlat.js
+++ b/generated/bench/js/realworld/RealWorldFlat.js
@@ -1986,9 +1986,9 @@ function writeRealPacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRealPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RealPacketMaxBytes.
+// WriteRealPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RealPacketMaxBytes.
 export const WriteRealPacketFlat = PRODUCTION ? writeRealPacketFlatProduction : writeRealPacketFlatChecked;
 
 // ReadRealPacketFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/bench/tables/c/BenchTableWire.h
+++ b/generated/bench/tables/c/BenchTableWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -210,10 +211,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_pickup_event( serialize
 /* Writes TableEvent. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_event( serialize_write_stream_t * stream, const TableEvent * value )
 {
-    if ( value->type > TABLE_EVENT_TYPE_MAX )
-    {
-        return 0; /* not a TableEventType value; nothing was written */
-    }
+    serialize_assert( value->type <= TABLE_EVENT_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;

--- a/generated/bench/tables/cpp/BenchTableWire.h
+++ b/generated/bench/tables/cpp/BenchTableWire.h
@@ -105,6 +105,7 @@ SCHEMA_READ_INLINE bool ReadTablePickupEvent( serialize::ReadStream & stream, Ta
 
 SCHEMA_WRITE_INLINE bool WriteTableEvent( serialize::WriteStream & stream, const TableEvent & value )
 {
+    serialize_assert( value.type <= TableEventType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case TableEventType::None:
@@ -122,7 +123,7 @@ SCHEMA_WRITE_INLINE bool WriteTableEvent( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a TableEventType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadTableEvent( serialize::ReadStream & stream, TableEvent & value )

--- a/generated/bench/tables/dart/BenchTable.dart
+++ b/generated/bench/tables/dart/BenchTable.dart
@@ -208,8 +208,7 @@ void initTableHitEvent(TableHitEvent value) {
 
 // writeTableHitEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tableHitEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tableHitEventMaxBytes. Returns the bytes written.
 int writeTableHitEvent(TableHitEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tableHitEventMaxBytes);
@@ -316,8 +315,7 @@ void initTableChatEvent(TableChatEvent value) {
 
 // writeTableChatEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tableChatEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tableChatEventMaxBytes. Returns the bytes written.
 int writeTableChatEvent(TableChatEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tableChatEventMaxBytes);
@@ -412,8 +410,7 @@ void initTablePickupEvent(TablePickupEvent value) {
 
 // writeTablePickupEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tablePickupEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tablePickupEventMaxBytes. Returns the bytes written.
 int writeTablePickupEvent(TablePickupEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tablePickupEventMaxBytes);
@@ -533,8 +530,7 @@ void zeroTableEvent(TableEvent value) {
 
 // writeTableEvent packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tableEventMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tableEventMaxBytes. Returns the bytes written.
 int writeTableEvent(TableEvent value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tableEventMaxBytes);

--- a/generated/bench/tables/js/BenchTableFlat.js
+++ b/generated/bench/tables/js/BenchTableFlat.js
@@ -80,9 +80,9 @@ function writeTableHitEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTableHitEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TableHitEventMaxBytes.
+// WriteTableHitEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TableHitEventMaxBytes.
 export const WriteTableHitEventFlat = PRODUCTION ? writeTableHitEventFlatProduction : writeTableHitEventFlatChecked;
 
 // ReadTableHitEventFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -150,9 +150,9 @@ function writeTableChatEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTableChatEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TableChatEventMaxBytes.
+// WriteTableChatEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TableChatEventMaxBytes.
 export const WriteTableChatEventFlat = PRODUCTION ? writeTableChatEventFlatProduction : writeTableChatEventFlatChecked;
 
 // ReadTableChatEventFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -216,9 +216,9 @@ function writeTablePickupEventFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTablePickupEventFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TablePickupEventMaxBytes.
+// WriteTablePickupEventFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TablePickupEventMaxBytes.
 export const WriteTablePickupEventFlat = PRODUCTION ? writeTablePickupEventFlatProduction : writeTablePickupEventFlatChecked;
 
 // ReadTablePickupEventFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/c-ludicrous/LudicrousWire.h
+++ b/generated/c-ludicrous/LudicrousWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -336,10 +337,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_
     {
         return 0;
     }
-    if ( value->keys_count < 0 || value->keys_count > 4 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->keys_count >= 0 && value->keys_count <= 4 );
     if ( !serialize_write_int( stream, value->keys_count, 0, 4 ) )
     {
         return 0;

--- a/generated/c/ArmDefaultsWire.h
+++ b/generated/c/ArmDefaultsWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -54,10 +55,7 @@ extern "C" {
 /* Writes DefaultArm. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_arm( serialize_write_stream_t * stream, const DefaultArm * value )
 {
-    if ( value->entries_count < 0 || value->entries_count > 2 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->entries_count >= 0 && value->entries_count <= 2 );
     if ( !serialize_write_int( stream, value->entries_count, 0, 2 ) )
     {
         return 0;
@@ -117,10 +115,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_arm( serialize_read_s
 /* Writes DefaultChoice. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_choice( serialize_write_stream_t * stream, const DefaultChoice * value )
 {
-    if ( value->type > DEFAULT_CHOICE_TYPE_MAX )
-    {
-        return 0; /* not a DefaultChoiceType value; nothing was written */
-    }
+    serialize_assert( value->type <= DEFAULT_CHOICE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -223,10 +218,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_bulk_arm( serialize_r
 /* Writes DefaultBulkChoice. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_bulk_choice( serialize_write_stream_t * stream, const DefaultBulkChoice * value )
 {
-    if ( value->type > DEFAULT_BULK_CHOICE_TYPE_MAX )
-    {
-        return 0; /* not a DefaultBulkChoiceType value; nothing was written */
-    }
+    serialize_assert( value->type <= DEFAULT_BULK_CHOICE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;

--- a/generated/c/ClausesWire.h
+++ b/generated/c/ClausesWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -165,10 +166,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 /* Writes W13. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w13( serialize_write_stream_t * stream, const W13 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 12 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 12 );
     if ( !serialize_write_int( stream, value->items_count, 0, 12 ) )
     {
         return 0;
@@ -220,10 +218,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w13( serialize_read_stream_t 
 /* Writes W17. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w17( serialize_write_stream_t * stream, const W17 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 9 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 9 );
     if ( !serialize_write_int( stream, value->items_count, 0, 9 ) )
     {
         return 0;
@@ -275,10 +270,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w17( serialize_read_stream_t 
 /* Writes W26. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w26( serialize_write_stream_t * stream, const W26 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 6 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 6 );
     if ( !serialize_write_int( stream, value->items_count, 0, 6 ) )
     {
         return 0;
@@ -330,10 +322,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w26( serialize_read_stream_t 
 /* Writes W1. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w1( serialize_write_stream_t * stream, const W1 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 20 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 20 );
     if ( !serialize_write_int( stream, value->items_count, 0, 20 ) )
     {
         return 0;
@@ -385,10 +374,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w1( serialize_read_stream_t *
 /* Writes W52. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w52( serialize_write_stream_t * stream, const W52 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -452,10 +438,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w52( serialize_read_stream_t 
 /* Writes W50. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w50( serialize_write_stream_t * stream, const W50 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -598,10 +581,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_tri3( serialize_read_stream_t
 /* Writes ArrTri3. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_tri3( serialize_write_stream_t * stream, const ArrTri3 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 10 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 10 );
     if ( !serialize_write_int( stream, value->items_count, 0, 10 ) )
     {
         return 0;
@@ -742,10 +722,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_empty_b( serialize_read_strea
 /* Writes EmptyUnion. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_empty_union( serialize_write_stream_t * stream, const EmptyUnion * value )
 {
-    if ( value->type > EMPTY_UNION_TYPE_MAX )
-    {
-        return 0; /* not a EmptyUnionType value; nothing was written */
-    }
+    serialize_assert( value->type <= EMPTY_UNION_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -840,6 +817,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_strs( serialize_write_strea
     {
         return 0;
     }
+    {
+        int32_t i;
+        for ( i = 0; i < value->s_length; i++ )
+        {
+            serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
+    }
     if ( !serialize_write_int( stream, value->s_length, 0, 8 ) )
     {
         return 0;
@@ -917,10 +901,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_nested( serialize_write
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 4 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 4 );
     if ( !serialize_write_int( stream, value->items_count, 0, 4 ) )
     {
         return 0;

--- a/generated/c/DegenerateWire.h
+++ b/generated/c/DegenerateWire.h
@@ -24,9 +24,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED

--- a/generated/c/JoinsWire.h
+++ b/generated/c/JoinsWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -523,6 +524,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_align( serialize_write_
     }
     if ( value->flag )
     {
+        {
+            int32_t i;
+            for ( i = 0; i < value->s_length; i++ )
+            {
+                serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
+            }
+        }
         if ( !serialize_write_int( stream, value->s_length, 0, 4 ) )
         {
             return 0;
@@ -619,10 +627,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_array( serialize_write_
     }
     if ( value->flag )
     {
-        if ( value->items_count < 0 || value->items_count > 3 )
-        {
-            return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-        }
+        serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
         if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
         {
             return 0;
@@ -783,10 +788,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide( serialize_read_stream_t
 /* Writes Uneven. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_uneven( serialize_write_stream_t * stream, const Uneven * value )
 {
-    if ( value->type > UNEVEN_TYPE_MAX )
-    {
-        return 0; /* not a UnevenType value; nothing was written */
-    }
+    serialize_assert( value->type <= UNEVEN_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -881,10 +883,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_uneven( serialize_write
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -949,10 +948,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -966,6 +962,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
             {
                 return 0;
             }
+        }
+    }
+    {
+        int32_t i;
+        for ( i = 0; i < value->s_length; i++ )
+        {
+            serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
         }
     }
     if ( !serialize_write_int( stream, value->s_length, 0, 4 ) )

--- a/generated/c/RenderWire.h
+++ b/generated/c/RenderWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -139,10 +140,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_wri
     {
         return 0;
     }
-    if ( value->sprites_count < 0 || value->sprites_count > RENDER_BLOCK_MAX_SPRITES )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->sprites_count >= 0 && value->sprites_count <= RENDER_BLOCK_MAX_SPRITES );
     if ( !serialize_write_int( stream, value->sprites_count, 0, RENDER_BLOCK_MAX_SPRITES ) )
     {
         return 0;

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -27,9 +27,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -596,10 +597,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_wri
     {
         return 0;
     }
-    if ( value->inputs_count < 0 || value->inputs_count > MAX_INPUTS_PER_PACKET )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->inputs_count >= 0 && value->inputs_count <= MAX_INPUTS_PER_PACKET );
     if ( !serialize_write_int( stream, value->inputs_count, 0, MAX_INPUTS_PER_PACKET ) )
     {
         return 0;
@@ -687,6 +685,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
     }
     if ( value->has_flags )
     {
+        serialize_assert( value->flags < ( 1ULL << 4 ) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) value->flags, 4 ) )
         {
             return 0;

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -26,9 +26,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -398,10 +399,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
             return 0;
         }
     }
-    if ( value->samples_count < 1 || value->samples_count > 8 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->samples_count >= 1 && value->samples_count <= 8 );
     if ( !serialize_write_int( stream, value->samples_count, 1, 8 ) )
     {
         return 0;
@@ -586,10 +584,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_st
 /* Writes ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_write_stream_t * stream, const ProbeShape * value )
 {
-    if ( value->type > PROBE_SHAPE_TYPE_MAX )
-    {
-        return 0; /* not a ProbeShapeType value; nothing was written */
-    }
+    serialize_assert( value->type <= PROBE_SHAPE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -648,10 +643,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_w
     {
         return 0;
     }
-    if ( value->extras_count < 0 || value->extras_count > 2 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->extras_count >= 0 && value->extras_count <= 2 );
     if ( !serialize_write_int( stream, value->extras_count, 0, 2 ) )
     {
         return 0;
@@ -914,6 +906,13 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_
 /* Writes Chat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
+    {
+        int32_t i;
+        for ( i = 0; i < value->text_length; i++ )
+        {
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
+    }
     if ( !serialize_write_int( stream, value->text_length, 0, MAX_CHAT_LENGTH ) )
     {
         return 0;
@@ -955,6 +954,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_wri
     {
         return 0;
     }
+    serialize_assert( value->flags < ( 1ULL << 8 ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->flags, 8 ) )
     {
         return 0;
@@ -1022,10 +1022,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 16 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 16 );
     if ( !serialize_write_int( stream, value->items_count, 0, 16 ) )
     {
         return 0;
@@ -1100,6 +1097,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     if ( !serialize_write_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
         return 0;
+    }
+    {
+        int32_t i;
+        for ( i = 0; i < value->text_length; i++ )
+        {
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
     }
     if ( !serialize_write_int( stream, value->text_length, 0, 255 ) )
     {

--- a/generated/cpp/ArmDefaultsWire.h
+++ b/generated/cpp/ArmDefaultsWire.h
@@ -56,10 +56,7 @@ namespace example {
 
 SCHEMA_WRITE_INLINE bool WriteDefaultArm( serialize::WriteStream & stream, const DefaultArm & value )
 {
-    if ( int32_t( value.entries_count ) < int32_t( 0 ) || int32_t( value.entries_count ) > int32_t( 2 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.entries_count ) >= int32_t( 0 ) && int32_t( value.entries_count ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value.entries_count ), 2 );
     for ( int32_t i = 0; i < value.entries_count; i++ )
     {
@@ -93,6 +90,7 @@ SCHEMA_READ_INLINE bool ReadDefaultArm( serialize::ReadStream & stream, DefaultA
 
 SCHEMA_WRITE_INLINE bool WriteDefaultChoice( serialize::WriteStream & stream, const DefaultChoice & value )
 {
+    serialize_assert( value.type <= DefaultChoiceType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case DefaultChoiceType::None:
@@ -107,7 +105,7 @@ SCHEMA_WRITE_INLINE bool WriteDefaultChoice( serialize::WriteStream & stream, co
         default:
             break;
     }
-    return false; // not a DefaultChoiceType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadDefaultChoice( serialize::ReadStream & stream, DefaultChoice & value )
@@ -172,6 +170,7 @@ SCHEMA_READ_INLINE bool ReadDefaultBulkArm( serialize::ReadStream & stream, Defa
 
 SCHEMA_WRITE_INLINE bool WriteDefaultBulkChoice( serialize::WriteStream & stream, const DefaultBulkChoice & value )
 {
+    serialize_assert( value.type <= DefaultBulkChoiceType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case DefaultBulkChoiceType::None:
@@ -186,7 +185,7 @@ SCHEMA_WRITE_INLINE bool WriteDefaultBulkChoice( serialize::WriteStream & stream
         default:
             break;
     }
-    return false; // not a DefaultBulkChoiceType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadDefaultBulkChoice( serialize::ReadStream & stream, DefaultBulkChoice & value )

--- a/generated/cpp/ClausesWire.h
+++ b/generated/cpp/ClausesWire.h
@@ -166,10 +166,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 
 SCHEMA_WRITE_INLINE bool WriteW13( serialize::WriteStream & stream, const W13 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 12 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 12 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -195,10 +192,7 @@ SCHEMA_READ_INLINE bool ReadW13( serialize::ReadStream & stream, W13 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW17( serialize::WriteStream & stream, const W17 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 9 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 9 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -220,10 +214,7 @@ SCHEMA_READ_INLINE bool ReadW17( serialize::ReadStream & stream, W17 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW26( serialize::WriteStream & stream, const W26 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 6 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.items_count ), 3 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -245,10 +236,7 @@ SCHEMA_READ_INLINE bool ReadW26( serialize::ReadStream & stream, W26 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW1( serialize::WriteStream & stream, const W1 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 20 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 20 ) );
     write_bits( stream, uint32_t( value.items_count ), 5 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -274,10 +262,7 @@ SCHEMA_READ_INLINE bool ReadW1( serialize::ReadStream & stream, W1 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW52( serialize::WriteStream & stream, const W52 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -299,10 +284,7 @@ SCHEMA_READ_INLINE bool ReadW52( serialize::ReadStream & stream, W52 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW50( serialize::WriteStream & stream, const W50 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -361,10 +343,7 @@ SCHEMA_READ_INLINE bool ReadTri3( serialize::ReadStream & stream, Tri3 & value )
 
 SCHEMA_WRITE_INLINE bool WriteArrTri3( serialize::WriteStream & stream, const ArrTri3 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 10 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 10 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -457,6 +436,7 @@ SCHEMA_READ_INLINE bool ReadEmptyB( serialize::ReadStream & stream, EmptyB & val
 
 SCHEMA_WRITE_INLINE bool WriteEmptyUnion( serialize::WriteStream & stream, const EmptyUnion & value )
 {
+    serialize_assert( value.type <= EmptyUnionType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case EmptyUnionType::None:
@@ -471,7 +451,7 @@ SCHEMA_WRITE_INLINE bool WriteEmptyUnion( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a EmptyUnionType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadEmptyUnion( serialize::ReadStream & stream, EmptyUnion & value )
@@ -555,10 +535,7 @@ SCHEMA_READ_INLINE bool ReadStrs( serialize::ReadStream & stream, Strs & value )
 SCHEMA_WRITE_INLINE bool WriteArrNested( serialize::WriteStream & stream, const ArrNested & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 4 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value.items_count ), 3 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/generated/cpp/JoinsWire.h
+++ b/generated/cpp/JoinsWire.h
@@ -372,10 +372,7 @@ SCHEMA_WRITE_INLINE bool WriteArmArray( serialize::WriteStream & stream, const A
     write_bool( stream, value.flag );
     if ( value.flag )
     {
-        if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-        {
-            return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
+        serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
         write_bits( stream, uint32_t( value.items_count ), 2 );
         for ( int32_t i = 0; i < value.items_count; i++ )
         {
@@ -444,6 +441,7 @@ SCHEMA_READ_INLINE bool ReadWide( serialize::ReadStream & stream, Wide & value )
 
 SCHEMA_WRITE_INLINE bool WriteUneven( serialize::WriteStream & stream, const Uneven & value )
 {
+    serialize_assert( value.type <= UnevenType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case UnevenType::None:
@@ -458,7 +456,7 @@ SCHEMA_WRITE_INLINE bool WriteUneven( serialize::WriteStream & stream, const Une
         default:
             break;
     }
-    return false; // not a UnevenType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadUneven( serialize::ReadStream & stream, Uneven & value )
@@ -505,10 +503,7 @@ SCHEMA_READ_INLINE bool ReadHoldsUneven( serialize::ReadStream & stream, HoldsUn
 SCHEMA_WRITE_INLINE bool WriteArrUneven( serialize::WriteStream & stream, const ArrUneven & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -539,10 +534,7 @@ SCHEMA_READ_INLINE bool ReadArrUneven( serialize::ReadStream & stream, ArrUneven
 SCHEMA_WRITE_INLINE bool WriteRegainAfterAlign( serialize::WriteStream & stream, const RegainAfterAlign & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/generated/cpp/RenderWire.h
+++ b/generated/cpp/RenderWire.h
@@ -86,10 +86,7 @@ SCHEMA_WRITE_INLINE bool WriteRenderBlock( serialize::WriteStream & stream, cons
 {
     write_bits( stream, value.worker_index, 32 );
     write_bits( stream, value.sprite_count_hint, 32 );
-    if ( int32_t( value.sprites_count ) < int32_t( 0 ) || int32_t( value.sprites_count ) > int32_t( RenderBlockMaxSprites ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.sprites_count ) >= int32_t( 0 ) && int32_t( value.sprites_count ) <= int32_t( RenderBlockMaxSprites ) );
     write_bits( stream, uint32_t( value.sprites_count ), 7 );
     for ( int32_t i = 0; i < value.sprites_count; i++ )
     {

--- a/generated/cpp/TypesWire.h
+++ b/generated/cpp/TypesWire.h
@@ -280,10 +280,7 @@ SCHEMA_WRITE_INLINE bool WriteInputPacket( serialize::WriteStream & stream, cons
     write_bits( stream, value.synchronize_sequence, 16 );
     write_bits( stream, value.current_frame, 64 );
     write_bits( stream, value.start_frame, 64 );
-    if ( int32_t( value.inputs_count ) < int32_t( 0 ) || int32_t( value.inputs_count ) > int32_t( MaxInputsPerPacket ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.inputs_count ) >= int32_t( 0 ) && int32_t( value.inputs_count ) <= int32_t( MaxInputsPerPacket ) );
     write_bits( stream, uint32_t( value.inputs_count ), 5 );
     for ( int32_t i = 0; i < value.inputs_count; i++ )
     {

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -247,10 +247,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
     {
         write_bits( stream, value.idle_ticks, 32 );
     }
-    if ( int32_t( value.samples_count ) < int32_t( 1 ) || int32_t( value.samples_count ) > int32_t( 8 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.samples_count ) >= int32_t( 1 ) && int32_t( value.samples_count ) <= int32_t( 8 ) );
     write_bits( stream, uint32_t( value.samples_count ) - uint32_t( 1 ), 3 );
     for ( int32_t i = 0; i < value.samples_count; i++ )
     {
@@ -355,6 +352,7 @@ SCHEMA_READ_INLINE bool ReadProbeSlab( serialize::ReadStream & stream, ProbeSlab
 
 SCHEMA_WRITE_INLINE bool WriteProbeShape( serialize::WriteStream & stream, const ProbeShape & value )
 {
+    serialize_assert( value.type <= ProbeShapeType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case ProbeShapeType::None:
@@ -369,7 +367,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeShape( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a ProbeShapeType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadProbeShape( serialize::ReadStream & stream, ProbeShape & value )
@@ -402,10 +400,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeCollider( serialize::WriteStream & stream, co
     {
         return false;
     }
-    if ( int32_t( value.extras_count ) < int32_t( 0 ) || int32_t( value.extras_count ) > int32_t( 2 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.extras_count ) >= int32_t( 0 ) && int32_t( value.extras_count ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value.extras_count ), 2 );
     for ( int32_t i = 0; i < value.extras_count; i++ )
     {
@@ -633,10 +628,7 @@ SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const T
     write_bits( stream, value.e, 8 );
     write_bits( stream, value.f, 8 );
     write_bool( stream, value.g );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 16 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 16 ) );
     write_bits( stream, uint32_t( value.items_count ), 5 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/generated/cpp/ludicrous/LudicrousWire.h
+++ b/generated/cpp/ludicrous/LudicrousWire.h
@@ -174,10 +174,7 @@ SCHEMA_WRITE_INLINE bool WriteLudicrousState( serialize::WriteStream & stream, c
     {
         return false;
     }
-    if ( int32_t( value.keys_count ) < int32_t( 0 ) || int32_t( value.keys_count ) > int32_t( 4 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.keys_count ) >= int32_t( 0 ) && int32_t( value.keys_count ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value.keys_count ), 3 );
     for ( int32_t i = 0; i < value.keys_count; i++ )
     {

--- a/generated/dart-ludicrous/Ludicrous.dart
+++ b/generated/dart-ludicrous/Ludicrous.dart
@@ -108,8 +108,7 @@ void initFixedProbe(FixedProbe value) {
 
 // writeFixedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedProbeMaxBytes. Returns the bytes written.
 int writeFixedProbe(FixedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedProbeMaxBytes);
@@ -308,8 +307,7 @@ void initUnsignedProbe(UnsignedProbe value) {
 
 // writeUnsignedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// unsignedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// unsignedProbeMaxBytes. Returns the bytes written.
 int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= unsignedProbeMaxBytes);
@@ -528,8 +526,7 @@ void initWideProbe(WideProbe value) {
 
 // writeWideProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideProbeMaxBytes. Returns the bytes written.
 int writeWideProbe(WideProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideProbeMaxBytes);
@@ -840,8 +837,7 @@ void initLudicrousState(LudicrousState value) {
 
 // writeLudicrousState packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// ludicrousStateMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// ludicrousStateMaxBytes. Returns the bytes written.
 int writeLudicrousState(LudicrousState value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= ludicrousStateMaxBytes);
@@ -991,9 +987,8 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (64 - scratchBits);
   }
-  if (value.keysCount < 0 || value.keysCount > 4) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.keysCount >= 0);
+  assert(value.keysCount <= 4);
   v = (value.wide.seed.hi);
   scratch |= v << scratchBits;
   scratchBits += 64;
@@ -1427,8 +1422,7 @@ void initDegenerateProbe(DegenerateProbe value) {
 
 // writeDegenerateProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// degenerateProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// degenerateProbeMaxBytes. Returns the bytes written.
 int writeDegenerateProbe(DegenerateProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= degenerateProbeMaxBytes);
@@ -1535,8 +1529,7 @@ void initFixedVec(FixedVec value) {
 
 // writeFixedVec packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedVecMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedVecMaxBytes. Returns the bytes written.
 int writeFixedVec(FixedVec value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedVecMaxBytes);
@@ -1684,8 +1677,7 @@ void initFixedQuat(FixedQuat value) {
 
 // writeFixedQuat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedQuatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedQuatMaxBytes. Returns the bytes written.
 int writeFixedQuat(FixedQuat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedQuatMaxBytes);

--- a/generated/dart/ArmDefaults.dart
+++ b/generated/dart/ArmDefaults.dart
@@ -42,8 +42,7 @@ void initDefaultArm(DefaultArm value) {
 
 // writeDefaultArm packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultArmMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultArmMaxBytes. Returns the bytes written.
 int writeDefaultArm(DefaultArm value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultArmMaxBytes);
@@ -51,9 +50,8 @@ int writeDefaultArm(DefaultArm value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.entriesCount < 0 || value.entriesCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.entriesCount >= 0);
+  assert(value.entriesCount <= 2);
   v = ((value.entriesCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -219,8 +217,7 @@ void zeroDefaultChoice(DefaultChoice value) {
 
 // writeDefaultChoice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultChoiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultChoiceMaxBytes. Returns the bytes written.
 int writeDefaultChoice(DefaultChoice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultChoiceMaxBytes);
@@ -241,9 +238,8 @@ int writeDefaultChoice(DefaultChoice value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      if (value.first.entriesCount < 0 || value.first.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.first.entriesCount >= 0);
+      assert(value.first.entriesCount <= 2);
       v = ((value.first.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -279,9 +275,8 @@ int writeDefaultChoice(DefaultChoice value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      if (value.second.entriesCount < 0 || value.second.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.second.entriesCount >= 0);
+      assert(value.second.entriesCount <= 2);
       v = ((value.second.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -511,8 +506,7 @@ void initDefaultChoicePacket(DefaultChoicePacket value) {
 
 // writeDefaultChoicePacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultChoicePacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultChoicePacketMaxBytes. Returns the bytes written.
 int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultChoicePacketMaxBytes);
@@ -533,10 +527,8 @@ int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
   }
   switch (value.choice.type) {
     case 1:
-      if (value.choice.first.entriesCount < 0 ||
-          value.choice.first.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.choice.first.entriesCount >= 0);
+      assert(value.choice.first.entriesCount <= 2);
       v = ((value.choice.first.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -572,10 +564,8 @@ int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      if (value.choice.second.entriesCount < 0 ||
-          value.choice.second.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.choice.second.entriesCount >= 0);
+      assert(value.choice.second.entriesCount <= 2);
       v = ((value.choice.second.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -816,8 +806,7 @@ void initDefaultBulkArm(DefaultBulkArm value) {
 
 // writeDefaultBulkArm packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultBulkArmMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultBulkArmMaxBytes. Returns the bytes written.
 int writeDefaultBulkArm(DefaultBulkArm value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultBulkArmMaxBytes);
@@ -825,9 +814,8 @@ int writeDefaultBulkArm(DefaultBulkArm value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.payload.entriesCount < 0 || value.payload.entriesCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.payload.entriesCount >= 0);
+  assert(value.payload.entriesCount <= 2);
   v = ((value.payload.entriesCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1069,8 +1057,7 @@ void zeroDefaultBulkChoice(DefaultBulkChoice value) {
 
 // writeDefaultBulkChoice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultBulkChoiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultBulkChoiceMaxBytes. Returns the bytes written.
 int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultBulkChoiceMaxBytes);
@@ -1091,10 +1078,8 @@ int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      if (value.first.payload.entriesCount < 0 ||
-          value.first.payload.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.first.payload.entriesCount >= 0);
+      assert(value.first.payload.entriesCount <= 2);
       v = ((value.first.payload.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -1175,10 +1160,8 @@ int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
         }
       }
     case 2:
-      if (value.second.payload.entriesCount < 0 ||
-          value.second.payload.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.second.payload.entriesCount >= 0);
+      assert(value.second.payload.entriesCount <= 2);
       v = ((value.second.payload.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;

--- a/generated/dart/Clauses.dart
+++ b/generated/dart/Clauses.dart
@@ -70,8 +70,7 @@ void initW13(W13 value) {
 
 // writeW13 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w13MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w13MaxBytes. Returns the bytes written.
 int writeW13(W13 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w13MaxBytes);
@@ -79,9 +78,8 @@ int writeW13(W13 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 12) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 12);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -248,8 +246,7 @@ void initW17(W17 value) {
 
 // writeW17 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w17MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w17MaxBytes. Returns the bytes written.
 int writeW17(W17 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w17MaxBytes);
@@ -257,9 +254,8 @@ int writeW17(W17 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 9) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 9);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -420,8 +416,7 @@ void initW26(W26 value) {
 
 // writeW26 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w26MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w26MaxBytes. Returns the bytes written.
 int writeW26(W26 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w26MaxBytes);
@@ -429,9 +424,8 @@ int writeW26(W26 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 6) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 6);
   v = ((value.itemsCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
@@ -586,8 +580,7 @@ void initW1(W1 value) {
 
 // writeW1 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w1MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w1MaxBytes. Returns the bytes written.
 int writeW1(W1 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w1MaxBytes);
@@ -595,9 +588,8 @@ int writeW1(W1 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 20) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 20);
   v = ((value.itemsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
@@ -1103,8 +1095,7 @@ void initW52(W52 value) {
 
 // writeW52 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w52MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w52MaxBytes. Returns the bytes written.
 int writeW52(W52 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w52MaxBytes);
@@ -1112,9 +1103,8 @@ int writeW52(W52 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1229,8 +1219,7 @@ void initW50(W50 value) {
 
 // writeW50 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w50MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w50MaxBytes. Returns the bytes written.
 int writeW50(W50 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w50MaxBytes);
@@ -1238,9 +1227,8 @@ int writeW50(W50 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1352,8 +1340,7 @@ void initF13(F13 value) {
 
 // writeF13 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// f13MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// f13MaxBytes. Returns the bytes written.
 int writeF13(F13 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= f13MaxBytes);
@@ -1448,8 +1435,7 @@ void initTri3(Tri3 value) {
 
 // writeTri3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tri3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tri3MaxBytes. Returns the bytes written.
 int writeTri3(Tri3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tri3MaxBytes);
@@ -1545,8 +1531,7 @@ void initArrTri3(ArrTri3 value) {
 
 // writeArrTri3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrTri3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrTri3MaxBytes. Returns the bytes written.
 int writeArrTri3(ArrTri3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrTri3MaxBytes);
@@ -1554,9 +1539,8 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 10) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 10);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -1897,8 +1881,7 @@ void initEleven(Eleven value) {
 
 // writeEleven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// elevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// elevenMaxBytes. Returns the bytes written.
 int writeEleven(Eleven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= elevenMaxBytes);
@@ -1991,8 +1974,7 @@ void initArrEleven(ArrEleven value) {
 
 // writeArrEleven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrElevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrElevenMaxBytes. Returns the bytes written.
 int writeArrEleven(ArrEleven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrElevenMaxBytes);
@@ -2087,8 +2069,7 @@ void initEmptyA(EmptyA value) {
 
 // writeEmptyA packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyAMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyAMaxBytes. Returns the bytes written.
 int writeEmptyA(EmptyA value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyAMaxBytes);
@@ -2136,8 +2117,7 @@ void initEmptyB(EmptyB value) {
 
 // writeEmptyB packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyBMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyBMaxBytes. Returns the bytes written.
 int writeEmptyB(EmptyB value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyBMaxBytes);
@@ -2210,8 +2190,7 @@ void zeroEmptyUnion(EmptyUnion value) {
 
 // writeEmptyUnion packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyUnionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyUnionMaxBytes. Returns the bytes written.
 int writeEmptyUnion(EmptyUnion value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyUnionMaxBytes);
@@ -2330,8 +2309,7 @@ void initHoldsEmptyUnion(HoldsEmptyUnion value) {
 
 // writeHoldsEmptyUnion packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// holdsEmptyUnionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// holdsEmptyUnionMaxBytes. Returns the bytes written.
 int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= holdsEmptyUnionMaxBytes);
@@ -2489,8 +2467,7 @@ void initStrs(Strs value) {
 
 // writeStrs packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// strsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// strsMaxBytes. Returns the bytes written.
 int writeStrs(Strs value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= strsMaxBytes);
@@ -2789,8 +2766,7 @@ void initArrNested(ArrNested value) {
 
 // writeArrNested packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrNestedMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrNestedMaxBytes. Returns the bytes written.
 int writeArrNested(ArrNested value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrNestedMaxBytes);
@@ -2798,9 +2774,8 @@ int writeArrNested(ArrNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 4) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 4);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x7) << 5);
   scratch |= v << scratchBits;
   scratchBits += 8;
@@ -3019,8 +2994,7 @@ void initSole(Sole value) {
 
 // writeSole packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// soleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// soleMaxBytes. Returns the bytes written.
 int writeSole(Sole value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= soleMaxBytes);

--- a/generated/dart/Degenerate.dart
+++ b/generated/dart/Degenerate.dart
@@ -52,8 +52,7 @@ void initVec2(Vec2 value) {
 
 // writeVec2 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// vec2MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// vec2MaxBytes. Returns the bytes written.
 int writeVec2(Vec2 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= vec2MaxBytes);
@@ -175,8 +174,7 @@ void initSpanF64(SpanF64 value) {
 
 // writeSpanF64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanF64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanF64MaxBytes. Returns the bytes written.
 int writeSpanF64(SpanF64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanF64MaxBytes);
@@ -276,8 +274,7 @@ void initSpanU64(SpanU64 value) {
 
 // writeSpanU64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanU64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanU64MaxBytes. Returns the bytes written.
 int writeSpanU64(SpanU64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanU64MaxBytes);
@@ -377,8 +374,7 @@ void initSpanI64(SpanI64 value) {
 
 // writeSpanI64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanI64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanI64MaxBytes. Returns the bytes written.
 int writeSpanI64(SpanI64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanI64MaxBytes);
@@ -478,8 +474,7 @@ void initSpanOne(SpanOne value) {
 
 // writeSpanOne packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanOneMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanOneMaxBytes. Returns the bytes written.
 int writeSpanOne(SpanOne value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanOneMaxBytes);
@@ -579,8 +574,7 @@ void initSpanChunk(SpanChunk value) {
 
 // writeSpanChunk packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanChunkMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanChunkMaxBytes. Returns the bytes written.
 int writeSpanChunk(SpanChunk value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanChunkMaxBytes);
@@ -673,8 +667,7 @@ void initSpanTail(SpanTail value) {
 
 // writeSpanTail packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanTailMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanTailMaxBytes. Returns the bytes written.
 int writeSpanTail(SpanTail value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanTailMaxBytes);
@@ -794,8 +787,7 @@ void initSpanTwice(SpanTwice value) {
 
 // writeSpanTwice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanTwiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanTwiceMaxBytes. Returns the bytes written.
 int writeSpanTwice(SpanTwice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanTwiceMaxBytes);
@@ -931,8 +923,7 @@ void initTrio(Trio value) {
 
 // writeTrio packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioMaxBytes. Returns the bytes written.
 int writeTrio(Trio value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioMaxBytes);
@@ -1032,8 +1023,7 @@ void initTrioSole(TrioSole value) {
 
 // writeTrioSole packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioSoleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioSoleMaxBytes. Returns the bytes written.
 int writeTrioSole(TrioSole value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioSoleMaxBytes);
@@ -1136,8 +1126,7 @@ void initTrioFirst(TrioFirst value) {
 
 // writeTrioFirst packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioFirstMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioFirstMaxBytes. Returns the bytes written.
 int writeTrioFirst(TrioFirst value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioFirstMaxBytes);
@@ -1267,8 +1256,7 @@ void initTrioStraddle(TrioStraddle value) {
 
 // writeTrioStraddle packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioStraddleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioStraddleMaxBytes. Returns the bytes written.
 int writeTrioStraddle(TrioStraddle value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioStraddleMaxBytes);

--- a/generated/dart/Joins.dart
+++ b/generated/dart/Joins.dart
@@ -85,8 +85,7 @@ void initArmsAgree(ArmsAgree value) {
 
 // writeArmsAgree packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsAgreeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsAgreeMaxBytes. Returns the bytes written.
 int writeArmsAgree(ArmsAgree value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsAgreeMaxBytes);
@@ -253,8 +252,7 @@ void initArmsDisagree(ArmsDisagree value) {
 
 // writeArmsDisagree packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsDisagreeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsDisagreeMaxBytes. Returns the bytes written.
 int writeArmsDisagree(ArmsDisagree value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsDisagreeMaxBytes);
@@ -434,8 +432,7 @@ void initArmEmpty(ArmEmpty value) {
 
 // writeArmEmpty packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armEmptyMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armEmptyMaxBytes. Returns the bytes written.
 int writeArmEmpty(ArmEmpty value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armEmptyMaxBytes);
@@ -609,8 +606,7 @@ void initArmsNested(ArmsNested value) {
 
 // writeArmsNested packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsNestedMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsNestedMaxBytes. Returns the bytes written.
 int writeArmsNested(ArmsNested value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsNestedMaxBytes);
@@ -857,8 +853,7 @@ void initArmAlign(ArmAlign value) {
 
 // writeArmAlign packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armAlignMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armAlignMaxBytes. Returns the bytes written.
 int writeArmAlign(ArmAlign value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armAlignMaxBytes);
@@ -1127,8 +1122,7 @@ void initArmArray(ArmArray value) {
 
 // writeArmArray packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armArrayMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armArrayMaxBytes. Returns the bytes written.
 int writeArmArray(ArmArray value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armArrayMaxBytes);
@@ -1146,9 +1140,8 @@ int writeArmArray(ArmArray value, ByteData view) {
     scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    if (value.itemsCount < 0 || value.itemsCount > 3) {
-      return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    assert(value.itemsCount >= 0);
+    assert(value.itemsCount <= 3);
     v = ((value.itemsCount) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
@@ -1376,8 +1369,7 @@ void initNarrow(Narrow value) {
 
 // writeNarrow packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// narrowMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// narrowMaxBytes. Returns the bytes written.
 int writeNarrow(Narrow value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= narrowMaxBytes);
@@ -1463,8 +1455,7 @@ void initWide(Wide value) {
 
 // writeWide packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideMaxBytes. Returns the bytes written.
 int writeWide(Wide value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideMaxBytes);
@@ -1575,8 +1566,7 @@ void zeroUneven(Uneven value) {
 
 // writeUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// unevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// unevenMaxBytes. Returns the bytes written.
 int writeUneven(Uneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= unevenMaxBytes);
@@ -1736,8 +1726,7 @@ void initHoldsUneven(HoldsUneven value) {
 
 // writeHoldsUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// holdsUnevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// holdsUnevenMaxBytes. Returns the bytes written.
 int writeHoldsUneven(HoldsUneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= holdsUnevenMaxBytes);
@@ -1932,8 +1921,7 @@ void initArrUneven(ArrUneven value) {
 
 // writeArrUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrUnevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrUnevenMaxBytes. Returns the bytes written.
 int writeArrUneven(ArrUneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrUnevenMaxBytes);
@@ -1941,9 +1929,8 @@ int writeArrUneven(ArrUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
   scratchBits += 7;
@@ -2173,8 +2160,7 @@ void initRegainAfterAlign(RegainAfterAlign value) {
 
 // writeRegainAfterAlign packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// regainAfterAlignMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// regainAfterAlignMaxBytes. Returns the bytes written.
 int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= regainAfterAlignMaxBytes);
@@ -2182,9 +2168,8 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
   scratchBits += 7;

--- a/generated/dart/Render.dart
+++ b/generated/dart/Render.dart
@@ -45,8 +45,7 @@ void initRenderSprite(RenderSprite value) {
 
 // writeRenderSprite packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// renderSpriteMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// renderSpriteMaxBytes. Returns the bytes written.
 int writeRenderSprite(RenderSprite value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= renderSpriteMaxBytes);
@@ -203,8 +202,7 @@ void initRenderBlock(RenderBlock value) {
 
 // writeRenderBlock packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// renderBlockMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// renderBlockMaxBytes. Returns the bytes written.
 int writeRenderBlock(RenderBlock value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= renderBlockMaxBytes);
@@ -212,9 +210,8 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.spritesCount < 0 || value.spritesCount > 64) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.spritesCount >= 0);
+  assert(value.spritesCount <= 64);
   v =
       ((value.workerIndex) & 0xffffffff) |
       (((value.spriteCountHint) & 0xffffffff) << 32);

--- a/generated/dart/Types.dart
+++ b/generated/dart/Types.dart
@@ -99,8 +99,7 @@ void initVec3(Vec3 value) {
 
 // writeVec3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// vec3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// vec3MaxBytes. Returns the bytes written.
 int writeVec3(Vec3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= vec3MaxBytes);
@@ -257,8 +256,7 @@ void initQuat(Quat value) {
 
 // writeQuat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quatMaxBytes. Returns the bytes written.
 int writeQuat(Quat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quatMaxBytes);
@@ -436,8 +434,7 @@ void initHandle(Handle value) {
 
 // writeHandle packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// handleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// handleMaxBytes. Returns the bytes written.
 int writeHandle(Handle value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= handleMaxBytes);
@@ -540,8 +537,7 @@ void initQuantizedPosition(QuantizedPosition value) {
 
 // writeQuantizedPosition packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedPositionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedPositionMaxBytes. Returns the bytes written.
 int writeQuantizedPosition(QuantizedPosition value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedPositionMaxBytes);
@@ -677,8 +673,7 @@ void initQuantizedVelocity(QuantizedVelocity value) {
 
 // writeQuantizedVelocity packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedVelocityMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedVelocityMaxBytes. Returns the bytes written.
 int writeQuantizedVelocity(QuantizedVelocity value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedVelocityMaxBytes);
@@ -818,8 +813,7 @@ void initQuantizedRotation(QuantizedRotation value) {
 
 // writeQuantizedRotation packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedRotationMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedRotationMaxBytes. Returns the bytes written.
 int writeQuantizedRotation(QuantizedRotation value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedRotationMaxBytes);
@@ -957,8 +951,7 @@ void initRigidBody(RigidBody value) {
 
 // writeRigidBody packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// rigidBodyMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// rigidBodyMaxBytes. Returns the bytes written.
 int writeRigidBody(RigidBody value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= rigidBodyMaxBytes);
@@ -1435,8 +1428,7 @@ void initInput(Input value) {
 
 // writeInput packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// inputMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// inputMaxBytes. Returns the bytes written.
 int writeInput(Input value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= inputMaxBytes);
@@ -1625,8 +1617,7 @@ void initInputPacket(InputPacket value) {
 
 // writeInputPacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// inputPacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// inputPacketMaxBytes. Returns the bytes written.
 int writeInputPacket(InputPacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= inputPacketMaxBytes);
@@ -1652,9 +1643,8 @@ int writeInputPacket(InputPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (64 - scratchBits);
   }
-  if (value.inputsCount < 0 || value.inputsCount > 16) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.inputsCount >= 0);
+  assert(value.inputsCount <= 16);
   v = (value.startFrame);
   scratch |= v << scratchBits;
   scratchBits += 64;
@@ -1933,8 +1923,7 @@ void initShipCreate(ShipCreate value) {
 
 // writeShipCreate packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// shipCreateMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// shipCreateMaxBytes. Returns the bytes written.
 int writeShipCreate(ShipCreate value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= shipCreateMaxBytes);
@@ -2249,8 +2238,7 @@ void initExpressionProbe(ExpressionProbe value) {
 
 // writeExpressionProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// expressionProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// expressionProbeMaxBytes. Returns the bytes written.
 int writeExpressionProbe(ExpressionProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= expressionProbeMaxBytes);
@@ -2369,8 +2357,7 @@ void initExtremeProbe(ExtremeProbe value) {
 
 // writeExtremeProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// extremeProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// extremeProbeMaxBytes. Returns the bytes written.
 int writeExtremeProbe(ExtremeProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= extremeProbeMaxBytes);
@@ -2595,8 +2582,7 @@ void initExtremeRow(ExtremeRow value) {
 
 // writeExtremeRow packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// extremeRowMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// extremeRowMaxBytes. Returns the bytes written.
 int writeExtremeRow(ExtremeRow value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= extremeRowMaxBytes);

--- a/generated/dart/Wire.dart
+++ b/generated/dart/Wire.dart
@@ -222,8 +222,7 @@ void initProbeHeader(ProbeHeader value) {
 
 // writeProbeHeader packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeHeaderMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeHeaderMaxBytes. Returns the bytes written.
 int writeProbeHeader(ProbeHeader value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeHeaderMaxBytes);
@@ -393,8 +392,7 @@ void initProbeBits(ProbeBits value) {
 
 // writeProbeBits packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeBitsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeBitsMaxBytes. Returns the bytes written.
 int writeProbeBits(ProbeBits value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeBitsMaxBytes);
@@ -594,8 +592,7 @@ void initProbeSample(ProbeSample value) {
 
 // writeProbeSample packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeSampleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeSampleMaxBytes. Returns the bytes written.
 int writeProbeSample(ProbeSample value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeSampleMaxBytes);
@@ -683,9 +680,8 @@ int writeProbeSample(ProbeSample value, ByteData view) {
       scratch = v >>> (32 - scratchBits);
     }
   }
-  if (value.samplesCount < 1 || value.samplesCount > 8) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.samplesCount >= 1);
+  assert(value.samplesCount <= 8);
   v = ((value.samplesCount - 1) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
@@ -929,8 +925,7 @@ void initProbeRing(ProbeRing value) {
 
 // writeProbeRing packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeRingMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeRingMaxBytes. Returns the bytes written.
 int writeProbeRing(ProbeRing value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeRingMaxBytes);
@@ -1020,8 +1015,7 @@ void initProbeSlab(ProbeSlab value) {
 
 // writeProbeSlab packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeSlabMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeSlabMaxBytes. Returns the bytes written.
 int writeProbeSlab(ProbeSlab value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeSlabMaxBytes);
@@ -1140,8 +1134,7 @@ void zeroProbeShape(ProbeShape value) {
 
 // writeProbeShape packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeShapeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeShapeMaxBytes. Returns the bytes written.
 int writeProbeShape(ProbeShape value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeShapeMaxBytes);
@@ -1319,8 +1312,7 @@ void initProbeCollider(ProbeCollider value) {
 
 // writeProbeCollider packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeColliderMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeColliderMaxBytes. Returns the bytes written.
 int writeProbeCollider(ProbeCollider value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeColliderMaxBytes);
@@ -1402,9 +1394,8 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
         scratch = v >>> (15 - scratchBits);
       }
   }
-  if (value.extrasCount < 0 || value.extrasCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.extrasCount >= 0);
+  assert(value.extrasCount <= 2);
   v = ((value.extrasCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1720,8 +1711,7 @@ void initProbeConfig(ProbeConfig value) {
 
 // writeProbeConfig packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeConfigMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeConfigMaxBytes. Returns the bytes written.
 int writeProbeConfig(ProbeConfig value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeConfigMaxBytes);
@@ -1819,8 +1809,7 @@ void initProbeArray(ProbeArray value) {
 
 // writeProbeArray packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeArrayMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeArrayMaxBytes. Returns the bytes written.
 int writeProbeArray(ProbeArray value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeArrayMaxBytes);
@@ -1910,9 +1899,8 @@ int writeProbeArray(ProbeArray value, ByteData view) {
         scratch = v >>> (32 - scratchBits);
       }
     }
-    if (e0.samplesCount < 1 || e0.samplesCount > 8) {
-      return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    assert(e0.samplesCount >= 1);
+    assert(e0.samplesCount <= 8);
     v = ((e0.samplesCount - 1) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
@@ -2193,8 +2181,7 @@ void initHeartbeat(Heartbeat value) {
 
 // writeHeartbeat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// heartbeatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// heartbeatMaxBytes. Returns the bytes written.
 int writeHeartbeat(Heartbeat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= heartbeatMaxBytes);
@@ -2254,8 +2241,7 @@ void initTest(Test value) {
 
 // writeTest packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// testMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// testMaxBytes. Returns the bytes written.
 int writeTest(Test value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= testMaxBytes);
@@ -2373,8 +2359,7 @@ void initBlock(Block value) {
 
 // writeBlock packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// blockMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// blockMaxBytes. Returns the bytes written.
 int writeBlock(Block value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= blockMaxBytes);
@@ -2538,8 +2523,7 @@ void initChat(Chat value) {
 
 // writeChat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// chatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// chatMaxBytes. Returns the bytes written.
 int writeChat(Chat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= chatMaxBytes);
@@ -2714,8 +2698,7 @@ void initProbeReport(ProbeReport value) {
 
 // writeProbeReport packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeReportMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeReportMaxBytes. Returns the bytes written.
 int writeProbeReport(ProbeReport value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeReportMaxBytes);
@@ -2997,8 +2980,7 @@ void initTestData(TestData value) {
 
 // writeTestData packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// testDataMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// testDataMaxBytes. Returns the bytes written.
 int writeTestData(TestData value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= testDataMaxBytes);
@@ -3012,9 +2994,8 @@ int writeTestData(TestData value, ByteData view) {
   assert(value.b <= 100);
   assert(value.c >= -100);
   assert(value.c <= 150);
-  if (value.itemsCount < 0 || value.itemsCount > 16) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 16);
   v =
       ((value.a + 100) & 0xff) |
       (((value.b + 100) & 0xff) << 8) |
@@ -3587,8 +3568,7 @@ void initCompressedProbe(CompressedProbe value) {
 
 // writeCompressedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// compressedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// compressedProbeMaxBytes. Returns the bytes written.
 int writeCompressedProbe(CompressedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= compressedProbeMaxBytes);

--- a/generated/java-ludicrous/Ludicrous.java
+++ b/generated/java-ludicrous/Ludicrous.java
@@ -1139,6 +1139,8 @@ public final class Ludicrous {
             assert value.wide.bias.compareTo(min) >= 0;
             assert value.wide.bias.compareTo(max) <= 0;
         }
+        assert value.keysCount >= 0;
+        assert value.keysCount <= 4;
         return true;
     }
 
@@ -1362,9 +1364,6 @@ public final class Ludicrous {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.keysCount < 0 || value.keysCount > 4) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.keysCount) & 0x7L;
         scratch |= v << scratchBits;

--- a/generated/java/ArmDefaults.java
+++ b/generated/java/ArmDefaults.java
@@ -65,6 +65,8 @@ public final class ArmDefaults {
     private static boolean checkWriteDefaultArm(DefaultArm value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= defaultArmMaxBytes;
+        assert value.entriesCount >= 0;
+        assert value.entriesCount <= 2;
         for (int i0 = 0; i0 < value.entriesCount; i0++) {
             final Wire.ProbeConfig e0 = value.entries[i0];
             assert (e0.preferred & 0xffL) >= 0;
@@ -84,9 +86,6 @@ public final class ArmDefaults {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.entriesCount < 0 || value.entriesCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.entriesCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -284,6 +283,8 @@ public final class ArmDefaults {
         assert (value.type & 0xffL) <= 2;
         switch (value.type) {
             case 1:
+                assert value.first.entriesCount >= 0;
+                assert value.first.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.first.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.first.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -293,6 +294,8 @@ public final class ArmDefaults {
                 assert (value.first.marker & 0xffL) <= 7;
                 break;
             case 2:
+                assert value.second.entriesCount >= 0;
+                assert value.second.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.second.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.second.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -325,9 +328,6 @@ public final class ArmDefaults {
         }
         switch (value.type) {
             case 1:
-                if (value.first.entriesCount < 0 || value.first.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.first.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -369,9 +369,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.second.entriesCount < 0 || value.second.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.second.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -643,6 +640,8 @@ public final class ArmDefaults {
         assert (value.choice.type & 0xffL) <= 2;
         switch (value.choice.type) {
             case 1:
+                assert value.choice.first.entriesCount >= 0;
+                assert value.choice.first.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.choice.first.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.choice.first.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -652,6 +651,8 @@ public final class ArmDefaults {
                 assert (value.choice.first.marker & 0xffL) <= 7;
                 break;
             case 2:
+                assert value.choice.second.entriesCount >= 0;
+                assert value.choice.second.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.choice.second.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.choice.second.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -684,9 +685,6 @@ public final class ArmDefaults {
         }
         switch (value.choice.type) {
             case 1:
-                if (value.choice.first.entriesCount < 0 || value.choice.first.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.choice.first.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -728,9 +726,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.choice.second.entriesCount < 0 || value.choice.second.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.choice.second.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -1005,6 +1000,8 @@ public final class ArmDefaults {
     private static boolean checkWriteDefaultBulkArm(DefaultBulkArm value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= defaultBulkArmMaxBytes;
+        assert value.payload.entriesCount >= 0;
+        assert value.payload.entriesCount <= 2;
         for (int i0 = 0; i0 < value.payload.entriesCount; i0++) {
             final Wire.ProbeConfig e0 = value.payload.entries[i0];
             assert (e0.preferred & 0xffL) >= 0;
@@ -1026,9 +1023,6 @@ public final class ArmDefaults {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.payload.entriesCount < 0 || value.payload.entriesCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.payload.entriesCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -1296,6 +1290,8 @@ public final class ArmDefaults {
         assert (value.type & 0xffL) <= 2;
         switch (value.type) {
             case 1:
+                assert value.first.payload.entriesCount >= 0;
+                assert value.first.payload.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.first.payload.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.first.payload.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -1307,6 +1303,8 @@ public final class ArmDefaults {
                 assert value.first.dataLength <= 2;
                 break;
             case 2:
+                assert value.second.payload.entriesCount >= 0;
+                assert value.second.payload.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.second.payload.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.second.payload.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -1341,9 +1339,6 @@ public final class ArmDefaults {
         }
         switch (value.type) {
             case 1:
-                if (value.first.payload.entriesCount < 0 || value.first.payload.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.first.payload.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -1420,9 +1415,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.second.payload.entriesCount < 0 || value.second.payload.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.second.payload.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;

--- a/generated/java/Clauses.java
+++ b/generated/java/Clauses.java
@@ -50,6 +50,8 @@ public final class Clauses {
     private static boolean checkWriteW13(W13 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w13MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 12;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffL) >= 0;
             assert (value.items[i0] & 0xffffL) <= 8191;
@@ -66,9 +68,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 12) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -193,6 +192,8 @@ public final class Clauses {
     private static boolean checkWriteW17(W17 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w17MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 9;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffffffL) >= 0;
             assert (value.items[i0] & 0xffffffffL) <= 131071;
@@ -209,9 +210,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 9) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -336,6 +334,8 @@ public final class Clauses {
     private static boolean checkWriteW26(W26 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w26MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 6;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffffffL) >= 0;
             assert (value.items[i0] & 0xffffffffL) <= 67108863;
@@ -352,9 +352,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 6) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x7L;
         scratch |= v << scratchBits;
         scratchBits += 3;
@@ -479,6 +476,8 @@ public final class Clauses {
     private static boolean checkWriteW1(W1 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w1MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 20;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffL) >= 0;
             assert (value.items[i0] & 0xffL) <= 1;
@@ -495,9 +494,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 20) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x1fL;
         scratch |= v << scratchBits;
         scratchBits += 5;
@@ -622,6 +618,8 @@ public final class Clauses {
     private static boolean checkWriteW52(W52 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w52MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 4503599627370495L;
@@ -638,9 +636,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -783,6 +778,8 @@ public final class Clauses {
     private static boolean checkWriteW50(W50 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w50MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 1125899906842623L;
@@ -799,9 +796,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -1186,6 +1180,8 @@ public final class Clauses {
     private static boolean checkWriteArrTri3(ArrTri3 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrTri3MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 10;
         return true;
     }
 
@@ -1198,9 +1194,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 10) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -2383,6 +2376,8 @@ public final class Clauses {
     private static boolean checkWriteArrNested(ArrNested value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrNestedMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 4;
         return true;
     }
 
@@ -2403,9 +2398,6 @@ public final class Clauses {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 4) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x7L;
         scratch |= v << scratchBits;

--- a/generated/java/Joins.java
+++ b/generated/java/Joins.java
@@ -1274,6 +1274,8 @@ public final class Joins {
         assert data.length % 8 == 0;
         assert data.length >= armArrayMaxBytes;
         if (value.flag) {
+            assert value.itemsCount >= 0;
+            assert value.itemsCount <= 3;
             for (int i0 = 0; i0 < value.itemsCount; i0++) {
                 assert (value.items[i0] & 0xffffL) >= 0;
                 assert (value.items[i0] & 0xffffL) <= 8191;
@@ -1310,9 +1312,6 @@ public final class Joins {
             scratch = v >>> (1 - scratchBits);
         }
         if (value.flag) {
-            if (value.itemsCount < 0 || value.itemsCount > 3) {
-                return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-            }
             v = (value.itemsCount) & 0x3L;
             scratch |= v << scratchBits;
             scratchBits += 2;
@@ -2222,6 +2221,8 @@ public final class Joins {
     private static boolean checkWriteArrUneven(ArrUneven value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrUnevenMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             final Uneven e0 = value.items[i0];
             assert (e0.type & 0xffL) >= 0;
@@ -2247,9 +2248,6 @@ public final class Joins {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
@@ -2525,6 +2523,8 @@ public final class Joins {
     private static boolean checkWriteRegainAfterAlign(RegainAfterAlign value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= regainAfterAlignMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffL) >= 0;
             assert (value.items[i0] & 0xffffL) <= 8191;
@@ -2551,9 +2551,6 @@ public final class Joins {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;

--- a/generated/java/Render.java
+++ b/generated/java/Render.java
@@ -283,6 +283,8 @@ public final class Render {
     private static boolean checkWriteRenderBlock(RenderBlock value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= renderBlockMaxBytes;
+        assert value.spritesCount >= 0;
+        assert value.spritesCount <= 64;
         for (int i0 = 0; i0 < value.spritesCount; i0++) {
             final RenderSprite e0 = value.sprites[i0];
             assert (e0.team & 0xffL) >= 0;
@@ -317,9 +319,6 @@ public final class Render {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.spritesCount < 0 || value.spritesCount > 64) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.spritesCount) & 0x7fL;
         scratch |= v << scratchBits;

--- a/generated/java/Types.java
+++ b/generated/java/Types.java
@@ -2230,6 +2230,8 @@ public final class Types {
     private static boolean checkWriteInputPacket(InputPacket value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= inputPacketMaxBytes;
+        assert value.inputsCount >= 0;
+        assert value.inputsCount <= 16;
         return true;
     }
 
@@ -2286,9 +2288,6 @@ public final class Types {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.inputsCount < 0 || value.inputsCount > 16) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.inputsCount) & 0x1fL;
         scratch |= v << scratchBits;

--- a/generated/java/Wire.java
+++ b/generated/java/Wire.java
@@ -658,6 +658,8 @@ public final class Wire {
             assert (value.weapon & 0xffL) >= 0;
             assert (value.weapon & 0xffL) <= 15;
         }
+        assert value.samplesCount >= 1;
+        assert value.samplesCount <= 8;
         return true;
     }
 
@@ -765,9 +767,6 @@ public final class Wire {
                 scratchBits -= 64;
                 scratch = v >>> (32 - scratchBits);
             }
-        }
-        if (value.samplesCount < 1 || value.samplesCount > 8) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.samplesCount - 1) & 0x7L;
         scratch |= v << scratchBits;
@@ -1512,6 +1511,8 @@ public final class Wire {
                 assert (value.backup.slab.width & 0xffL) <= 100;
                 break;
         }
+        assert value.extrasCount >= 0;
+        assert value.extrasCount <= 2;
         for (int i0 = 0; i0 < value.extrasCount; i0++) {
             final ProbeShape e0 = value.extras[i0];
             assert (e0.type & 0xffL) >= 0;
@@ -1627,9 +1628,6 @@ public final class Wire {
                     scratch = v >>> (8 - scratchBits);
                 }
                 break;
-        }
-        if (value.extrasCount < 0 || value.extrasCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.extrasCount) & 0x3L;
         scratch |= v << scratchBits;
@@ -2156,6 +2154,8 @@ public final class Wire {
                 assert (e0.weapon & 0xffL) >= 0;
                 assert (e0.weapon & 0xffL) <= 15;
             }
+            assert e0.samplesCount >= 1;
+            assert e0.samplesCount <= 8;
         }
         assert (value.config.preferred & 0xffL) >= 0;
         assert (value.config.preferred & 0xffL) <= 15;
@@ -2268,9 +2268,6 @@ public final class Wire {
                     scratchBits -= 64;
                     scratch = v >>> (32 - scratchBits);
                 }
-            }
-            if (e0.samplesCount < 1 || e0.samplesCount > 8) {
-                return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
             }
             v = (e0.samplesCount - 1) & 0x7L;
             scratch |= v << scratchBits;
@@ -3558,6 +3555,8 @@ public final class Wire {
         assert value.b <= 100;
         assert value.c >= -100;
         assert value.c <= 150;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 16;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 255;
@@ -3641,9 +3640,6 @@ public final class Wire {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (1 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 16) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x1fL;
         scratch |= v << scratchBits;

--- a/generated/js-ludicrous/LudicrousFlat.js
+++ b/generated/js-ludicrous/LudicrousFlat.js
@@ -187,9 +187,9 @@ function writeFixedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedProbeMaxBytes.
+// WriteFixedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedProbeMaxBytes.
 export const WriteFixedProbeFlat = PRODUCTION ? writeFixedProbeFlatProduction : writeFixedProbeFlatChecked;
 
 // ReadFixedProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -456,9 +456,9 @@ function writeUnsignedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteUnsignedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold UnsignedProbeMaxBytes.
+// WriteUnsignedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold UnsignedProbeMaxBytes.
 export const WriteUnsignedProbeFlat = PRODUCTION ? writeUnsignedProbeFlatProduction : writeUnsignedProbeFlatChecked;
 
 // ReadUnsignedProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -875,9 +875,9 @@ function writeWideProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideProbeMaxBytes.
+// WriteWideProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideProbeMaxBytes.
 export const WriteWideProbeFlat = PRODUCTION ? writeWideProbeFlatProduction : writeWideProbeFlatChecked;
 
 // ReadWideProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1239,9 +1239,6 @@ function writeLudicrousStateFlatProduction(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.KeysCount) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -1583,7 +1580,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.KeysCount) & 0x7)) >>> 0;
@@ -1692,9 +1689,9 @@ function writeLudicrousStateFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteLudicrousStateFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold LudicrousStateMaxBytes.
+// WriteLudicrousStateFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold LudicrousStateMaxBytes.
 export const WriteLudicrousStateFlat = PRODUCTION ? writeLudicrousStateFlatProduction : writeLudicrousStateFlatChecked;
 
 // ReadLudicrousStateFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2065,9 +2062,9 @@ function writeDegenerateProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDegenerateProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DegenerateProbeMaxBytes.
+// WriteDegenerateProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DegenerateProbeMaxBytes.
 export const WriteDegenerateProbeFlat = PRODUCTION ? writeDegenerateProbeFlatProduction : writeDegenerateProbeFlatChecked;
 
 // ReadDegenerateProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2234,9 +2231,9 @@ function writeFixedVecFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedVecFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedVecMaxBytes.
+// WriteFixedVecFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedVecMaxBytes.
 export const WriteFixedVecFlat = PRODUCTION ? writeFixedVecFlatProduction : writeFixedVecFlatChecked;
 
 // ReadFixedVecFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2417,9 +2414,9 @@ function writeFixedQuatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedQuatMaxBytes.
+// WriteFixedQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedQuatMaxBytes.
 export const WriteFixedQuatFlat = PRODUCTION ? writeFixedQuatFlatProduction : writeFixedQuatFlatChecked;
 
 // ReadFixedQuatFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/ArmDefaultsFlat.js
+++ b/generated/js/ArmDefaultsFlat.js
@@ -41,9 +41,6 @@ export const FLAT_READ_SLACK = 8;
 function writeDefaultArmFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.EntriesCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -92,7 +89,7 @@ function writeDefaultArmFlatProduction(value, view) {
 function writeDefaultArmFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.EntriesCount) || value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.EntriesCount) || value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.EntriesCount) & 0x3)) >>> 0;
@@ -146,9 +143,9 @@ function writeDefaultArmFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultArmFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultArmMaxBytes.
+// WriteDefaultArmFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultArmMaxBytes.
 export const WriteDefaultArmFlat = PRODUCTION ? writeDefaultArmFlatProduction : writeDefaultArmFlatChecked;
 
 // ReadDefaultArmFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -221,9 +218,6 @@ function writeDefaultChoicePacketFlatProduction(value, view) {
   }
   switch (value.Choice.Type) {
     case 1: {
-      if (value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-        return -1;
-      }
       v = (((value.Choice.First.EntriesCount) & 0x3)) >>> 0;
       lo = (lo | (v << sb)) >>> 0;
       sb += 2;
@@ -266,9 +260,6 @@ function writeDefaultChoicePacketFlatProduction(value, view) {
       break;
     }
     case 2: {
-      if (value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-        return -1;
-      }
       v = (((value.Choice.Second.EntriesCount) & 0x3)) >>> 0;
       lo = (lo | (v << sb)) >>> 0;
       sb += 2;
@@ -334,7 +325,7 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
   }
   switch (value.Choice.Type) {
     case 1: {
-      if (!Number.isInteger(value.Choice.First.EntriesCount) || value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+      if (!Number.isInteger(value.Choice.First.EntriesCount) || value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
         return -1;
       }
       v = (((value.Choice.First.EntriesCount) & 0x3)) >>> 0;
@@ -385,7 +376,7 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Choice.Second.EntriesCount) || value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+      if (!Number.isInteger(value.Choice.Second.EntriesCount) || value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
         return -1;
       }
       v = (((value.Choice.Second.EntriesCount) & 0x3)) >>> 0;
@@ -442,9 +433,9 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultChoicePacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultChoicePacketMaxBytes.
+// WriteDefaultChoicePacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultChoicePacketMaxBytes.
 export const WriteDefaultChoicePacketFlat = PRODUCTION ? writeDefaultChoicePacketFlatProduction : writeDefaultChoicePacketFlatChecked;
 
 // ReadDefaultChoicePacketFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -590,9 +581,6 @@ export function ReadDefaultChoicePacketFlat(value, view, numBits) {
 function writeDefaultBulkArmFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.Payload.EntriesCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -673,7 +661,7 @@ function writeDefaultBulkArmFlatProduction(value, view) {
 function writeDefaultBulkArmFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Payload.EntriesCount) || value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.Payload.EntriesCount) || value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.Payload.EntriesCount) & 0x3)) >>> 0;
@@ -762,9 +750,9 @@ function writeDefaultBulkArmFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultBulkArmFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultBulkArmMaxBytes.
+// WriteDefaultBulkArmFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultBulkArmMaxBytes.
 export const WriteDefaultBulkArmFlat = PRODUCTION ? writeDefaultBulkArmFlatProduction : writeDefaultBulkArmFlatChecked;
 
 // ReadDefaultBulkArmFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/ClausesFlat.js
+++ b/generated/js/ClausesFlat.js
@@ -22,9 +22,6 @@ export const FLAT_READ_SLACK = 8;
 function writeW13FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -54,7 +51,7 @@ function writeW13FlatProduction(value, view) {
 function writeW13FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -86,9 +83,9 @@ function writeW13FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW13Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W13MaxBytes.
+// WriteW13Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W13MaxBytes.
 export const WriteW13Flat = PRODUCTION ? writeW13FlatProduction : writeW13FlatChecked;
 
 // ReadW13Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -131,9 +128,6 @@ export function ReadW13Flat(value, view, numBits) {
 function writeW17FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -163,7 +157,7 @@ function writeW17FlatProduction(value, view) {
 function writeW17FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -195,9 +189,9 @@ function writeW17FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW17Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W17MaxBytes.
+// WriteW17Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W17MaxBytes.
 export const WriteW17Flat = PRODUCTION ? writeW17FlatProduction : writeW17FlatChecked;
 
 // ReadW17Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -240,9 +234,6 @@ export function ReadW17Flat(value, view, numBits) {
 function writeW26FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -272,7 +263,7 @@ function writeW26FlatProduction(value, view) {
 function writeW26FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x7)) >>> 0;
@@ -304,9 +295,9 @@ function writeW26FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW26Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W26MaxBytes.
+// WriteW26Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W26MaxBytes.
 export const WriteW26Flat = PRODUCTION ? writeW26FlatProduction : writeW26FlatChecked;
 
 // ReadW26Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -349,9 +340,6 @@ export function ReadW26Flat(value, view, numBits) {
 function writeW1FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x1f)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 5;
@@ -381,7 +369,7 @@ function writeW1FlatProduction(value, view) {
 function writeW1FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x1f)) >>> 0;
@@ -413,9 +401,9 @@ function writeW1FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW1Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W1MaxBytes.
+// WriteW1Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W1MaxBytes.
 export const WriteW1Flat = PRODUCTION ? writeW1FlatProduction : writeW1FlatChecked;
 
 // ReadW1Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -458,9 +446,6 @@ export function ReadW1Flat(value, view, numBits) {
 function writeW52FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -500,7 +485,7 @@ function writeW52FlatProduction(value, view) {
 function writeW52FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -542,9 +527,9 @@ function writeW52FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW52Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W52MaxBytes.
+// WriteW52Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W52MaxBytes.
 export const WriteW52Flat = PRODUCTION ? writeW52FlatProduction : writeW52FlatChecked;
 
 // ReadW52Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -595,9 +580,6 @@ export function ReadW52Flat(value, view, numBits) {
 function writeW50FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -637,7 +619,7 @@ function writeW50FlatProduction(value, view) {
 function writeW50FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -679,9 +661,9 @@ function writeW50FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW50Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W50MaxBytes.
+// WriteW50Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W50MaxBytes.
 export const WriteW50Flat = PRODUCTION ? writeW50FlatProduction : writeW50FlatChecked;
 
 // ReadW50Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -772,9 +754,9 @@ function writeF13FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteF13Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold F13MaxBytes.
+// WriteF13Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold F13MaxBytes.
 export const WriteF13Flat = PRODUCTION ? writeF13FlatProduction : writeF13FlatChecked;
 
 // ReadF13Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -836,9 +818,9 @@ function writeTri3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Tri3MaxBytes.
+// WriteTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Tri3MaxBytes.
 export const WriteTri3Flat = PRODUCTION ? writeTri3FlatProduction : writeTri3FlatChecked;
 
 // ReadTri3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -866,9 +848,6 @@ export function ReadTri3Flat(value, view, numBits) {
 function writeArrTri3FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -899,7 +878,7 @@ function writeArrTri3FlatProduction(value, view) {
 function writeArrTri3FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -929,9 +908,9 @@ function writeArrTri3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrTri3MaxBytes.
+// WriteArrTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrTri3MaxBytes.
 export const WriteArrTri3Flat = PRODUCTION ? writeArrTri3FlatProduction : writeArrTri3FlatChecked;
 
 // ReadArrTri3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -1010,9 +989,9 @@ function writeElevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ElevenMaxBytes.
+// WriteElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ElevenMaxBytes.
 export const WriteElevenFlat = PRODUCTION ? writeElevenFlatProduction : writeElevenFlatChecked;
 
 // ReadElevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1079,9 +1058,9 @@ function writeArrElevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrElevenMaxBytes.
+// WriteArrElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrElevenMaxBytes.
 export const WriteArrElevenFlat = PRODUCTION ? writeArrElevenFlatProduction : writeArrElevenFlatChecked;
 
 // ReadArrElevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1128,9 +1107,9 @@ function writeEmptyAFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteEmptyAFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold EmptyAMaxBytes.
+// WriteEmptyAFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold EmptyAMaxBytes.
 export const WriteEmptyAFlat = PRODUCTION ? writeEmptyAFlatProduction : writeEmptyAFlatChecked;
 
 // ReadEmptyAFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1161,9 +1140,9 @@ function writeEmptyBFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteEmptyBFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold EmptyBMaxBytes.
+// WriteEmptyBFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold EmptyBMaxBytes.
 export const WriteEmptyBFlat = PRODUCTION ? writeEmptyBFlatProduction : writeEmptyBFlatChecked;
 
 // ReadEmptyBFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1249,9 +1228,9 @@ function writeHoldsEmptyUnionFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHoldsEmptyUnionFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HoldsEmptyUnionMaxBytes.
+// WriteHoldsEmptyUnionFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HoldsEmptyUnionMaxBytes.
 export const WriteHoldsEmptyUnionFlat = PRODUCTION ? writeHoldsEmptyUnionFlatProduction : writeHoldsEmptyUnionFlatChecked;
 
 // ReadHoldsEmptyUnionFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1513,9 +1492,9 @@ function writeStrsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteStrsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold StrsMaxBytes.
+// WriteStrsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold StrsMaxBytes.
 export const WriteStrsFlat = PRODUCTION ? writeStrsFlatProduction : writeStrsFlatChecked;
 
 // ReadStrsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1641,9 +1620,6 @@ export function ReadStrsFlat(value, view, numBits) {
 function writeArrNestedFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x7) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 8;
@@ -1683,7 +1659,7 @@ function writeArrNestedFlatProduction(value, view) {
 function writeArrNestedFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x7) << 5)) >>> 0;
@@ -1722,9 +1698,9 @@ function writeArrNestedFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrNestedMaxBytes.
+// WriteArrNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrNestedMaxBytes.
 export const WriteArrNestedFlat = PRODUCTION ? writeArrNestedFlatProduction : writeArrNestedFlatChecked;
 
 // ReadArrNestedFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1824,9 +1800,9 @@ function writeSoleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SoleMaxBytes.
+// WriteSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SoleMaxBytes.
 export const WriteSoleFlat = PRODUCTION ? writeSoleFlatProduction : writeSoleFlatChecked;
 
 // ReadSoleFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/DegenerateFlat.js
+++ b/generated/js/DegenerateFlat.js
@@ -113,9 +113,9 @@ function writeVec2FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteVec2Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Vec2MaxBytes.
+// WriteVec2Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Vec2MaxBytes.
 export const WriteVec2Flat = PRODUCTION ? writeVec2FlatProduction : writeVec2FlatChecked;
 
 // ReadVec2Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -224,9 +224,9 @@ function writeSpanF64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanF64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanF64MaxBytes.
+// WriteSpanF64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanF64MaxBytes.
 export const WriteSpanF64Flat = PRODUCTION ? writeSpanF64FlatProduction : writeSpanF64FlatChecked;
 
 // ReadSpanF64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -321,9 +321,9 @@ function writeSpanU64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanU64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanU64MaxBytes.
+// WriteSpanU64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanU64MaxBytes.
 export const WriteSpanU64Flat = PRODUCTION ? writeSpanU64FlatProduction : writeSpanU64FlatChecked;
 
 // ReadSpanU64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -420,9 +420,9 @@ function writeSpanI64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanI64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanI64MaxBytes.
+// WriteSpanI64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanI64MaxBytes.
 export const WriteSpanI64Flat = PRODUCTION ? writeSpanI64FlatProduction : writeSpanI64FlatChecked;
 
 // ReadSpanI64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -519,9 +519,9 @@ function writeSpanOneFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanOneFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanOneMaxBytes.
+// WriteSpanOneFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanOneMaxBytes.
 export const WriteSpanOneFlat = PRODUCTION ? writeSpanOneFlatProduction : writeSpanOneFlatChecked;
 
 // ReadSpanOneFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -598,9 +598,9 @@ function writeSpanChunkFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanChunkFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanChunkMaxBytes.
+// WriteSpanChunkFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanChunkMaxBytes.
 export const WriteSpanChunkFlat = PRODUCTION ? writeSpanChunkFlatProduction : writeSpanChunkFlatChecked;
 
 // ReadSpanChunkFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -704,9 +704,9 @@ function writeSpanTailFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanTailFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanTailMaxBytes.
+// WriteSpanTailFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanTailMaxBytes.
 export const WriteSpanTailFlat = PRODUCTION ? writeSpanTailFlatProduction : writeSpanTailFlatChecked;
 
 // ReadSpanTailFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -850,9 +850,9 @@ function writeSpanTwiceFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanTwiceFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanTwiceMaxBytes.
+// WriteSpanTwiceFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanTwiceMaxBytes.
 export const WriteSpanTwiceFlat = PRODUCTION ? writeSpanTwiceFlatProduction : writeSpanTwiceFlatChecked;
 
 // ReadSpanTwiceFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -978,9 +978,9 @@ function writeTrioFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioMaxBytes.
+// WriteTrioFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioMaxBytes.
 export const WriteTrioFlat = PRODUCTION ? writeTrioFlatProduction : writeTrioFlatChecked;
 
 // ReadTrioFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1091,9 +1091,9 @@ function writeTrioSoleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioSoleMaxBytes.
+// WriteTrioSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioSoleMaxBytes.
 export const WriteTrioSoleFlat = PRODUCTION ? writeTrioSoleFlatProduction : writeTrioSoleFlatChecked;
 
 // ReadTrioSoleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1222,9 +1222,9 @@ function writeTrioFirstFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioFirstFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioFirstMaxBytes.
+// WriteTrioFirstFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioFirstMaxBytes.
 export const WriteTrioFirstFlat = PRODUCTION ? writeTrioFirstFlatProduction : writeTrioFirstFlatChecked;
 
 // ReadTrioFirstFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1551,9 +1551,9 @@ function writeTrioStraddleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioStraddleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioStraddleMaxBytes.
+// WriteTrioStraddleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioStraddleMaxBytes.
 export const WriteTrioStraddleFlat = PRODUCTION ? writeTrioStraddleFlatProduction : writeTrioStraddleFlatChecked;
 
 // ReadTrioStraddleFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/JoinsFlat.js
+++ b/generated/js/JoinsFlat.js
@@ -115,9 +115,9 @@ function writeArmsAgreeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsAgreeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsAgreeMaxBytes.
+// WriteArmsAgreeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsAgreeMaxBytes.
 export const WriteArmsAgreeFlat = PRODUCTION ? writeArmsAgreeFlatProduction : writeArmsAgreeFlatChecked;
 
 // ReadArmsAgreeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -267,9 +267,9 @@ function writeArmsDisagreeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsDisagreeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsDisagreeMaxBytes.
+// WriteArmsDisagreeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsDisagreeMaxBytes.
 export const WriteArmsDisagreeFlat = PRODUCTION ? writeArmsDisagreeFlatProduction : writeArmsDisagreeFlatChecked;
 
 // ReadArmsDisagreeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -408,9 +408,9 @@ function writeArmEmptyFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmEmptyFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmEmptyMaxBytes.
+// WriteArmEmptyFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmEmptyMaxBytes.
 export const WriteArmEmptyFlat = PRODUCTION ? writeArmEmptyFlatProduction : writeArmEmptyFlatChecked;
 
 // ReadArmEmptyFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -599,9 +599,9 @@ function writeArmsNestedFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsNestedMaxBytes.
+// WriteArmsNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsNestedMaxBytes.
 export const WriteArmsNestedFlat = PRODUCTION ? writeArmsNestedFlatProduction : writeArmsNestedFlatChecked;
 
 // ReadArmsNestedFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -856,9 +856,9 @@ function writeArmAlignFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmAlignMaxBytes.
+// WriteArmAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmAlignMaxBytes.
 export const WriteArmAlignFlat = PRODUCTION ? writeArmAlignFlatProduction : writeArmAlignFlatChecked;
 
 // ReadArmAlignFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -981,9 +981,6 @@ function writeArmArrayFlatProduction(value, view) {
     lo = sb === 0 ? 0 : v >>> (6 - sb);
   }
   if (value.Flag) {
-    if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-      return -1;
-    }
     v = (((value.ItemsCount) & 0x3)) >>> 0;
     lo = (lo | (v << sb)) >>> 0;
     sb += 2;
@@ -1043,7 +1040,7 @@ function writeArmArrayFlatChecked(value, view) {
     lo = sb === 0 ? 0 : v >>> (6 - sb);
   }
   if (value.Flag) {
-    if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+    if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
       return -1;
     }
     v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -1095,9 +1092,9 @@ function writeArmArrayFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmArrayMaxBytes.
+// WriteArmArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmArrayMaxBytes.
 export const WriteArmArrayFlat = PRODUCTION ? writeArmArrayFlatProduction : writeArmArrayFlatChecked;
 
 // ReadArmArrayFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1210,9 +1207,9 @@ function writeNarrowFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteNarrowFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold NarrowMaxBytes.
+// WriteNarrowFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold NarrowMaxBytes.
 export const WriteNarrowFlat = PRODUCTION ? writeNarrowFlatProduction : writeNarrowFlatChecked;
 
 // ReadNarrowFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1291,9 +1288,9 @@ function writeWideFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideMaxBytes.
+// WriteWideFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideMaxBytes.
 export const WriteWideFlat = PRODUCTION ? writeWideFlatProduction : writeWideFlatChecked;
 
 // ReadWideFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1456,9 +1453,9 @@ function writeHoldsUnevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHoldsUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HoldsUnevenMaxBytes.
+// WriteHoldsUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HoldsUnevenMaxBytes.
 export const WriteHoldsUnevenFlat = PRODUCTION ? writeHoldsUnevenFlatProduction : writeHoldsUnevenFlatChecked;
 
 // ReadHoldsUnevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1552,9 +1549,6 @@ export function ReadHoldsUnevenFlat(value, view, numBits) {
 function writeArrUnevenFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 7;
@@ -1630,7 +1624,7 @@ function writeArrUnevenFlatProduction(value, view) {
 function writeArrUnevenFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
@@ -1708,9 +1702,9 @@ function writeArrUnevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrUnevenMaxBytes.
+// WriteArrUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrUnevenMaxBytes.
 export const WriteArrUnevenFlat = PRODUCTION ? writeArrUnevenFlatProduction : writeArrUnevenFlatChecked;
 
 // ReadArrUnevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1818,9 +1812,6 @@ export function ReadArrUnevenFlat(value, view, numBits) {
 function writeRegainAfterAlignFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 7;
@@ -1918,7 +1909,7 @@ function writeRegainAfterAlignFlatProduction(value, view) {
 function writeRegainAfterAlignFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
@@ -2021,9 +2012,9 @@ function writeRegainAfterAlignFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRegainAfterAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RegainAfterAlignMaxBytes.
+// WriteRegainAfterAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RegainAfterAlignMaxBytes.
 export const WriteRegainAfterAlignFlat = PRODUCTION ? writeRegainAfterAlignFlatProduction : writeRegainAfterAlignFlatChecked;
 
 // ReadRegainAfterAlignFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/RenderFlat.js
+++ b/generated/js/RenderFlat.js
@@ -132,9 +132,9 @@ function writeRenderSpriteFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRenderSpriteFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RenderSpriteMaxBytes.
+// WriteRenderSpriteFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RenderSpriteMaxBytes.
 export const WriteRenderSpriteFlat = PRODUCTION ? writeRenderSpriteFlatProduction : writeRenderSpriteFlatChecked;
 
 // ReadRenderSpriteFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -208,9 +208,6 @@ function writeRenderBlockFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.SpriteCountHint) >>> 0)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -297,7 +294,7 @@ function writeRenderBlockFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.SpriteCountHint) >>> 0)) >>> 0;
@@ -376,9 +373,9 @@ function writeRenderBlockFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRenderBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RenderBlockMaxBytes.
+// WriteRenderBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RenderBlockMaxBytes.
 export const WriteRenderBlockFlat = PRODUCTION ? writeRenderBlockFlatProduction : writeRenderBlockFlatChecked;
 
 // ReadRenderBlockFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/TypesFlat.js
+++ b/generated/js/TypesFlat.js
@@ -151,9 +151,9 @@ function writeVec3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteVec3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Vec3MaxBytes.
+// WriteVec3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Vec3MaxBytes.
 export const WriteVec3Flat = PRODUCTION ? writeVec3FlatProduction : writeVec3FlatChecked;
 
 // ReadVec3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -389,9 +389,9 @@ function writeQuatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuatMaxBytes.
+// WriteQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuatMaxBytes.
 export const WriteQuatFlat = PRODUCTION ? writeQuatFlatProduction : writeQuatFlatChecked;
 
 // ReadQuatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -513,9 +513,9 @@ function writeHandleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHandleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HandleMaxBytes.
+// WriteHandleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HandleMaxBytes.
 export const WriteHandleFlat = PRODUCTION ? writeHandleFlatProduction : writeHandleFlatChecked;
 
 // ReadHandleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -624,9 +624,9 @@ function writeQuantizedPositionFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedPositionFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedPositionMaxBytes.
+// WriteQuantizedPositionFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedPositionMaxBytes.
 export const WriteQuantizedPositionFlat = PRODUCTION ? writeQuantizedPositionFlatProduction : writeQuantizedPositionFlatChecked;
 
 // ReadQuantizedPositionFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -755,9 +755,9 @@ function writeQuantizedVelocityFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedVelocityFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedVelocityMaxBytes.
+// WriteQuantizedVelocityFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedVelocityMaxBytes.
 export const WriteQuantizedVelocityFlat = PRODUCTION ? writeQuantizedVelocityFlatProduction : writeQuantizedVelocityFlatChecked;
 
 // ReadQuantizedVelocityFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -871,9 +871,9 @@ function writeQuantizedRotationFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedRotationFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedRotationMaxBytes.
+// WriteQuantizedRotationFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedRotationMaxBytes.
 export const WriteQuantizedRotationFlat = PRODUCTION ? writeQuantizedRotationFlatProduction : writeQuantizedRotationFlatChecked;
 
 // ReadQuantizedRotationFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1454,9 +1454,9 @@ function writeRigidBodyFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRigidBodyFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RigidBodyMaxBytes.
+// WriteRigidBodyFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RigidBodyMaxBytes.
 export const WriteRigidBodyFlat = PRODUCTION ? writeRigidBodyFlatProduction : writeRigidBodyFlatChecked;
 
 // ReadRigidBodyFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1951,9 +1951,9 @@ function writeInputFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteInputFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold InputMaxBytes.
+// WriteInputFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold InputMaxBytes.
 export const WriteInputFlat = PRODUCTION ? writeInputFlatProduction : writeInputFlatChecked;
 
 // ReadInputFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2110,9 +2110,6 @@ function writeInputPacketFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.InputsCount) & 0x1f)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -2292,7 +2289,7 @@ function writeInputPacketFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.InputsCount) & 0x1f)) >>> 0;
@@ -2422,9 +2419,9 @@ function writeInputPacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteInputPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold InputPacketMaxBytes.
+// WriteInputPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold InputPacketMaxBytes.
 export const WriteInputPacketFlat = PRODUCTION ? writeInputPacketFlatProduction : writeInputPacketFlatChecked;
 
 // ReadInputPacketFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2849,9 +2846,9 @@ function writeShipCreateFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteShipCreateFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ShipCreateMaxBytes.
+// WriteShipCreateFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ShipCreateMaxBytes.
 export const WriteShipCreateFlat = PRODUCTION ? writeShipCreateFlatProduction : writeShipCreateFlatChecked;
 
 // ReadShipCreateFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3053,9 +3050,9 @@ function writeExpressionProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExpressionProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExpressionProbeMaxBytes.
+// WriteExpressionProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExpressionProbeMaxBytes.
 export const WriteExpressionProbeFlat = PRODUCTION ? writeExpressionProbeFlatProduction : writeExpressionProbeFlatChecked;
 
 // ReadExpressionProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3300,9 +3297,9 @@ function writeExtremeProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExtremeProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExtremeProbeMaxBytes.
+// WriteExtremeProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExtremeProbeMaxBytes.
 export const WriteExtremeProbeFlat = PRODUCTION ? writeExtremeProbeFlatProduction : writeExtremeProbeFlatChecked;
 
 // ReadExtremeProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3593,9 +3590,9 @@ function writeExtremeRowFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExtremeRowFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExtremeRowMaxBytes.
+// WriteExtremeRowFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExtremeRowMaxBytes.
 export const WriteExtremeRowFlat = PRODUCTION ? writeExtremeRowFlatProduction : writeExtremeRowFlatChecked;
 
 // ReadExtremeRowFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/generated/js/WireFlat.js
+++ b/generated/js/WireFlat.js
@@ -107,9 +107,9 @@ function writeProbeHeaderFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeHeaderFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeHeaderMaxBytes.
+// WriteProbeHeaderFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeHeaderMaxBytes.
 export const WriteProbeHeaderFlat = PRODUCTION ? writeProbeHeaderFlatProduction : writeProbeHeaderFlatChecked;
 
 // ReadProbeHeaderFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -343,9 +343,9 @@ function writeProbeBitsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeBitsMaxBytes.
+// WriteProbeBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeBitsMaxBytes.
 export const WriteProbeBitsFlat = PRODUCTION ? writeProbeBitsFlatProduction : writeProbeBitsFlatChecked;
 
 // ReadProbeBitsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -515,9 +515,6 @@ function writeProbeSampleFlatProduction(value, view) {
       lo = sb === 0 ? 0 : v >>> (32 - sb);
     }
   }
-  if (value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((((value.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -634,7 +631,7 @@ function writeProbeSampleFlatChecked(value, view) {
       lo = sb === 0 ? 0 : v >>> (32 - sb);
     }
   }
-  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((((value.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
@@ -663,9 +660,9 @@ function writeProbeSampleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeSampleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeSampleMaxBytes.
+// WriteProbeSampleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeSampleMaxBytes.
 export const WriteProbeSampleFlat = PRODUCTION ? writeProbeSampleFlatProduction : writeProbeSampleFlatChecked;
 
 // ReadProbeSampleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -827,9 +824,9 @@ function writeProbeRingFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeRingFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeRingMaxBytes.
+// WriteProbeRingFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeRingMaxBytes.
 export const WriteProbeRingFlat = PRODUCTION ? writeProbeRingFlatProduction : writeProbeRingFlatChecked;
 
 // ReadProbeRingFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -891,9 +888,9 @@ function writeProbeSlabFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeSlabFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeSlabMaxBytes.
+// WriteProbeSlabFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeSlabMaxBytes.
 export const WriteProbeSlabFlat = PRODUCTION ? writeProbeSlabFlatProduction : writeProbeSlabFlatChecked;
 
 // ReadProbeSlabFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -993,9 +990,6 @@ function writeProbeColliderFlatProduction(value, view) {
       }
       break;
     }
-  }
-  if (value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.ExtrasCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -1135,7 +1129,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
   }
-  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ExtrasCount) & 0x3)) >>> 0;
@@ -1197,9 +1191,9 @@ function writeProbeColliderFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeColliderFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeColliderMaxBytes.
+// WriteProbeColliderFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeColliderMaxBytes.
 export const WriteProbeColliderFlat = PRODUCTION ? writeProbeColliderFlatProduction : writeProbeColliderFlatChecked;
 
 // ReadProbeColliderFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1453,9 +1447,9 @@ function writeProbeConfigFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeConfigFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeConfigMaxBytes.
+// WriteProbeConfigFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeConfigMaxBytes.
 export const WriteProbeConfigFlat = PRODUCTION ? writeProbeConfigFlatProduction : writeProbeConfigFlatChecked;
 
 // ReadProbeConfigFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1571,9 +1565,6 @@ function writeProbeArrayFlatProduction(value, view) {
         sb -= 32;
         lo = sb === 0 ? 0 : v >>> (32 - sb);
       }
-    }
-    if (e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-      return -1;
     }
     v = (((((e0.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
     lo = (lo | (v << sb)) >>> 0;
@@ -1712,7 +1703,7 @@ function writeProbeArrayFlatChecked(value, view) {
         lo = sb === 0 ? 0 : v >>> (32 - sb);
       }
     }
-    if (!Number.isInteger(e0.SamplesCount) || e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+    if (!Number.isInteger(e0.SamplesCount) || e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
       return -1;
     }
     v = (((((e0.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
@@ -1763,9 +1754,9 @@ function writeProbeArrayFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeArrayMaxBytes.
+// WriteProbeArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeArrayMaxBytes.
 export const WriteProbeArrayFlat = PRODUCTION ? writeProbeArrayFlatProduction : writeProbeArrayFlatChecked;
 
 // ReadProbeArrayFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1930,9 +1921,9 @@ function writeHeartbeatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHeartbeatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HeartbeatMaxBytes.
+// WriteHeartbeatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HeartbeatMaxBytes.
 export const WriteHeartbeatFlat = PRODUCTION ? writeHeartbeatFlatProduction : writeHeartbeatFlatChecked;
 
 // ReadHeartbeatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2008,9 +1999,9 @@ function writeTestFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTestFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TestMaxBytes.
+// WriteTestFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TestMaxBytes.
 export const WriteTestFlat = PRODUCTION ? writeTestFlatProduction : writeTestFlatChecked;
 
 // ReadTestFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2157,9 +2148,9 @@ function writeBlockFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BlockMaxBytes.
+// WriteBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BlockMaxBytes.
 export const WriteBlockFlat = PRODUCTION ? writeBlockFlatProduction : writeBlockFlatChecked;
 
 // ReadBlockFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2307,9 +2298,9 @@ function writeChatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteChatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ChatMaxBytes.
+// WriteChatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ChatMaxBytes.
 export const WriteChatFlat = PRODUCTION ? writeChatFlatProduction : writeChatFlatChecked;
 
 // ReadChatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2535,9 +2526,9 @@ function writeProbeReportFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeReportFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeReportMaxBytes.
+// WriteProbeReportFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeReportMaxBytes.
 export const WriteProbeReportFlat = PRODUCTION ? writeProbeReportFlatProduction : writeProbeReportFlatChecked;
 
 // ReadProbeReportFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2646,9 +2637,6 @@ function writeTestDataFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = ((value.E & 0xff) | ((value.F & 0xff) << 8) | ((value.G ? 1 : 0) << 16) | (((value.ItemsCount) & 0x1f) << 17)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -2892,7 +2880,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.E & 0xff) | ((value.F & 0xff) << 8) | ((value.G ? 1 : 0) << 16) | (((value.ItemsCount) & 0x1f) << 17)) >>> 0;
@@ -3127,9 +3115,9 @@ function writeTestDataFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTestDataFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TestDataMaxBytes.
+// WriteTestDataFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TestDataMaxBytes.
 export const WriteTestDataFlat = PRODUCTION ? writeTestDataFlatProduction : writeTestDataFlatChecked;
 
 // ReadTestDataFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3487,9 +3475,9 @@ function writeCompressedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteCompressedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold CompressedProbeMaxBytes.
+// WriteCompressedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold CompressedProbeMaxBytes.
 export const WriteCompressedProbeFlat = PRODUCTION ? writeCompressedProbeFlatProduction : writeCompressedProbeFlatChecked;
 
 // ReadCompressedProbeFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -604,9 +604,10 @@ func (g *gen) emitWireHeader() {
 		// comments below it stay one line each
 		g.pf("/* Every write_x/read_x returns 1 on success, 0 on failure — the stream\n")
 		g.pf("   latches the error, so a caller may check once at the end of a message.\n")
-		g.pf("   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE\n")
-		g.pf("   it rides, and every read reconstructs the selected arm with its declared\n")
-		g.pf("   initial values before decoding it (SPEC §4.8, §5). */\n\n")
+		g.pf("   Reads REFUSE out-of-range values, never clamp, in every build. A tag on\n")
+		g.pf("   WRITE is asserted before it rides — caller error, gone under NDEBUG — and\n")
+		g.pf("   every read reconstructs the selected arm with its declared initial values\n")
+		g.pf("   before decoding it (SPEC §4.8, §5). */\n\n")
 		g.emitSpineInlineMacros()
 	}
 	if fileHasStrings(g.file) {
@@ -627,10 +628,12 @@ func (g *gen) emitWireHeader() {
 }
 
 // emitUnionWire emits the union's write/read pair (SPEC §4.8): the write
-// validates the tag BEFORE it rides (the message dispatch rule — an
-// out-of-set tag writes nothing), the read rejects a tag above the count and
-// reconstructs exactly the selected arm with its declared initial values before
-// decoding it, including when the tag is unchanged (§5).
+// ASSERTS the tag before it rides — an out-of-set tag is caller error like
+// every other write-side value, caught in debug and the caller's
+// responsibility in release (SPEC §5) — the read rejects a tag above the
+// count in every build and reconstructs exactly the selected arm with its
+// declared initial values before decoding it, including when the tag is
+// unchanged (§5).
 func (g *gen) emitUnionWire(d *ir.Union) {
 	tag := d.Name + "Type"
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(d.Max))
@@ -639,9 +642,14 @@ func (g *gen) emitUnionWire(d *ir.Union) {
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(d.Name), d.Name)
 	if d.Max == 0 {
 		g.pf("    (void) stream; /* only None exists; the degenerate tag range [0, 0] costs zero bits */\n")
-		g.pf("    return value->type == %s_NONE;\n}\n\n", screaming(tag))
+		g.pf("    (void) value; /* any other tag is caller error: asserted in debug, the caller's\n")
+		g.pf("                     responsibility in release (SPEC §5) */\n")
+		g.pf("    serialize_assert( value->type == %s_NONE );\n", screaming(tag))
+		g.pf("    return 1;\n}\n\n")
 	} else {
-		g.pf("    if ( value->type > %s_MAX )\n    {\n        return 0; /* not a %s value; nothing was written */\n    }\n", screaming(tag), tag)
+		// the tag is a write-side contract like every other value the caller
+		// supplies: asserted before it rides, gone under NDEBUG (SPEC §5)
+		g.pf("    serialize_assert( value->type <= %s_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */\n", screaming(tag))
 		g.call("    ", fmt.Sprintf("serialize_write_bits( stream, (serialize_uint32_t) value->type, %d )", bits))
 		g.pf("    switch ( value->type )\n    {\n")
 		for i, v := range d.Variants {

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -26,20 +26,27 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 		// Composed from primitives, NOT serialize_write_string: schema frames
 		// the length over [0, N] where the runtime's string call frames it over
 		// [0, N-1]. One bit of difference, and every following field shifts.
+		//
+		// An interior null among the used bytes is writer misuse, not content:
+		// a debug assert that compiles out under NDEBUG, the same guard the
+		// C++ backend folds in. The READ side refuses it in every build, as
+		// validation of untrusted bytes (SPEC §4.7, §5).
+		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < value->%s_length; i++ )\n%s    {\n", ind, ind, ind, f.Name, ind)
+		g.pf("%s        serialize_assert( value->%s[i] != 0 ); /* interior null on write (SPEC §4.7) */\n", ind, f.Name)
+		g.pf("%s    }\n%s}\n", ind, ind)
 		g.call(ind, fmt.Sprintf("serialize_write_int( stream, value->%s_length, 0, %s )", f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size))))
 		g.call(ind, fmt.Sprintf("serialize_write_bytes( stream, (const serialize_uint8_t *) value->%s, (int) value->%s_length )", f.Name, f.Name))
 	case f.Type.Kind == ir.TBytes:
 		g.call(ind, fmt.Sprintf("serialize_write_int( stream, value->%s_length, 0, %s )", f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size))))
 		g.call(ind, fmt.Sprintf("serialize_write_bytes( stream, value->%s, (int) value->%s_length )", f.Name, f.Name))
 	case f.Array == ir.ArrayCounted:
-		// a count outside its wire range is refused in every build, ahead of
-		// the runtime call whose own range check is an assert. The count
-		// guards the element loop and the pack subtracts the low bound, so a
-		// count below the minimum wraps and an unchecked write reports
-		// success on bytes no reader accepts (SPEC §4.6)
+		// the count is a writer contract like any other range: a debug assert
+		// that compiles out under NDEBUG, ahead of the runtime call whose own
+		// range check is an assert too. What is written is the caller's
+		// responsibility in release; catching a bad count in debug is ours
+		// (SPEC §4.6, §5)
 		bound := g.renderInt(f.ArrayExpr, big.NewInt(f.ArrayBound))
-		g.pf("%sif ( value->%s_count < %d || value->%s_count > %s )\n%s{\n", ind, f.Name, f.ArrayMin, f.Name, bound, ind)
-		g.pf("%s    return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */\n%s}\n", ind, ind)
+		g.pf("%sserialize_assert( value->%s_count >= %d && value->%s_count <= %s );\n", ind, f.Name, f.ArrayMin, f.Name, bound)
 		g.call(ind, fmt.Sprintf("serialize_write_int( stream, value->%s_count, %d, %s )", f.Name, f.ArrayMin, bound))
 		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < value->%s_count; i++ )\n%s    {\n", ind, ind, ind, f.Name, ind)
 		g.emitWriteScalar(f, fmt.Sprintf("value->%s[i]", f.Name), ind+"        ")
@@ -106,6 +113,12 @@ func (g *gen) emitWriteScalar(f *ir.Field, expr, ind string) {
 			// bits == 0: a degenerate range costs nothing — the value is
 			// recovered from the range alone on read
 		case *ir.Flags:
+			if ref.WireBits < 64 {
+				// storage is wider than the wire: a mask bit above the wire
+				// width is writer misuse, not silent truncation — a debug
+				// assert, the same guard the C++ backend folds in (SPEC §5)
+				g.pf("%sserialize_assert( %s < ( 1ULL << %d ) );\n", ind, expr, ref.WireBits)
+			}
 			if ref.WireBits > 32 {
 				wide := *f
 				wide.Type.Width = ref.WireBits

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -52,10 +52,11 @@ func (g *gen) emitUnionMaxBits(d *ir.Union) {
 }
 
 // emitUnionWire is the message dispatch pair scaled down to a field type
-// (SPEC §4.8): the write validates the tag BEFORE it rides — an out-of-set
-// tag writes nothing, it never desyncs the stream — and the read rejects a
-// tag above the count inside read_int, then constructs the selected arm
-// with its defaults before decoding it.
+// (SPEC §4.8): the write ASSERTS the tag before it rides — an out-of-set tag
+// is caller error like every other write-side value, caught in debug and the
+// caller's responsibility in release (SPEC §5) — and the read rejects a tag
+// above the count inside read_int, in every build, then constructs the
+// selected arm with its defaults before decoding it.
 func (g *gen) emitUnionWire(d *ir.Union) {
 	g.needsSerialize = true
 	tag := d.Name + "Type"
@@ -63,11 +64,16 @@ func (g *gen) emitUnionWire(d *ir.Union) {
 	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", d.Name, d.Name)
 	if d.Max == 0 {
 		g.pf("    (void) stream;\n")
-		g.pf("    // an empty union holds only None and its degenerate tag range [0, 0]\n")
-		g.pf("    // costs zero bits (SPEC §4.8)\n")
-		g.pf("    return value.type == %s::None;\n}\n\n", tag)
+		g.pf("    (void) value; // an empty union holds only None and its degenerate tag range\n")
+		g.pf("    // [0, 0] costs zero bits (SPEC §4.8); any other tag is caller error, asserted\n")
+		g.pf("    // in debug and the caller's responsibility in release (SPEC §5)\n")
+		g.pf("    serialize_assert( value.type == %s::None );\n", tag)
+		g.pf("    return true;\n}\n\n")
 	} else {
 		bits := bitsRequired(big.NewInt(0), big.NewInt(d.Max))
+		// the tag is a write-side contract like every other value the caller
+		// supplies: asserted before it rides, gone under NDEBUG (SPEC §5)
+		g.pf("    serialize_assert( value.type <= %s::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)\n", tag)
 		g.pf("    switch ( value.type )\n    {\n")
 		g.pf("        case %s::None:\n", tag)
 		g.pf("            write_bits( stream, 0u, %d );\n", bits)
@@ -84,7 +90,7 @@ func (g *gen) emitUnionWire(d *ir.Union) {
 		g.pf("        default:\n")
 		g.pf("            break;\n")
 		g.pf("    }\n")
-		g.pf("    return false; // not a %s value; nothing was written (SPEC §4.8)\n}\n\n", tag)
+		g.pf("    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)\n}\n\n")
 	}
 
 	g.pf("SCHEMA_READ_INLINE bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", d.Name, d.Name)
@@ -358,18 +364,16 @@ func (g *gen) emitWriteRangedFold32(expr, lo, hi string, bits int64, loZero bool
 	}
 }
 
-// emitWriteCount writes a counted array's count. A scalar's range is a §5
-// writer contract held by an assert. A count outside [lo, hi] is REFUSED in
-// every build instead, because the count guards the element loop and the pack
-// subtracts the low bound, so a count below lo wraps and an unchecked write
-// reports success on bytes no reader accepts (SPEC §4.6).
+// emitWriteCount writes a counted array's count. The count is a §5 writer
+// contract like any other scalar range, held by an assert and compiled out
+// under NDEBUG: what is written is the caller's responsibility in release, and
+// it is the assert's duty to catch a bad count in debug (SPEC §4.6, §5).
 //
 // bits is always at least 1 here. §4.6 refuses [Min..N]T with Min at or above
 // N, so a count range is never degenerate and the zero-bit path a scalar range
 // needs has no case to serve.
 func (g *gen) emitWriteCount(expr, lo, hi string, bits int64, loZero bool, ind string) {
-	g.pf("%sif ( int32_t( %s ) < int32_t( %s ) || int32_t( %s ) > int32_t( %s ) )\n%s{\n", ind, expr, lo, expr, hi, ind)
-	g.pf("%s    return false; // a count outside its wire range is refused in every build (SPEC §4.6)\n%s}\n", ind, ind)
+	g.pf("%sserialize_assert( int32_t( %s ) >= int32_t( %s ) && int32_t( %s ) <= int32_t( %s ) );\n", ind, expr, lo, expr, hi)
 	if loZero {
 		g.pf("%swrite_bits( stream, uint32_t( %s ), %d );\n", ind, expr, bits)
 	} else {

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -348,8 +348,7 @@ func (g *gen) emitWriteFunction(name, low string, items []ir.Item) {
 
 	g.bpf("// write%s packs value into view — the trusted writer (contracts asserted,\n", name)
 	g.bpf("// compiled out without --enable-asserts). The buffer behind view must hold\n")
-	g.bpf("// %sMaxBytes. Returns the bytes written, or -1 when a count is outside its\n", low)
-	g.bpf("// wire range, which is refused in every build (SPEC §4.6).\n")
+	g.bpf("// %sMaxBytes. Returns the bytes written.\n", low)
 	g.emitSignature("int", "write"+name, []string{name + " value", "ByteData view"})
 	g.bpf("  assert(view.lengthInBytes %% 8 == 0);\n")
 	g.bpf("  assert(view.lengthInBytes >= %sMaxBytes);\n", low)
@@ -528,16 +527,10 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 		g.loopDepth--
 	case ir.ArrayCounted:
 		count := name + "Count"
-		// the count guards the loop, and a count outside its wire range is
-		// refused in EVERY build rather than asserted: a wrapped count is
-		// bytes no reader accepts (SPEC §4.6)
-		guard := fmt.Sprintf("%sif (%s < %d || %s > %d) {", ind, count, f.ArrayMin, count, f.ArrayBound)
-		if len(guard) <= 80 {
-			g.pf("%s\n", guard)
-		} else {
-			g.pf("%sif (%s < %d ||\n%s    %s > %d) {\n", ind, count, f.ArrayMin, ind, count, f.ArrayBound)
-		}
-		g.pf("%s  return -1; // a count outside its wire range is refused in every build (SPEC §4.6)\n%s}\n", ind, ind)
+		// the count guards the loop; its range is a writer contract like any
+		// other, asserted and gone without --enable-asserts (SPEC §4.6, §5)
+		g.pf("%sassert(%s >= %d);\n", ind, count, f.ArrayMin)
+		g.pf("%sassert(%s <= %d);\n", ind, count, f.ArrayBound)
 		g.emitWriteOffset(count, big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), ind)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++

--- a/internal/codegen/java/functions.go
+++ b/internal/codegen/java/functions.go
@@ -404,6 +404,9 @@ func (g *gen) hasCheckField(f *ir.Field) bool {
 	if f.Array == ir.ArrayFixed && g.bulkBytes[f] {
 		return false // bare uint8 elements carry no contract
 	}
+	if f.Array == ir.ArrayCounted {
+		return true // the count's own range binds, whatever the elements are
+	}
 	return g.hasCheckScalar(f)
 }
 
@@ -473,10 +476,11 @@ func (g *gen) emitCheckField(f *ir.Field, path, ind string) {
 		g.pf("%s}\n", ind)
 		g.loopDepth--
 	case ir.ArrayCounted:
-		// the count is not a contract here: the writer refuses a count
-		// outside its wire range in every build (SPEC §4.6), so only the
-		// elements' contracts walk
+		// the count's own range is the first contract here (SPEC §4.6), then
+		// the elements' contracts walk
 		count := name + "Count"
+		g.pf("%sassert %s >= %d;\n", ind, count, f.ArrayMin)
+		g.pf("%sassert %s <= %d;\n", ind, count, f.ArrayBound)
 		if !g.hasCheckScalar(f) {
 			return
 		}
@@ -782,11 +786,9 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 		g.loopDepth--
 	case ir.ArrayCounted:
 		count := name + "Count"
-		// the count guards the loop, and a count outside its wire range is
-		// refused in EVERY build rather than left to the -ea predicate: a
-		// wrapped count is bytes no reader accepts (SPEC §4.6)
-		g.pf("%sif (%s < %d || %s > %d) {\n%s    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)\n%s}\n",
-			ind, count, f.ArrayMin, count, f.ArrayBound, ind, ind)
+		// the count guards the loop; its range is a writer contract like any
+		// other, asserted in the checkWrite predicate and gone without -ea
+		// (SPEC §4.6, §5)
 		g.emitWriteOffset(count, big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), ind)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -484,9 +484,9 @@ func (g *fgen) emitStructFlat(st *ir.Struct) {
 
 	g.emitWriteVariant(st, false)
 	g.emitWriteVariant(st, true)
-	g.bpf("// Write%sFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a\n", st.Name)
-	g.bpf("// count outside its wire range in every build (SPEC §4.6), and any other\n")
-	g.bpf("// contract in the checked build. The buffer behind view must hold %sMaxBytes.\n", st.Name)
+	g.bpf("// Write%sFlat(value, view) -> bytes written (>= 0), or -1 on a refused\n", st.Name)
+	g.bpf("// writer contract in the checked build — the production writer holds none\n")
+	g.bpf("// of them (SPEC §5). The buffer behind view must hold %sMaxBytes.\n", st.Name)
 	g.bpf("export const Write%sFlat = PRODUCTION ? write%sFlatProduction : write%sFlatChecked;\n\n", st.Name, st.Name, st.Name)
 
 	g.emitReadFlat(st)
@@ -666,15 +666,12 @@ func (g *fgen) emitWriteField(f *ir.Field, path, ind string) {
 		g.loopDepth--
 	case ir.ArrayCounted:
 		count := name + "Count"
-		// the count guards the loop, and a count outside its wire range is
-		// refused in EVERY build, the production writer included: a wrapped
-		// count is bytes no reader accepts (SPEC §4.6). The checked writer
-		// also holds the count to an integer, its contract on every number.
-		cond := fmt.Sprintf("%s < %d || %s > %d", count, f.ArrayMin, count, f.ArrayBound)
-		if g.checked {
-			cond = fmt.Sprintf("!Number.isInteger(%s) || %s", count, cond)
-		}
-		g.pf("%sif (%s) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)\n%s  return -1;\n%s}\n", ind, cond, ind, ind)
+		// the count guards the loop; its range is a writer contract like any
+		// other, held by the CHECKED writer and gone from the production one
+		// (SPEC §4.6, §5). The checked writer also holds the count to an
+		// integer, its contract on every number.
+		cond := fmt.Sprintf("!Number.isInteger(%s) || %s < %d || %s > %d", count, count, f.ArrayMin, count, f.ArrayBound)
+		g.guard(cond, " // the count guards the loop; its range is a writer contract (SPEC §4.6)", ind)
 		g.emitWriteRangedNum(count, f.ArrayMin, f.ArrayBound, ind)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -415,10 +415,11 @@ int main( void )
         serialize_read_stream_init( &r, buffer, bytes );
         check( !read_probe_collider( &r, &out ), "a corrupt union arm payload is refused (SPEC §4.8)" );
 
-        /* the write side validates the tag BEFORE it rides */
-        in.shape.type = (ProbeShapeType) 3;
-        serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
-        check( !write_probe_collider( &w, &in ), "an out-of-set union tag writes nothing (SPEC §4.8)" );
+        /* NO write-side case for an out-of-set tag: the tag on WRITE is a
+           caller-error contract like every other write-side value, a
+           serialize_assert that would abort this (assert-live) suite and that
+           is gone under NDEBUG (SPEC §4.8, §5). The read half above is the
+           every-build one, and it is the one a test can hold. */
     }
 
     /* ---- TestData: signed narrows, full-range ints, align, fixed bytes, string ---- */

--- a/test/dart/main.dart
+++ b/test/dart/main.dart
@@ -826,16 +826,15 @@ void main() {
       writeChat(bad, writeView);
     }, 'an out-of-range string length must trip the writer contract');
 
-    // A COUNT IS NOT A CHECKED-TWIN CONTRACT (SPEC §4.6): the count guards
-    // the element loop and the pack subtracts the low bound, so a count
-    // outside its wire range is refused in EVERY build — with asserts and
-    // without — rather than left to a predicate release removes.
-    {
+    // A COUNT IS A WRITER CONTRACT LIKE ANY OTHER (SPEC §4.6, §5):
+    // "writing packets correctness is the caller's responsibility, and it is
+    // our duty to catch it with asserts in debug." The count asserts with
+    // --enable-asserts and is gone from release.
+    expectAssert(() {
       final bad = InputPacket();
       bad.inputsCount = 17; // above [0, MaxInputsPerPacket]
-      check(writeInputPacket(bad, writeView) == -1,
-          'a count above its wire range is refused in every build');
-    }
+      writeInputPacket(bad, writeView);
+    }, 'a count above its wire range must trip the writer contract');
 
     expectAssert(() {
       final bad = ShipCreate();

--- a/test/java/Main.java
+++ b/test/java/Main.java
@@ -518,16 +518,16 @@ public final class Main {
             Wire.writeChat(bad, writeBuf);
         }, "an out-of-range string length must trip the writer contract");
 
-        // A COUNT IS NOT A CHECKED-TWIN CONTRACT (SPEC §4.6): the count guards
-        // the element loop and the pack subtracts the low bound, so a count
-        // outside its wire range is refused in EVERY build — with -ea and
-        // without — rather than left to a predicate the JVM can disable.
-        {
+        // A COUNT IS A WRITER CONTRACT LIKE ANY OTHER (SPEC §4.6, §5):
+        // "writing packets correctness is the caller's responsibility, and it
+        // is our duty to catch it with asserts in debug." The count rides in
+        // the checkWriteInputPacket predicate, so it fires with -ea and is
+        // gone without.
+        expectAssert(() -> {
             final Types.InputPacket bad = new Types.InputPacket();
             bad.inputsCount = 17; // above [0, MaxInputsPerPacket]
-            check(Types.writeInputPacket(bad, writeBuf) == -1,
-                "a count above its wire range is refused in every build");
-        }
+            Types.writeInputPacket(bad, writeBuf);
+        }, "a count above its wire range must trip the writer contract");
 
         expectAssert(() -> {
             final Types.ShipCreate bad = new Types.ShipCreate();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -758,12 +758,11 @@ int main()
             check( !ReadProbeCollider( crs, bad ) );
         }
 
-        // the write side validates the tag BEFORE it rides (SPEC §4.8):
-        // an out-of-set tag writes nothing
-        ProbeShape rogue;
-        rogue.type = ProbeShapeType( 3 );
-        serialize::WriteStream bs( buffer, sizeof( buffer ) );
-        check( !WriteProbeShape( bs, rogue ) );
+        // NO write-side case for an out-of-set tag: the tag on WRITE is a
+        // caller-error contract like every other write-side value, a
+        // serialize_assert that would abort this (debug) suite and that is
+        // gone under NDEBUG (SPEC §4.8, §5). The read half above is the
+        // every-build one, and it is the one a test can hold.
     }
     {
         ProbeArray in; // defaults are the constructed state, transitively

--- a/test/packet-void/c_main.c
+++ b/test/packet-void/c_main.c
@@ -78,9 +78,10 @@ int main(int argc, char **argv)
         serialize_write_stream_init(&w, buffer, sizeof(buffer_words));
         CHECK(write_empty(&w, &empty) && serialize_write_bits_processed(&w) == 0, "empty union writes nothing");
 
-        value.type = 3;
-        serialize_write_stream_init(&w, buffer, sizeof(buffer_words));
-        CHECK(!write_mixed(&w, &value) && serialize_write_bits_processed(&w) == 0, "invalid tag writes nothing");
+        /* NO out-of-set tag case on the WRITE: the tag is a caller-error
+           contract like every other write-side value, a serialize_assert that
+           would abort this (assert-live) binary and that is gone under NDEBUG
+           (SPEC §4.8, §5). The read side below refuses one in every build. */
     }
 
     if (!write_only)

--- a/test/packet-void/cpp_main.cpp
+++ b/test/packet-void/cpp_main.cpp
@@ -82,9 +82,10 @@ int main(int argc, char **argv)
         serialize::WriteStream we(buffer, sizeof(buffer));
         CHECK(WriteEmpty(we, empty) && we.GetBitsProcessed() == 0, "empty union writes nothing");
 
-        value.type = MixedType(3);
-        serialize::WriteStream wi(buffer, sizeof(buffer));
-        CHECK(!WriteMixed(wi, value) && wi.GetBitsProcessed() == 0, "invalid tag writes nothing");
+        // NO out-of-set tag case on the WRITE: the tag is a caller-error
+        // contract like every other write-side value, a serialize_assert that
+        // would abort this (assert-live) binary and that is gone under NDEBUG
+        // (SPEC §4.8, §5). The read side below refuses one in every build.
     }
 
     if (!write_only)

--- a/testdata/golden/c/ArmDefaultsWire.h
+++ b/testdata/golden/c/ArmDefaultsWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -54,10 +55,7 @@ extern "C" {
 /* Writes DefaultArm. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_arm( serialize_write_stream_t * stream, const DefaultArm * value )
 {
-    if ( value->entries_count < 0 || value->entries_count > 2 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->entries_count >= 0 && value->entries_count <= 2 );
     if ( !serialize_write_int( stream, value->entries_count, 0, 2 ) )
     {
         return 0;
@@ -117,10 +115,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_arm( serialize_read_s
 /* Writes DefaultChoice. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_choice( serialize_write_stream_t * stream, const DefaultChoice * value )
 {
-    if ( value->type > DEFAULT_CHOICE_TYPE_MAX )
-    {
-        return 0; /* not a DefaultChoiceType value; nothing was written */
-    }
+    serialize_assert( value->type <= DEFAULT_CHOICE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -223,10 +218,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_bulk_arm( serialize_r
 /* Writes DefaultBulkChoice. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_bulk_choice( serialize_write_stream_t * stream, const DefaultBulkChoice * value )
 {
-    if ( value->type > DEFAULT_BULK_CHOICE_TYPE_MAX )
-    {
-        return 0; /* not a DefaultBulkChoiceType value; nothing was written */
-    }
+    serialize_assert( value->type <= DEFAULT_BULK_CHOICE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;

--- a/testdata/golden/c/ClausesWire.h
+++ b/testdata/golden/c/ClausesWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -165,10 +166,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 /* Writes W13. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w13( serialize_write_stream_t * stream, const W13 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 12 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 12 );
     if ( !serialize_write_int( stream, value->items_count, 0, 12 ) )
     {
         return 0;
@@ -220,10 +218,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w13( serialize_read_stream_t 
 /* Writes W17. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w17( serialize_write_stream_t * stream, const W17 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 9 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 9 );
     if ( !serialize_write_int( stream, value->items_count, 0, 9 ) )
     {
         return 0;
@@ -275,10 +270,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w17( serialize_read_stream_t 
 /* Writes W26. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w26( serialize_write_stream_t * stream, const W26 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 6 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 6 );
     if ( !serialize_write_int( stream, value->items_count, 0, 6 ) )
     {
         return 0;
@@ -330,10 +322,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w26( serialize_read_stream_t 
 /* Writes W1. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w1( serialize_write_stream_t * stream, const W1 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 20 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 20 );
     if ( !serialize_write_int( stream, value->items_count, 0, 20 ) )
     {
         return 0;
@@ -385,10 +374,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w1( serialize_read_stream_t *
 /* Writes W52. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w52( serialize_write_stream_t * stream, const W52 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -452,10 +438,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w52( serialize_read_stream_t 
 /* Writes W50. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w50( serialize_write_stream_t * stream, const W50 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -598,10 +581,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_tri3( serialize_read_stream_t
 /* Writes ArrTri3. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_tri3( serialize_write_stream_t * stream, const ArrTri3 * value )
 {
-    if ( value->items_count < 0 || value->items_count > 10 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 10 );
     if ( !serialize_write_int( stream, value->items_count, 0, 10 ) )
     {
         return 0;
@@ -742,10 +722,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_empty_b( serialize_read_strea
 /* Writes EmptyUnion. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_empty_union( serialize_write_stream_t * stream, const EmptyUnion * value )
 {
-    if ( value->type > EMPTY_UNION_TYPE_MAX )
-    {
-        return 0; /* not a EmptyUnionType value; nothing was written */
-    }
+    serialize_assert( value->type <= EMPTY_UNION_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -840,6 +817,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_strs( serialize_write_strea
     {
         return 0;
     }
+    {
+        int32_t i;
+        for ( i = 0; i < value->s_length; i++ )
+        {
+            serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
+    }
     if ( !serialize_write_int( stream, value->s_length, 0, 8 ) )
     {
         return 0;
@@ -917,10 +901,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_nested( serialize_write
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 4 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 4 );
     if ( !serialize_write_int( stream, value->items_count, 0, 4 ) )
     {
         return 0;

--- a/testdata/golden/c/DegenerateWire.h
+++ b/testdata/golden/c/DegenerateWire.h
@@ -24,9 +24,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED

--- a/testdata/golden/c/JoinsWire.h
+++ b/testdata/golden/c/JoinsWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -523,6 +524,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_align( serialize_write_
     }
     if ( value->flag )
     {
+        {
+            int32_t i;
+            for ( i = 0; i < value->s_length; i++ )
+            {
+                serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
+            }
+        }
         if ( !serialize_write_int( stream, value->s_length, 0, 4 ) )
         {
             return 0;
@@ -619,10 +627,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_array( serialize_write_
     }
     if ( value->flag )
     {
-        if ( value->items_count < 0 || value->items_count > 3 )
-        {
-            return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-        }
+        serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
         if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
         {
             return 0;
@@ -783,10 +788,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide( serialize_read_stream_t
 /* Writes Uneven. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_uneven( serialize_write_stream_t * stream, const Uneven * value )
 {
-    if ( value->type > UNEVEN_TYPE_MAX )
-    {
-        return 0; /* not a UnevenType value; nothing was written */
-    }
+    serialize_assert( value->type <= UNEVEN_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -881,10 +883,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_uneven( serialize_write
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -949,10 +948,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 3 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 3 );
     if ( !serialize_write_int( stream, value->items_count, 0, 3 ) )
     {
         return 0;
@@ -966,6 +962,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
             {
                 return 0;
             }
+        }
+    }
+    {
+        int32_t i;
+        for ( i = 0; i < value->s_length; i++ )
+        {
+            serialize_assert( value->s[i] != 0 ); /* interior null on write (SPEC §4.7) */
         }
     }
     if ( !serialize_write_int( stream, value->s_length, 0, 4 ) )

--- a/testdata/golden/c/RenderWire.h
+++ b/testdata/golden/c/RenderWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -139,10 +140,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_wri
     {
         return 0;
     }
-    if ( value->sprites_count < 0 || value->sprites_count > RENDER_BLOCK_MAX_SPRITES )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->sprites_count >= 0 && value->sprites_count <= RENDER_BLOCK_MAX_SPRITES );
     if ( !serialize_write_int( stream, value->sprites_count, 0, RENDER_BLOCK_MAX_SPRITES ) )
     {
         return 0;

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -27,9 +27,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -596,10 +597,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_wri
     {
         return 0;
     }
-    if ( value->inputs_count < 0 || value->inputs_count > MAX_INPUTS_PER_PACKET )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->inputs_count >= 0 && value->inputs_count <= MAX_INPUTS_PER_PACKET );
     if ( !serialize_write_int( stream, value->inputs_count, 0, MAX_INPUTS_PER_PACKET ) )
     {
         return 0;
@@ -687,6 +685,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
     }
     if ( value->has_flags )
     {
+        serialize_assert( value->flags < ( 1ULL << 4 ) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) value->flags, 4 ) )
         {
             return 0;

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -26,9 +26,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -398,10 +399,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
             return 0;
         }
     }
-    if ( value->samples_count < 1 || value->samples_count > 8 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->samples_count >= 1 && value->samples_count <= 8 );
     if ( !serialize_write_int( stream, value->samples_count, 1, 8 ) )
     {
         return 0;
@@ -586,10 +584,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_st
 /* Writes ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_write_stream_t * stream, const ProbeShape * value )
 {
-    if ( value->type > PROBE_SHAPE_TYPE_MAX )
-    {
-        return 0; /* not a ProbeShapeType value; nothing was written */
-    }
+    serialize_assert( value->type <= PROBE_SHAPE_TYPE_MAX ); /* an out-of-set tag is caller error (SPEC §4.8, §5) */
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->type, 2 ) )
     {
         return 0;
@@ -648,10 +643,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_w
     {
         return 0;
     }
-    if ( value->extras_count < 0 || value->extras_count > 2 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->extras_count >= 0 && value->extras_count <= 2 );
     if ( !serialize_write_int( stream, value->extras_count, 0, 2 ) )
     {
         return 0;
@@ -914,6 +906,13 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_
 /* Writes Chat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
+    {
+        int32_t i;
+        for ( i = 0; i < value->text_length; i++ )
+        {
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
+    }
     if ( !serialize_write_int( stream, value->text_length, 0, MAX_CHAT_LENGTH ) )
     {
         return 0;
@@ -955,6 +954,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_wri
     {
         return 0;
     }
+    serialize_assert( value->flags < ( 1ULL << 8 ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->flags, 8 ) )
     {
         return 0;
@@ -1022,10 +1022,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
-    if ( value->items_count < 0 || value->items_count > 16 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->items_count >= 0 && value->items_count <= 16 );
     if ( !serialize_write_int( stream, value->items_count, 0, 16 ) )
     {
         return 0;
@@ -1100,6 +1097,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     if ( !serialize_write_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
         return 0;
+    }
+    {
+        int32_t i;
+        for ( i = 0; i < value->text_length; i++ )
+        {
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
     }
     if ( !serialize_write_int( stream, value->text_length, 0, 255 ) )
     {

--- a/testdata/golden/cpp/ArmDefaultsWire.h
+++ b/testdata/golden/cpp/ArmDefaultsWire.h
@@ -56,10 +56,7 @@ namespace example {
 
 SCHEMA_WRITE_INLINE bool WriteDefaultArm( serialize::WriteStream & stream, const DefaultArm & value )
 {
-    if ( int32_t( value.entries_count ) < int32_t( 0 ) || int32_t( value.entries_count ) > int32_t( 2 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.entries_count ) >= int32_t( 0 ) && int32_t( value.entries_count ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value.entries_count ), 2 );
     for ( int32_t i = 0; i < value.entries_count; i++ )
     {
@@ -93,6 +90,7 @@ SCHEMA_READ_INLINE bool ReadDefaultArm( serialize::ReadStream & stream, DefaultA
 
 SCHEMA_WRITE_INLINE bool WriteDefaultChoice( serialize::WriteStream & stream, const DefaultChoice & value )
 {
+    serialize_assert( value.type <= DefaultChoiceType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case DefaultChoiceType::None:
@@ -107,7 +105,7 @@ SCHEMA_WRITE_INLINE bool WriteDefaultChoice( serialize::WriteStream & stream, co
         default:
             break;
     }
-    return false; // not a DefaultChoiceType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadDefaultChoice( serialize::ReadStream & stream, DefaultChoice & value )
@@ -172,6 +170,7 @@ SCHEMA_READ_INLINE bool ReadDefaultBulkArm( serialize::ReadStream & stream, Defa
 
 SCHEMA_WRITE_INLINE bool WriteDefaultBulkChoice( serialize::WriteStream & stream, const DefaultBulkChoice & value )
 {
+    serialize_assert( value.type <= DefaultBulkChoiceType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case DefaultBulkChoiceType::None:
@@ -186,7 +185,7 @@ SCHEMA_WRITE_INLINE bool WriteDefaultBulkChoice( serialize::WriteStream & stream
         default:
             break;
     }
-    return false; // not a DefaultBulkChoiceType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadDefaultBulkChoice( serialize::ReadStream & stream, DefaultBulkChoice & value )

--- a/testdata/golden/cpp/ClausesWire.h
+++ b/testdata/golden/cpp/ClausesWire.h
@@ -166,10 +166,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 
 SCHEMA_WRITE_INLINE bool WriteW13( serialize::WriteStream & stream, const W13 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 12 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 12 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -195,10 +192,7 @@ SCHEMA_READ_INLINE bool ReadW13( serialize::ReadStream & stream, W13 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW17( serialize::WriteStream & stream, const W17 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 9 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 9 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -220,10 +214,7 @@ SCHEMA_READ_INLINE bool ReadW17( serialize::ReadStream & stream, W17 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW26( serialize::WriteStream & stream, const W26 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 6 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.items_count ), 3 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -245,10 +236,7 @@ SCHEMA_READ_INLINE bool ReadW26( serialize::ReadStream & stream, W26 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW1( serialize::WriteStream & stream, const W1 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 20 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 20 ) );
     write_bits( stream, uint32_t( value.items_count ), 5 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -274,10 +262,7 @@ SCHEMA_READ_INLINE bool ReadW1( serialize::ReadStream & stream, W1 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW52( serialize::WriteStream & stream, const W52 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -299,10 +284,7 @@ SCHEMA_READ_INLINE bool ReadW52( serialize::ReadStream & stream, W52 & value )
 
 SCHEMA_WRITE_INLINE bool WriteW50( serialize::WriteStream & stream, const W50 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -361,10 +343,7 @@ SCHEMA_READ_INLINE bool ReadTri3( serialize::ReadStream & stream, Tri3 & value )
 
 SCHEMA_WRITE_INLINE bool WriteArrTri3( serialize::WriteStream & stream, const ArrTri3 & value )
 {
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 10 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 10 ) );
     write_bits( stream, uint32_t( value.items_count ), 4 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -457,6 +436,7 @@ SCHEMA_READ_INLINE bool ReadEmptyB( serialize::ReadStream & stream, EmptyB & val
 
 SCHEMA_WRITE_INLINE bool WriteEmptyUnion( serialize::WriteStream & stream, const EmptyUnion & value )
 {
+    serialize_assert( value.type <= EmptyUnionType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case EmptyUnionType::None:
@@ -471,7 +451,7 @@ SCHEMA_WRITE_INLINE bool WriteEmptyUnion( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a EmptyUnionType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadEmptyUnion( serialize::ReadStream & stream, EmptyUnion & value )
@@ -555,10 +535,7 @@ SCHEMA_READ_INLINE bool ReadStrs( serialize::ReadStream & stream, Strs & value )
 SCHEMA_WRITE_INLINE bool WriteArrNested( serialize::WriteStream & stream, const ArrNested & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 4 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value.items_count ), 3 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/testdata/golden/cpp/JoinsWire.h
+++ b/testdata/golden/cpp/JoinsWire.h
@@ -372,10 +372,7 @@ SCHEMA_WRITE_INLINE bool WriteArmArray( serialize::WriteStream & stream, const A
     write_bool( stream, value.flag );
     if ( value.flag )
     {
-        if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-        {
-            return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
+        serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
         write_bits( stream, uint32_t( value.items_count ), 2 );
         for ( int32_t i = 0; i < value.items_count; i++ )
         {
@@ -444,6 +441,7 @@ SCHEMA_READ_INLINE bool ReadWide( serialize::ReadStream & stream, Wide & value )
 
 SCHEMA_WRITE_INLINE bool WriteUneven( serialize::WriteStream & stream, const Uneven & value )
 {
+    serialize_assert( value.type <= UnevenType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case UnevenType::None:
@@ -458,7 +456,7 @@ SCHEMA_WRITE_INLINE bool WriteUneven( serialize::WriteStream & stream, const Une
         default:
             break;
     }
-    return false; // not a UnevenType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadUneven( serialize::ReadStream & stream, Uneven & value )
@@ -505,10 +503,7 @@ SCHEMA_READ_INLINE bool ReadHoldsUneven( serialize::ReadStream & stream, HoldsUn
 SCHEMA_WRITE_INLINE bool WriteArrUneven( serialize::WriteStream & stream, const ArrUneven & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {
@@ -539,10 +534,7 @@ SCHEMA_READ_INLINE bool ReadArrUneven( serialize::ReadStream & stream, ArrUneven
 SCHEMA_WRITE_INLINE bool WriteRegainAfterAlign( serialize::WriteStream & stream, const RegainAfterAlign & value )
 {
     write_bits( stream, value.lead, 5 );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 3 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.items_count ), 2 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/testdata/golden/cpp/RenderWire.h
+++ b/testdata/golden/cpp/RenderWire.h
@@ -86,10 +86,7 @@ SCHEMA_WRITE_INLINE bool WriteRenderBlock( serialize::WriteStream & stream, cons
 {
     write_bits( stream, value.worker_index, 32 );
     write_bits( stream, value.sprite_count_hint, 32 );
-    if ( int32_t( value.sprites_count ) < int32_t( 0 ) || int32_t( value.sprites_count ) > int32_t( RenderBlockMaxSprites ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.sprites_count ) >= int32_t( 0 ) && int32_t( value.sprites_count ) <= int32_t( RenderBlockMaxSprites ) );
     write_bits( stream, uint32_t( value.sprites_count ), 7 );
     for ( int32_t i = 0; i < value.sprites_count; i++ )
     {

--- a/testdata/golden/cpp/TypesWire.h
+++ b/testdata/golden/cpp/TypesWire.h
@@ -280,10 +280,7 @@ SCHEMA_WRITE_INLINE bool WriteInputPacket( serialize::WriteStream & stream, cons
     write_bits( stream, value.synchronize_sequence, 16 );
     write_bits( stream, value.current_frame, 64 );
     write_bits( stream, value.start_frame, 64 );
-    if ( int32_t( value.inputs_count ) < int32_t( 0 ) || int32_t( value.inputs_count ) > int32_t( MaxInputsPerPacket ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.inputs_count ) >= int32_t( 0 ) && int32_t( value.inputs_count ) <= int32_t( MaxInputsPerPacket ) );
     write_bits( stream, uint32_t( value.inputs_count ), 5 );
     for ( int32_t i = 0; i < value.inputs_count; i++ )
     {

--- a/testdata/golden/cpp/WireWire.h
+++ b/testdata/golden/cpp/WireWire.h
@@ -247,10 +247,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
     {
         write_bits( stream, value.idle_ticks, 32 );
     }
-    if ( int32_t( value.samples_count ) < int32_t( 1 ) || int32_t( value.samples_count ) > int32_t( 8 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.samples_count ) >= int32_t( 1 ) && int32_t( value.samples_count ) <= int32_t( 8 ) );
     write_bits( stream, uint32_t( value.samples_count ) - uint32_t( 1 ), 3 );
     for ( int32_t i = 0; i < value.samples_count; i++ )
     {
@@ -355,6 +352,7 @@ SCHEMA_READ_INLINE bool ReadProbeSlab( serialize::ReadStream & stream, ProbeSlab
 
 SCHEMA_WRITE_INLINE bool WriteProbeShape( serialize::WriteStream & stream, const ProbeShape & value )
 {
+    serialize_assert( value.type <= ProbeShapeType::Max ); // an out-of-set tag is caller error (SPEC §4.8, §5)
     switch ( value.type )
     {
         case ProbeShapeType::None:
@@ -369,7 +367,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeShape( serialize::WriteStream & stream, const
         default:
             break;
     }
-    return false; // not a ProbeShapeType value; nothing was written (SPEC §4.8)
+    return true; // an out-of-set tag selected no arm, so no bits rode: the assert above is the contract (SPEC §5)
 }
 
 SCHEMA_READ_INLINE bool ReadProbeShape( serialize::ReadStream & stream, ProbeShape & value )
@@ -402,10 +400,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeCollider( serialize::WriteStream & stream, co
     {
         return false;
     }
-    if ( int32_t( value.extras_count ) < int32_t( 0 ) || int32_t( value.extras_count ) > int32_t( 2 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.extras_count ) >= int32_t( 0 ) && int32_t( value.extras_count ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value.extras_count ), 2 );
     for ( int32_t i = 0; i < value.extras_count; i++ )
     {
@@ -633,10 +628,7 @@ SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const T
     write_bits( stream, value.e, 8 );
     write_bits( stream, value.f, 8 );
     write_bool( stream, value.g );
-    if ( int32_t( value.items_count ) < int32_t( 0 ) || int32_t( value.items_count ) > int32_t( 16 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.items_count ) >= int32_t( 0 ) && int32_t( value.items_count ) <= int32_t( 16 ) );
     write_bits( stream, uint32_t( value.items_count ), 5 );
     for ( int32_t i = 0; i < value.items_count; i++ )
     {

--- a/testdata/golden/dart/ArmDefaults.dart
+++ b/testdata/golden/dart/ArmDefaults.dart
@@ -42,8 +42,7 @@ void initDefaultArm(DefaultArm value) {
 
 // writeDefaultArm packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultArmMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultArmMaxBytes. Returns the bytes written.
 int writeDefaultArm(DefaultArm value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultArmMaxBytes);
@@ -51,9 +50,8 @@ int writeDefaultArm(DefaultArm value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.entriesCount < 0 || value.entriesCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.entriesCount >= 0);
+  assert(value.entriesCount <= 2);
   v = ((value.entriesCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -219,8 +217,7 @@ void zeroDefaultChoice(DefaultChoice value) {
 
 // writeDefaultChoice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultChoiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultChoiceMaxBytes. Returns the bytes written.
 int writeDefaultChoice(DefaultChoice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultChoiceMaxBytes);
@@ -241,9 +238,8 @@ int writeDefaultChoice(DefaultChoice value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      if (value.first.entriesCount < 0 || value.first.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.first.entriesCount >= 0);
+      assert(value.first.entriesCount <= 2);
       v = ((value.first.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -279,9 +275,8 @@ int writeDefaultChoice(DefaultChoice value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      if (value.second.entriesCount < 0 || value.second.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.second.entriesCount >= 0);
+      assert(value.second.entriesCount <= 2);
       v = ((value.second.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -511,8 +506,7 @@ void initDefaultChoicePacket(DefaultChoicePacket value) {
 
 // writeDefaultChoicePacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultChoicePacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultChoicePacketMaxBytes. Returns the bytes written.
 int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultChoicePacketMaxBytes);
@@ -533,10 +527,8 @@ int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
   }
   switch (value.choice.type) {
     case 1:
-      if (value.choice.first.entriesCount < 0 ||
-          value.choice.first.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.choice.first.entriesCount >= 0);
+      assert(value.choice.first.entriesCount <= 2);
       v = ((value.choice.first.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -572,10 +564,8 @@ int writeDefaultChoicePacket(DefaultChoicePacket value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      if (value.choice.second.entriesCount < 0 ||
-          value.choice.second.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.choice.second.entriesCount >= 0);
+      assert(value.choice.second.entriesCount <= 2);
       v = ((value.choice.second.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -816,8 +806,7 @@ void initDefaultBulkArm(DefaultBulkArm value) {
 
 // writeDefaultBulkArm packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultBulkArmMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultBulkArmMaxBytes. Returns the bytes written.
 int writeDefaultBulkArm(DefaultBulkArm value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultBulkArmMaxBytes);
@@ -825,9 +814,8 @@ int writeDefaultBulkArm(DefaultBulkArm value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.payload.entriesCount < 0 || value.payload.entriesCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.payload.entriesCount >= 0);
+  assert(value.payload.entriesCount <= 2);
   v = ((value.payload.entriesCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1069,8 +1057,7 @@ void zeroDefaultBulkChoice(DefaultBulkChoice value) {
 
 // writeDefaultBulkChoice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// defaultBulkChoiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// defaultBulkChoiceMaxBytes. Returns the bytes written.
 int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= defaultBulkChoiceMaxBytes);
@@ -1091,10 +1078,8 @@ int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      if (value.first.payload.entriesCount < 0 ||
-          value.first.payload.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.first.payload.entriesCount >= 0);
+      assert(value.first.payload.entriesCount <= 2);
       v = ((value.first.payload.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;
@@ -1175,10 +1160,8 @@ int writeDefaultBulkChoice(DefaultBulkChoice value, ByteData view) {
         }
       }
     case 2:
-      if (value.second.payload.entriesCount < 0 ||
-          value.second.payload.entriesCount > 2) {
-        return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-      }
+      assert(value.second.payload.entriesCount >= 0);
+      assert(value.second.payload.entriesCount <= 2);
       v = ((value.second.payload.entriesCount) & 0x3);
       scratch |= v << scratchBits;
       scratchBits += 2;

--- a/testdata/golden/dart/Clauses.dart
+++ b/testdata/golden/dart/Clauses.dart
@@ -70,8 +70,7 @@ void initW13(W13 value) {
 
 // writeW13 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w13MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w13MaxBytes. Returns the bytes written.
 int writeW13(W13 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w13MaxBytes);
@@ -79,9 +78,8 @@ int writeW13(W13 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 12) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 12);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -248,8 +246,7 @@ void initW17(W17 value) {
 
 // writeW17 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w17MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w17MaxBytes. Returns the bytes written.
 int writeW17(W17 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w17MaxBytes);
@@ -257,9 +254,8 @@ int writeW17(W17 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 9) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 9);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -420,8 +416,7 @@ void initW26(W26 value) {
 
 // writeW26 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w26MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w26MaxBytes. Returns the bytes written.
 int writeW26(W26 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w26MaxBytes);
@@ -429,9 +424,8 @@ int writeW26(W26 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 6) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 6);
   v = ((value.itemsCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
@@ -586,8 +580,7 @@ void initW1(W1 value) {
 
 // writeW1 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w1MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w1MaxBytes. Returns the bytes written.
 int writeW1(W1 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w1MaxBytes);
@@ -595,9 +588,8 @@ int writeW1(W1 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 20) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 20);
   v = ((value.itemsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
@@ -1103,8 +1095,7 @@ void initW52(W52 value) {
 
 // writeW52 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w52MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w52MaxBytes. Returns the bytes written.
 int writeW52(W52 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w52MaxBytes);
@@ -1112,9 +1103,8 @@ int writeW52(W52 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1229,8 +1219,7 @@ void initW50(W50 value) {
 
 // writeW50 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// w50MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// w50MaxBytes. Returns the bytes written.
 int writeW50(W50 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= w50MaxBytes);
@@ -1238,9 +1227,8 @@ int writeW50(W50 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1352,8 +1340,7 @@ void initF13(F13 value) {
 
 // writeF13 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// f13MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// f13MaxBytes. Returns the bytes written.
 int writeF13(F13 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= f13MaxBytes);
@@ -1448,8 +1435,7 @@ void initTri3(Tri3 value) {
 
 // writeTri3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// tri3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// tri3MaxBytes. Returns the bytes written.
 int writeTri3(Tri3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= tri3MaxBytes);
@@ -1545,8 +1531,7 @@ void initArrTri3(ArrTri3 value) {
 
 // writeArrTri3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrTri3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrTri3MaxBytes. Returns the bytes written.
 int writeArrTri3(ArrTri3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrTri3MaxBytes);
@@ -1554,9 +1539,8 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 10) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 10);
   v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
@@ -1897,8 +1881,7 @@ void initEleven(Eleven value) {
 
 // writeEleven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// elevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// elevenMaxBytes. Returns the bytes written.
 int writeEleven(Eleven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= elevenMaxBytes);
@@ -1991,8 +1974,7 @@ void initArrEleven(ArrEleven value) {
 
 // writeArrEleven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrElevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrElevenMaxBytes. Returns the bytes written.
 int writeArrEleven(ArrEleven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrElevenMaxBytes);
@@ -2087,8 +2069,7 @@ void initEmptyA(EmptyA value) {
 
 // writeEmptyA packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyAMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyAMaxBytes. Returns the bytes written.
 int writeEmptyA(EmptyA value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyAMaxBytes);
@@ -2136,8 +2117,7 @@ void initEmptyB(EmptyB value) {
 
 // writeEmptyB packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyBMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyBMaxBytes. Returns the bytes written.
 int writeEmptyB(EmptyB value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyBMaxBytes);
@@ -2210,8 +2190,7 @@ void zeroEmptyUnion(EmptyUnion value) {
 
 // writeEmptyUnion packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// emptyUnionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// emptyUnionMaxBytes. Returns the bytes written.
 int writeEmptyUnion(EmptyUnion value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= emptyUnionMaxBytes);
@@ -2330,8 +2309,7 @@ void initHoldsEmptyUnion(HoldsEmptyUnion value) {
 
 // writeHoldsEmptyUnion packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// holdsEmptyUnionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// holdsEmptyUnionMaxBytes. Returns the bytes written.
 int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= holdsEmptyUnionMaxBytes);
@@ -2489,8 +2467,7 @@ void initStrs(Strs value) {
 
 // writeStrs packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// strsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// strsMaxBytes. Returns the bytes written.
 int writeStrs(Strs value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= strsMaxBytes);
@@ -2789,8 +2766,7 @@ void initArrNested(ArrNested value) {
 
 // writeArrNested packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrNestedMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrNestedMaxBytes. Returns the bytes written.
 int writeArrNested(ArrNested value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrNestedMaxBytes);
@@ -2798,9 +2774,8 @@ int writeArrNested(ArrNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 4) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 4);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x7) << 5);
   scratch |= v << scratchBits;
   scratchBits += 8;
@@ -3019,8 +2994,7 @@ void initSole(Sole value) {
 
 // writeSole packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// soleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// soleMaxBytes. Returns the bytes written.
 int writeSole(Sole value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= soleMaxBytes);

--- a/testdata/golden/dart/Degenerate.dart
+++ b/testdata/golden/dart/Degenerate.dart
@@ -52,8 +52,7 @@ void initVec2(Vec2 value) {
 
 // writeVec2 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// vec2MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// vec2MaxBytes. Returns the bytes written.
 int writeVec2(Vec2 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= vec2MaxBytes);
@@ -175,8 +174,7 @@ void initSpanF64(SpanF64 value) {
 
 // writeSpanF64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanF64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanF64MaxBytes. Returns the bytes written.
 int writeSpanF64(SpanF64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanF64MaxBytes);
@@ -276,8 +274,7 @@ void initSpanU64(SpanU64 value) {
 
 // writeSpanU64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanU64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanU64MaxBytes. Returns the bytes written.
 int writeSpanU64(SpanU64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanU64MaxBytes);
@@ -377,8 +374,7 @@ void initSpanI64(SpanI64 value) {
 
 // writeSpanI64 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanI64MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanI64MaxBytes. Returns the bytes written.
 int writeSpanI64(SpanI64 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanI64MaxBytes);
@@ -478,8 +474,7 @@ void initSpanOne(SpanOne value) {
 
 // writeSpanOne packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanOneMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanOneMaxBytes. Returns the bytes written.
 int writeSpanOne(SpanOne value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanOneMaxBytes);
@@ -579,8 +574,7 @@ void initSpanChunk(SpanChunk value) {
 
 // writeSpanChunk packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanChunkMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanChunkMaxBytes. Returns the bytes written.
 int writeSpanChunk(SpanChunk value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanChunkMaxBytes);
@@ -673,8 +667,7 @@ void initSpanTail(SpanTail value) {
 
 // writeSpanTail packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanTailMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanTailMaxBytes. Returns the bytes written.
 int writeSpanTail(SpanTail value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanTailMaxBytes);
@@ -794,8 +787,7 @@ void initSpanTwice(SpanTwice value) {
 
 // writeSpanTwice packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// spanTwiceMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// spanTwiceMaxBytes. Returns the bytes written.
 int writeSpanTwice(SpanTwice value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= spanTwiceMaxBytes);
@@ -931,8 +923,7 @@ void initTrio(Trio value) {
 
 // writeTrio packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioMaxBytes. Returns the bytes written.
 int writeTrio(Trio value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioMaxBytes);
@@ -1032,8 +1023,7 @@ void initTrioSole(TrioSole value) {
 
 // writeTrioSole packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioSoleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioSoleMaxBytes. Returns the bytes written.
 int writeTrioSole(TrioSole value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioSoleMaxBytes);
@@ -1136,8 +1126,7 @@ void initTrioFirst(TrioFirst value) {
 
 // writeTrioFirst packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioFirstMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioFirstMaxBytes. Returns the bytes written.
 int writeTrioFirst(TrioFirst value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioFirstMaxBytes);
@@ -1267,8 +1256,7 @@ void initTrioStraddle(TrioStraddle value) {
 
 // writeTrioStraddle packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// trioStraddleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// trioStraddleMaxBytes. Returns the bytes written.
 int writeTrioStraddle(TrioStraddle value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= trioStraddleMaxBytes);

--- a/testdata/golden/dart/Joins.dart
+++ b/testdata/golden/dart/Joins.dart
@@ -85,8 +85,7 @@ void initArmsAgree(ArmsAgree value) {
 
 // writeArmsAgree packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsAgreeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsAgreeMaxBytes. Returns the bytes written.
 int writeArmsAgree(ArmsAgree value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsAgreeMaxBytes);
@@ -253,8 +252,7 @@ void initArmsDisagree(ArmsDisagree value) {
 
 // writeArmsDisagree packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsDisagreeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsDisagreeMaxBytes. Returns the bytes written.
 int writeArmsDisagree(ArmsDisagree value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsDisagreeMaxBytes);
@@ -434,8 +432,7 @@ void initArmEmpty(ArmEmpty value) {
 
 // writeArmEmpty packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armEmptyMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armEmptyMaxBytes. Returns the bytes written.
 int writeArmEmpty(ArmEmpty value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armEmptyMaxBytes);
@@ -609,8 +606,7 @@ void initArmsNested(ArmsNested value) {
 
 // writeArmsNested packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armsNestedMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armsNestedMaxBytes. Returns the bytes written.
 int writeArmsNested(ArmsNested value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armsNestedMaxBytes);
@@ -857,8 +853,7 @@ void initArmAlign(ArmAlign value) {
 
 // writeArmAlign packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armAlignMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armAlignMaxBytes. Returns the bytes written.
 int writeArmAlign(ArmAlign value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armAlignMaxBytes);
@@ -1127,8 +1122,7 @@ void initArmArray(ArmArray value) {
 
 // writeArmArray packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// armArrayMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// armArrayMaxBytes. Returns the bytes written.
 int writeArmArray(ArmArray value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= armArrayMaxBytes);
@@ -1146,9 +1140,8 @@ int writeArmArray(ArmArray value, ByteData view) {
     scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    if (value.itemsCount < 0 || value.itemsCount > 3) {
-      return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    assert(value.itemsCount >= 0);
+    assert(value.itemsCount <= 3);
     v = ((value.itemsCount) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
@@ -1376,8 +1369,7 @@ void initNarrow(Narrow value) {
 
 // writeNarrow packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// narrowMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// narrowMaxBytes. Returns the bytes written.
 int writeNarrow(Narrow value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= narrowMaxBytes);
@@ -1463,8 +1455,7 @@ void initWide(Wide value) {
 
 // writeWide packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideMaxBytes. Returns the bytes written.
 int writeWide(Wide value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideMaxBytes);
@@ -1575,8 +1566,7 @@ void zeroUneven(Uneven value) {
 
 // writeUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// unevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// unevenMaxBytes. Returns the bytes written.
 int writeUneven(Uneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= unevenMaxBytes);
@@ -1736,8 +1726,7 @@ void initHoldsUneven(HoldsUneven value) {
 
 // writeHoldsUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// holdsUnevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// holdsUnevenMaxBytes. Returns the bytes written.
 int writeHoldsUneven(HoldsUneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= holdsUnevenMaxBytes);
@@ -1932,8 +1921,7 @@ void initArrUneven(ArrUneven value) {
 
 // writeArrUneven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// arrUnevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// arrUnevenMaxBytes. Returns the bytes written.
 int writeArrUneven(ArrUneven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= arrUnevenMaxBytes);
@@ -1941,9 +1929,8 @@ int writeArrUneven(ArrUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
   scratchBits += 7;
@@ -2173,8 +2160,7 @@ void initRegainAfterAlign(RegainAfterAlign value) {
 
 // writeRegainAfterAlign packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// regainAfterAlignMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// regainAfterAlignMaxBytes. Returns the bytes written.
 int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= regainAfterAlignMaxBytes);
@@ -2182,9 +2168,8 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.itemsCount < 0 || value.itemsCount > 3) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 3);
   v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
   scratchBits += 7;

--- a/testdata/golden/dart/Render.dart
+++ b/testdata/golden/dart/Render.dart
@@ -45,8 +45,7 @@ void initRenderSprite(RenderSprite value) {
 
 // writeRenderSprite packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// renderSpriteMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// renderSpriteMaxBytes. Returns the bytes written.
 int writeRenderSprite(RenderSprite value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= renderSpriteMaxBytes);
@@ -203,8 +202,7 @@ void initRenderBlock(RenderBlock value) {
 
 // writeRenderBlock packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// renderBlockMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// renderBlockMaxBytes. Returns the bytes written.
 int writeRenderBlock(RenderBlock value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= renderBlockMaxBytes);
@@ -212,9 +210,8 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  if (value.spritesCount < 0 || value.spritesCount > 64) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.spritesCount >= 0);
+  assert(value.spritesCount <= 64);
   v =
       ((value.workerIndex) & 0xffffffff) |
       (((value.spriteCountHint) & 0xffffffff) << 32);

--- a/testdata/golden/dart/Types.dart
+++ b/testdata/golden/dart/Types.dart
@@ -99,8 +99,7 @@ void initVec3(Vec3 value) {
 
 // writeVec3 packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// vec3MaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// vec3MaxBytes. Returns the bytes written.
 int writeVec3(Vec3 value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= vec3MaxBytes);
@@ -257,8 +256,7 @@ void initQuat(Quat value) {
 
 // writeQuat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quatMaxBytes. Returns the bytes written.
 int writeQuat(Quat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quatMaxBytes);
@@ -436,8 +434,7 @@ void initHandle(Handle value) {
 
 // writeHandle packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// handleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// handleMaxBytes. Returns the bytes written.
 int writeHandle(Handle value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= handleMaxBytes);
@@ -540,8 +537,7 @@ void initQuantizedPosition(QuantizedPosition value) {
 
 // writeQuantizedPosition packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedPositionMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedPositionMaxBytes. Returns the bytes written.
 int writeQuantizedPosition(QuantizedPosition value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedPositionMaxBytes);
@@ -677,8 +673,7 @@ void initQuantizedVelocity(QuantizedVelocity value) {
 
 // writeQuantizedVelocity packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedVelocityMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedVelocityMaxBytes. Returns the bytes written.
 int writeQuantizedVelocity(QuantizedVelocity value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedVelocityMaxBytes);
@@ -818,8 +813,7 @@ void initQuantizedRotation(QuantizedRotation value) {
 
 // writeQuantizedRotation packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// quantizedRotationMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// quantizedRotationMaxBytes. Returns the bytes written.
 int writeQuantizedRotation(QuantizedRotation value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= quantizedRotationMaxBytes);
@@ -957,8 +951,7 @@ void initRigidBody(RigidBody value) {
 
 // writeRigidBody packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// rigidBodyMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// rigidBodyMaxBytes. Returns the bytes written.
 int writeRigidBody(RigidBody value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= rigidBodyMaxBytes);
@@ -1435,8 +1428,7 @@ void initInput(Input value) {
 
 // writeInput packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// inputMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// inputMaxBytes. Returns the bytes written.
 int writeInput(Input value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= inputMaxBytes);
@@ -1625,8 +1617,7 @@ void initInputPacket(InputPacket value) {
 
 // writeInputPacket packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// inputPacketMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// inputPacketMaxBytes. Returns the bytes written.
 int writeInputPacket(InputPacket value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= inputPacketMaxBytes);
@@ -1652,9 +1643,8 @@ int writeInputPacket(InputPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (64 - scratchBits);
   }
-  if (value.inputsCount < 0 || value.inputsCount > 16) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.inputsCount >= 0);
+  assert(value.inputsCount <= 16);
   v = (value.startFrame);
   scratch |= v << scratchBits;
   scratchBits += 64;
@@ -1933,8 +1923,7 @@ void initShipCreate(ShipCreate value) {
 
 // writeShipCreate packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// shipCreateMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// shipCreateMaxBytes. Returns the bytes written.
 int writeShipCreate(ShipCreate value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= shipCreateMaxBytes);
@@ -2249,8 +2238,7 @@ void initExpressionProbe(ExpressionProbe value) {
 
 // writeExpressionProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// expressionProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// expressionProbeMaxBytes. Returns the bytes written.
 int writeExpressionProbe(ExpressionProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= expressionProbeMaxBytes);
@@ -2369,8 +2357,7 @@ void initExtremeProbe(ExtremeProbe value) {
 
 // writeExtremeProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// extremeProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// extremeProbeMaxBytes. Returns the bytes written.
 int writeExtremeProbe(ExtremeProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= extremeProbeMaxBytes);
@@ -2595,8 +2582,7 @@ void initExtremeRow(ExtremeRow value) {
 
 // writeExtremeRow packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// extremeRowMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// extremeRowMaxBytes. Returns the bytes written.
 int writeExtremeRow(ExtremeRow value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= extremeRowMaxBytes);

--- a/testdata/golden/dart/Wire.dart
+++ b/testdata/golden/dart/Wire.dart
@@ -222,8 +222,7 @@ void initProbeHeader(ProbeHeader value) {
 
 // writeProbeHeader packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeHeaderMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeHeaderMaxBytes. Returns the bytes written.
 int writeProbeHeader(ProbeHeader value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeHeaderMaxBytes);
@@ -393,8 +392,7 @@ void initProbeBits(ProbeBits value) {
 
 // writeProbeBits packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeBitsMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeBitsMaxBytes. Returns the bytes written.
 int writeProbeBits(ProbeBits value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeBitsMaxBytes);
@@ -594,8 +592,7 @@ void initProbeSample(ProbeSample value) {
 
 // writeProbeSample packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeSampleMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeSampleMaxBytes. Returns the bytes written.
 int writeProbeSample(ProbeSample value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeSampleMaxBytes);
@@ -683,9 +680,8 @@ int writeProbeSample(ProbeSample value, ByteData view) {
       scratch = v >>> (32 - scratchBits);
     }
   }
-  if (value.samplesCount < 1 || value.samplesCount > 8) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.samplesCount >= 1);
+  assert(value.samplesCount <= 8);
   v = ((value.samplesCount - 1) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
@@ -929,8 +925,7 @@ void initProbeRing(ProbeRing value) {
 
 // writeProbeRing packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeRingMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeRingMaxBytes. Returns the bytes written.
 int writeProbeRing(ProbeRing value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeRingMaxBytes);
@@ -1020,8 +1015,7 @@ void initProbeSlab(ProbeSlab value) {
 
 // writeProbeSlab packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeSlabMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeSlabMaxBytes. Returns the bytes written.
 int writeProbeSlab(ProbeSlab value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeSlabMaxBytes);
@@ -1140,8 +1134,7 @@ void zeroProbeShape(ProbeShape value) {
 
 // writeProbeShape packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeShapeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeShapeMaxBytes. Returns the bytes written.
 int writeProbeShape(ProbeShape value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeShapeMaxBytes);
@@ -1319,8 +1312,7 @@ void initProbeCollider(ProbeCollider value) {
 
 // writeProbeCollider packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeColliderMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeColliderMaxBytes. Returns the bytes written.
 int writeProbeCollider(ProbeCollider value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeColliderMaxBytes);
@@ -1402,9 +1394,8 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
         scratch = v >>> (15 - scratchBits);
       }
   }
-  if (value.extrasCount < 0 || value.extrasCount > 2) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.extrasCount >= 0);
+  assert(value.extrasCount <= 2);
   v = ((value.extrasCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
@@ -1720,8 +1711,7 @@ void initProbeConfig(ProbeConfig value) {
 
 // writeProbeConfig packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeConfigMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeConfigMaxBytes. Returns the bytes written.
 int writeProbeConfig(ProbeConfig value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeConfigMaxBytes);
@@ -1819,8 +1809,7 @@ void initProbeArray(ProbeArray value) {
 
 // writeProbeArray packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeArrayMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeArrayMaxBytes. Returns the bytes written.
 int writeProbeArray(ProbeArray value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeArrayMaxBytes);
@@ -1910,9 +1899,8 @@ int writeProbeArray(ProbeArray value, ByteData view) {
         scratch = v >>> (32 - scratchBits);
       }
     }
-    if (e0.samplesCount < 1 || e0.samplesCount > 8) {
-      return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    assert(e0.samplesCount >= 1);
+    assert(e0.samplesCount <= 8);
     v = ((e0.samplesCount - 1) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
@@ -2193,8 +2181,7 @@ void initHeartbeat(Heartbeat value) {
 
 // writeHeartbeat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// heartbeatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// heartbeatMaxBytes. Returns the bytes written.
 int writeHeartbeat(Heartbeat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= heartbeatMaxBytes);
@@ -2254,8 +2241,7 @@ void initTest(Test value) {
 
 // writeTest packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// testMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// testMaxBytes. Returns the bytes written.
 int writeTest(Test value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= testMaxBytes);
@@ -2373,8 +2359,7 @@ void initBlock(Block value) {
 
 // writeBlock packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// blockMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// blockMaxBytes. Returns the bytes written.
 int writeBlock(Block value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= blockMaxBytes);
@@ -2538,8 +2523,7 @@ void initChat(Chat value) {
 
 // writeChat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// chatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// chatMaxBytes. Returns the bytes written.
 int writeChat(Chat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= chatMaxBytes);
@@ -2714,8 +2698,7 @@ void initProbeReport(ProbeReport value) {
 
 // writeProbeReport packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// probeReportMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// probeReportMaxBytes. Returns the bytes written.
 int writeProbeReport(ProbeReport value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= probeReportMaxBytes);
@@ -2997,8 +2980,7 @@ void initTestData(TestData value) {
 
 // writeTestData packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// testDataMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// testDataMaxBytes. Returns the bytes written.
 int writeTestData(TestData value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= testDataMaxBytes);
@@ -3012,9 +2994,8 @@ int writeTestData(TestData value, ByteData view) {
   assert(value.b <= 100);
   assert(value.c >= -100);
   assert(value.c <= 150);
-  if (value.itemsCount < 0 || value.itemsCount > 16) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.itemsCount >= 0);
+  assert(value.itemsCount <= 16);
   v =
       ((value.a + 100) & 0xff) |
       (((value.b + 100) & 0xff) << 8) |
@@ -3587,8 +3568,7 @@ void initCompressedProbe(CompressedProbe value) {
 
 // writeCompressedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// compressedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// compressedProbeMaxBytes. Returns the bytes written.
 int writeCompressedProbe(CompressedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= compressedProbeMaxBytes);

--- a/testdata/golden/java/ArmDefaults.java
+++ b/testdata/golden/java/ArmDefaults.java
@@ -65,6 +65,8 @@ public final class ArmDefaults {
     private static boolean checkWriteDefaultArm(DefaultArm value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= defaultArmMaxBytes;
+        assert value.entriesCount >= 0;
+        assert value.entriesCount <= 2;
         for (int i0 = 0; i0 < value.entriesCount; i0++) {
             final Wire.ProbeConfig e0 = value.entries[i0];
             assert (e0.preferred & 0xffL) >= 0;
@@ -84,9 +86,6 @@ public final class ArmDefaults {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.entriesCount < 0 || value.entriesCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.entriesCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -284,6 +283,8 @@ public final class ArmDefaults {
         assert (value.type & 0xffL) <= 2;
         switch (value.type) {
             case 1:
+                assert value.first.entriesCount >= 0;
+                assert value.first.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.first.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.first.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -293,6 +294,8 @@ public final class ArmDefaults {
                 assert (value.first.marker & 0xffL) <= 7;
                 break;
             case 2:
+                assert value.second.entriesCount >= 0;
+                assert value.second.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.second.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.second.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -325,9 +328,6 @@ public final class ArmDefaults {
         }
         switch (value.type) {
             case 1:
-                if (value.first.entriesCount < 0 || value.first.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.first.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -369,9 +369,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.second.entriesCount < 0 || value.second.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.second.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -643,6 +640,8 @@ public final class ArmDefaults {
         assert (value.choice.type & 0xffL) <= 2;
         switch (value.choice.type) {
             case 1:
+                assert value.choice.first.entriesCount >= 0;
+                assert value.choice.first.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.choice.first.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.choice.first.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -652,6 +651,8 @@ public final class ArmDefaults {
                 assert (value.choice.first.marker & 0xffL) <= 7;
                 break;
             case 2:
+                assert value.choice.second.entriesCount >= 0;
+                assert value.choice.second.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.choice.second.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.choice.second.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -684,9 +685,6 @@ public final class ArmDefaults {
         }
         switch (value.choice.type) {
             case 1:
-                if (value.choice.first.entriesCount < 0 || value.choice.first.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.choice.first.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -728,9 +726,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.choice.second.entriesCount < 0 || value.choice.second.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.choice.second.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -1005,6 +1000,8 @@ public final class ArmDefaults {
     private static boolean checkWriteDefaultBulkArm(DefaultBulkArm value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= defaultBulkArmMaxBytes;
+        assert value.payload.entriesCount >= 0;
+        assert value.payload.entriesCount <= 2;
         for (int i0 = 0; i0 < value.payload.entriesCount; i0++) {
             final Wire.ProbeConfig e0 = value.payload.entries[i0];
             assert (e0.preferred & 0xffL) >= 0;
@@ -1026,9 +1023,6 @@ public final class ArmDefaults {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.payload.entriesCount < 0 || value.payload.entriesCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.payload.entriesCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -1296,6 +1290,8 @@ public final class ArmDefaults {
         assert (value.type & 0xffL) <= 2;
         switch (value.type) {
             case 1:
+                assert value.first.payload.entriesCount >= 0;
+                assert value.first.payload.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.first.payload.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.first.payload.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -1307,6 +1303,8 @@ public final class ArmDefaults {
                 assert value.first.dataLength <= 2;
                 break;
             case 2:
+                assert value.second.payload.entriesCount >= 0;
+                assert value.second.payload.entriesCount <= 2;
                 for (int i0 = 0; i0 < value.second.payload.entriesCount; i0++) {
                     final Wire.ProbeConfig e0 = value.second.payload.entries[i0];
                     assert (e0.preferred & 0xffL) >= 0;
@@ -1341,9 +1339,6 @@ public final class ArmDefaults {
         }
         switch (value.type) {
             case 1:
-                if (value.first.payload.entriesCount < 0 || value.first.payload.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.first.payload.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;
@@ -1420,9 +1415,6 @@ public final class ArmDefaults {
                 }
                 break;
             case 2:
-                if (value.second.payload.entriesCount < 0 || value.second.payload.entriesCount > 2) {
-                    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-                }
                 v = (value.second.payload.entriesCount) & 0x3L;
                 scratch |= v << scratchBits;
                 scratchBits += 2;

--- a/testdata/golden/java/Clauses.java
+++ b/testdata/golden/java/Clauses.java
@@ -50,6 +50,8 @@ public final class Clauses {
     private static boolean checkWriteW13(W13 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w13MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 12;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffL) >= 0;
             assert (value.items[i0] & 0xffffL) <= 8191;
@@ -66,9 +68,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 12) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -193,6 +192,8 @@ public final class Clauses {
     private static boolean checkWriteW17(W17 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w17MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 9;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffffffL) >= 0;
             assert (value.items[i0] & 0xffffffffL) <= 131071;
@@ -209,9 +210,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 9) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -336,6 +334,8 @@ public final class Clauses {
     private static boolean checkWriteW26(W26 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w26MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 6;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffffffL) >= 0;
             assert (value.items[i0] & 0xffffffffL) <= 67108863;
@@ -352,9 +352,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 6) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x7L;
         scratch |= v << scratchBits;
         scratchBits += 3;
@@ -479,6 +476,8 @@ public final class Clauses {
     private static boolean checkWriteW1(W1 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w1MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 20;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffL) >= 0;
             assert (value.items[i0] & 0xffL) <= 1;
@@ -495,9 +494,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 20) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x1fL;
         scratch |= v << scratchBits;
         scratchBits += 5;
@@ -622,6 +618,8 @@ public final class Clauses {
     private static boolean checkWriteW52(W52 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w52MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 4503599627370495L;
@@ -638,9 +636,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -783,6 +778,8 @@ public final class Clauses {
     private static boolean checkWriteW50(W50 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= w50MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 1125899906842623L;
@@ -799,9 +796,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
         scratchBits += 2;
@@ -1186,6 +1180,8 @@ public final class Clauses {
     private static boolean checkWriteArrTri3(ArrTri3 value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrTri3MaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 10;
         return true;
     }
 
@@ -1198,9 +1194,6 @@ public final class Clauses {
         int scratchBits = 0;
         int wordIndex = 0;
         long v = 0;
-        if (value.itemsCount < 0 || value.itemsCount > 10) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-        }
         v = (value.itemsCount) & 0xfL;
         scratch |= v << scratchBits;
         scratchBits += 4;
@@ -2383,6 +2376,8 @@ public final class Clauses {
     private static boolean checkWriteArrNested(ArrNested value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrNestedMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 4;
         return true;
     }
 
@@ -2403,9 +2398,6 @@ public final class Clauses {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 4) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x7L;
         scratch |= v << scratchBits;

--- a/testdata/golden/java/Joins.java
+++ b/testdata/golden/java/Joins.java
@@ -1274,6 +1274,8 @@ public final class Joins {
         assert data.length % 8 == 0;
         assert data.length >= armArrayMaxBytes;
         if (value.flag) {
+            assert value.itemsCount >= 0;
+            assert value.itemsCount <= 3;
             for (int i0 = 0; i0 < value.itemsCount; i0++) {
                 assert (value.items[i0] & 0xffffL) >= 0;
                 assert (value.items[i0] & 0xffffL) <= 8191;
@@ -1310,9 +1312,6 @@ public final class Joins {
             scratch = v >>> (1 - scratchBits);
         }
         if (value.flag) {
-            if (value.itemsCount < 0 || value.itemsCount > 3) {
-                return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-            }
             v = (value.itemsCount) & 0x3L;
             scratch |= v << scratchBits;
             scratchBits += 2;
@@ -2222,6 +2221,8 @@ public final class Joins {
     private static boolean checkWriteArrUneven(ArrUneven value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= arrUnevenMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             final Uneven e0 = value.items[i0];
             assert (e0.type & 0xffL) >= 0;
@@ -2247,9 +2248,6 @@ public final class Joins {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;
@@ -2525,6 +2523,8 @@ public final class Joins {
     private static boolean checkWriteRegainAfterAlign(RegainAfterAlign value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= regainAfterAlignMaxBytes;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 3;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert (value.items[i0] & 0xffffL) >= 0;
             assert (value.items[i0] & 0xffffL) <= 8191;
@@ -2551,9 +2551,6 @@ public final class Joins {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (5 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 3) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x3L;
         scratch |= v << scratchBits;

--- a/testdata/golden/java/Render.java
+++ b/testdata/golden/java/Render.java
@@ -283,6 +283,8 @@ public final class Render {
     private static boolean checkWriteRenderBlock(RenderBlock value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= renderBlockMaxBytes;
+        assert value.spritesCount >= 0;
+        assert value.spritesCount <= 64;
         for (int i0 = 0; i0 < value.spritesCount; i0++) {
             final RenderSprite e0 = value.sprites[i0];
             assert (e0.team & 0xffL) >= 0;
@@ -317,9 +319,6 @@ public final class Render {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.spritesCount < 0 || value.spritesCount > 64) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.spritesCount) & 0x7fL;
         scratch |= v << scratchBits;

--- a/testdata/golden/java/Types.java
+++ b/testdata/golden/java/Types.java
@@ -2230,6 +2230,8 @@ public final class Types {
     private static boolean checkWriteInputPacket(InputPacket value, byte[] data) {
         assert data.length % 8 == 0;
         assert data.length >= inputPacketMaxBytes;
+        assert value.inputsCount >= 0;
+        assert value.inputsCount <= 16;
         return true;
     }
 
@@ -2286,9 +2288,6 @@ public final class Types {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.inputsCount < 0 || value.inputsCount > 16) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.inputsCount) & 0x1fL;
         scratch |= v << scratchBits;

--- a/testdata/golden/java/Wire.java
+++ b/testdata/golden/java/Wire.java
@@ -658,6 +658,8 @@ public final class Wire {
             assert (value.weapon & 0xffL) >= 0;
             assert (value.weapon & 0xffL) <= 15;
         }
+        assert value.samplesCount >= 1;
+        assert value.samplesCount <= 8;
         return true;
     }
 
@@ -765,9 +767,6 @@ public final class Wire {
                 scratchBits -= 64;
                 scratch = v >>> (32 - scratchBits);
             }
-        }
-        if (value.samplesCount < 1 || value.samplesCount > 8) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.samplesCount - 1) & 0x7L;
         scratch |= v << scratchBits;
@@ -1512,6 +1511,8 @@ public final class Wire {
                 assert (value.backup.slab.width & 0xffL) <= 100;
                 break;
         }
+        assert value.extrasCount >= 0;
+        assert value.extrasCount <= 2;
         for (int i0 = 0; i0 < value.extrasCount; i0++) {
             final ProbeShape e0 = value.extras[i0];
             assert (e0.type & 0xffL) >= 0;
@@ -1627,9 +1628,6 @@ public final class Wire {
                     scratch = v >>> (8 - scratchBits);
                 }
                 break;
-        }
-        if (value.extrasCount < 0 || value.extrasCount > 2) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.extrasCount) & 0x3L;
         scratch |= v << scratchBits;
@@ -2156,6 +2154,8 @@ public final class Wire {
                 assert (e0.weapon & 0xffL) >= 0;
                 assert (e0.weapon & 0xffL) <= 15;
             }
+            assert e0.samplesCount >= 1;
+            assert e0.samplesCount <= 8;
         }
         assert (value.config.preferred & 0xffL) >= 0;
         assert (value.config.preferred & 0xffL) <= 15;
@@ -2268,9 +2268,6 @@ public final class Wire {
                     scratchBits -= 64;
                     scratch = v >>> (32 - scratchBits);
                 }
-            }
-            if (e0.samplesCount < 1 || e0.samplesCount > 8) {
-                return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
             }
             v = (e0.samplesCount - 1) & 0x7L;
             scratch |= v << scratchBits;
@@ -3558,6 +3555,8 @@ public final class Wire {
         assert value.b <= 100;
         assert value.c >= -100;
         assert value.c <= 150;
+        assert value.itemsCount >= 0;
+        assert value.itemsCount <= 16;
         for (int i0 = 0; i0 < value.itemsCount; i0++) {
             assert value.items[i0] >= 0;
             assert value.items[i0] <= 255;
@@ -3641,9 +3640,6 @@ public final class Wire {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (1 - scratchBits);
-        }
-        if (value.itemsCount < 0 || value.itemsCount > 16) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.itemsCount) & 0x1fL;
         scratch |= v << scratchBits;

--- a/testdata/golden/js/ArmDefaultsFlat.js
+++ b/testdata/golden/js/ArmDefaultsFlat.js
@@ -41,9 +41,6 @@ export const FLAT_READ_SLACK = 8;
 function writeDefaultArmFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.EntriesCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -92,7 +89,7 @@ function writeDefaultArmFlatProduction(value, view) {
 function writeDefaultArmFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.EntriesCount) || value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.EntriesCount) || value.EntriesCount < 0 || value.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.EntriesCount) & 0x3)) >>> 0;
@@ -146,9 +143,9 @@ function writeDefaultArmFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultArmFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultArmMaxBytes.
+// WriteDefaultArmFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultArmMaxBytes.
 export const WriteDefaultArmFlat = PRODUCTION ? writeDefaultArmFlatProduction : writeDefaultArmFlatChecked;
 
 // ReadDefaultArmFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -221,9 +218,6 @@ function writeDefaultChoicePacketFlatProduction(value, view) {
   }
   switch (value.Choice.Type) {
     case 1: {
-      if (value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-        return -1;
-      }
       v = (((value.Choice.First.EntriesCount) & 0x3)) >>> 0;
       lo = (lo | (v << sb)) >>> 0;
       sb += 2;
@@ -266,9 +260,6 @@ function writeDefaultChoicePacketFlatProduction(value, view) {
       break;
     }
     case 2: {
-      if (value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-        return -1;
-      }
       v = (((value.Choice.Second.EntriesCount) & 0x3)) >>> 0;
       lo = (lo | (v << sb)) >>> 0;
       sb += 2;
@@ -334,7 +325,7 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
   }
   switch (value.Choice.Type) {
     case 1: {
-      if (!Number.isInteger(value.Choice.First.EntriesCount) || value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+      if (!Number.isInteger(value.Choice.First.EntriesCount) || value.Choice.First.EntriesCount < 0 || value.Choice.First.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
         return -1;
       }
       v = (((value.Choice.First.EntriesCount) & 0x3)) >>> 0;
@@ -385,7 +376,7 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Choice.Second.EntriesCount) || value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+      if (!Number.isInteger(value.Choice.Second.EntriesCount) || value.Choice.Second.EntriesCount < 0 || value.Choice.Second.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
         return -1;
       }
       v = (((value.Choice.Second.EntriesCount) & 0x3)) >>> 0;
@@ -442,9 +433,9 @@ function writeDefaultChoicePacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultChoicePacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultChoicePacketMaxBytes.
+// WriteDefaultChoicePacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultChoicePacketMaxBytes.
 export const WriteDefaultChoicePacketFlat = PRODUCTION ? writeDefaultChoicePacketFlatProduction : writeDefaultChoicePacketFlatChecked;
 
 // ReadDefaultChoicePacketFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -590,9 +581,6 @@ export function ReadDefaultChoicePacketFlat(value, view, numBits) {
 function writeDefaultBulkArmFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.Payload.EntriesCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -673,7 +661,7 @@ function writeDefaultBulkArmFlatProduction(value, view) {
 function writeDefaultBulkArmFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Payload.EntriesCount) || value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.Payload.EntriesCount) || value.Payload.EntriesCount < 0 || value.Payload.EntriesCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.Payload.EntriesCount) & 0x3)) >>> 0;
@@ -762,9 +750,9 @@ function writeDefaultBulkArmFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDefaultBulkArmFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DefaultBulkArmMaxBytes.
+// WriteDefaultBulkArmFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DefaultBulkArmMaxBytes.
 export const WriteDefaultBulkArmFlat = PRODUCTION ? writeDefaultBulkArmFlatProduction : writeDefaultBulkArmFlatChecked;
 
 // ReadDefaultBulkArmFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/ClausesFlat.js
+++ b/testdata/golden/js/ClausesFlat.js
@@ -22,9 +22,6 @@ export const FLAT_READ_SLACK = 8;
 function writeW13FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -54,7 +51,7 @@ function writeW13FlatProduction(value, view) {
 function writeW13FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 12) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -86,9 +83,9 @@ function writeW13FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW13Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W13MaxBytes.
+// WriteW13Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W13MaxBytes.
 export const WriteW13Flat = PRODUCTION ? writeW13FlatProduction : writeW13FlatChecked;
 
 // ReadW13Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -131,9 +128,6 @@ export function ReadW13Flat(value, view, numBits) {
 function writeW17FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -163,7 +157,7 @@ function writeW17FlatProduction(value, view) {
 function writeW17FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 9) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -195,9 +189,9 @@ function writeW17FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW17Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W17MaxBytes.
+// WriteW17Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W17MaxBytes.
 export const WriteW17Flat = PRODUCTION ? writeW17FlatProduction : writeW17FlatChecked;
 
 // ReadW17Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -240,9 +234,6 @@ export function ReadW17Flat(value, view, numBits) {
 function writeW26FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -272,7 +263,7 @@ function writeW26FlatProduction(value, view) {
 function writeW26FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 6) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x7)) >>> 0;
@@ -304,9 +295,9 @@ function writeW26FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW26Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W26MaxBytes.
+// WriteW26Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W26MaxBytes.
 export const WriteW26Flat = PRODUCTION ? writeW26FlatProduction : writeW26FlatChecked;
 
 // ReadW26Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -349,9 +340,6 @@ export function ReadW26Flat(value, view, numBits) {
 function writeW1FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x1f)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 5;
@@ -381,7 +369,7 @@ function writeW1FlatProduction(value, view) {
 function writeW1FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 20) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x1f)) >>> 0;
@@ -413,9 +401,9 @@ function writeW1FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW1Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W1MaxBytes.
+// WriteW1Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W1MaxBytes.
 export const WriteW1Flat = PRODUCTION ? writeW1FlatProduction : writeW1FlatChecked;
 
 // ReadW1Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -458,9 +446,6 @@ export function ReadW1Flat(value, view, numBits) {
 function writeW52FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -500,7 +485,7 @@ function writeW52FlatProduction(value, view) {
 function writeW52FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -542,9 +527,9 @@ function writeW52FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW52Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W52MaxBytes.
+// WriteW52Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W52MaxBytes.
 export const WriteW52Flat = PRODUCTION ? writeW52FlatProduction : writeW52FlatChecked;
 
 // ReadW52Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -595,9 +580,6 @@ export function ReadW52Flat(value, view, numBits) {
 function writeW50FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 2;
@@ -637,7 +619,7 @@ function writeW50FlatProduction(value, view) {
 function writeW50FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -679,9 +661,9 @@ function writeW50FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteW50Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold W50MaxBytes.
+// WriteW50Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold W50MaxBytes.
 export const WriteW50Flat = PRODUCTION ? writeW50FlatProduction : writeW50FlatChecked;
 
 // ReadW50Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -772,9 +754,9 @@ function writeF13FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteF13Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold F13MaxBytes.
+// WriteF13Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold F13MaxBytes.
 export const WriteF13Flat = PRODUCTION ? writeF13FlatProduction : writeF13FlatChecked;
 
 // ReadF13Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -836,9 +818,9 @@ function writeTri3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Tri3MaxBytes.
+// WriteTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Tri3MaxBytes.
 export const WriteTri3Flat = PRODUCTION ? writeTri3FlatProduction : writeTri3FlatChecked;
 
 // ReadTri3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -866,9 +848,6 @@ export function ReadTri3Flat(value, view, numBits) {
 function writeArrTri3FlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 4;
@@ -899,7 +878,7 @@ function writeArrTri3FlatProduction(value, view) {
 function writeArrTri3FlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 10) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ItemsCount) & 0xf)) >>> 0;
@@ -929,9 +908,9 @@ function writeArrTri3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrTri3MaxBytes.
+// WriteArrTri3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrTri3MaxBytes.
 export const WriteArrTri3Flat = PRODUCTION ? writeArrTri3FlatProduction : writeArrTri3FlatChecked;
 
 // ReadArrTri3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -1010,9 +989,9 @@ function writeElevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ElevenMaxBytes.
+// WriteElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ElevenMaxBytes.
 export const WriteElevenFlat = PRODUCTION ? writeElevenFlatProduction : writeElevenFlatChecked;
 
 // ReadElevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1079,9 +1058,9 @@ function writeArrElevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrElevenMaxBytes.
+// WriteArrElevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrElevenMaxBytes.
 export const WriteArrElevenFlat = PRODUCTION ? writeArrElevenFlatProduction : writeArrElevenFlatChecked;
 
 // ReadArrElevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1128,9 +1107,9 @@ function writeEmptyAFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteEmptyAFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold EmptyAMaxBytes.
+// WriteEmptyAFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold EmptyAMaxBytes.
 export const WriteEmptyAFlat = PRODUCTION ? writeEmptyAFlatProduction : writeEmptyAFlatChecked;
 
 // ReadEmptyAFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1161,9 +1140,9 @@ function writeEmptyBFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteEmptyBFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold EmptyBMaxBytes.
+// WriteEmptyBFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold EmptyBMaxBytes.
 export const WriteEmptyBFlat = PRODUCTION ? writeEmptyBFlatProduction : writeEmptyBFlatChecked;
 
 // ReadEmptyBFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1249,9 +1228,9 @@ function writeHoldsEmptyUnionFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHoldsEmptyUnionFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HoldsEmptyUnionMaxBytes.
+// WriteHoldsEmptyUnionFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HoldsEmptyUnionMaxBytes.
 export const WriteHoldsEmptyUnionFlat = PRODUCTION ? writeHoldsEmptyUnionFlatProduction : writeHoldsEmptyUnionFlatChecked;
 
 // ReadHoldsEmptyUnionFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1513,9 +1492,9 @@ function writeStrsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteStrsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold StrsMaxBytes.
+// WriteStrsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold StrsMaxBytes.
 export const WriteStrsFlat = PRODUCTION ? writeStrsFlatProduction : writeStrsFlatChecked;
 
 // ReadStrsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1641,9 +1620,6 @@ export function ReadStrsFlat(value, view, numBits) {
 function writeArrNestedFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x7) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 8;
@@ -1683,7 +1659,7 @@ function writeArrNestedFlatProduction(value, view) {
 function writeArrNestedFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 4) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x7) << 5)) >>> 0;
@@ -1722,9 +1698,9 @@ function writeArrNestedFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrNestedMaxBytes.
+// WriteArrNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrNestedMaxBytes.
 export const WriteArrNestedFlat = PRODUCTION ? writeArrNestedFlatProduction : writeArrNestedFlatChecked;
 
 // ReadArrNestedFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1824,9 +1800,9 @@ function writeSoleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SoleMaxBytes.
+// WriteSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SoleMaxBytes.
 export const WriteSoleFlat = PRODUCTION ? writeSoleFlatProduction : writeSoleFlatChecked;
 
 // ReadSoleFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/DegenerateFlat.js
+++ b/testdata/golden/js/DegenerateFlat.js
@@ -113,9 +113,9 @@ function writeVec2FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteVec2Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Vec2MaxBytes.
+// WriteVec2Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Vec2MaxBytes.
 export const WriteVec2Flat = PRODUCTION ? writeVec2FlatProduction : writeVec2FlatChecked;
 
 // ReadVec2Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -224,9 +224,9 @@ function writeSpanF64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanF64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanF64MaxBytes.
+// WriteSpanF64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanF64MaxBytes.
 export const WriteSpanF64Flat = PRODUCTION ? writeSpanF64FlatProduction : writeSpanF64FlatChecked;
 
 // ReadSpanF64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -321,9 +321,9 @@ function writeSpanU64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanU64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanU64MaxBytes.
+// WriteSpanU64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanU64MaxBytes.
 export const WriteSpanU64Flat = PRODUCTION ? writeSpanU64FlatProduction : writeSpanU64FlatChecked;
 
 // ReadSpanU64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -420,9 +420,9 @@ function writeSpanI64FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanI64Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanI64MaxBytes.
+// WriteSpanI64Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanI64MaxBytes.
 export const WriteSpanI64Flat = PRODUCTION ? writeSpanI64FlatProduction : writeSpanI64FlatChecked;
 
 // ReadSpanI64Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -519,9 +519,9 @@ function writeSpanOneFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanOneFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanOneMaxBytes.
+// WriteSpanOneFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanOneMaxBytes.
 export const WriteSpanOneFlat = PRODUCTION ? writeSpanOneFlatProduction : writeSpanOneFlatChecked;
 
 // ReadSpanOneFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -598,9 +598,9 @@ function writeSpanChunkFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanChunkFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanChunkMaxBytes.
+// WriteSpanChunkFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanChunkMaxBytes.
 export const WriteSpanChunkFlat = PRODUCTION ? writeSpanChunkFlatProduction : writeSpanChunkFlatChecked;
 
 // ReadSpanChunkFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -704,9 +704,9 @@ function writeSpanTailFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanTailFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanTailMaxBytes.
+// WriteSpanTailFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanTailMaxBytes.
 export const WriteSpanTailFlat = PRODUCTION ? writeSpanTailFlatProduction : writeSpanTailFlatChecked;
 
 // ReadSpanTailFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -850,9 +850,9 @@ function writeSpanTwiceFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteSpanTwiceFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold SpanTwiceMaxBytes.
+// WriteSpanTwiceFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold SpanTwiceMaxBytes.
 export const WriteSpanTwiceFlat = PRODUCTION ? writeSpanTwiceFlatProduction : writeSpanTwiceFlatChecked;
 
 // ReadSpanTwiceFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -978,9 +978,9 @@ function writeTrioFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioMaxBytes.
+// WriteTrioFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioMaxBytes.
 export const WriteTrioFlat = PRODUCTION ? writeTrioFlatProduction : writeTrioFlatChecked;
 
 // ReadTrioFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1091,9 +1091,9 @@ function writeTrioSoleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioSoleMaxBytes.
+// WriteTrioSoleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioSoleMaxBytes.
 export const WriteTrioSoleFlat = PRODUCTION ? writeTrioSoleFlatProduction : writeTrioSoleFlatChecked;
 
 // ReadTrioSoleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1222,9 +1222,9 @@ function writeTrioFirstFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioFirstFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioFirstMaxBytes.
+// WriteTrioFirstFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioFirstMaxBytes.
 export const WriteTrioFirstFlat = PRODUCTION ? writeTrioFirstFlatProduction : writeTrioFirstFlatChecked;
 
 // ReadTrioFirstFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1551,9 +1551,9 @@ function writeTrioStraddleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTrioStraddleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TrioStraddleMaxBytes.
+// WriteTrioStraddleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TrioStraddleMaxBytes.
 export const WriteTrioStraddleFlat = PRODUCTION ? writeTrioStraddleFlatProduction : writeTrioStraddleFlatChecked;
 
 // ReadTrioStraddleFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/JoinsFlat.js
+++ b/testdata/golden/js/JoinsFlat.js
@@ -115,9 +115,9 @@ function writeArmsAgreeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsAgreeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsAgreeMaxBytes.
+// WriteArmsAgreeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsAgreeMaxBytes.
 export const WriteArmsAgreeFlat = PRODUCTION ? writeArmsAgreeFlatProduction : writeArmsAgreeFlatChecked;
 
 // ReadArmsAgreeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -267,9 +267,9 @@ function writeArmsDisagreeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsDisagreeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsDisagreeMaxBytes.
+// WriteArmsDisagreeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsDisagreeMaxBytes.
 export const WriteArmsDisagreeFlat = PRODUCTION ? writeArmsDisagreeFlatProduction : writeArmsDisagreeFlatChecked;
 
 // ReadArmsDisagreeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -408,9 +408,9 @@ function writeArmEmptyFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmEmptyFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmEmptyMaxBytes.
+// WriteArmEmptyFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmEmptyMaxBytes.
 export const WriteArmEmptyFlat = PRODUCTION ? writeArmEmptyFlatProduction : writeArmEmptyFlatChecked;
 
 // ReadArmEmptyFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -599,9 +599,9 @@ function writeArmsNestedFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmsNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmsNestedMaxBytes.
+// WriteArmsNestedFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmsNestedMaxBytes.
 export const WriteArmsNestedFlat = PRODUCTION ? writeArmsNestedFlatProduction : writeArmsNestedFlatChecked;
 
 // ReadArmsNestedFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -856,9 +856,9 @@ function writeArmAlignFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmAlignMaxBytes.
+// WriteArmAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmAlignMaxBytes.
 export const WriteArmAlignFlat = PRODUCTION ? writeArmAlignFlatProduction : writeArmAlignFlatChecked;
 
 // ReadArmAlignFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -981,9 +981,6 @@ function writeArmArrayFlatProduction(value, view) {
     lo = sb === 0 ? 0 : v >>> (6 - sb);
   }
   if (value.Flag) {
-    if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-      return -1;
-    }
     v = (((value.ItemsCount) & 0x3)) >>> 0;
     lo = (lo | (v << sb)) >>> 0;
     sb += 2;
@@ -1043,7 +1040,7 @@ function writeArmArrayFlatChecked(value, view) {
     lo = sb === 0 ? 0 : v >>> (6 - sb);
   }
   if (value.Flag) {
-    if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+    if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
       return -1;
     }
     v = (((value.ItemsCount) & 0x3)) >>> 0;
@@ -1095,9 +1092,9 @@ function writeArmArrayFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArmArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArmArrayMaxBytes.
+// WriteArmArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArmArrayMaxBytes.
 export const WriteArmArrayFlat = PRODUCTION ? writeArmArrayFlatProduction : writeArmArrayFlatChecked;
 
 // ReadArmArrayFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1210,9 +1207,9 @@ function writeNarrowFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteNarrowFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold NarrowMaxBytes.
+// WriteNarrowFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold NarrowMaxBytes.
 export const WriteNarrowFlat = PRODUCTION ? writeNarrowFlatProduction : writeNarrowFlatChecked;
 
 // ReadNarrowFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1291,9 +1288,9 @@ function writeWideFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideMaxBytes.
+// WriteWideFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideMaxBytes.
 export const WriteWideFlat = PRODUCTION ? writeWideFlatProduction : writeWideFlatChecked;
 
 // ReadWideFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1456,9 +1453,9 @@ function writeHoldsUnevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHoldsUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HoldsUnevenMaxBytes.
+// WriteHoldsUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HoldsUnevenMaxBytes.
 export const WriteHoldsUnevenFlat = PRODUCTION ? writeHoldsUnevenFlatProduction : writeHoldsUnevenFlatChecked;
 
 // ReadHoldsUnevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1552,9 +1549,6 @@ export function ReadHoldsUnevenFlat(value, view, numBits) {
 function writeArrUnevenFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 7;
@@ -1630,7 +1624,7 @@ function writeArrUnevenFlatProduction(value, view) {
 function writeArrUnevenFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
@@ -1708,9 +1702,9 @@ function writeArrUnevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteArrUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ArrUnevenMaxBytes.
+// WriteArrUnevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ArrUnevenMaxBytes.
 export const WriteArrUnevenFlat = PRODUCTION ? writeArrUnevenFlatProduction : writeArrUnevenFlatChecked;
 
 // ReadArrUnevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1818,9 +1812,6 @@ export function ReadArrUnevenFlat(value, view, numBits) {
 function writeRegainAfterAlignFlatProduction(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 7;
@@ -1918,7 +1909,7 @@ function writeRegainAfterAlignFlatProduction(value, view) {
 function writeRegainAfterAlignFlatChecked(value, view) {
   let v = 0;
   let lo = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 3) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.Lead & 0x1f) | (((value.ItemsCount) & 0x3) << 5)) >>> 0;
@@ -2021,9 +2012,9 @@ function writeRegainAfterAlignFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRegainAfterAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RegainAfterAlignMaxBytes.
+// WriteRegainAfterAlignFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RegainAfterAlignMaxBytes.
 export const WriteRegainAfterAlignFlat = PRODUCTION ? writeRegainAfterAlignFlatProduction : writeRegainAfterAlignFlatChecked;
 
 // ReadRegainAfterAlignFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/RenderFlat.js
+++ b/testdata/golden/js/RenderFlat.js
@@ -132,9 +132,9 @@ function writeRenderSpriteFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRenderSpriteFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RenderSpriteMaxBytes.
+// WriteRenderSpriteFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RenderSpriteMaxBytes.
 export const WriteRenderSpriteFlat = PRODUCTION ? writeRenderSpriteFlatProduction : writeRenderSpriteFlatChecked;
 
 // ReadRenderSpriteFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -208,9 +208,6 @@ function writeRenderBlockFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.SpriteCountHint) >>> 0)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -297,7 +294,7 @@ function writeRenderBlockFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > 64) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.SpriteCountHint) >>> 0)) >>> 0;
@@ -376,9 +373,9 @@ function writeRenderBlockFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRenderBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RenderBlockMaxBytes.
+// WriteRenderBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RenderBlockMaxBytes.
 export const WriteRenderBlockFlat = PRODUCTION ? writeRenderBlockFlatProduction : writeRenderBlockFlatChecked;
 
 // ReadRenderBlockFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/TypesFlat.js
+++ b/testdata/golden/js/TypesFlat.js
@@ -151,9 +151,9 @@ function writeVec3FlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteVec3Flat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold Vec3MaxBytes.
+// WriteVec3Flat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold Vec3MaxBytes.
 export const WriteVec3Flat = PRODUCTION ? writeVec3FlatProduction : writeVec3FlatChecked;
 
 // ReadVec3Flat(value, view, numBits) -> bool. The buffer behind view must
@@ -389,9 +389,9 @@ function writeQuatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuatMaxBytes.
+// WriteQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuatMaxBytes.
 export const WriteQuatFlat = PRODUCTION ? writeQuatFlatProduction : writeQuatFlatChecked;
 
 // ReadQuatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -513,9 +513,9 @@ function writeHandleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHandleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HandleMaxBytes.
+// WriteHandleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HandleMaxBytes.
 export const WriteHandleFlat = PRODUCTION ? writeHandleFlatProduction : writeHandleFlatChecked;
 
 // ReadHandleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -624,9 +624,9 @@ function writeQuantizedPositionFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedPositionFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedPositionMaxBytes.
+// WriteQuantizedPositionFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedPositionMaxBytes.
 export const WriteQuantizedPositionFlat = PRODUCTION ? writeQuantizedPositionFlatProduction : writeQuantizedPositionFlatChecked;
 
 // ReadQuantizedPositionFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -755,9 +755,9 @@ function writeQuantizedVelocityFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedVelocityFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedVelocityMaxBytes.
+// WriteQuantizedVelocityFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedVelocityMaxBytes.
 export const WriteQuantizedVelocityFlat = PRODUCTION ? writeQuantizedVelocityFlatProduction : writeQuantizedVelocityFlatChecked;
 
 // ReadQuantizedVelocityFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -871,9 +871,9 @@ function writeQuantizedRotationFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteQuantizedRotationFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold QuantizedRotationMaxBytes.
+// WriteQuantizedRotationFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold QuantizedRotationMaxBytes.
 export const WriteQuantizedRotationFlat = PRODUCTION ? writeQuantizedRotationFlatProduction : writeQuantizedRotationFlatChecked;
 
 // ReadQuantizedRotationFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1454,9 +1454,9 @@ function writeRigidBodyFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteRigidBodyFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold RigidBodyMaxBytes.
+// WriteRigidBodyFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold RigidBodyMaxBytes.
 export const WriteRigidBodyFlat = PRODUCTION ? writeRigidBodyFlatProduction : writeRigidBodyFlatChecked;
 
 // ReadRigidBodyFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1951,9 +1951,9 @@ function writeInputFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteInputFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold InputMaxBytes.
+// WriteInputFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold InputMaxBytes.
 export const WriteInputFlat = PRODUCTION ? writeInputFlatProduction : writeInputFlatChecked;
 
 // ReadInputFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2110,9 +2110,6 @@ function writeInputPacketFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.InputsCount) & 0x1f)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -2292,7 +2289,7 @@ function writeInputPacketFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > 16) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.InputsCount) & 0x1f)) >>> 0;
@@ -2422,9 +2419,9 @@ function writeInputPacketFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteInputPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold InputPacketMaxBytes.
+// WriteInputPacketFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold InputPacketMaxBytes.
 export const WriteInputPacketFlat = PRODUCTION ? writeInputPacketFlatProduction : writeInputPacketFlatChecked;
 
 // ReadInputPacketFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2849,9 +2846,9 @@ function writeShipCreateFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteShipCreateFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ShipCreateMaxBytes.
+// WriteShipCreateFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ShipCreateMaxBytes.
 export const WriteShipCreateFlat = PRODUCTION ? writeShipCreateFlatProduction : writeShipCreateFlatChecked;
 
 // ReadShipCreateFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3053,9 +3050,9 @@ function writeExpressionProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExpressionProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExpressionProbeMaxBytes.
+// WriteExpressionProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExpressionProbeMaxBytes.
 export const WriteExpressionProbeFlat = PRODUCTION ? writeExpressionProbeFlatProduction : writeExpressionProbeFlatChecked;
 
 // ReadExpressionProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3300,9 +3297,9 @@ function writeExtremeProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExtremeProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExtremeProbeMaxBytes.
+// WriteExtremeProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExtremeProbeMaxBytes.
 export const WriteExtremeProbeFlat = PRODUCTION ? writeExtremeProbeFlatProduction : writeExtremeProbeFlatChecked;
 
 // ReadExtremeProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3593,9 +3590,9 @@ function writeExtremeRowFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteExtremeRowFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ExtremeRowMaxBytes.
+// WriteExtremeRowFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ExtremeRowMaxBytes.
 export const WriteExtremeRowFlat = PRODUCTION ? writeExtremeRowFlatProduction : writeExtremeRowFlatChecked;
 
 // ReadExtremeRowFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/js/WireFlat.js
+++ b/testdata/golden/js/WireFlat.js
@@ -107,9 +107,9 @@ function writeProbeHeaderFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeHeaderFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeHeaderMaxBytes.
+// WriteProbeHeaderFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeHeaderMaxBytes.
 export const WriteProbeHeaderFlat = PRODUCTION ? writeProbeHeaderFlatProduction : writeProbeHeaderFlatChecked;
 
 // ReadProbeHeaderFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -343,9 +343,9 @@ function writeProbeBitsFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeBitsMaxBytes.
+// WriteProbeBitsFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeBitsMaxBytes.
 export const WriteProbeBitsFlat = PRODUCTION ? writeProbeBitsFlatProduction : writeProbeBitsFlatChecked;
 
 // ReadProbeBitsFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -515,9 +515,6 @@ function writeProbeSampleFlatProduction(value, view) {
       lo = sb === 0 ? 0 : v >>> (32 - sb);
     }
   }
-  if (value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((((value.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -634,7 +631,7 @@ function writeProbeSampleFlatChecked(value, view) {
       lo = sb === 0 ? 0 : v >>> (32 - sb);
     }
   }
-  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((((value.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
@@ -663,9 +660,9 @@ function writeProbeSampleFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeSampleFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeSampleMaxBytes.
+// WriteProbeSampleFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeSampleMaxBytes.
 export const WriteProbeSampleFlat = PRODUCTION ? writeProbeSampleFlatProduction : writeProbeSampleFlatChecked;
 
 // ReadProbeSampleFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -827,9 +824,9 @@ function writeProbeRingFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeRingFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeRingMaxBytes.
+// WriteProbeRingFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeRingMaxBytes.
 export const WriteProbeRingFlat = PRODUCTION ? writeProbeRingFlatProduction : writeProbeRingFlatChecked;
 
 // ReadProbeRingFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -891,9 +888,9 @@ function writeProbeSlabFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeSlabFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeSlabMaxBytes.
+// WriteProbeSlabFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeSlabMaxBytes.
 export const WriteProbeSlabFlat = PRODUCTION ? writeProbeSlabFlatProduction : writeProbeSlabFlatChecked;
 
 // ReadProbeSlabFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -993,9 +990,6 @@ function writeProbeColliderFlatProduction(value, view) {
       }
       break;
     }
-  }
-  if (value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = (((value.ExtrasCount) & 0x3)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -1135,7 +1129,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
   }
-  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.ExtrasCount) & 0x3)) >>> 0;
@@ -1197,9 +1191,9 @@ function writeProbeColliderFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeColliderFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeColliderMaxBytes.
+// WriteProbeColliderFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeColliderMaxBytes.
 export const WriteProbeColliderFlat = PRODUCTION ? writeProbeColliderFlatProduction : writeProbeColliderFlatChecked;
 
 // ReadProbeColliderFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1453,9 +1447,9 @@ function writeProbeConfigFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeConfigFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeConfigMaxBytes.
+// WriteProbeConfigFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeConfigMaxBytes.
 export const WriteProbeConfigFlat = PRODUCTION ? writeProbeConfigFlatProduction : writeProbeConfigFlatChecked;
 
 // ReadProbeConfigFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1571,9 +1565,6 @@ function writeProbeArrayFlatProduction(value, view) {
         sb -= 32;
         lo = sb === 0 ? 0 : v >>> (32 - sb);
       }
-    }
-    if (e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-      return -1;
     }
     v = (((((e0.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
     lo = (lo | (v << sb)) >>> 0;
@@ -1712,7 +1703,7 @@ function writeProbeArrayFlatChecked(value, view) {
         lo = sb === 0 ? 0 : v >>> (32 - sb);
       }
     }
-    if (!Number.isInteger(e0.SamplesCount) || e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+    if (!Number.isInteger(e0.SamplesCount) || e0.SamplesCount < 1 || e0.SamplesCount > 8) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
       return -1;
     }
     v = (((((e0.SamplesCount >>> 0) - 1) >>> 0) & 0x7)) >>> 0;
@@ -1763,9 +1754,9 @@ function writeProbeArrayFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeArrayMaxBytes.
+// WriteProbeArrayFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeArrayMaxBytes.
 export const WriteProbeArrayFlat = PRODUCTION ? writeProbeArrayFlatProduction : writeProbeArrayFlatChecked;
 
 // ReadProbeArrayFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1930,9 +1921,9 @@ function writeHeartbeatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteHeartbeatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold HeartbeatMaxBytes.
+// WriteHeartbeatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold HeartbeatMaxBytes.
 export const WriteHeartbeatFlat = PRODUCTION ? writeHeartbeatFlatProduction : writeHeartbeatFlatChecked;
 
 // ReadHeartbeatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2008,9 +1999,9 @@ function writeTestFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTestFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TestMaxBytes.
+// WriteTestFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TestMaxBytes.
 export const WriteTestFlat = PRODUCTION ? writeTestFlatProduction : writeTestFlatChecked;
 
 // ReadTestFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2157,9 +2148,9 @@ function writeBlockFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold BlockMaxBytes.
+// WriteBlockFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold BlockMaxBytes.
 export const WriteBlockFlat = PRODUCTION ? writeBlockFlatProduction : writeBlockFlatChecked;
 
 // ReadBlockFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2307,9 +2298,9 @@ function writeChatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteChatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ChatMaxBytes.
+// WriteChatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ChatMaxBytes.
 export const WriteChatFlat = PRODUCTION ? writeChatFlatProduction : writeChatFlatChecked;
 
 // ReadChatFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2535,9 +2526,9 @@ function writeProbeReportFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteProbeReportFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold ProbeReportMaxBytes.
+// WriteProbeReportFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold ProbeReportMaxBytes.
 export const WriteProbeReportFlat = PRODUCTION ? writeProbeReportFlatProduction : writeProbeReportFlatChecked;
 
 // ReadProbeReportFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2646,9 +2637,6 @@ function writeTestDataFlatProduction(value, view) {
     wi += 4;
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
-  }
-  if (value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
   }
   v = ((value.E & 0xff) | ((value.F & 0xff) << 8) | ((value.G ? 1 : 0) << 16) | (((value.ItemsCount) & 0x1f) << 17)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
@@ -2892,7 +2880,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = ((value.E & 0xff) | ((value.F & 0xff) << 8) | ((value.G ? 1 : 0) << 16) | (((value.ItemsCount) & 0x1f) << 17)) >>> 0;
@@ -3127,9 +3115,9 @@ function writeTestDataFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteTestDataFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold TestDataMaxBytes.
+// WriteTestDataFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold TestDataMaxBytes.
 export const WriteTestDataFlat = PRODUCTION ? writeTestDataFlatProduction : writeTestDataFlatChecked;
 
 // ReadTestDataFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -3487,9 +3475,9 @@ function writeCompressedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteCompressedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold CompressedProbeMaxBytes.
+// WriteCompressedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold CompressedProbeMaxBytes.
 export const WriteCompressedProbeFlat = PRODUCTION ? writeCompressedProbeFlatProduction : writeCompressedProbeFlatChecked;
 
 // ReadCompressedProbeFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/ludicrous/c/LudicrousWire.h
+++ b/testdata/golden/ludicrous/c/LudicrousWire.h
@@ -25,9 +25,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -336,10 +337,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_
     {
         return 0;
     }
-    if ( value->keys_count < 0 || value->keys_count > 4 )
-    {
-        return 0; /* a count outside its wire range is refused in every build (SPEC §4.6) */
-    }
+    serialize_assert( value->keys_count >= 0 && value->keys_count <= 4 );
     if ( !serialize_write_int( stream, value->keys_count, 0, 4 ) )
     {
         return 0;

--- a/testdata/golden/ludicrous/cpp/LudicrousWire.h
+++ b/testdata/golden/ludicrous/cpp/LudicrousWire.h
@@ -174,10 +174,7 @@ SCHEMA_WRITE_INLINE bool WriteLudicrousState( serialize::WriteStream & stream, c
     {
         return false;
     }
-    if ( int32_t( value.keys_count ) < int32_t( 0 ) || int32_t( value.keys_count ) > int32_t( 4 ) )
-    {
-        return false; // a count outside its wire range is refused in every build (SPEC §4.6)
-    }
+    serialize_assert( int32_t( value.keys_count ) >= int32_t( 0 ) && int32_t( value.keys_count ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value.keys_count ), 3 );
     for ( int32_t i = 0; i < value.keys_count; i++ )
     {

--- a/testdata/golden/ludicrous/dart/Ludicrous.dart
+++ b/testdata/golden/ludicrous/dart/Ludicrous.dart
@@ -108,8 +108,7 @@ void initFixedProbe(FixedProbe value) {
 
 // writeFixedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedProbeMaxBytes. Returns the bytes written.
 int writeFixedProbe(FixedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedProbeMaxBytes);
@@ -308,8 +307,7 @@ void initUnsignedProbe(UnsignedProbe value) {
 
 // writeUnsignedProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// unsignedProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// unsignedProbeMaxBytes. Returns the bytes written.
 int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= unsignedProbeMaxBytes);
@@ -528,8 +526,7 @@ void initWideProbe(WideProbe value) {
 
 // writeWideProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideProbeMaxBytes. Returns the bytes written.
 int writeWideProbe(WideProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideProbeMaxBytes);
@@ -840,8 +837,7 @@ void initLudicrousState(LudicrousState value) {
 
 // writeLudicrousState packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// ludicrousStateMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// ludicrousStateMaxBytes. Returns the bytes written.
 int writeLudicrousState(LudicrousState value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= ludicrousStateMaxBytes);
@@ -991,9 +987,8 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (64 - scratchBits);
   }
-  if (value.keysCount < 0 || value.keysCount > 4) {
-    return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
-  }
+  assert(value.keysCount >= 0);
+  assert(value.keysCount <= 4);
   v = (value.wide.seed.hi);
   scratch |= v << scratchBits;
   scratchBits += 64;
@@ -1427,8 +1422,7 @@ void initDegenerateProbe(DegenerateProbe value) {
 
 // writeDegenerateProbe packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// degenerateProbeMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// degenerateProbeMaxBytes. Returns the bytes written.
 int writeDegenerateProbe(DegenerateProbe value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= degenerateProbeMaxBytes);
@@ -1535,8 +1529,7 @@ void initFixedVec(FixedVec value) {
 
 // writeFixedVec packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedVecMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedVecMaxBytes. Returns the bytes written.
 int writeFixedVec(FixedVec value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedVecMaxBytes);
@@ -1684,8 +1677,7 @@ void initFixedQuat(FixedQuat value) {
 
 // writeFixedQuat packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// fixedQuatMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// fixedQuatMaxBytes. Returns the bytes written.
 int writeFixedQuat(FixedQuat value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= fixedQuatMaxBytes);

--- a/testdata/golden/ludicrous/java/Ludicrous.java
+++ b/testdata/golden/ludicrous/java/Ludicrous.java
@@ -1139,6 +1139,8 @@ public final class Ludicrous {
             assert value.wide.bias.compareTo(min) >= 0;
             assert value.wide.bias.compareTo(max) <= 0;
         }
+        assert value.keysCount >= 0;
+        assert value.keysCount <= 4;
         return true;
     }
 
@@ -1362,9 +1364,6 @@ public final class Ludicrous {
             wordIndex++;
             scratchBits -= 64;
             scratch = v >>> (32 - scratchBits);
-        }
-        if (value.keysCount < 0 || value.keysCount > 4) {
-            return -1; // a count outside its wire range is refused in every build (SPEC §4.6)
         }
         v = (value.keysCount) & 0x7L;
         scratch |= v << scratchBits;

--- a/testdata/golden/ludicrous/js/LudicrousFlat.js
+++ b/testdata/golden/ludicrous/js/LudicrousFlat.js
@@ -187,9 +187,9 @@ function writeFixedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedProbeMaxBytes.
+// WriteFixedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedProbeMaxBytes.
 export const WriteFixedProbeFlat = PRODUCTION ? writeFixedProbeFlatProduction : writeFixedProbeFlatChecked;
 
 // ReadFixedProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -456,9 +456,9 @@ function writeUnsignedProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteUnsignedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold UnsignedProbeMaxBytes.
+// WriteUnsignedProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold UnsignedProbeMaxBytes.
 export const WriteUnsignedProbeFlat = PRODUCTION ? writeUnsignedProbeFlatProduction : writeUnsignedProbeFlatChecked;
 
 // ReadUnsignedProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -875,9 +875,9 @@ function writeWideProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideProbeMaxBytes.
+// WriteWideProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideProbeMaxBytes.
 export const WriteWideProbeFlat = PRODUCTION ? writeWideProbeFlatProduction : writeWideProbeFlatChecked;
 
 // ReadWideProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -1239,9 +1239,6 @@ function writeLudicrousStateFlatProduction(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
-    return -1;
-  }
   v = (((value.KeysCount) & 0x7)) >>> 0;
   lo = (lo | (v << sb)) >>> 0;
   sb += 3;
@@ -1583,7 +1580,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     sb -= 32;
     lo = sb === 0 ? 0 : v >>> (32 - sb);
   }
-  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; a count outside its wire range is refused in every build (SPEC §4.6)
+  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop; its range is a writer contract (SPEC §4.6)
     return -1;
   }
   v = (((value.KeysCount) & 0x7)) >>> 0;
@@ -1692,9 +1689,9 @@ function writeLudicrousStateFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteLudicrousStateFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold LudicrousStateMaxBytes.
+// WriteLudicrousStateFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold LudicrousStateMaxBytes.
 export const WriteLudicrousStateFlat = PRODUCTION ? writeLudicrousStateFlatProduction : writeLudicrousStateFlatChecked;
 
 // ReadLudicrousStateFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2065,9 +2062,9 @@ function writeDegenerateProbeFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteDegenerateProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold DegenerateProbeMaxBytes.
+// WriteDegenerateProbeFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold DegenerateProbeMaxBytes.
 export const WriteDegenerateProbeFlat = PRODUCTION ? writeDegenerateProbeFlatProduction : writeDegenerateProbeFlatChecked;
 
 // ReadDegenerateProbeFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2234,9 +2231,9 @@ function writeFixedVecFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedVecFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedVecMaxBytes.
+// WriteFixedVecFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedVecMaxBytes.
 export const WriteFixedVecFlat = PRODUCTION ? writeFixedVecFlatProduction : writeFixedVecFlatChecked;
 
 // ReadFixedVecFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -2417,9 +2414,9 @@ function writeFixedQuatFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteFixedQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold FixedQuatMaxBytes.
+// WriteFixedQuatFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold FixedQuatMaxBytes.
 export const WriteFixedQuatFlat = PRODUCTION ? writeFixedQuatFlatProduction : writeFixedQuatFlatChecked;
 
 // ReadFixedQuatFlat(value, view, numBits) -> bool. The buffer behind view must

--- a/testdata/golden/packet-wide/c/WideTextWire.h
+++ b/testdata/golden/packet-wide/c/WideTextWire.h
@@ -24,9 +24,10 @@ extern "C" {
 
 /* Every write_x/read_x returns 1 on success, 0 on failure — the stream
    latches the error, so a caller may check once at the end of a message.
-   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
-   it rides, and every read reconstructs the selected arm with its declared
-   initial values before decoding it (SPEC §4.8, §5). */
+   Reads REFUSE out-of-range values, never clamp, in every build. A tag on
+   WRITE is asserted before it rides — caller error, gone under NDEBUG — and
+   every read reconstructs the selected arm with its declared initial values
+   before decoding it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -270,6 +271,13 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_four( serialize_read_str
 /* Writes NarrowFifteen. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow_fifteen( serialize_write_stream_t * stream, const NarrowFifteen * value )
 {
+    {
+        int32_t i;
+        for ( i = 0; i < value->text_length; i++ )
+        {
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.7) */
+        }
+    }
     if ( !serialize_write_int( stream, value->text_length, 0, 15 ) )
     {
         return 0;

--- a/testdata/golden/packet-wide/dart/WideText.dart
+++ b/testdata/golden/packet-wide/dart/WideText.dart
@@ -91,8 +91,7 @@ void initWideSeven(WideSeven value) {
 
 // writeWideSeven packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideSevenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideSevenMaxBytes. Returns the bytes written.
 int writeWideSeven(WideSeven value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideSevenMaxBytes);
@@ -238,8 +237,7 @@ void initWideFour(WideFour value) {
 
 // writeWideFour packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideFourMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideFourMaxBytes. Returns the bytes written.
 int writeWideFour(WideFour value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideFourMaxBytes);
@@ -386,8 +384,7 @@ void initNarrowFifteen(NarrowFifteen value) {
 
 // writeNarrowFifteen packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// narrowFifteenMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// narrowFifteenMaxBytes. Returns the bytes written.
 int writeNarrowFifteen(NarrowFifteen value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= narrowFifteenMaxBytes);
@@ -555,8 +552,7 @@ void initWideInterop(WideInterop value) {
 
 // writeWideInterop packs value into view — the trusted writer (contracts asserted,
 // compiled out without --enable-asserts). The buffer behind view must hold
-// wideInteropMaxBytes. Returns the bytes written, or -1 when a count is outside its
-// wire range, which is refused in every build (SPEC §4.6).
+// wideInteropMaxBytes. Returns the bytes written.
 int writeWideInterop(WideInterop value, ByteData view) {
   assert(view.lengthInBytes % 8 == 0);
   assert(view.lengthInBytes >= wideInteropMaxBytes);

--- a/testdata/golden/packet-wide/js/WideTextFlat.js
+++ b/testdata/golden/packet-wide/js/WideTextFlat.js
@@ -100,9 +100,9 @@ function writeWideSevenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideSevenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideSevenMaxBytes.
+// WriteWideSevenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideSevenMaxBytes.
 export const WriteWideSevenFlat = PRODUCTION ? writeWideSevenFlatProduction : writeWideSevenFlatChecked;
 
 // ReadWideSevenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -208,9 +208,9 @@ function writeWideFourFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideFourFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideFourMaxBytes.
+// WriteWideFourFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideFourMaxBytes.
 export const WriteWideFourFlat = PRODUCTION ? writeWideFourFlatProduction : writeWideFourFlatChecked;
 
 // ReadWideFourFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -357,9 +357,9 @@ function writeNarrowFifteenFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteNarrowFifteenFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold NarrowFifteenMaxBytes.
+// WriteNarrowFifteenFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold NarrowFifteenMaxBytes.
 export const WriteNarrowFifteenFlat = PRODUCTION ? writeNarrowFifteenFlatProduction : writeNarrowFifteenFlatChecked;
 
 // ReadNarrowFifteenFlat(value, view, numBits) -> bool. The buffer behind view must
@@ -488,9 +488,9 @@ function writeWideInteropFlatChecked(value, view) {
   return ((wi * 8 + sb) + 7) >> 3;
 }
 
-// WriteWideInteropFlat(value, view) -> bytes written (>= 0), or -1 on a refusal: a
-// count outside its wire range in every build (SPEC §4.6), and any other
-// contract in the checked build. The buffer behind view must hold WideInteropMaxBytes.
+// WriteWideInteropFlat(value, view) -> bytes written (>= 0), or -1 on a refused
+// writer contract in the checked build — the production writer holds none
+// of them (SPEC §5). The buffer behind view must hold WideInteropMaxBytes.
 export const WriteWideInteropFlat = PRODUCTION ? writeWideInteropFlatProduction : writeWideInteropFlatChecked;
 
 // ReadWideInteropFlat(value, view, numBits) -> bool. The buffer behind view must


### PR DESCRIPTION
Glenn's rulings, verbatim, today: "checks are *DEBUG ONLY*"; "Of course, on read side we MUST always do the checks!"; on the counted array's count, the one exception the spec kept in every build: "debug only."; "consistency matters. writing packets correctness is the caller's responsibility, and it is our duty to catch it with asserts in debug."; "For each language, do not force this in. If the language simply doesn't have this concept (Golang) then it is not something we can do."; "The bottom line is that a user of schema/serialize in that languages should feel that the implementation is native to their language and how it is used in best practice."

**What was wrong.** SPEC §4.6 mandated that a count outside its wire range is refused by the write in every build in all nine targets, "the one write-side contract that is never a debug-only assert", and compiler/countedbirth_test.go forbade it being an assert. §4.8 kept a union tag outside its variant set as an every-build write refusal by structure. Both are caller error like every other write-side value.

**What changes, per target.** The count on write becomes a debug assert in C++ (serialize_assert), C (serialize_assert), Java (inside the checkWrite predicate the rest of its contracts use), Dart (assert) and JavaScript's flat tier (inside guard(), gone from the production writer). The union tag on write becomes a debug assert in C++ and C (Java and Dart already asserted it; JS flat already guarded it; Rust's tag is the enum discriminant; C# converts it in #697). Release behaviour, stated: C++ asserts before the switch and, with no arm selected, no bits ride and the write returns true; C's tag write already sat above the switch, so the tag rides unmasked, since serialize.c documents that masking is an invented release defence the C++ writer does not perform (issue #52); what a release build writes on a bad tag or count is defined and unspecified, not guaranteed to be refused by a reader (a cold read corrected an earlier "bytes no reader accepts" here and in the spec), and a bad count in release is an out-of-bounds read of the caller's array, the exposure string and bytes lengths already carry, caught by the debug assert. C also gains the two asserts it lacked against C++: a flags value wider than its wire width, and interior nulls in a string(N) on write. Go and Elixir keep their every-build checks, by the ruling: no idiom, no forcing. Every read-side check stays in every build in all nine.

**The spec.** §4.6 and §5 rewritten to the final form for all nine (seven are DEBUG ONLY with each language's idiom, two hold in EVERY BUILD, no exception to the tier split, the read-side paragraph, the union tag as one of these contracts), §4.8's write sentence, §4.7's interior-null sentence, USAGE.md's string(N) sentence, TUTORIAL.md's printed C++ that no longer existed, FAQ.md's roll call, PERFORMANCE.md's "Reading the table honestly" (no write-side check stays in every build in C or C++). The spec states Rust and C# in their post-change form with a dated implementation note that #696 and #697, landing right after, remove.

**Tests.** countedbirth_test.go inverted for the five targets (assert text present, the old refusal gone from release), Go and Elixir keeping the every-build claim, Rust and C# left for their PRs; new compiler/uniontagwrite_test.go with the same shape for the tag; Java's and Dart's count cases move into their existing expectAssert helpers; JS needed nothing (its case was already inside CHECKED_MODE); four C and C++ cases that wrote an out-of-set tag and expected a refusal are dropped, not moved, because neither suite has a death-test leg and the assert now aborts the binary, each leaving a comment and its read-side twin.

**Receipts.** go test ./..., go vet, gofmt clean; make shape-gate clean, wire constants unmoved (49 110 112 135 156 160 392 438 2147 3504 17176), protocol ids unmoved; make test (C++, tables, wide, block), make test-c, make test-java, make test-dart, make test-js and the packet-wide legs green on the count change; the union-tag pass ran make test and make test-c with the codegen-only legs skipped (their toolchains are not on this worktree's PATH); CI runs them all. 110 files, +1745 -2050. Two Opus workers under Rowan's brief; the first caught its own mid-flight bug (a flags assert briefly emitted on the read path) and said so; the second overruled by Rowan on the tag (it had judged the tag dispatch, not a guard; the rule has no exception). Commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)