### PR TITLE
c: a fixed-width struct's reader guards once, and C's packet round trip ties C++

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -250,6 +250,18 @@ the row means, and the receipt is that the C++ leg's emitted loop is
 identical in shape before and after (the same 135 instructions and 2 branches;
 register allocation differs).
 
+**And the packet round trip closed the same day.** With the raw reader at
+99.2% the remaining C-to-C++ distance sat in the GENERATED packet read, where
+clang was spilling `stream->num_bits` and reloading it for every field's
+past-end test; the C backend now emits one `serialize_read_bits_remaining`
+guard at the top of a read function whose struct has a FIXED wire width, the
+per-field tests fold into it (the entity read loop goes 157 to 111 instructions counting blocks by their loop header, 161 to 115 counting the contiguous region
+; spill reloads per message 307 to 120), and the round trip went
+from 93.1% to 101.9% of C++ best — 4,226,614 to 4,669,166 messages a second,
+inside the §2.8 tie band and so reported as a tie
+(`bench/results/2026-09-07-arm64-studio-c-read-guard-pass.csv`, seven
+interleaved rounds, window OK, control delta 0.5%, twin gate OK).
+
 Two further rows — `bench_string` and `bench_wstring` — are DEFINED in
 BENCH-STANDARD §1.8 (measure-first, issue #64) and not yet implemented in
 these runners; the definitions land ahead of any further string/wstring

--- a/bench/results/2026-09-07-arm64-studio-c-read-guard-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-c-read-guard-pass.csv
@@ -1,0 +1,45 @@
+# schema bench results
+# date: 2026-09-07T18:30:55Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 0fa2af86-dirty (c-read-guard)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: a742a3d (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c
+# load_start: 4.57 4.32 5.22
+# load_end: 5.73 4.92 5.32
+# load_max: 6.33
+# core_busy_pct: n/a
+# foreign_procs: 9
+# control_start_median: 6647696   control_end_median: 6681434
+# control_delta_pct: 0.5   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8705630,8456713,8814087,3636.42,4.11,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4625637,4475990,4669166,1932.17,4.18,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,92183,90701,94058,5759.86,3.64,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,122904,119584,123635,7679.39,3.30,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8606879,8503093,8781780,3595.17,3.24,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4547404,4479961,4583899,1899.49,2.29,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,91318,89170,93594,5705.78,4.84,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,121934,120097,123623,7618.81,2.89,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -177,7 +177,16 @@ against 4,279,494 on the pass before it, 93.1% of C++ against 94.3%, both moves 
 spread — the fix bought the raw-read row and left the packet path alone. So the remaining
 distance is no longer the raw reader, at 99.2%, but the generated packet read, where the round
 trip's seven points now live; at this pass's precision (combined spread 5.8 points against 8.3
-before) that is outside the §2.8 band and no longer a tie, a finding under investigation.
+before) that is outside the §2.8 band and no longer a tie, a finding under investigation. That
+investigation closed the same day: the generated C read was executing ~193 more loads and ~200
+more spill reloads per message than C++'s for identical work, because clang spilled
+`stream->num_bits` and reloaded it for every field's past-end test, and the C backend now emits
+one `serialize_read_bits_remaining` guard at the top of a read function whose struct has a FIXED
+wire width — every per-field test folds into it, the refusal is unchanged because every field is
+always read — taking the round trip from 93.1% to 101.9% of C++ best, 4,226,614 to 4,669,166
+messages a second, which is inside the §2.8 band (6.5 points) and so a tie again
+([CSV](../bench/results/2026-09-07-arm64-studio-c-read-guard-pass.csv), seven interleaved rounds,
+window OK, control delta 0.5%, twin gate OK).
 
 **The two dated `<!-- CAPTION -->` lines above this section are the provenance the
 2026-08-15 passes recorded, and they predate both halves of C's move**: the runtime's own

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -386,6 +386,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_ints( serialize_write
 /* Reads BenchInts. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_stream_t * stream, BenchInts * value )
 {
+    /* fixed 110-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 110 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -577,6 +583,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_bits( serialize_write
 /* Reads BenchBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_bits( serialize_read_stream_t * stream, BenchBits * value )
 {
+    /* fixed 156-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 156 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 7 ) )
@@ -722,6 +734,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_entity( serialize_wri
 /* Reads MixedEntity. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_stream_t * stream, MixedEntity * value )
 {
+    /* fixed 135-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 135 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 12 ) )
@@ -893,6 +911,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_stat( serialize_write
 /* Reads MixedStat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_stat( serialize_read_stream_t * stream, MixedStat * value )
 {
+    /* fixed 18-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 18 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 8 ) )
@@ -945,6 +969,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_hit_event( serialize_
 /* Reads MixedHitEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_read_stream_t * stream, MixedHitEvent * value )
 {
+    /* fixed 28-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 28 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 12 ) )
@@ -1006,6 +1036,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_chat_event( serialize
 /* Reads MixedChatEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_chat_event( serialize_read_stream_t * stream, MixedChatEvent * value )
 {
+    /* fixed 14-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 14 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -1049,6 +1085,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_pickup_event( seriali
 /* Reads MixedPickupEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_pickup_event( serialize_read_stream_t * stream, MixedPickupEvent * value )
 {
+    /* fixed 18-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 18 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 10 ) )

--- a/generated/bench/tables/c/BenchTableWire.h
+++ b/generated/bench/tables/c/BenchTableWire.h
@@ -78,6 +78,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_hit_event( serialize_
 /* Reads TableHitEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_hit_event( serialize_read_stream_t * stream, TableHitEvent * value )
 {
+    /* fixed 28-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 28 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 12 ) )
@@ -139,6 +145,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_chat_event( serialize
 /* Reads TableChatEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_chat_event( serialize_read_stream_t * stream, TableChatEvent * value )
 {
+    /* fixed 14-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 14 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -182,6 +194,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_pickup_event( seriali
 /* Reads TablePickupEvent. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_pickup_event( serialize_read_stream_t * stream, TablePickupEvent * value )
 {
+    /* fixed 18-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 18 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 10 ) )

--- a/generated/c-ludicrous/LudicrousWire.h
+++ b/generated/c-ludicrous/LudicrousWire.h
@@ -101,6 +101,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_writ
 /* Reads FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
+    /* fixed 156-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 156 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int32_t fixed_value;
         fixed_value = 0;
@@ -210,6 +216,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
 /* Reads UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
+    /* fixed 196-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 196 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int64_t fixed_value = 0;
         if ( !serialize_read_fixed64( stream, &fixed_value, 16, 16, 0, 360 ) )
@@ -297,6 +309,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write
 /* Reads WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
+    /* fixed 403-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 403 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
     {
         return 0;
@@ -439,6 +457,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize
 /* Reads DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
+    /* fixed 8-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 8 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     value->locked_fixed = (int32_t) -196608LL;
     value->locked_int = (int32_t) (7);
     value->locked_wide = serialize_int128_from_int64( -12345678901234 );
@@ -483,6 +507,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_
 /* Reads FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
+    /* fixed 102-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 102 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int64_t fixed_value;
         fixed_value = 0;
@@ -550,6 +580,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write
 /* Reads FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int32_t fixed_value;
         fixed_value = 0;

--- a/generated/c/ClausesWire.h
+++ b/generated/c/ClausesWire.h
@@ -536,6 +536,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_f13( serialize_write_stream
 /* Reads F13. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_f13( serialize_read_stream_t * stream, F13 * value )
 {
+    /* fixed 91-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 91 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 7; i++ )
@@ -576,6 +582,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_tri3( serialize_write_strea
 /* Reads Tri3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_tri3( serialize_read_stream_t * stream, Tri3 * value )
 {
+    /* fixed 3-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 3 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 1 ) )
@@ -656,6 +668,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_eleven( serialize_write_str
 /* Reads Eleven. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_eleven( serialize_read_stream_t * stream, Eleven * value )
 {
+    /* fixed 11-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 11 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -694,6 +712,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_eleven( serialize_write
 /* Reads ArrEleven. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_arr_eleven( serialize_read_stream_t * stream, ArrEleven * value )
 {
+    /* fixed 99-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 99 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 9; i++ )
@@ -991,6 +1015,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_sole( serialize_write_strea
 /* Reads Sole. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_sole( serialize_read_stream_t * stream, Sole * value )
 {
+    /* fixed 13-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 13 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 13 ) )

--- a/generated/c/DegenerateWire.h
+++ b/generated/c/DegenerateWire.h
@@ -67,6 +67,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec2( serialize_write_strea
 /* Reads Vec2. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec2( serialize_read_stream_t * stream, Vec2 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -97,6 +103,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_f64( serialize_write_s
 /* Reads SpanF64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_f64( serialize_read_stream_t * stream, SpanF64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -129,6 +141,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_u64( serialize_write_s
 /* Reads SpanU64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_u64( serialize_read_stream_t * stream, SpanU64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -165,6 +183,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_i64( serialize_write_s
 /* Reads SpanI64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_i64( serialize_read_stream_t * stream, SpanI64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -201,6 +225,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_one( serialize_write_s
 /* Reads SpanOne. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_one( serialize_read_stream_t * stream, SpanOne * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 1; i++ )
@@ -237,6 +267,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_chunk( serialize_write
 /* Reads SpanChunk. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_chunk( serialize_read_stream_t * stream, SpanChunk * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 4; i++ )
@@ -277,6 +313,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_tail( serialize_write_
 /* Reads SpanTail. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_tail( serialize_read_stream_t * stream, SpanTail * value )
 {
+    /* fixed 160-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 160 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -327,6 +369,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_twice( serialize_write
 /* Reads SpanTwice. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_twice( serialize_read_stream_t * stream, SpanTwice * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -371,6 +419,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio( serialize_write_strea
 /* Reads Trio. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio( serialize_read_stream_t * stream, Trio * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 20 ) )
@@ -411,6 +465,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_sole( serialize_write_
 /* Reads TrioSole. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_sole( serialize_read_stream_t * stream, TrioSole * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !read_trio( stream, &value->inner ) )
     {
         return 0;
@@ -435,6 +495,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_first( serialize_write
 /* Reads TrioFirst. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_first( serialize_read_stream_t * stream, TrioFirst * value )
 {
+    /* fixed 80-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 80 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !read_trio( stream, &value->inner ) )
     {
         return 0;
@@ -522,6 +588,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_straddle( serialize_wr
 /* Reads TrioStraddle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_straddle( serialize_read_stream_t * stream, TrioStraddle * value )
 {
+    /* fixed 408-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 408 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t lo = 0;
         serialize_uint32_t hi = 0;

--- a/generated/c/JoinsWire.h
+++ b/generated/c/JoinsWire.h
@@ -733,6 +733,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow( serialize_write_str
 /* Reads Narrow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow( serialize_read_stream_t * stream, Narrow * value )
 {
+    /* fixed 3-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 3 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -764,6 +770,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide( serialize_write_strea
 /* Reads Wide. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide( serialize_read_stream_t * stream, Wide * value )
 {
+    /* fixed 37-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 37 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t lo = 0;
         serialize_uint32_t hi = 0;

--- a/generated/c/RenderWire.h
+++ b/generated/c/RenderWire.h
@@ -81,6 +81,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
 /* Reads RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
+    /* fixed 138-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 138 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t raw = 0;
         if ( !serialize_read_uint64( stream, &raw ) )

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -74,6 +74,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_strea
 /* Reads Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
+    /* fixed 192-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 192 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -114,6 +120,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_strea
 /* Reads Quat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -151,6 +163,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_str
 /* Reads Handle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
+    /* fixed 22-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 22 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -200,6 +218,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( seriali
 /* Reads QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
+    /* fixed 75-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 75 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -269,6 +293,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( seriali
 /* Reads QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
+    /* fixed 69-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 69 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -343,6 +373,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( seriali
 /* Reads QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
+    /* fixed 48-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 48 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -526,6 +562,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stre
 /* Reads Input. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
+    /* fixed 168-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 168 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_float( stream, &value->stick_x ) )
     {
         return 0;
@@ -820,6 +862,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize
 /* Reads ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_read_stream_t * stream, ExpressionProbe * value )
 {
+    /* fixed 16-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 16 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -904,6 +952,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
 /* Reads ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read_stream_t * stream, ExtremeProbe * value )
 {
+    /* fixed 320-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 320 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t lo = 0;
@@ -1021,6 +1075,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
 /* Reads ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_row( serialize_read_stream_t * stream, ExtremeRow * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t lo = 0;

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -287,6 +287,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write
 /* Reads ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
+    /* fixed 202-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 202 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 9 ) )
@@ -529,6 +535,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write
 /* Reads ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_stream_t * stream, ProbeRing * value )
 {
+    /* fixed 16-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 16 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 16 ) )
@@ -558,6 +570,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write
 /* Reads ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_stream_t * stream, ProbeSlab * value )
 {
+    /* fixed 15-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 15 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -723,6 +741,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
 /* Reads ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
+    /* fixed 36-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 36 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 32 ) )
@@ -830,6 +854,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
 /* Reads Test. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
+    /* fixed 46-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 46 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 16 ) )
@@ -1341,6 +1371,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize
 /* Reads CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
+    /* fixed 24-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 24 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_compressed_float_precomputed( stream, &value->boundary, 1000u, 10, 10.0f, 0.0f ) )
     {
         return 0;

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -725,6 +725,30 @@ func (g *gen) emitReadFunc(st *ir.Struct) {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1;\n}\n\n")
 		return
 	}
+	// A struct whose wire width is FIXED reads the same bits on every path,
+	// so ir.FixedWireBits is exact rather than an upper bound: one guard at
+	// the top proves every field's past-end test and the compiler folds all
+	// of them away. serialize.h documents exactly this contract on
+	// serialize_read_bits — the test there is against num_bits, which nothing
+	// on the read path writes, so it is the SAME question a caller's group
+	// guard already answered.
+	//
+	// The refusal and the stream's terminal state are IDENTICAL (what the
+	// output struct holds after a refused read is not promised either way,
+	// and the guard writes none of it where a field-level refusal wrote the
+	// fields before it). Every field is always
+	// read (that is what fixed means), so a stream holding fewer than MaxBits
+	// bits fails at some field today and at the guard now, and
+	// serialize_read_fail leaves the same terminal state either way: error
+	// latched, cursor at num_bits + 1. Nothing that decoded before stops
+	// decoding, because a stream that held enough bits still holds enough.
+	//
+	// Nothing here touches the wire or the write side. A zero-bit struct gets
+	// no guard: it reads nothing, so there is nothing to prove.
+	if bits, fixed := ir.FixedWireBits(st); fixed && bits > 0 {
+		g.pf("    /* fixed %d-bit wire: one guard, and every per-field past-end test below folds into it */\n", bits)
+		g.pf("    if ( serialize_read_bits_remaining( stream ) < %d )\n    {\n        return serialize_read_fail( stream );\n    }\n\n", bits)
+	}
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; /* items only — reserved/const/align carry no storage */\n")
 	}

--- a/ir/wire.go
+++ b/ir/wire.go
@@ -188,6 +188,80 @@ func MaxBitsStruct(st *Struct) int64 {
 	return walk(st.Items)
 }
 
+// FixedWireBits reports whether EVERY legal encoding of st occupies exactly
+// the same number of wire bits, and returns that width. It is the condition
+// under which [MaxBitsStruct] is EXACT rather than an upper bound.
+//
+// Not fixed: a branch (the two sides need not agree), an align (0..7 bits of
+// pad), a counted array (the element count varies), a string/bytes/wstring (a
+// declared length is a bound, not a width), a union (arms differ and
+// [MaxBitsUnion] takes the largest), and a pointer (the reference is fixed but
+// nothing here is entitled to speak for the referent). Everything else has one
+// width and only one: ranged and bare ints, bits, bool, fixed-point, float32
+// compressed or bare, float64, enums, flags, fixed arrays of those, and
+// by-value nestings of structs that are themselves fixed.
+//
+// The walk descends BY-VALUE EDGES ONLY and stops at pointers, exactly as
+// [MaxBitsStruct] does, so it terminates on every legal declaration.
+//
+// This is what lets a reader hoist its per-field past-end tests: a reader that
+// has proved it holds MaxBitsStruct(st) bits cannot fail on any field of st,
+// because every field is always read and the total is exact.
+func FixedWireBits(st *Struct) (int64, bool) {
+	if !fixedItems(st.Items) {
+		return 0, false
+	}
+	return MaxBitsStruct(st), true
+}
+
+func fixedItems(items []Item) bool {
+	for _, item := range items {
+		switch item := item.(type) {
+		case *FieldItem:
+			if !fixedField(item.F) {
+				return false
+			}
+		case *ConstItem, *ReservedItem:
+			// a literal bit count, the same on every path
+		default:
+			// *Branch, *AlignItem, and any item kind this analysis has not
+			// been taught. Unknown is NOT fixed: a wrong "not fixed" costs a
+			// hoisted guard, a wrong "fixed" would change what a read refuses.
+			_ = item
+			return false
+		}
+	}
+	return true
+}
+
+func fixedField(f *Field) bool {
+	if f.Type.Pointer || f.Array == ArrayCounted {
+		return false
+	}
+	switch f.Type.Kind {
+	case TInt, TBits, TBool, TFloat32, TFloat64, TFixed:
+		return true
+	case TString, TBytes, TWString:
+		return false
+	case TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *Enum:
+			return true
+		case *Flags:
+			return true
+		case *Struct:
+			_, ok := FixedWireBits(ref)
+			return ok
+		case *Union:
+			return false
+		default:
+			_ = ref
+			return false
+		}
+	}
+	return false
+}
+
 // ---- static byte-alignment analysis ----
 //
 // wirePos tracks the wire bit position modulo 8 through a struct's items.

--- a/testdata/golden/c/ClausesWire.h
+++ b/testdata/golden/c/ClausesWire.h
@@ -536,6 +536,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_f13( serialize_write_stream
 /* Reads F13. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_f13( serialize_read_stream_t * stream, F13 * value )
 {
+    /* fixed 91-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 91 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 7; i++ )
@@ -576,6 +582,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_tri3( serialize_write_strea
 /* Reads Tri3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_tri3( serialize_read_stream_t * stream, Tri3 * value )
 {
+    /* fixed 3-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 3 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 1 ) )
@@ -656,6 +668,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_eleven( serialize_write_str
 /* Reads Eleven. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_eleven( serialize_read_stream_t * stream, Eleven * value )
 {
+    /* fixed 11-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 11 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -694,6 +712,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arr_eleven( serialize_write
 /* Reads ArrEleven. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_arr_eleven( serialize_read_stream_t * stream, ArrEleven * value )
 {
+    /* fixed 99-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 99 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 9; i++ )
@@ -991,6 +1015,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_sole( serialize_write_strea
 /* Reads Sole. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_sole( serialize_read_stream_t * stream, Sole * value )
 {
+    /* fixed 13-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 13 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 13 ) )

--- a/testdata/golden/c/DegenerateWire.h
+++ b/testdata/golden/c/DegenerateWire.h
@@ -67,6 +67,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec2( serialize_write_strea
 /* Reads Vec2. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec2( serialize_read_stream_t * stream, Vec2 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -97,6 +103,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_f64( serialize_write_s
 /* Reads SpanF64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_f64( serialize_read_stream_t * stream, SpanF64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -129,6 +141,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_u64( serialize_write_s
 /* Reads SpanU64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_u64( serialize_read_stream_t * stream, SpanU64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -165,6 +183,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_i64( serialize_write_s
 /* Reads SpanI64. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_i64( serialize_read_stream_t * stream, SpanI64 * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -201,6 +225,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_one( serialize_write_s
 /* Reads SpanOne. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_one( serialize_read_stream_t * stream, SpanOne * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 1; i++ )
@@ -237,6 +267,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_chunk( serialize_write
 /* Reads SpanChunk. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_chunk( serialize_read_stream_t * stream, SpanChunk * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 4; i++ )
@@ -277,6 +313,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_tail( serialize_write_
 /* Reads SpanTail. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_tail( serialize_read_stream_t * stream, SpanTail * value )
 {
+    /* fixed 160-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 160 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -327,6 +369,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_span_twice( serialize_write
 /* Reads SpanTwice. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_span_twice( serialize_read_stream_t * stream, SpanTwice * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         int32_t i;
         for ( i = 0; i < 2; i++ )
@@ -371,6 +419,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio( serialize_write_strea
 /* Reads Trio. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio( serialize_read_stream_t * stream, Trio * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 20 ) )
@@ -411,6 +465,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_sole( serialize_write_
 /* Reads TrioSole. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_sole( serialize_read_stream_t * stream, TrioSole * value )
 {
+    /* fixed 64-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 64 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !read_trio( stream, &value->inner ) )
     {
         return 0;
@@ -435,6 +495,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_first( serialize_write
 /* Reads TrioFirst. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_first( serialize_read_stream_t * stream, TrioFirst * value )
 {
+    /* fixed 80-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 80 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !read_trio( stream, &value->inner ) )
     {
         return 0;
@@ -522,6 +588,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_trio_straddle( serialize_wr
 /* Reads TrioStraddle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_trio_straddle( serialize_read_stream_t * stream, TrioStraddle * value )
 {
+    /* fixed 408-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 408 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t lo = 0;
         serialize_uint32_t hi = 0;

--- a/testdata/golden/c/JoinsWire.h
+++ b/testdata/golden/c/JoinsWire.h
@@ -733,6 +733,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow( serialize_write_str
 /* Reads Narrow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow( serialize_read_stream_t * stream, Narrow * value )
 {
+    /* fixed 3-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 3 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -764,6 +770,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide( serialize_write_strea
 /* Reads Wide. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide( serialize_read_stream_t * stream, Wide * value )
 {
+    /* fixed 37-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 37 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t lo = 0;
         serialize_uint32_t hi = 0;

--- a/testdata/golden/c/RenderWire.h
+++ b/testdata/golden/c/RenderWire.h
@@ -81,6 +81,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
 /* Reads RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
+    /* fixed 138-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 138 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t raw = 0;
         if ( !serialize_read_uint64( stream, &raw ) )

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -74,6 +74,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_strea
 /* Reads Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
+    /* fixed 192-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 192 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -114,6 +120,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_strea
 /* Reads Quat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_double( stream, &value->x ) )
     {
         return 0;
@@ -151,6 +163,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_str
 /* Reads Handle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
+    /* fixed 22-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 22 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -200,6 +218,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( seriali
 /* Reads QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
+    /* fixed 75-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 75 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -269,6 +293,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( seriali
 /* Reads QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
+    /* fixed 69-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 69 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -343,6 +373,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( seriali
 /* Reads QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
+    /* fixed 48-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 48 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -526,6 +562,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stre
 /* Reads Input. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
+    /* fixed 168-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 168 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_float( stream, &value->stick_x ) )
     {
         return 0;
@@ -820,6 +862,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize
 /* Reads ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_read_stream_t * stream, ExpressionProbe * value )
 {
+    /* fixed 16-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 16 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -904,6 +952,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
 /* Reads ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read_stream_t * stream, ExtremeProbe * value )
 {
+    /* fixed 320-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 320 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t lo = 0;
@@ -1021,6 +1075,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
 /* Reads ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_row( serialize_read_stream_t * stream, ExtremeRow * value )
 {
+    /* fixed 256-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 256 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t lo = 0;

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -287,6 +287,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write
 /* Reads ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
+    /* fixed 202-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 202 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 9 ) )
@@ -529,6 +535,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write
 /* Reads ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_stream_t * stream, ProbeRing * value )
 {
+    /* fixed 16-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 16 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 16 ) )
@@ -558,6 +570,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write
 /* Reads ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_stream_t * stream, ProbeSlab * value )
 {
+    /* fixed 15-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 15 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint64_t offset_value = 0;
         serialize_uint32_t raw = 0;
@@ -723,6 +741,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
 /* Reads ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
+    /* fixed 36-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 36 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 32 ) )
@@ -830,6 +854,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
 /* Reads Test. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
+    /* fixed 46-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 46 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_uint32_t raw = 0;
         if ( !serialize_read_bits( stream, &raw, 16 ) )
@@ -1341,6 +1371,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize
 /* Reads CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
+    /* fixed 24-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 24 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_compressed_float_precomputed( stream, &value->boundary, 1000u, 10, 10.0f, 0.0f ) )
     {
         return 0;

--- a/testdata/golden/ludicrous/c/LudicrousWire.h
+++ b/testdata/golden/ludicrous/c/LudicrousWire.h
@@ -101,6 +101,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_writ
 /* Reads FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
+    /* fixed 156-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 156 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int32_t fixed_value;
         fixed_value = 0;
@@ -210,6 +216,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
 /* Reads UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
+    /* fixed 196-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 196 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int64_t fixed_value = 0;
         if ( !serialize_read_fixed64( stream, &fixed_value, 16, 16, 0, 360 ) )
@@ -297,6 +309,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write
 /* Reads WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
+    /* fixed 403-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 403 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
     {
         return 0;
@@ -439,6 +457,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize
 /* Reads DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
+    /* fixed 8-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 8 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     value->locked_fixed = (int32_t) -196608LL;
     value->locked_int = (int32_t) (7);
     value->locked_wide = serialize_int128_from_int64( -12345678901234 );
@@ -483,6 +507,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_
 /* Reads FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
+    /* fixed 102-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 102 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int64_t fixed_value;
         fixed_value = 0;
@@ -550,6 +580,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write
 /* Reads FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
+    /* fixed 128-bit wire: one guard, and every per-field past-end test below folds into it */
+    if ( serialize_read_bits_remaining( stream ) < 128 )
+    {
+        return serialize_read_fail( stream );
+    }
+
     {
         serialize_int32_t fixed_value;
         fixed_value = 0;


### PR DESCRIPTION
**The 7%, found by disassembly.** The C leg's generated packet read executed 547 loads per message against C++'s 354 and 218 spill reloads against 18, for the same instruction count: clang spilled `stream->num_bits` to the stack in the C bench's translation unit and reloaded it for every field's past-end test (26 in the straight-line read, 13 x 8 in the entity loop, 1 x 80 in the stat loop), and rematerialized the range constants, where C++ keeps the same value in a callee-saved register. Read alone was at 86% of C++; write was at parity; the round trip at 93%.

**What changes.** `ir.FixedWireBits`: a struct whose every legal encoding occupies exactly the same number of wire bits (no branch, no align, no counted array, no string, bytes or wstring, no union, no pointer; by-value nestings of fixed structs count). The C emitter's read function for such a struct opens with one guard, `if ( serialize_read_bits_remaining( stream ) < <bits> ) return serialize_read_fail( stream );`, so the compiler proves every per-field past-end test from it and folds them, which serialize.c's own header documents as the intended use. The refusal is identical: every field is always read, so a stream holding fewer bits failed at some field before and fails at the guard now, with the same terminal state; every stream that decoded still decodes. 52 read functions in the C output gain the guard (BenchMixed itself does not: counted arrays, a union, strings); no other language's output moves; the goldens are pure insertions; the wire and the protocol ids do not move.

**Emitted code**, bench TU, -O3 -DNDEBUG: entity read loop 160 to 111 instructions; per message on the read side, loads 641 to 455, spill reloads 307 to 120, conditional branches 469 to 280 (C++: 359 loads, 19 reloads, 469 branches); write side unchanged to the instruction.

**The pass.** cpp,c twins, seven interleaved rounds, window OK, control delta 0.5%, twin gate OK, serialize.c a742a3d (1.10.0) build-verified, corpus unchanged. C as a percentage of C++ on best rates, against the pin pass an hour before: packet write 100.3 to 100.4%; packet round trip 93.1 to 101.9% (C 4,669,166 against C++ 4,583,899 messages a second); raw bit write 99.7 to 100.5%; raw bit read 99.2 to 100.0%. Read-only, derived: C 86.2 to 103.5% of C++. render.awk: C measured 98.2% of C++, inside the §2.8 band of 6.5 points, a statistical tie, where the pin pass read 107.4% against 5.8 and no tie. Parity, not a lead: C is inside the band, so no claim is made that the C++ emitter needs the same guard on this evidence; the derived read ratio points that way and is a follow-up to measure, not a change made here.

**Receipts.** make test-c green (both conformance legs, packet-wide, packet-text, packet-void, packet-defaults, the tables gates; six negative controls red as designed); go test ./... 34 ok; go vet, gofmt, make shape-gate clean; wire sizes 49/14/20/438/204 unmoved. SPEC.md has no sentence the guard contradicts. bench/README.md and PERFORMANCE.md's dated paragraph carry the result and close the finding they had left open.

Found by one Opus worker's disassembly and implemented by another under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)