### PR TITLE
The C runtime pin moves to serialize.c 1.10.0; the raw bit read row closes

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -49,7 +49,7 @@ concurrency:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
   SERIALIZE_TAG: v1.16.2
-  SERIALIZE_C_TAG: v1.9.2
+  SERIALIZE_C_TAG: v1.10.0
   SERIALIZE_GO_TAG: v1.15.1
   SERIALIZE_RS_TAG: v2.4.0
   SERIALIZE_CS_TAG: v1.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ concurrency:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
   SERIALIZE_TAG: v1.16.2
-  SERIALIZE_C_TAG: v1.9.2
+  SERIALIZE_C_TAG: v1.10.0
   SERIALIZE_GO_TAG: v1.15.1
   SERIALIZE_RS_TAG: v2.4.0
   SERIALIZE_CS_TAG: v1.9.1

--- a/bench/README.md
+++ b/bench/README.md
@@ -237,7 +237,11 @@ compiled in, not absent. Point C's past-end test at `num_bits` instead of
 changed) and the C leg emits 135 / 2 — C++'s shape exactly. That pins the residual
 C-vs-C++ bitpacker/read gap to one field indirection in serialize.c's failure
 latch, in emitted code; the probe's rate was not measured, and the probe
-breaks the sticky-failure contract, so it is a diagnosis and not a fix.
+breaks the sticky-failure contract, so it is a diagnosis and not a fix. serialize.c **v1.10.0** made
+the fix: the failed-read latch moved into the cursor and the past-end test now reads `num_bits`,
+exactly the shape the probe predicted, and the C leg's bitpacker/read went from **61.9% to 99.2%
+of C++ best** — 76,492 to 122,221 messages a second — on the pass that moved this repo's pin
+(`bench/results/2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv`).
 
 So the read row now reports how well each runtime's CHECKED read optimizes,
 which is a real difference between the runtimes — not a difference in what the

--- a/bench/results/2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv
@@ -1,0 +1,45 @@
+# schema bench results
+# date: 2026-09-07T17:50:30Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 442b8e91-dirty (serialize-c-1-10-0)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: a742a3d (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c
+# load_start: 6.27 6.05 5.65
+# load_end: 7.79 6.15 5.74
+# load_max: 7.79
+# core_busy_pct: n/a
+# foreign_procs: 12
+# control_start_median: 6551378   control_end_median: 6410008
+# control_delta_pct: 2.2   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8415987,8244533,8578720,3515.44,3.97,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4176729,4121247,4226614,1744.66,2.52,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,90195,87257,91169,5635.64,4.34,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,121179,119906,122221,7571.61,1.91,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8389967,8186308,8554718,3504.57,4.39,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4441217,4391912,4539074,1855.14,3.31,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,90514,87334,91432,5655.57,4.53,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,121108,119758,123179,7567.14,2.82,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -167,7 +167,17 @@ round trip 4,408,928 against 4,636,506. Two passes over identical code earlier t
 differed by 0.4%, and a pass with the refusals compiled out by hand moved C by 0.4% and 0.1%
 against them. By row, C is within 3% of C++ on the packet write and faster on the raw
 bit-packer write, and C++ reads raw bits 1.58 times faster; the remaining C-to-C++ distance is
-the C runtime's read path, not the generated code's checks.
+the C runtime's read path, not the generated code's checks. serialize.c v1.10.0 closed that read path
+later the same day: latching a failed read in the cursor, the way C++'s `ReadStream` does, lets the
+per-read past-end test fold into the caller's remaining-bits guard, and the raw bit read went from
+76,492 to 122,221 messages a second — 61.9% of C++ to 99.2%
+([CSV](../bench/results/2026-09-07-arm64-studio-serialize-c-1-10-0-pass.csv), seven interleaved
+rounds, window OK, control delta 2.2%). The round trip is where it was: 4,226,614 messages a second
+against 4,279,494 on the pass before it, 93.1% of C++ against 94.3%, both moves inside the rows'
+spread — the fix bought the raw-read row and left the packet path alone. So the remaining
+distance is no longer the raw reader, at 99.2%, but the generated packet read, where the round
+trip's seven points now live; at this pass's precision (combined spread 5.8 points against 8.3
+before) that is outside the §2.8 band and no longer a tie, a finding under investigation.
 
 **The two dated `<!-- CAPTION -->` lines above this section are the provenance the
 2026-08-15 passes recorded, and they predate both halves of C's move**: the runtime's own

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -86,7 +86,7 @@ repository. Clone them beside it, at the tags this build is pinned to:
 ```
 $ cd ..
 $ git clone --branch v1.16.2 https://github.com/mas-bandwidth/serialize.git
-$ git clone --branch v1.9.2  https://github.com/mas-bandwidth/serialize.c.git
+$ git clone --branch v1.10.0 https://github.com/mas-bandwidth/serialize.c.git
 ```
 
 Nothing to build in either. Part 3 adds `-I ../serialize` to a compile line and


### PR DESCRIPTION
serialize.c 1.10.0 (mas-bandwidth/serialize.c #66, tagged today): a failed read latches in the cursor as C++'s ReadStream does, bits_limit leaves the read stream, reads test against num_bits, so a caller's remaining-bits guard folds the per-read past-end test. STANDARD.md and the corpus are byte-identical to 1.9.2; nothing in schema's generated C, bench or tests reads the removed field or embeds the struct's size; the exported symbol surface lost nothing.

**The pin.** SERIALIZE_C_TAG in certify.yml and ci.yml, and TUTORIAL.md's clone line, to v1.10.0; the six clone sites dereference the variable.

**The pass.** cpp,c twins, seven rounds, window OK, control delta 2.2%, twin gate OK, serialize.c a742a3d build-verified by the §3.5 pre-flight. C as a percentage of C++ on best rates, against the last pass on 1.9.2 with both legs checked (#698's): bitpacker/read 61.9% to 99.2% (C 76,492 to 122,221 messages a second, +59.8%); bitpacker/write 100.3% to 99.7%; packet write 100.1% to 100.3%; packet round trip 94.3% to 93.1%: C's own row moved 1.2% (4,279,494 to 4,226,614) and C++'s 0.03%, both inside the rows' spreads, and this pass was the quieter of the two (foreign_procs 12 against 29, load max 7.8 against 10.3), so the round trip is where it was and the change is in C's row alone; a cold read corrected an earlier version of this sentence that blamed drift on the C++ row. One thing to read right: render.awk prints C at 107% with no tie note where the previous pass said tie at 106%; the measurement did not move, the band did: this pass's combined spread is 5.8 points against 8.3 before, and 107 sits outside it. That is the C-versus-C++ round-trip gap stated at a precision that makes it real, and it is the next thing to find; the remaining distance is the generated packet read, not the raw reader. Note for #699: this pass, as a window-OK pass outside the band, would turn its pair lock RED; the lock waits for parity by the maintainer's word.

**Receipts.** make test-c green against the new runtime (both C conformance legs with ASan and UBSan inside it; wire sizes 49/14/20/438/204 unmoved); `ledger --check` green (cpp 220.24 to 220.31 ns). PERFORMANCE.md's dated section and bench/README.md's bitpacker row carry the numbers.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)