### PR TITLE
bench: the README's table is the nine-language sitting on the tree at the end of the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,18 @@ Cost to serialize a representative game packet, relative to generated C++ at
 
 | Language | % |
 |---|---:|
+| C | 100% |
 | C++ | 100% |
-| C | 107% |
-| Java | 169% |
-| Rust | 173% |
-| Go | 231% |
-| C# | 253% |
-| Dart | 267% |
-| JavaScript | 292% |
-| Elixir | 1451% |
+| Rust | 166% |
+| Java | 170% |
+| Go | 228% |
+| C# | 238% |
+| Dart | 266% |
+| JavaScript | 288% |
+| Elixir | 1479% |
 
-Measured by [the benchmark](bench/) on an Apple M3 Ultra, 2026-09-07, JavaScript on the
-pinned node 26.7.0; [PERFORMANCE.md](docs/PERFORMANCE.md) has every toolchain, the earlier
+Measured by [the benchmark](bench/) on an Apple M3 Ultra, 2026-09-07, the runtimes at
+their release tags; [PERFORMANCE.md](docs/PERFORMANCE.md) has every toolchain, the earlier
 Apple M2 table and what moved between them. One 438-byte packet exercising every construct.
 
 ## Install and build

--- a/bench/results/2026-09-07-arm64-studio-final-sitting.md
+++ b/bench/results/2026-09-07-arm64-studio-final-sitting.md
@@ -1,0 +1,89 @@
+# 2026-09-07, Apple M3 Ultra Studio — the final nine-language sitting
+
+`bench/run.sh` over all nine legs on `main` at `eb3fe549`, taken after everything of
+2026-09-07 had landed (#691, #692, #694, #695, #696, #697, #698, #700, #701, #702). This is
+the sitting the README's table is rendered from.
+
+CSV: [`2026-09-07-arm64-studio-ninelang-final-sitting.csv`](2026-09-07-arm64-studio-ninelang-final-sitting.csv)
+
+## Preamble essentials
+
+| | |
+|---|---|
+| date | 2026-09-07T19:07:43Z |
+| machine | `arm64 studio`, Darwin 25.6.0, Apple M3 Ultra |
+| build | Release |
+| schema commit | `eb3fe549` (= `origin/main`) |
+| corpus | `6b213fbfa1a03a99`, one 438-byte packet, 4,000,000 iterations, 7 measured runs per leg |
+| C / C++ | Apple clang 21.0.0, `-O3 -DNDEBUG` |
+| Go | go 1.27.1 |
+| Rust | cargo/rustc 1.98.0, `--release`, opt-level 3 |
+| .NET | SDK 10.0.400, Release, workstation GC |
+| node | v26.7.0 (the pin), `NODE_ENV=production` |
+| Java | OpenJDK 21.0.12.1 (the pin), no `-ea` |
+| Dart | 3.13.2 (the pin), AOT |
+| Elixir | 1.20.4 on OTP 29.0.5 (the pins) |
+| pinning / noise | none / unlabelled |
+
+Runtime checkouts, at CI's tags (`.github/workflows/ci.yml`):
+
+| runtime | tag | commit |
+|---|---|---|
+| serialize | v1.16.2 | `93b8ea2` |
+| serialize.c | v1.10.0 | `a742a3d` |
+| serialize.go | v1.15.1 | `963f6df` |
+| serialize.rs | v2.4.0 | `5e26a78` |
+| serialize.cs | v1.9.1 | `1bf2b19` |
+| serialize.js | v1.4.2 | `de0591c` |
+
+All nine legs ran — no `# skipped:` line, no ABSENT row. Every leg passed its wire golden
+gate (`OK (corpus_id 6b213fbfa1a03a99)` nine times).
+
+## The rendered table
+
+`awk -F, -v skips="" -f bench/render.awk bench/results/2026-09-07-arm64-studio-ninelang-final-sitting.csv`
+
+```
+subject: schema-GENERATED code (family gen) — what the compiler delivers; C++ = 100%
+  language        %
+  c            100%
+  cpp          100%
+  rust         166%
+  java         170%
+  go           228%
+  cs           238%
+  dart         266%
+  js           288%
+  elixir      1479%
+  §2.8 TIE: c measured 99.4% of cpp, inside the tie band (4.5 points) — reported as a statistical tie at 100%
+```
+
+C is INSIDE the §2.8 band, so the lock's C-outside-the-band warning (PR #699) does not fire on
+this sitting. A sitting carries no window verdict — no control legs, no twins, no bands — so
+these ratios hold within this sitting only.
+
+## The rows behind the render
+
+Best (`max`) rate, `bench_mixed`, family `gen`, the js flat tier:
+
+| leg | round_trip best | spread | write best | spread | `checks` |
+|---|---:|---:|---:|---:|---|
+| C | 4,630,594 | 1.79% | 9,072,866 | 8.75% | removed |
+| C++ | 4,602,160 | 2.67% | 9,039,191 | 2.79% | removed |
+| Rust | 2,779,604 | 1.83% | 8,430,347 | 1.56% | removed |
+| Java | 2,709,171 | 1.53% | 6,776,821 | 2.30% | contract |
+| Go | 2,016,309 | 0.76% | 4,046,120 | 2.72% | always |
+| C# | 1,936,083 | 1.23% | 4,114,886 | 1.02% | removed |
+| Dart | 1,727,886 | 3.03% | 2,950,146 | 0.45% | contract |
+| JavaScript | 1,599,166 | 1.17% | 2,977,833 | 2.04% | contract |
+| Elixir | 311,093 | 2.12% | 473,543 | 6.71% | contract |
+
+Rust's and C#'s `checks` columns read `always` in the node-26 sitting and `removed` here:
+that is #696 and #697, and their write legs moved +11.6% and +9.2% with it. C's round trip
+moved +5.8% on #701 and #702. What moved against the node-26 sitting and the Air's, row by
+row, is in [docs/PERFORMANCE.md](../../docs/PERFORMANCE.md) under "The table at the end of
+the day".
+
+`go run ./bench/tools ledger --check`: green, exit 0, no failure output (the series prints). The newest cpp round-trip
+point on the (`arm64 studio`, `6b213fbfa1a03a99`) axis is 217.29 ns/msg against the previous
+sitting's 218.15 — an improvement, nowhere near the gate.

--- a/bench/results/2026-09-07-arm64-studio-ninelang-final-sitting.csv
+++ b/bench/results/2026-09-07-arm64-studio-ninelang-final-sitting.csv
@@ -1,0 +1,61 @@
+# schema bench results
+# date: 2026-09-07T19:07:43Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: eb3fe549 (studio-final-sitting)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: a742a3d (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,7,8870572,8791528,9039191,3705.32,2.79,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,7,4562910,4480206,4602160,1905.97,2.67,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,7,91173,90148,91815,5696.76,1.83,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,7,119895,119612,124780,7491.37,4.31,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,7,8815641,8301494,9072866,3682.38,8.75,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,7,4602044,4548235,4630594,1922.32,1.79,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,7,91780,90942,92795,5734.65,2.02,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,7,121849,120821,122501,7613.44,1.38,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,7,4033981,3936207,4046120,1685.03,2.72,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,7,2012640,2000983,2016309,840.70,0.76,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,7,12183,12117,12264,761.22,1.21,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,7,14103,13972,14164,881.17,1.36,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,7,8330767,8300637,8430347,3479.84,1.56,6b213fbfa1a03a99,gen,crate,removed,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,7,2749713,2729240,2779604,1148.58,1.83,6b213fbfa1a03a99,gen,crate,removed,O3,unknown
+rust,bitpacker,write,24576,65518,7,35788,35608,36309,2236.16,1.96,6b213fbfa1a03a99,bits,crate,removed,O3,unknown
+rust,bitpacker,read,24576,65518,7,45726,45347,45882,2857.12,1.17,6b213fbfa1a03a99,bits,crate,removed,O3,unknown
+cs,bench_mixed,write,4000000,438,7,4088214,4073332,4114886,1707.69,1.02,6b213fbfa1a03a99,gen,asm,removed,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1930028,1912274,1936083,806.19,1.23,6b213fbfa1a03a99,gen,asm,removed,default,unknown
+cs,bitpacker,write,24576,65518,7,21726,21477,21975,1357.52,2.29,6b213fbfa1a03a99,bits,asm,removed,default,unknown
+cs,bitpacker,read,24576,65518,7,23091,22763,23188,1442.79,1.84,6b213fbfa1a03a99,bits,asm,removed,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2939070,2917958,2977833,1227.68,2.04,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1584723,1580576,1599166,661.95,1.17,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,8265,8106,8301,516.40,2.35,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6036,5947,6068,377.17,2.01,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,7,6644412,6623934,6776821,2775.43,2.30,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,7,2701378,2667923,2709171,1128.39,1.53,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,7,2943313,2936940,2950146,1229.45,0.45,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,7,1714885,1675924,1727886,716.32,3.03,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,4000000,438,7,467055,442220,473543,195.09,6.71,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,4000000,438,7,308146,304572,311093,128.72,2.12,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -7,24 +7,24 @@
 
 ## 2026-09-07: the Studio's nine-language table, and what moved since the Air's
 
-The README's table is now a sitting on the Apple M3 Ultra Studio taken on the pinned node
-26.7.0 ([CSV](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv),
-15:45:27Z), every leg gated on the wire goldens, seven measured runs per leg, rendered by the
+The first table of the day on the new node pin was a sitting on the Apple M3 Ultra Studio
+taken on node 26.7.0 ([CSV](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv),
+15:45:27Z; the README's table until the day's last sitting, below), every leg gated on the wire goldens, seven measured runs per leg, rendered by the
 README's own instrument (`bench/render.awk`: round-trip best rate, C++ = 100%). Its preamble
-records schema commit 3d01b479; main's 7622f23b after it changed only `bench/tools`,
-`bench/run.sh`, docs and results, so the generated code and the runtime checkouts this sitting
-measured are the ones on today's main. Five legs ran on the toolchains the repository pins:
+records schema commit 3d01b479 and serialize.c at v1.9.2; main moved past both later the same
+day (the emitter changes of #695 onward, the pin of #701), which is why the day ends with
+another sitting. Five legs ran on the toolchains the repository pins:
 node 26.7.0 (the pin was 20.20.2 until 2026-09-07; the two older Studio sittings below ran on
 it, the Air's already on 26.7.0), OpenJDK 21.0.12.1 (the Temurin build `make/java.mk` names),
 Dart 3.13.2, Erlang/OTP 29.0.5 with Elixir 1.20.4, and .NET SDK 10.0.400 for the `10.0` in
 `.github/dotnet-version`. The other four ran on the machine's compilers, which the repository
 does not pin: Apple clang 21.0.0, go 1.27.1 (CI runs 1.26) and cargo 1.98.0 (CI resolves stable
-at run time); the runtimes were at the tags CI checks out. It is C++ = 100% like the tables
+at run time); the runtimes were at the tags CI checked out that afternoon. It is C++ = 100% like the tables
 below it because the C = 100% form the standard prefers is not producible for these rows: the
 `rel` tool refuses rows without an inline verdict, and none of these carry one. The two node-20
 Studio sittings it replaces, and the Air's table before them, stand beside it:
 
-| language | [Studio, node 26.7.0](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv) (the README's) | [Studio, sitting 2](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv), node 20.20.2 | [Studio, sitting 1](../bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv), node 20.20.2 | [Air (Apple M2), 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv), node 26.7.0 |
+| language | [Studio, node 26.7.0](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv) | [Studio, sitting 2](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv), node 20.20.2 | [Studio, sitting 1](../bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv), node 20.20.2 | [Air (Apple M2), 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv), node 26.7.0 |
 |---|---:|---:|---:|---:|
 | C++ | 100% | 100% | 100% | 100% |
 | C | 107% | 107% | 109% | 100%, a §2.8 tie (measured 98%) |
@@ -93,6 +93,47 @@ These are the first passes the driver has aggregated since 2026-08-31: its `aggr
 refused every pass since then, failing closed, because a parameter shadowed the path-column
 list (#689), and these passes were the ones that found it. The passes' own caveats and the
 rates are in [the note beside the CSVs](../bench/results/2026-09-07-arm64-studio-four-leg-passes.md).
+
+**The table at the end of the day.** One more nine-language `bench/run.sh` sitting on the
+same Studio after everything of 2026-09-07 had landed
+([CSV](../bench/results/2026-09-07-arm64-studio-ninelang-final-sitting.csv), 19:07:43Z; schema
+commit `eb3fe549`, the runtimes at CI's tags — serialize v1.16.2 `93b8ea2`, serialize.c
+v1.10.0 `a742a3d`, serialize.go v1.15.1 `963f6df`, serialize.rs v2.4.0 `5e26a78`,
+serialize.cs v1.9.1 `1bf2b19`, serialize.js v1.4.2 `de0591c`), all nine legs, none skipped,
+every leg gated on the wire goldens, seven measured runs each, rendered by `bench/render.awk`.
+It is the README's table now. Beside it, the node-26 sitting it replaces and the Air's:
+
+| language | [Studio, final sitting](../bench/results/2026-09-07-arm64-studio-ninelang-final-sitting.csv) (the README's) | [Studio, node 26.7.0](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv) | [Air (Apple M2), 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv) |
+|---|---:|---:|---:|
+| C++ | 100% | 100% | 100% |
+| C | 100%, a §2.8 tie (measured 99.4%) | 107% | 100%, a §2.8 tie (measured 98%) |
+| Rust | 166% | 173% | 154% |
+| Java | 170% | 169% | 162% |
+| Go | 228% | 231% | 210% |
+| C# | 238% | 253% | 225% |
+| Dart | 266% | 267% | 227% |
+| JavaScript | 288% | 292% | 264% |
+| Elixir | 1479% | 1451% | 1283% |
+
+Three rows moved by more than the usual few points, and each of the three is a change of the
+day rather than variance. **C, 107% to a tie at 100% (measured 99.4%)**: its best round-trip
+rate went 4,378,533 to 4,630,594 messages a second, +5.8% against within-sitting spreads of
+1.40 and 1.79 points, which is the serialize.c v1.10.0 pin (#701) and the fixed-width
+remaining-bits read guard (#702) arriving together — the isolating passes above measure them
+one at a time and this sitting only confirms them side by side. **Rust, 173% to 166%**: its
+write leg went 7,554,548 to 8,430,347 messages a second, +11.6% against spreads of 1.62 and
+1.56, and its `checks` column moved `always` to `removed` — that is #696 compiling every
+write-side check out of a release profile, and it is the whole of the row's move. **C#, 253%
+to 238%**: the same story from #697, write leg 3,768,372 to 4,114,886, +9.2% against spreads
+of 1.93 and 1.02, `checks` likewise `always` to `removed`. Elixir's 1451% to 1479% is the
+largest of the rest and is sitting-to-sitting variance, unexplained: its absolute rate fell
+3.2% against spreads of 4.13 and 2.12 points and nothing landed today in its emitter. Java
+(+1), Dart (-1), Go (-3) and JavaScript (-4) all moved less than 1.8% in absolute rate, inside
+the same variance. C++, the denominator, fell 1.4% (4,665,785 to 4,602,160) inside its own
+spreads of 3.16 and 2.67, so a point or so of Rust's and C#'s improvement is the denominator
+and not them. `go run ./bench/tools ledger --check` is green on this sitting: the newest cpp
+round-trip point on the (arm64 studio, `6b213fbfa1a03a99`) axis is 217.29 ns/msg against the
+previous point's 218.15 (the read-guard pass), an improvement, so nothing approaches the gate.
 
 Generated-code performance as time relative to C++ (100%; higher is slower), medians across
 the corpus on an **Apple M3 Ultra**, the 2026-08-15 five-language pass **at `-O3`**
@@ -211,10 +252,12 @@ the runs they caption and is not true of C now. The C/C++ ratio is no longer a r
 two check models; the pass above is the first rendered without one, and the 2026-08-15 tables
 stand as they were measured.
 
-Rust remains the per-field-checked writer of the set. The older reading of the table — that C
-and Rust, the two then-per-field-checked writers, landing within 5% of each other on every
-round-trip write row was independent confirmation of the cost of that guarantee — describes
-the C that measured, not the C that is here now.
+Since #696 the same day, Rust no longer is the per-field-checked writer of the set either: its
+write-side checks are `debug_assert!`, gone in release, and Go is the one compiled leg whose
+writer validates in every build, by that language's own practice. The older reading of the
+table — that C and Rust, the two then-per-field-checked writers, landing within 5% of each
+other on every round-trip write row was independent confirmation of the cost of that
+guarantee — describes the C and the Rust that measured, not the ones here now.
 
 Relative numbers move with compiler and microarchitecture. Treat the table as a dated
 snapshot, not a verdict. Full tables, the pre-campaign baseline of the same day, and


### PR DESCRIPTION
One `bench/run.sh` sitting on the Apple M3 Ultra at main eb3fe549, all nine legs, every leg gated on the wire goldens, the runtimes at CI's tags (serialize v1.16.2, serialize.c v1.10.0, serialize.go v1.15.1, serialize.rs v2.4.0, serialize.cs v1.9.1, serialize.js v1.4.2), the codegen-only legs on the pinned toolchains, node 26.7.0, .NET 10.0.400; 2026-09-07T19:07:43Z. Rendered by the README's instrument: C++ 100, C 100 (a §2.8 tie: 99.4% inside 4.5 points), Rust 166, Java 170, Go 228, C# 238, Dart 266, JavaScript 288, Elixir 1479.

**What moved since the node-26 sitting the table replaces, by best round-trip rate.** C +5.8% (the read guard, #702, and serialize.c 1.10.0, #701): 106.6% of C++ to a tie. Rust +2.9% and C# +5.0% on the round trip; on the write rows Rust +11.6% (7,554,548 to 8,430,347) and C# +9.2% (3,768,372 to 4,114,886), with their `checks` column moving always to removed: #696 and #697 compiling out. C++ -1.4%, Java -1.7%, Go -0.2%, Dart -1.1%, JavaScript +0.1%, Elixir -3.2%: sitting-to-sitting variance, unexplained. Every number is in bench/results/2026-09-07-arm64-studio-final-sitting.md with its arithmetic; PERFORMANCE.md's dated section closes with the table beside the node-26 sitting's and the Air's; the stale sentence naming Rust as the per-field-checked writer is corrected. `ledger --check` green (cpp 218.15 to 217.29 ns/msg; the pair lock's newest certified pass unchanged, this being a sitting).

Measured and written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login. The v2.5.0 tag follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)