### PR TITLE
Repair validated bounds, defaults and table recovery findings from #710

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3884,7 +3884,7 @@ tables-lists-unreached-negative-control: bin/schema build/tables-generated/.stam
 .PHONY: tables-lists-cook-check-negative-control
 tables-lists-cook-check-negative-control:
 	@rm -rf build/list-cook-check-control && mkdir -p build/list-cook-check-control
-	@sed -e 's@if start < s.base || end > s.extent {@if ( start < s.base || end > s.extent ) \&\& false { // SABOTAGED@' \
+	@sed -e 's@start, end, fits := arrayExtent(at, delta, count, size, s.base, s.extent)@start, end, fits := at + delta, at + delta + count * size, true // SABOTAGED@' \
 		internal/tablecook/check.go > build/list-cook-check-control/check.go.txt
 
 	@cmp -s internal/tablecook/check.go build/list-cook-check-control/check.go.txt && \
@@ -3895,6 +3895,8 @@ tables-lists-cook-check-negative-control:
 			-run 'TestCookCheckListSlot' ./internal/tablecook/ > build/list-cook-check-control/log 2>&1; then \
 		echo "NEGATIVE CONTROL FAILED: dropping cook-check's element-array clause left its test GREEN"; exit 1; \
 	fi
+	@grep -q "FAILED: cook-check accepted a list slot" build/list-cook-check-control/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the test went red, but not on containment"; cat build/list-cook-check-control/log; exit 1; }
 	@echo "negative control: dropping cook-check's element-array clause turns its test RED"
 
 # AND THE MAP SLOT'S OWN TWO (schema#380, §7.4). The containment clause is
@@ -3909,6 +3911,8 @@ tables-maps-cook-check-negative-control:
 			-run 'TestCookCheckMapSlot' ./internal/tablecook/ > build/map-cook-check-control/shared.log 2>&1; then \
 		echo "NEGATIVE CONTROL FAILED: dropping the shared containment clause left the map-slot test GREEN"; exit 1; \
 	fi
+	@grep -q -- "--- FAIL: TestCookCheckMapSlot/the_entries_leave_the_node" build/map-cook-check-control/shared.log || \
+		{ echo "NEGATIVE CONTROL FAILED: the shared test went red, but not on containment"; cat build/map-cook-check-control/shared.log; exit 1; }
 	@sed -e 's@		if order > 0 {@		if order > 0 \&\& false { // SABOTAGED: the entries may descend@' \
 		-e 's@		if order == 0 {@		if order == 0 \&\& false { // SABOTAGED: a key may repeat@' \
 		internal/tablecook/check.go > build/map-cook-check-control/check.go.txt

--- a/Makefile
+++ b/Makefile
@@ -3904,8 +3904,9 @@ tables-lists-cook-check-negative-control:
 # turn the MAP's test red too; the ascending clause is the map's alone, and it
 # gets its own sabotage, because a shared control that never fired on the
 # fifth clause would leave it untested.
+# The prerequisite creates the shared overlay even when CI runs maps alone.
 .PHONY: tables-maps-cook-check-negative-control
-tables-maps-cook-check-negative-control:
+tables-maps-cook-check-negative-control: tables-lists-cook-check-negative-control
 	@rm -rf build/map-cook-check-control && mkdir -p build/map-cook-check-control
 	@if go test -count=1 -overlay=build/list-cook-check-control/overlay.json \
 			-run 'TestCookCheckMapSlot' ./internal/tablecook/ > build/map-cook-check-control/shared.log 2>&1; then \

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -196,19 +196,8 @@ func main() {
 		if err := os.MkdirAll(*out, 0o755); err != nil {
 			fatalf("%v", err)
 		}
-		names := make([]string, 0, len(files))
-		for n := range files {
-			names = append(names, n)
-		}
-		sort.Strings(names)
-		for _, n := range names {
-			path := filepath.Join(*out, n)
-			if err := os.WriteFile(path, files[n], 0o644); err != nil {
-				fatalf("%v", err)
-			}
-			if verbose {
-				fmt.Printf("wrote %s\n", path)
-			}
+		if err := writeGenerated(*out, files, verbose); err != nil {
+			fail(err)
 		}
 	case "pack":
 		// docs/SPEC-TABLES.md §17: the tree IS the table, the text in it is §16's,
@@ -668,5 +657,32 @@ func (t *messageTrees) Set(value string) error {
 		return fmt.Errorf("--batch takes Table=tree-dir, and %q is not one", value)
 	}
 	*t = append(*t, compiler.MessageTree{Root: root, Dir: dir})
+	return nil
+}
+
+// writeGenerated confines even third-party generator output and existing
+// symlinks to the requested output tree.
+func writeGenerated(dir string, files map[string][]byte, verbose bool) error {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		if !filepath.IsLocal(name) || strings.Contains(name, "\\") {
+			return fmt.Errorf("generator output %q is not a local path", name)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	for _, name := range names {
+		if err := out.WriteFile(name, files[name], 0o644); err != nil {
+			return err
+		}
+		if verbose {
+			fmt.Printf("wrote %s\n", filepath.Join(dir, name))
+		}
+	}
 	return nil
 }

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -675,7 +675,7 @@ func writeGenerated(dir string, files map[string][]byte, verbose bool) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }() // only the directory handle; file writes close and report their own errors
 	for _, name := range names {
 		if err := out.WriteFile(name, files[name], 0o644); err != nil {
 			return err

--- a/cmd/schema/output_test.go
+++ b/cmd/schema/output_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGeneratedOutputIsConfined(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "out")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"../escape", filepath.Join(parent, "absolute"), `..\escape`} {
+		if err := writeGenerated(dir, map[string][]byte{name: []byte("new")}, false); err == nil {
+			t.Fatalf("accepted %q", name)
+		}
+	}
+	outside := filepath.Join(parent, "existing")
+	if err := os.WriteFile(outside, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := writeGenerated(dir, map[string][]byte{"link": []byte("new")}, false); err == nil {
+		t.Fatal("followed escaping link")
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil || string(data) != "original" {
+		t.Fatalf("outside file changed: %q, %v", data, err)
+	}
+	if err := writeGenerated(dir, map[string][]byte{"ok.h": []byte("ok")}, false); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -314,7 +314,7 @@ func TestIssue710ListRefusal(t *testing.T) {
 		for _, b := range wire {
 			fmt.Fprintf(&cpp, "%d,", b)
 		}
-		fmt.Fprintf(&cpp, "}; %sBuilder b; TableReport r; if(%sLoadBuilder(b,wire,sizeof(wire),&r) || r.malformed || r.unknown || r.kind_mismatch || b.GetRoot()->after!=0) return 1; TableRefuseReason reason; if(%sLoadMeasure(wire,sizeof(wire),NULL,&reason)!=-1 || reason!=count_over_extent_cap) return 2; }\n", tc.root, tc.root, tc.root)
+		fmt.Fprintf(&cpp, "}; %sBuilder b; TableReport r; if(%sLoadBuilder(b,wire,sizeof(wire),&r) || r.malformed || r.unknown || r.kind_mismatch || b.GetRoot()->after!=0) return 1; TableRefuseReason reason = count_over_length; if(%sLoadMeasure(wire,sizeof(wire),NULL,&reason)!=-1 || reason!=count_over_extent_cap) return 2; }\n", tc.root, tc.root, tc.root)
 	}
 	cpp.WriteString("return 0;}\n")
 	issue710CompileRun(t, dir, "c++", ".cpp", cpp.String())

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -112,6 +112,8 @@ func TestIssue710TableRecovery(t *testing.T) {
  table Element { value int32 = 7 }
  table Rows { items [..2]Element; after int32 }
  table Mapping { items map[uint32]Element; after int32 }
+ enum Key { First, Second }
+ table Keyed { items [Key]Element; after int32 }
  `
 	// The grammar terminates fields by newlines rather than semicolons.
 	u := unitFromSource(t, strings.ReplaceAll(src, "; ", "\n"))
@@ -131,6 +133,9 @@ func TestIssue710TableRecovery(t *testing.T) {
 			return v.Fields[0].Count == 1 && v.Fields[0].Elems[0].Tab.Fields[0].Cell.I == 7
 		}, `Rows v; TableReport r; if (!RowsLoad(v, wire, sizeof(wire), &r) || !r.malformed || v.after!=42 || v.items_count!=1 || v.items[0].value!=7) return 2;`},
 		{"map", "Mapping", issue710Wire(append([]byte{1, 14, 11, 13, 1, 8, 3, byte(ir.TableKindU32), 1, 0, 0, 0, 0, 0}, after...), fieldID("Mapping", 0), fieldID("Mapping", 1), ir.MapKeyWireId), func(v *tabletext.Instance) bool { return len(v.Fields[0].Entries) == 0 }, `MappingBuilder b; TableReport r; const bool ok=MappingLoadBuilder(b,wire,sizeof(wire),&r); const Mapping * v=b.GetRoot(); const bool pass=ok && r.malformed && v && v->after==42 && v->items.count==0; if(!pass) return 3;`},
+		{"keyed", "Keyed", issue710Wire(append([]byte{1, byte(ir.TableKindKeyed), 21, 13, 2, 4, 8, 3, byte(ir.TableKindI32), 99, 0, 0, 0, 0, 0, 5, 7, 3, byte(ir.TableKindI32), 55, 0, 0, 0, 0}, after...), fieldID("Keyed", 0), fieldID("Keyed", 1), fieldID("Element", 0), ir.TableWireId(u.Enums["Key"].VariantWireName(0)), ir.TableWireId(u.Enums["Key"].VariantWireName(1))), func(v *tabletext.Instance) bool {
+			return v.Fields[0].Elems[0].Tab.Fields[0].Cell.I == 7 && v.Fields[0].Elems[1].Tab.Fields[0].Cell.I == 55
+		}, `Keyed v; TableReport r; if (!KeyedLoad(v, wire, sizeof(wire), &r) || !r.malformed || v.after!=42 || v.items.slots[0].value!=7 || v.items.slots[1].value!=55) return 4;`},
 	}
 	c := New()
 	files, err := c.Generate(u, "cpp", Options{})
@@ -174,14 +179,13 @@ func issue710CompileRun(t *testing.T, dir, compiler, ext, source string) {
 	if err := os.WriteFile(path, []byte(source), 0644); err != nil {
 		t.Fatal(err)
 	}
-	args := []string{"-O1", "-g", "-Wall", "-Wextra", "-Werror"}
+	// Signed-overflow regressions need UBSan on every run: plain optimized
+	// code can return the expected answer after undefined arithmetic.
+	args := []string{"-O1", "-g", "-Wall", "-Wextra", "-Werror", "-fsanitize=address,undefined", "-fno-sanitize-recover=all"}
 	if ext == ".cpp" {
 		args = append(args, "-std=c++17")
 	} else {
 		args = append(args, "-std=c99")
-	}
-	if os.Getenv("SCHEMA_TEST_SANITIZE") == "1" {
-		args = append(args, "-fsanitize=address,undefined", "-fno-sanitize-recover=all")
 	}
 	args = append(args, path, "-o", bin)
 	if out, err := exec.Command(compiler, args...).CombinedOutput(); err != nil {
@@ -266,9 +270,9 @@ int main(void) {
     p[n-1]=0;
     if(!schema_interior_null%s(p,n)) return 12;
     p[n-1]='a';
-    p[n-2]=0xf0;
+    p[n-1]=0xf0;
     if(schema_utf8_valid%s(p,n)) return 13;
-    p[n-2]='a';
+    p[n-1]='a';
     p[n-4]=0xf0;p[n-3]=0x90;p[n-2]=0x80;p[n-1]=0x80;
     if(!schema_utf8_valid%s(p,n)) return 14;
     free(p);
@@ -281,13 +285,15 @@ int main(void) {
 }
 
 func TestIssue710ListRefusal(t *testing.T) {
-	u := unitFromSource(t, "package p\ntable Lists { items []int32\n after int32 }\ntable Nested { child Lists\n after int32 }\n")
+	u := unitFromSource(t, "package p\ntable Lists { items []int32\n after int32 }\ntable Nested { child Lists\n after int32 }\nenum Key { First }\ntable KeyedLists { items [Key]Lists\n after int32 }\n")
 	m := tabletext.NewModel(u)
-	ids := []uint64{ir.TableWireId("items"), ir.TableWireId("after"), ir.TableWireId("child")}
+	ids := []uint64{ir.TableWireId("items"), ir.TableWireId("after"), ir.TableWireId("child"), ir.TableWireId(u.Enums["Key"].VariantWireName(0))}
 	// count 2^31, followed by a sibling that must never decode.
 	body := []byte{1, 14, 6, byte(ir.TableKindI32), 0x80, 0x80, 0x80, 0x80, 8, 2, byte(ir.TableKindI32), 42, 0, 0, 0}
 	nested := append([]byte{3, 13, byte(len(body) + 1)}, body...)
 	nested = append(nested, 0, 2, byte(ir.TableKindI32), 42, 0, 0, 0)
+	keyed := append([]byte{1, byte(ir.TableKindKeyed), byte(len(body) + 5), 13, 1, 4, byte(len(body) + 1)}, body...)
+	keyed = append(keyed, 0, 2, byte(ir.TableKindI32), 42, 0, 0, 0)
 	dir := t.TempDir()
 	files, err := New().Generate(u, "cpp", Options{})
 	if err != nil {
@@ -303,7 +309,7 @@ func TestIssue710ListRefusal(t *testing.T) {
 	for _, tc := range []struct {
 		root string
 		body []byte
-	}{{"Lists", body}, {"Nested", nested}} {
+	}{{"Lists", body}, {"Nested", nested}, {"KeyedLists", keyed}} {
 		wire := issue710Wire(tc.body, ids...)
 		v := m.New(u.Tables[tc.root])
 		var r tabletext.Report

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -1,0 +1,321 @@
+package compiler
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
+	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func TestIssue710DirectoryList(t *testing.T) {
+	u := unitFromSource(t, "package p\ntable Root { items []int32 }\n")
+	c := New()
+	expanded, flat := t.TempDir(), t.TempDir()
+	if err := os.Mkdir(filepath.Join(expanded, "items"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for i, value := range []string{"3", "7", "11"} {
+		if err := os.WriteFile(filepath.Join(expanded, "items", fmt.Sprintf("%02d.json", i)), []byte(value), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(flat, "Root.json"), []byte(`{"items":[3,7,11]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	want, _, r, err := c.Pack(u, "Root", flat)
+	if err != nil || !r.Silent() {
+		t.Fatalf("flat: %+v %v", r, err)
+	}
+	_, _, _, err = c.Pack(u, "Root", expanded)
+	if err == nil || !strings.Contains(err.Error(), "VARIABLE-LENGTH") {
+		t.Fatalf("directory list must refuse before reading elements: %v", err)
+	}
+	m := tabletext.NewModel(u)
+	v := m.New(u.Tables["Root"])
+	var decoded tabletext.Report
+	if ok, err := tablewire.Decode(m, v, want, &decoded); !ok || err != nil || !decoded.Silent() || v.Fields[0].Count != 3 {
+		t.Fatalf("JSON list round trip: %+v %v", decoded, err)
+	}
+}
+
+func TestIssue710UnpackPaths(t *testing.T) {
+	c := New()
+	for _, key := range []string{"../escape", "..", "a/b", `a\b`, "C:drive", "a\x00b"} {
+		t.Run(fmt.Sprintf("%q", key), func(t *testing.T) {
+			u := unitFromSource(t, "package p\ntable Root { x int32 | json = \""+key+"\" }\n")
+			m := tabletext.NewModel(u)
+			wire, err := tablewire.Encode(m, m.New(u.Tables["Root"]))
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(t.TempDir(), "out")
+			if _, err := c.Unpack(u, "Root", wire, dir); err == nil {
+				t.Fatalf("accepted unsafe tree key %q", key)
+			}
+			if _, err := c.UnpackOneFile(u, "Root", wire, dir); err != nil {
+				t.Fatalf("one-file key %q: %v", key, err)
+			}
+			if _, _, _, err := c.Pack(u, "Root", dir); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	u := unitFromSource(t, "package p\ntable Root { x int32 }\n")
+	m := tabletext.NewModel(u)
+	wire, err := tablewire.Encode(m, m.New(u.Tables["Root"]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "out")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "original")
+	if err := os.WriteFile(outside, []byte("unchanged"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "x.json")); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if _, err := c.Unpack(u, "Root", wire, dir); err == nil {
+		t.Fatal("followed outside symlink")
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil || string(got) != "unchanged" {
+		t.Fatalf("outside changed: %q %v", got, err)
+	}
+}
+
+// Small, explicit file-form fixtures test the recovery contract, with a sibling
+// after the damaged field so resetting the value cannot hide a stopped parent.
+func issue710Wire(body []byte, ids ...uint64) []byte {
+	wire := append([]byte{ir.TableWireForm}, body...)
+	wire = append(wire, 0)
+	for _, id := range ids {
+		wire = binary.LittleEndian.AppendUint64(wire, id)
+	}
+	return binary.LittleEndian.AppendUint64(wire, uint64(len(ids)))
+}
+
+func TestIssue710TableRecovery(t *testing.T) {
+	src := `package p
+ table Text { label string(32) = "untitled"; after int32 }
+ table Element { value int32 = 7 }
+ table Rows { items [..2]Element; after int32 }
+ table Mapping { items map[uint32]Element; after int32 }
+ `
+	// The grammar terminates fields by newlines rather than semicolons.
+	u := unitFromSource(t, strings.ReplaceAll(src, "; ", "\n"))
+	m := tabletext.NewModel(u)
+	fieldID := func(root string, i int) uint64 { return ir.TableFieldWireId(u.Tables[root].Fields[i]) }
+	after := []byte{2, byte(ir.TableKindI32), 42, 0, 0, 0}
+	var cases = []struct {
+		name, root string
+		wire       []byte
+		check      func(*tabletext.Instance) bool
+		cpp        string
+	}{
+		{"default", "Text", issue710Wire(append([]byte{1, 12, 2, 'x', 0}, after...), fieldID("Text", 0), fieldID("Text", 1)), func(v *tabletext.Instance) bool {
+			return string(v.Fields[0].Cell.Str) == "untitled" && v.Fields[0].Count == 8
+		}, `Text v; TableReport r; if (!TextLoad(v, wire, sizeof(wire), &r) || !r.malformed || v.after!=42 || v.label_length!=8 || strcmp(v.label,"untitled")!=0) return 1;`},
+		{"array", "Rows", issue710Wire(append([]byte{1, 14, 11, 13, 1, 8, 3, byte(ir.TableKindI32), 99, 0, 0, 0, 0, 0}, after...), fieldID("Rows", 0), fieldID("Rows", 1), fieldID("Element", 0)), func(v *tabletext.Instance) bool {
+			return v.Fields[0].Count == 1 && v.Fields[0].Elems[0].Tab.Fields[0].Cell.I == 7
+		}, `Rows v; TableReport r; if (!RowsLoad(v, wire, sizeof(wire), &r) || !r.malformed || v.after!=42 || v.items_count!=1 || v.items[0].value!=7) return 2;`},
+		{"map", "Mapping", issue710Wire(append([]byte{1, 14, 11, 13, 1, 8, 3, byte(ir.TableKindU32), 1, 0, 0, 0, 0, 0}, after...), fieldID("Mapping", 0), fieldID("Mapping", 1), ir.MapKeyWireId), func(v *tabletext.Instance) bool { return len(v.Fields[0].Entries) == 0 }, `MappingBuilder b; TableReport r; const bool ok=MappingLoadBuilder(b,wire,sizeof(wire),&r); const Mapping * v=b.GetRoot(); const bool pass=ok && r.malformed && v && v->after==42 && v->items.count==0; if(!pass) return 3;`},
+	}
+	c := New()
+	files, err := c.Generate(u, "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var cpp strings.Builder
+	cpp.WriteString("#include <cstring>\n#include \"ProbeTable.h\"\nusing namespace p;\nint main(){\n")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := m.New(u.Tables[tc.root])
+			var r tabletext.Report
+			ok, err := tablewire.Decode(m, v, tc.wire, &r)
+			if !ok || err != nil || !r.Malformed || r.KindMismatch != 0 || v.Fields[1].Cell.I != 42 || !tc.check(v) {
+				t.Fatalf("decode: ok=%v err=%v report=%+v value=%+v", ok, err, r, v.Fields)
+			}
+		})
+		cpp.WriteString("{const uint8_t wire[]={")
+		for _, b := range tc.wire {
+			fmt.Fprintf(&cpp, "%d,", b)
+		}
+		cpp.WriteString("};\n" + tc.cpp + "\n}\n")
+	}
+	cpp.WriteString("return 0;}\n")
+	issue710CompileRun(t, dir, "c++", ".cpp", cpp.String())
+}
+
+func issue710CompileRun(t *testing.T, dir, compiler, ext, source string) {
+	t.Helper()
+	if _, err := exec.LookPath(compiler); err != nil {
+		t.Skipf("%s unavailable: %v", compiler, err)
+	}
+	path := filepath.Join(dir, "test"+ext)
+	bin := filepath.Join(dir, "test")
+	if err := os.WriteFile(path, []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"-O1", "-g", "-Wall", "-Wextra", "-Werror"}
+	if ext == ".cpp" {
+		args = append(args, "-std=c++17")
+	} else {
+		args = append(args, "-std=c99")
+	}
+	if os.Getenv("SCHEMA_TEST_SANITIZE") == "1" {
+		args = append(args, "-fsanitize=address,undefined", "-fno-sanitize-recover=all")
+	}
+	args = append(args, path, "-o", bin)
+	if out, err := exec.Command(compiler, args...).CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, out)
+	}
+	if out, err := exec.Command(bin).CombinedOutput(); err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+}
+
+// Run the emitted helpers at the actual signed length limit. The single 2 GiB
+// allocation is reused for both scans, freed before the next language runs,
+// and omitted by go test -short. No packet or consumer process is involved.
+func TestIssue710PacketStringBounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("INT32_MAX string helper boundary requires a 2 GiB allocation")
+	}
+	u := unitFromSource(t, "package p\ntype Text { label string(8) }\n")
+	c := New()
+	for _, lang := range []string{"c", "cpp"} {
+		t.Run(lang, func(t *testing.T) {
+			files, err := c.Generate(u, lang, Options{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var source string
+			for _, data := range files {
+				if strings.Contains(string(data), "schema_utf8_valid") {
+					source = string(data)
+					break
+				}
+			}
+			suffix, compiler, ext := "", "c++", ".cpp"
+			if lang == "c" {
+				suffix = "_"
+				compiler = "cc"
+				ext = ".c"
+			}
+			extract := func(name string) string {
+				at := strings.Index(source, name+"(")
+				if at < 0 {
+					at = strings.Index(source, name+" (")
+				}
+				if at < 0 {
+					t.Fatalf("missing %s", name)
+				}
+				begin := strings.LastIndex(source[:at], "\n") + 1
+				open := at + strings.Index(source[at:], "{")
+				depth := 1
+				end := open + 1
+				for ; end < len(source) && depth > 0; end++ {
+					if source[end] == '{' {
+						depth++
+					}
+					if source[end] == '}' {
+						depth--
+					}
+				}
+				if depth != 0 {
+					t.Fatal("unclosed helper")
+				}
+				return source[begin:end] + "\n"
+			}
+			program := `#include <stdint.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#define SCHEMA_UNUSED
+#define SCHEMA_READ_INLINE inline
+#define SCHEMA_C_READ_INLINE inline
+typedef uint8_t serialize_uint8_t;
+typedef uint32_t serialize_uint32_t;
+typedef uint64_t serialize_uint64_t;
+` + extract("schema_utf8_valid"+suffix) + extract("schema_interior_null"+suffix) + fmt.Sprintf(`
+int main(void) {
+    const int32_t n=INT32_MAX;
+    uint8_t *p=(uint8_t *)malloc((size_t)n);
+    if(!p) {fprintf(stderr,"INT32_MAX test allocation failed\n");return 10;}
+    memset(p, 'a', (size_t)n);
+    if(schema_interior_null%s(p,n)) return 11;
+    p[n-1]=0;
+    if(!schema_interior_null%s(p,n)) return 12;
+    p[n-1]='a';
+    p[n-2]=0xf0;
+    if(schema_utf8_valid%s(p,n)) return 13;
+    p[n-2]='a';
+    p[n-4]=0xf0;p[n-3]=0x90;p[n-2]=0x80;p[n-1]=0x80;
+    if(!schema_utf8_valid%s(p,n)) return 14;
+    free(p);
+    return 0;
+}
+`, suffix, suffix, suffix, suffix)
+			issue710CompileRun(t, t.TempDir(), compiler, ext, program)
+		})
+	}
+}
+
+func TestIssue710ListRefusal(t *testing.T) {
+	u := unitFromSource(t, "package p\ntable Lists { items []int32\n after int32 }\ntable Nested { child Lists\n after int32 }\n")
+	m := tabletext.NewModel(u)
+	ids := []uint64{ir.TableWireId("items"), ir.TableWireId("after"), ir.TableWireId("child")}
+	// count 2^31, followed by a sibling that must never decode.
+	body := []byte{1, 14, 6, byte(ir.TableKindI32), 0x80, 0x80, 0x80, 0x80, 8, 2, byte(ir.TableKindI32), 42, 0, 0, 0}
+	nested := append([]byte{3, 13, byte(len(body) + 1)}, body...)
+	nested = append(nested, 0, 2, byte(ir.TableKindI32), 42, 0, 0, 0)
+	dir := t.TempDir()
+	files, err := New().Generate(u, "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var cpp strings.Builder
+	cpp.WriteString("#include \"ProbeTable.h\"\nusing namespace p;\nint main(){\n")
+	for _, tc := range []struct {
+		root string
+		body []byte
+	}{{"Lists", body}, {"Nested", nested}} {
+		wire := issue710Wire(tc.body, ids...)
+		v := m.New(u.Tables[tc.root])
+		var r tabletext.Report
+		ok, err := tablewire.Decode(m, v, wire, &r)
+		if ok || !tablewire.Refused(err) || r.Malformed || r.Unknown != 0 || r.KindMismatch != 0 || v.Fields[1].Cell.I != 0 {
+			t.Fatalf("%s refusal: ok=%v err=%v report=%+v", tc.root, ok, err, r)
+		}
+		cpp.WriteString("{const uint8_t wire[]={")
+		for _, b := range wire {
+			fmt.Fprintf(&cpp, "%d,", b)
+		}
+		fmt.Fprintf(&cpp, "}; %sBuilder b; TableReport r; if(%sLoadBuilder(b,wire,sizeof(wire),&r) || r.malformed || r.unknown || r.kind_mismatch || b.GetRoot()->after!=0) return 1; TableRefuseReason reason; if(%sLoadMeasure(wire,sizeof(wire),NULL,&reason)!=-1 || reason!=count_over_extent_cap) return 2; }\n", tc.root, tc.root, tc.root)
+	}
+	cpp.WriteString("return 0;}\n")
+	issue710CompileRun(t, dir, "c++", ".cpp", cpp.String())
+}

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -333,3 +333,31 @@ func TestIssue710ListRefusal(t *testing.T) {
 	cpp.WriteString("return 0;}\n")
 	issue710CompileRun(t, dir, "c++", ".cpp", cpp.String())
 }
+
+func TestIssue710CTableBounds(t *testing.T) {
+	u := unitFromSource(t, "package p\ntable Root { value int32 }\n")
+	files, err := New().Generate(u, "c", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := `#include "ProbeTable.h"
+int main(void) {
+    TableReader r=table_reader_make(NULL,INT64_MAX,NULL);
+    r.offset=INT64_MAX-3;
+    if(table_reader_has(&r,8) || table_reader_has(&r,-1)) return 1;
+    if(!table_reader_has(&r,3)) return 2;
+    r.offset=INT64_MAX;
+    if(!table_reader_has(&r,0) || table_reader_has(&r,1)) return 3;
+    r.offset=-1;
+    if(table_reader_has(&r,1)) return 4;
+    return 0;
+}
+`
+	issue710CompileRun(t, dir, "cc", ".c", source)
+}

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -307,8 +308,21 @@ func TestIssue710ListRefusal(t *testing.T) {
 		v := m.New(u.Tables[tc.root])
 		var r tabletext.Report
 		ok, err := tablewire.Decode(m, v, wire, &r)
-		if ok || !tablewire.Refused(err) || r.Malformed || r.Unknown != 0 || r.KindMismatch != 0 || v.Fields[1].Cell.I != 0 {
+		_, countRefused := errors.AsType[*tablewire.CountRefusal](err)
+		if ok || !countRefused || r.Malformed || r.Unknown != 0 || r.KindMismatch != 0 || v.Fields[1].Cell.I != 0 {
 			t.Fatalf("%s refusal: ok=%v err=%v report=%+v", tc.root, ok, err, r)
+		}
+		// Count refusal is distinct from a pre-decode form refusal: public
+		// tools must return it as an error, not report a successful empty read.
+		if _, err := New().ReadReport(u, tc.root, wire); err == nil {
+			t.Fatal("ReadReport hid the storage-cap refusal")
+		}
+		out := filepath.Join(t.TempDir(), "not-written")
+		if _, err := New().Unpack(u, tc.root, wire, out); err == nil {
+			t.Fatal("Unpack hid the storage-cap refusal")
+		}
+		if _, err := os.Stat(out); !os.IsNotExist(err) {
+			t.Fatalf("refused unpack touched the output directory: %v", err)
 		}
 		cpp.WriteString("{const uint8_t wire[]={")
 		for _, b := range wire {

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3177,12 +3177,15 @@ one document rather than two.
   the array.
 
   **A BODY'S TERMINATOR IS THE END OF ITS PAYLOAD**, and that holds for a
-  kind `13` field and for an arm whose payload is a body alike. The zero
+  kind `13` field, an array element, a map entry and an arm whose payload is a body alike. The zero
   reference is the last byte of the payload's `L`. A terminator that arrives
   earlier leaves bytes inside `L` that no field claims, which is framing
   damage: `malformed` counts, the field reads its declared default and a
   union reads `None`, and the enclosing body continues past the payload by
-  `L`.
+  `L`. An array element takes its own declared defaults. A map checks the
+  entry's terminator during the key scan, before choosing a slot: malformed
+  entry framing stops the map with its earlier ascending prefix intact, and
+  the parent continues past the map's `L`.
 
   **AN ARM HEADER IS A FIELD HEADER**: the arm id reference, the arm's KIND
   byte, `L`, then `L` bytes of arm payload. One framing serves a field and an
@@ -12730,6 +12733,12 @@ The tree MIRRORS the root table's shape, and nothing else:
 - a **byte buffer** (§2.5) is inline base64 in that file, as §16.2 spells it;
   a blob held in the tree as a file of its own, named by a relative path, is
   the include named in §15.
+
+The expanded output requires every field key to be one portable path
+component: no `.` or `..`, separators, drive colon, control characters, or
+trailing dot or space. A key that cannot name such a component remains valid
+in JSON; use `unpack --one-file` for it. Filesystem writes and pruning are
+confined to the selected output directory, including through existing symlinks.
 
 Each file's content is read under §16's rules, so everything about kinds,
 presence, numbers, clamping and the report is that section's and is not

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -12734,9 +12734,11 @@ The tree MIRRORS the root table's shape, and nothing else:
   a blob held in the tree as a file of its own, named by a relative path, is
   the include named in §15.
 
-The expanded output requires every field key to be one portable path
+The expanded output requires every field key to be one safe local path
 component: no `.` or `..`, separators, drive colon, control characters, or
-trailing dot or space. A key that cannot name such a component remains valid
+trailing dot or space. Platform-specific filename rules also apply; this does
+not promise that a tree written on one OS can be used on every other OS.
+A key that cannot name such a component remains valid
 in JSON; use `unpack --one-file` for it. Filesystem writes and pruning are
 confined to the selected output directory, including through existing symlinks.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1396,7 +1396,13 @@ All compile errors with positions:
   constant arithmetic is overflow-guarded, division by zero is refused — and
   an integer constant too large for float64 is an error in ANY float position
   rather than a silent infinity; the checker still carries the NaN arm as
-  defense in depth.
+  defense in depth. The derived float32 subtraction and division must also
+  remain positive and at most `4294967040`, the runtime's upper clamp; a
+  triple that overflows or requires that clamp is refused. Fractional counts
+  below one legitimately encode one step. Codec widths use
+  `ir.CompressedFloatParams`' float32 arithmetic. The projection's `steps`
+  token retains its historical float64 formula, alongside all three original
+  parameters, to preserve existing protocol IDs; it is not the codec width.
 - **Degenerate ranges: min == max is legal and costs zero bits.** A ranged
   integer, `int128`, `fixed` or `ufixed` field with equal bounds carries
   nothing on the wire; the reader recovers the value from the range alone

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1267,7 +1267,7 @@ int main()
     ship.cargo[1] = 22;
     ship.cargo[2] = 33;
 
-    uint8_t buffer[ShipStateMaxBytes];
+    uint8_t buffer[ShipStateMaxBytes + 8]; // reader allocation includes eight bytes of slack
     serialize::WriteStream writer( buffer, sizeof( buffer ) );
     WriteShipState( writer, ship );
     writer.Flush();
@@ -1673,7 +1673,7 @@ int main()
     strcpy( second.chat.text, "on my way" );
     second.chat.text_length = 9;
 
-    uint8_t buffer[PacketMaxBytes];
+    uint8_t buffer[PacketMaxBytes + 8]; // pass the true packet length to the reader
     serialize::WriteStream w( buffer, sizeof( buffer ) );
     WritePacket( w, packet );
     w.Flush();

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -90,7 +90,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -134,7 +134,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -91,7 +91,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -135,7 +135,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -296,7 +296,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -5061,6 +5061,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             TableEntityLoadBody( elem, value.entities[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; TableEntityReset( value.entities[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -5114,6 +5115,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             TableStatLoadBody( elem, value.stats[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; TableStatReset( value.stats[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -5266,7 +5268,13 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.player_name[0] = 0; value.player_name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.player_name, 0, sizeof( value.player_name ) );
+    value.player_name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 15 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 15 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.player_name, r.buffer + r.offset, (size_t) keep );

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -5271,8 +5271,8 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.player_name, 0, sizeof( value.player_name ) );
-    value.player_name_length = 0;
+                    memset( value.player_name, 0, sizeof( value.player_name ) );
+                    value.player_name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/generated/c/ClausesWire.h
+++ b/generated/c/ClausesWire.h
@@ -90,7 +90,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -134,7 +134,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/generated/c/JoinsWire.h
+++ b/generated/c/JoinsWire.h
@@ -90,7 +90,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -134,7 +134,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -91,7 +91,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -135,7 +135,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/generated/cpp/ClausesWire.h
+++ b/generated/cpp/ClausesWire.h
@@ -91,7 +91,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -135,7 +135,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/generated/cpp/JoinsWire.h
+++ b/generated/cpp/JoinsWire.h
@@ -92,7 +92,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -136,7 +136,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -92,7 +92,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -136,7 +136,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1760,6 +1760,10 @@ func (c *checker) resolveDefault(f *ast.Field, out *ir.Field) {
 				c.errf(lit.Pos, "field %s: default %q is not valid UTF-8, which is what a string(N) holds (SPEC §4.2, §4.7)", f.Name, lit.Value)
 				return
 			}
+			if out.Type.Kind == ir.TString && strings.IndexByte(lit.Value, 0) >= 0 {
+				c.errf(lit.Pos, "field %s: a string(N) default cannot contain a zero byte (SPEC §4.7)", f.Name)
+				return
+			}
 			out.HasDefault = true
 			out.DefBytes = []byte(lit.Value)
 		case ir.TWString:
@@ -1803,6 +1807,10 @@ func (c *checker) resolveDefault(f *ast.Field, out *ir.Field) {
 	case ir.TFloat32, ir.TFloat64:
 		v, ok := c.evalFloat(f.Default)
 		if !ok {
+			return
+		}
+		if out.Type.Kind == ir.TFloat32 && (math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > math.MaxFloat32) {
+			c.errf(f.Default.ExprPos(), "field %s: default %g does not fit finite float32 storage", f.Name, v)
 			return
 		}
 		if out.HasFloatRange && (v < out.FMin || v > out.FMax) {
@@ -1998,8 +2006,16 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 				f.Name, fmax, fmin, res)
 			return
 		}
+		if !ir.ValidCompressedFloatParams(fmin, fmax, res) {
+			c.errf(byKey["resolution"].Pos, "field %s: compressed-float step derivation overflows or requires the upper clamp at float32 (SPEC §4.3)", f.Name)
+			return
+		}
 		out.HasFloatRange = true
 		out.FMin, out.FMax, out.Resolution = fmin, fmax, res
+		// Steps is a frozen projection token computed from the source triple.
+		// The projection also includes every triple parameter, so this is
+		// not the codec's width or a source of false protocol matches.
+		// Runtime widths come only from ir.CompressedFloatParams.
 		out.Steps = int64(steps)
 		// `nearest` is a FROZEN projection token: every compressed-float
 		// line renders `round=nearest`, and keeping the assignment keeps

--- a/internal/check/issue710_test.go
+++ b/internal/check/issue710_test.go
@@ -1,0 +1,33 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIssue710DefaultsAndFloatDerivation(t *testing.T) {
+	for _, tc := range []struct{ field, want string }{
+		{"text string(8) = \"a\x00b\"", "zero byte"},
+		{"x float32 = 1e39", "finite float32"},
+		{"x float32 = -1e39", "finite float32"},
+		{"x float32 | min = -3e38, max = 3e38, resolution = 1e38", "step derivation"},
+		{"x float32 | min = 0, max = 4294967200, resolution = 1", "step derivation"},
+	} {
+		t.Run(tc.want+tc.field[:1], func(t *testing.T) {
+			errs := runUnit(t, map[string]string{"T.schema": "package p\ntype T { " + tc.field + " }\n"})
+			if !strings.Contains(fmt.Sprint(errs), tc.want) {
+				t.Fatalf("got %v, want %q", errs, tc.want)
+			}
+		})
+	}
+	for _, field := range []string{
+		"text bytes(8) = \"a\x00b\"", "x float32 = 3.4028234663852886e38", "x float64 = 1e39",
+		"x float32 | min = 0, max = 1, resolution = 2",
+		"x float32 | min = 0, max = 16777217, resolution = 1",
+	} {
+		if errs := runUnit(t, map[string]string{"T.schema": "package p\ntype T { " + field + " }\n"}); len(errs) != 0 {
+			t.Fatalf("valid %s: %v", field, errs)
+		}
+	}
+}

--- a/internal/codegen/c/nullscan.go
+++ b/internal/codegen/c/nullscan.go
@@ -29,7 +29,7 @@ func (g *gen) emitInteriorNullScan() {
 	g.pf("    serialize_uint64_t word;\n")
 	g.pf("    int32_t i = 0;\n")
 	g.pf("    if ( length >= 8 )\n    {\n")
-	g.pf("        for ( ; i + 8 <= length; i += 8 )\n        {\n")
+	g.pf("        for ( ; i <= length - 8; i += 8 )\n        {\n")
 	g.pf("            memcpy( &word, bytes + i, 8 );\n")
 	g.pf("            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )\n")
 	g.pf("            {\n                return 1;\n            }\n        }\n")

--- a/internal/codegen/c/utf8.go
+++ b/internal/codegen/c/utf8.go
@@ -41,7 +41,7 @@ func (g *gen) emitUtf8Validator() {
 	g.pf("        else if ( ( lead & 0xF0 ) == 0xE0 )\n        {\n            continuations = 2;\n            code_point = lead & 0x0F;\n        }\n")
 	g.pf("        else if ( ( lead & 0xF8 ) == 0xF0 )\n        {\n            continuations = 3;\n            code_point = lead & 0x07;\n        }\n")
 	g.pf("        else\n        {\n            return 0;\n        }\n")
-	g.pf("        if ( i + continuations >= length )\n        {\n            return 0;\n        }\n")
+	g.pf("        if ( continuations >= length - i )\n        {\n            return 0;\n        }\n")
 	g.pf("        for ( k = 1; k <= continuations; k++ )\n        {\n")
 	g.pf("            if ( ( bytes[i + k] & 0xC0 ) != 0x80 )\n            {\n                return 0;\n            }\n")
 	g.pf("            code_point = ( code_point << 6 ) | (serialize_uint32_t) ( bytes[i + k] & 0x3F );\n        }\n")

--- a/internal/codegen/cpp/nullscan.go
+++ b/internal/codegen/cpp/nullscan.go
@@ -31,7 +31,7 @@ func (g *gen) emitInteriorNullScan() {
 	g.pf("    uint64_t word;\n")
 	g.pf("    int32_t i = 0;\n")
 	g.pf("    if ( length >= 8 )\n    {\n")
-	g.pf("        for ( ; i + 8 <= length; i += 8 )\n        {\n")
+	g.pf("        for ( ; i <= length - 8; i += 8 )\n        {\n")
 	g.pf("            memcpy( &word, bytes + i, 8 );\n")
 	g.pf("            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )\n")
 	g.pf("            {\n                return true;\n            }\n        }\n")

--- a/internal/codegen/cpp/utf8.go
+++ b/internal/codegen/cpp/utf8.go
@@ -52,7 +52,7 @@ func (g *gen) emitUtf8Validator() {
 	g.pf("        else if ( ( lead & 0xF0 ) == 0xE0 )\n        {\n            continuations = 2;\n            code_point = lead & 0x0F;\n        }\n")
 	g.pf("        else if ( ( lead & 0xF8 ) == 0xF0 )\n        {\n            continuations = 3;\n            code_point = lead & 0x07;\n        }\n")
 	g.pf("        else\n        {\n            return false;\n        }\n")
-	g.pf("        if ( i + continuations >= length )\n        {\n            return false;\n        }\n")
+	g.pf("        if ( continuations >= length - i )\n        {\n            return false;\n        }\n")
 	g.pf("        for ( int32_t k = 1; k <= continuations; k++ )\n        {\n")
 	g.pf("            if ( ( bytes[i + k] & 0xC0 ) != 0x80 )\n            {\n                return false;\n            }\n")
 	g.pf("            code_point = ( code_point << 6 ) | uint32_t( bytes[i + k] & 0x3F );\n        }\n")

--- a/internal/codegen/cpptable/arms.go
+++ b/internal/codegen/cpptable/arms.go
@@ -276,6 +276,7 @@ func (g *tableGen) emitArmLoad(v ir.UnionVariant, base, ind, rdr, tag, none, sfx
 	switch {
 	case v.Body():
 		g.pf("%s%s;\n", ind, g.loadCall(g.unionField, v.Type, rdr, value))
+		g.emitLoadRefusal(v.Type, ind)
 		// A BODY'S TERMINATOR IS THE END OF ITS PAYLOAD (§3): an arm whose
 		// terminator is not the last byte of its `L` is framing damage — the
 		// payload stops, the union reads None, and the enclosing body

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -1535,6 +1535,7 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	// bomb on worker threads — while a whole-object value-init costs cl
 	// O(bytes) to COMPILE (#320). Reset applies the same declared defaults in
 	// place, with neither cost.
+	g.emitLoadRefusal(st.Name, "    ")
 	g.pf("    %sReset( value ); // prefill declared defaults in place, then overlay\n", st.Name)
 	if g.retain {
 		g.pf("    // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT\n")
@@ -1822,7 +1823,10 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%suint64_t len = 0;\n", ind)
 		g.pf("%sif ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s// ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared\n%s// default, one malformed counts, and the parent reads on past L\n", ind, ind)
-		g.pf("%sif ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.%s[0] = 0; value.%s_length = 0; r.offset += (int64_t) len; break; }\n", ind, f.Name, f.Name)
+		g.pf("%sif ( !TableUtf8Valid( r.buffer + r.offset, len ) )\n%s{\n", ind, ind)
+		g.pf("%s    r.report->malformed = true;\n", ind)
+		g.emitTableResetField(f)
+		g.pf("%s    r.offset += (int64_t) len; break;\n%s}\n", ind, ind)
 		g.pf("%suint64_t keep = len;\n", ind)
 		g.pf("%sif ( keep > %d ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, %d ); r.report->clamped++; } // at a code point boundary (§3)\n", ind, f.Type.Size, f.Type.Size)
 		g.pf("%smemcpy( value.%s, r.buffer + r.offset, (size_t) keep );\n", ind, f.Name)
@@ -1955,6 +1959,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%sif ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );\n", ind, ind)
 		g.pf("%s    %s;\n", ind, g.loadCall(f, f.Type.Name, "sub", "value."+f.Name))
+		g.emitLoadRefusal(f.Type.Name, ind+"    ")
 		// A BODY'S TERMINATOR IS THE END OF ITS PAYLOAD (§3): a body whose
 		// terminator is not the last byte of its `L` is framing damage —
 		// the payload stops, the field reads its declared defaults, and the
@@ -2035,6 +2040,8 @@ func (g *tableGen) emitTableReadElementInto(f *ir.Field, kind int, dst, ind, rdr
 		g.pf("%sif ( !%s.getleb( elem_len%s ) || !%s.room( elem_len%s ) ) { r.report->malformed = true; break; }\n", ind, rdr, sfx, rdr, sfx)
 		g.pf("%s{\n%s    TableReader elem%s( %s.buffer + %s.offset, (int64_t) elem_len%s, r.report, r.ids );\n", ind, ind, sfx, rdr, rdr, sfx)
 		g.pf("%s    %s;\n", ind, g.loadCall(f, f.Type.Name, "elem"+sfx, dst))
+		g.emitLoadRefusal(f.Type.Name, ind+"    ")
+		g.pf("%s    if ( elem%s.offset != elem%s.size ) { r.report->malformed = true; %sReset( %s ); }\n", ind, sfx, sfx, f.Type.Name, dst)
 		g.pf("%s}\n", ind)
 		g.pf("%s%s.offset += (int64_t) elem_len%s;\n", ind, rdr, sfx)
 	case tkEnum:

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -1825,7 +1825,10 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s// ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared\n%s// default, one malformed counts, and the parent reads on past L\n", ind, ind)
 		g.pf("%sif ( !TableUtf8Valid( r.buffer + r.offset, len ) )\n%s{\n", ind, ind)
 		g.pf("%s    r.report->malformed = true;\n", ind)
+		savedIndent := g.indent
+		g.indent += ind
 		g.emitTableResetField(f)
+		g.indent = savedIndent
 		g.pf("%s    r.offset += (int64_t) len; break;\n%s}\n", ind, ind)
 		g.pf("%suint64_t keep = len;\n", ind)
 		g.pf("%sif ( keep > %d ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, %d ); r.report->clamped++; } // at a code point boundary (§3)\n", ind, f.Type.Size, f.Type.Size)

--- a/internal/codegen/cpptable/maps.go
+++ b/internal/codegen/cpptable/maps.go
@@ -1132,7 +1132,7 @@ func (g *tableGen) emitMapKeyReader(f *ir.Field) {
 	g.pf("    for ( ;; )\n    {\n")
 	g.pf("        uint64_t field_ref = 0;\n")
 	g.pf("        if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }\n")
-	g.pf("        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT\n")
+	g.pf("        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L\n")
 	g.pf("        if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }\n")
 	g.pf("        const uint64_t field_id = ids->at( field_ref );\n")
 	g.pf("        if ( !r.has( 1 ) ) { out.malformed = true; return out; }\n")
@@ -1266,6 +1266,7 @@ func (g *tableGen) emitMapReadField(f *ir.Field) {
 	g.pf("%s            TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );\n", ind)
 	g.inStep("fill.map->count - 1", func() {
 		g.pf("%s            %s;\n", ind, g.loadCall(f, n, "elem", "*slot"))
+		g.emitLoadRefusal(n, ind+"            ")
 	})
 	g.pf("%s        }\n", ind)
 	if mapKeyIsString(f) {

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -76,6 +76,14 @@ func (g *tableGen) loadCall(f *ir.Field, name, reader, expr string) string {
 	return fmt.Sprintf("%sLoadBody( %s, %s )", name, reader, expr)
 }
 
+// emitLoadRefusal stops the containing decode before its framing recovery can
+// turn a nested builder storage refusal into a malformed event.
+func (g *tableGen) emitLoadRefusal(name, ind string) {
+	if g.anyExtent && g.isVar(name) {
+		g.pf("%sif ( nodes.refused ) { return false; }\n", ind)
+	}
+}
+
 // walker returns true when a member needs the pointer-graph walkers: every
 // variable member, plus every table some pointer targets (a pointed-at table
 // may itself be pointer-free, and still needs to be allocated, packed,
@@ -1150,6 +1158,9 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("            if ( directory[k + 1].offset != kTableNodeAbsent )\n            {\n")
 	g.pf("                TableReader sub( body, length, out, &ids_table );\n")
 	g.pf("                %sNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );\n", n)
+	if g.anyExtent {
+		g.pf("                if ( nodes.refused ) { break; }\n")
+	}
 	g.pf("            }\n")
 	g.pf("            k++;\n")
 	g.pf("        }\n    }\n")

--- a/internal/codegen/cpptable/widen.go
+++ b/internal/codegen/cpptable/widen.go
@@ -276,6 +276,7 @@ func (g *tableGen) emitKeyedTriples(f *ir.Field, kind int, ind string, widened b
 		g.inStep("int32_t( slot ) - 1", func() {
 			g.pf("%s            %s;\n", ind, g.loadCall(f, f.Type.Name, "elem", slot))
 			g.emitLoadRefusal(f.Type.Name, ind+"            ")
+			g.pf("%s            if ( elem.offset != elem.size ) { r.report->malformed = true; %sReset( %s ); }\n", ind, f.Type.Name, slot)
 		})
 	case kind == tkEnum:
 		g.emitEnumRefLoad(f, slot, ind+"            ", "elem", onTrunc)

--- a/internal/codegen/cpptable/widen.go
+++ b/internal/codegen/cpptable/widen.go
@@ -275,6 +275,7 @@ func (g *tableGen) emitKeyedTriples(f *ir.Field, kind int, ind string, widened b
 	case kind == tkTable:
 		g.inStep("int32_t( slot ) - 1", func() {
 			g.pf("%s            %s;\n", ind, g.loadCall(f, f.Type.Name, "elem", slot))
+			g.emitLoadRefusal(f.Type.Name, ind+"            ")
 		})
 	case kind == tkEnum:
 		g.emitEnumRefLoad(f, slot, ind+"            ", "elem", onTrunc)

--- a/internal/codegen/ctable/ctable.go
+++ b/internal/codegen/ctable/ctable.go
@@ -516,7 +516,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED ` + forceInline + ` int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED ` + forceInline + ` int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED ` + forceInline + ` uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED ` + forceInline + ` uint16_t table_reader_get16( TableReader * r )
 {

--- a/internal/parser/decimal_test.go
+++ b/internal/parser/decimal_test.go
@@ -1,0 +1,22 @@
+package parser
+
+import (
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"testing"
+)
+
+func TestLeadingZeroIntegersAreDecimal(t *testing.T) {
+	for _, tc := range []struct {
+		text string
+		want int64
+	}{{"08", 8}, {"010", 10}, {"0x10", 16}, {"0b10", 2}} {
+		f, errs := Parse("T.schema", []byte("package p\nconst X = "+tc.text+"\n"))
+		if len(errs) > 0 {
+			t.Fatalf("%s: %v", tc.text, errs)
+		}
+		c := f.Decls[0].(*ast.ConstDecl)
+		if v := c.Expr.(*ast.IntLit).Value.Int64(); v != tc.want {
+			t.Fatalf("%s = %d, want %d", tc.text, v, tc.want)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -974,7 +974,11 @@ func (p *parser) parsePrimary() ast.Expr {
 	case scanner.Int:
 		p.advance()
 		v := new(big.Int)
-		if _, ok := v.SetString(t.Text, 0); !ok {
+		base := 10
+		if strings.HasPrefix(t.Text, "0x") || strings.HasPrefix(t.Text, "0X") || strings.HasPrefix(t.Text, "0b") || strings.HasPrefix(t.Text, "0B") {
+			base = 0
+		}
+		if _, ok := v.SetString(t.Text, base); !ok {
 			p.errf(t.Pos, "malformed integer literal %q", t.Text)
 		}
 		return &ast.IntLit{Pos: t.Pos, Value: v, Text: t.Text}
@@ -987,7 +991,7 @@ func (p *parser) parsePrimary() ast.Expr {
 		return &ast.FloatLit{Pos: t.Pos, Value: v, Text: t.Text}
 	case scanner.String:
 		p.advance()
-		return &ast.StringLit{Pos: t.Pos, Value: strings.Trim(t.Text, `"`)}
+		return &ast.StringLit{Pos: t.Pos, Value: t.Text[1 : len(t.Text)-1]}
 	case scanner.Ident:
 		p.advance()
 		// E.Max / E.Count — contextual after '.' (SPEC §4.2)

--- a/internal/tablecook/bounds.go
+++ b/internal/tablecook/bounds.go
@@ -1,0 +1,17 @@
+package tablecook
+
+// arrayExtent proves containment before adding a relative offset or multiplying
+// a count. All coordinates are nonnegative offsets into one byte slice.
+func arrayExtent(at, delta, count, size, base, extent int64) (start, end int64, ok bool) {
+	if base < 0 || extent < base || at < base || at > extent || count < 0 || size <= 0 {
+		return 0, 0, false
+	}
+	if delta < base-at || delta > extent-at {
+		return 0, 0, false
+	}
+	start = at + delta
+	if count > (extent-start)/size {
+		return 0, 0, false
+	}
+	return start, start + count*size, true
+}

--- a/internal/tablecook/bounds_test.go
+++ b/internal/tablecook/bounds_test.go
@@ -1,0 +1,44 @@
+package tablecook
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func TestArrayExtentArithmetic(t *testing.T) {
+	for _, tc := range []struct {
+		name                                 string
+		at, delta, count, size, base, extent int64
+		fits                                 bool
+	}{
+		{"exact", 16, 16, 4, 8, 0, 64, true},
+		{"backwards inside holder", 32, -16, 2, 8, 8, 64, true},
+		{"past end", 16, 16, 5, 8, 0, 64, false},
+		{"before holder", 32, -32, 1, 8, 8, 64, false},
+		{"offset overflow", 16, math.MaxInt64, 1, 8, 0, 64, false},
+		{"offset underflow", 16, math.MinInt64, 1, 8, 0, 64, false},
+		{"product overflow", 16, 16, math.MaxInt32, 1 << 34, 0, 64, false},
+		{"end overflow", 16, 16, 1, math.MaxInt64, 0, 64, false},
+		{"zero size", 16, 16, 1, 0, 0, 64, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := arrayExtent(tc.at, tc.delta, tc.count, tc.size, tc.base, tc.extent)
+			if ok != tc.fits {
+				t.Fatalf("[%d,%d), fits=%v", start, end, ok)
+			}
+		})
+	}
+}
+
+func TestPlacedArrayRejectsOverflow(t *testing.T) {
+	for _, tc := range []struct{ delta, size int64 }{{math.MaxInt64, 8}, {16, 1 << 34}} {
+		buf := make([]byte, 64)
+		binary.LittleEndian.PutUint64(buf[16:], uint64(tc.delta))
+		binary.LittleEndian.PutUint32(buf[24:], math.MaxInt32)
+		s := &scan{buf: buf, ord: binary.LittleEndian, base: 0, extent: 64}
+		if _, _, err := s.placedArray(16, tc.size, 8, "element", "list"); err == nil {
+			t.Fatal("overflow accepted")
+		}
+	}
+}

--- a/internal/tablecook/check.go
+++ b/internal/tablecook/check.go
@@ -269,7 +269,7 @@ func (s *scan) placedArray(at, size, align int64, what, container string) (start
 	}
 	start, end, fits := arrayExtent(at, delta, count, size, s.base, s.extent)
 	if !fits {
-		return 0, 0, fmt.Errorf("the %s array at %d with delta %d, count %d and size %d leaves the node's extent [%d, %d)", what, at, delta, count, size, s.base, s.extent)
+		return 0, 0, fmt.Errorf("the array leaves the node's extent [%d, %d): %s array at %d with delta %d, count %d and size %d", s.base, s.extent, what, at, delta, count, size)
 	}
 	if start%align != 0 {
 		return 0, 0, fmt.Errorf("the %s array starts at %d, which is not aligned to %d", what, start, align)

--- a/internal/tablecook/check.go
+++ b/internal/tablecook/check.go
@@ -267,10 +267,9 @@ func (s *scan) placedArray(at, size, align int64, what, container string) (start
 	if count == 0 {
 		return 0, 0, fmt.Errorf("the count is 0 and the reference is not null: an empty %s's reference is null in every encoding", container)
 	}
-	start = at + delta
-	end := start + count*size
-	if start < s.base || end > s.extent {
-		return 0, 0, fmt.Errorf("the %s array runs [%d, %d) and its holder's extent is [%d, %d): the array leaves the node", what, start, end, s.base, s.extent)
+	start, end, fits := arrayExtent(at, delta, count, size, s.base, s.extent)
+	if !fits {
+		return 0, 0, fmt.Errorf("the %s array at %d with delta %d, count %d and size %d leaves the node's extent [%d, %d)", what, at, delta, count, size, s.base, s.extent)
 	}
 	if start%align != 0 {
 		return 0, 0, fmt.Errorf("the %s array starts at %d, which is not aligned to %d", what, start, align)

--- a/internal/tablecook/region.go
+++ b/internal/tablecook/region.go
@@ -117,6 +117,9 @@ func Layout(m *tabletext.Model, g *tablewire.NodeGraph) (*Region, error) {
 	offset := int64(0)
 	for _, node := range g.Nodes {
 		if node.Blob != nil {
+			if uint64(len(node.Blob.Data)) > math.MaxUint32 {
+				return nil, fmt.Errorf("blob length %d exceeds the cook uint32 length limit", len(node.Blob.Data))
+			}
 			// a BYTE BUFFER's node: the header and its bytes, at eight (§7.2)
 			offset = alignUp(offset, BlobAlign)
 			n := Node{Offset: offset, Blob: node.Blob, String: node.Kind == ir.TString}

--- a/internal/tablecook/uncook.go
+++ b/internal/tablecook/uncook.go
@@ -181,9 +181,9 @@ func (r *regionReader) list(at int64, f *ir.Field, fv *tabletext.Field) error {
 		return fmt.Errorf("field %s: the count is 0 and the reference is not null: an empty list's reference is null in every encoding", f.Name)
 	}
 	size, _ := ir.ListElementLayout(r.m.Unit, f)
-	start := at + delta
-	if start < 0 || start+count*size > int64(len(r.buf)) {
-		return fmt.Errorf("field %s: the element array runs [%d, %d) and the data part is %d bytes: the array leaves the region", f.Name, start, start+count*size, len(r.buf))
+	start, _, fits := arrayExtent(at, delta, count, size, 0, int64(len(r.buf)))
+	if !fits {
+		return fmt.Errorf("field %s: the element array at %d with delta %d, count %d and size %d leaves the region of %d bytes", f.Name, at, delta, count, size, len(r.buf))
 	}
 	fv.Elems = fv.Elems[:0]
 	for range count {

--- a/internal/tablepack/unpack.go
+++ b/internal/tablepack/unpack.go
@@ -176,7 +176,7 @@ func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, o
 		for _, f := range st.Fields {
 			key := ir.TableFieldJsonKey(f)
 			if !treeComponent(key) {
-				return fmt.Errorf("field %s: JSON key %q is not one portable path component; use --one-file to preserve this key in JSON", f.Name, key)
+				return fmt.Errorf("field %s: JSON key %q is not one safe local path component; use --one-file to preserve this key in JSON", f.Name, key)
 			}
 		}
 	}
@@ -326,7 +326,7 @@ func DescribeAnnouncement(m *tabletext.Model, announcement []byte) (string, tabl
 }
 
 // JSON keys may name arbitrary text. Only the expanded filesystem form needs
-// a portable component; the one-file form keeps the original JSON vocabulary.
+// a safe local component; the one-file form keeps the original JSON vocabulary.
 func treeComponent(key string) bool {
 	return key != "" && key != "." && key != ".." && filepath.IsLocal(key) &&
 		!strings.ContainsAny(key, "/\\:") && strings.IndexFunc(key, unicode.IsControl) < 0 &&

--- a/internal/tablepack/unpack.go
+++ b/internal/tablepack/unpack.go
@@ -187,7 +187,7 @@ func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, o
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }() // only the directory handle; file writes close and report their own errors
 	// what the ROOT's shape owns at this level, whichever shape is written:
 	// every field key, and the root's own name
 	owned := map[string]bool{root: true}
@@ -244,7 +244,7 @@ func unpackKeyed(m *tabletext.Model, fv *tabletext.Field, parent *os.Root, dir s
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }() // only the directory handle; file writes close and report their own errors
 	f := fv.Def
 	written := map[string]bool{}
 	owned := map[string]bool{}

--- a/internal/tablepack/unpack.go
+++ b/internal/tablepack/unpack.go
@@ -5,9 +5,11 @@ package tablepack
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
 	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
@@ -170,9 +172,22 @@ func unpackWith(m *tabletext.Model, root string, wire []byte, dir string, oneFil
 // message writes is the tree a file writes.
 func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, oneFile bool) error {
 	st := inst.Def
+	if !oneFile {
+		for _, f := range st.Fields {
+			key := ir.TableFieldJsonKey(f)
+			if !treeComponent(key) {
+				return fmt.Errorf("field %s: JSON key %q is not one portable path component; use --one-file to preserve this key in JSON", f.Name, key)
+			}
+		}
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
+	out, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
 	// what the ROOT's shape owns at this level, whichever shape is written:
 	// every field key, and the root's own name
 	owned := map[string]bool{root: true}
@@ -185,10 +200,10 @@ func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, o
 			return err
 		}
 		name := root + ".json"
-		if err := os.WriteFile(filepath.Join(dir, name), append(text, '\n'), 0o644); err != nil {
+		if err := out.WriteFile(name, append(text, '\n'), 0o644); err != nil {
 			return err
 		}
-		return prune(dir, owned, map[string]bool{name: true})
+		return prune(out, owned, map[string]bool{name: true})
 	}
 	guards := tabletext.Guards(st)
 	written := map[string]bool{}
@@ -203,7 +218,7 @@ func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, o
 			continue
 		}
 		if f.KeyEnum != "" {
-			if err := unpackKeyed(m, fv, filepath.Join(dir, key)); err != nil {
+			if err := unpackKeyed(m, fv, out, key); err != nil {
 				return err
 			}
 			written[key] = true
@@ -213,18 +228,23 @@ func writeTree(m *tabletext.Model, inst *tabletext.Instance, root, dir string, o
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(dir, key+".json"), append(text, '\n'), 0o644); err != nil {
+		if err := out.WriteFile(key+".json", append(text, '\n'), 0o644); err != nil {
 			return err
 		}
 		written[key+".json"] = true
 	}
-	return prune(dir, owned, written)
+	return prune(out, owned, written)
 }
 
-func unpackKeyed(m *tabletext.Model, fv *tabletext.Field, dir string) error {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+func unpackKeyed(m *tabletext.Model, fv *tabletext.Field, parent *os.Root, dir string) error {
+	if err := parent.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
+	out, err := parent.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
 	f := fv.Def
 	written := map[string]bool{}
 	owned := map[string]bool{}
@@ -238,12 +258,12 @@ func unpackKeyed(m *tabletext.Model, fv *tabletext.Field, dir string) error {
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(dir, name+".json"), append(text, '\n'), 0o644); err != nil {
+		if err := out.WriteFile(name+".json", append(text, '\n'), 0o644); err != nil {
 			return err
 		}
 		written[name+".json"] = true
 	}
-	return prune(dir, owned, written)
+	return prune(out, owned, written)
 }
 
 // prune removes the entries at one level that NAME something this level owns —
@@ -251,8 +271,8 @@ func unpackKeyed(m *tabletext.Model, fv *tabletext.Field, dir string) error {
 // write. Both spellings of a value are pruned, so a stale `<field>/` directory
 // left beside a fresh `<field>.json` cannot become "two entries claim one
 // value" on the next pack. Anything the level does not own is left alone.
-func prune(dir string, owned, written map[string]bool) error {
-	entries, err := os.ReadDir(dir)
+func prune(out *os.Root, owned, written map[string]bool) error {
+	entries, err := fs.ReadDir(out.FS(), ".")
 	if err != nil {
 		return err
 	}
@@ -264,7 +284,7 @@ func prune(dir string, owned, written map[string]bool) error {
 		if !ok || !owned[key] {
 			continue
 		}
-		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+		if err := out.RemoveAll(e.Name()); err != nil {
 			return err
 		}
 	}
@@ -303,4 +323,12 @@ func DescribeAnnouncement(m *tabletext.Model, announcement []byte) (string, tabl
 		fmt.Fprintf(&b, "%4d  %016x  %-24s  kind %-2d  %s\n", i+1, e.Id, name, e.Kind, ir.TableMessageShapeString(e.Kind, e.Shape))
 	}
 	return b.String(), report, nil
+}
+
+// JSON keys may name arbitrary text. Only the expanded filesystem form needs
+// a portable component; the one-file form keeps the original JSON vocabulary.
+func treeComponent(key string) bool {
+	return key != "" && key != "." && key != ".." && filepath.IsLocal(key) &&
+		!strings.ContainsAny(key, "/\\:") && strings.IndexFunc(key, unicode.IsControl) < 0 &&
+		!strings.HasSuffix(key, ".") && !strings.HasSuffix(key, " ")
 }

--- a/internal/tabletext/value.go
+++ b/internal/tabletext/value.go
@@ -302,6 +302,8 @@ func (m *Model) fieldDefault(f *ir.Field) Cell {
 		return Cell{}
 	}
 	switch f.Type.Kind {
+	case ir.TString, ir.TBytes:
+		return Cell{Str: append([]byte(nil), f.DefBytes...)}
 	case ir.TBool:
 		return Cell{B: f.HasDefault && f.DefBool}
 	case ir.TFloat32, ir.TFloat64:

--- a/internal/tablewire/decode.go
+++ b/internal/tablewire/decode.go
@@ -150,6 +150,8 @@ func bodyExtent(body []byte, ids []uint64) (end int, terminated bool) {
 }
 
 type wireReader struct {
+	countRefusal *bool // shared by every nested file reader; not a malformed event
+
 	buf    []byte
 	off    int
 	report *tabletext.Report
@@ -207,7 +209,7 @@ func (r *wireReader) id(ref uint64) (uint64, bool) {
 }
 
 func (r *wireReader) sub(n int) *wireReader {
-	return &wireReader{buf: r.buf[r.off : r.off+n], report: r.report, m: r.m, ids: r.ids, st: r.st, rt: r.rt}
+	return &wireReader{buf: r.buf[r.off : r.off+n], report: r.report, m: r.m, ids: r.ids, st: r.st, rt: r.rt, countRefusal: r.countRefusal}
 }
 
 // subTo spans from the cursor to `end`, the last byte of the body the cursor
@@ -317,6 +319,9 @@ func (r *wireReader) bodyAt(inst *tabletext.Instance, nested bool) bool {
 		index[ir.TableFieldWireId(inst.Fields[i].Def)] = i
 	}
 	for {
+		if r.countRefused() {
+			return false
+		}
 		ref, ok := r.leb()
 		if !ok {
 			r.report.Malformed = true
@@ -528,6 +533,9 @@ func (r *wireReader) field(fv *tabletext.Field) bool {
 			r.m.Refill(fv.Cell.Tab)
 		}
 		sub.bodyAt(fv.Cell.Tab, true)
+		if r.countRefused() {
+			return false
+		}
 		// A BODY'S TERMINATOR IS THE END OF ITS PAYLOAD (§3): a body whose
 		// terminator is not the last byte of its L is framing damage — the
 		// payload stops, the field reads its declared defaults, and the
@@ -673,6 +681,9 @@ func (r *wireReader) mapField(fv *tabletext.Field) bool {
 			whole.off = 0
 			decoded := r.m.NewMapEntry(f)
 			whole.bodyAt(decoded, true)
+			if r.countRefused() {
+				return false
+			}
 			if order == 0 {
 				// EQUAL: a DUPLICATE. Last wins WHOLE — the slot the earlier
 				// entry took is replaced by this one's decode, so a field the
@@ -712,7 +723,7 @@ func (r *wireReader) mapKey(f *ir.Field, entry *tabletext.Instance, kindBad, wid
 			return key, false
 		}
 		if ref == 0 {
-			return key, true // no key field is the key's DEFAULT
+			return key, scan.off == len(scan.buf) // the terminator must consume the entry's L
 		}
 		id, named := scan.id(ref)
 		if !named || !scan.has(1) {
@@ -857,7 +868,9 @@ func (r *wireReader) arrayBody(fv *tabletext.Field, framed int) (ok, selected bo
 			// so the walk stops here rather than sizing a slot list from a
 			// number the wire chose.
 			if count > uint64(math.MaxInt32) {
-				r.report.Malformed = true
+				if r.countRefusal != nil {
+					*r.countRefusal = true
+				}
 				r.off = end
 				return false, false
 			}
@@ -959,6 +972,13 @@ func (r *wireReader) element(fv *tabletext.Field, i int, ek int) bool {
 			r.m.Refill(fv.Elems[i].Tab)
 		}
 		sub.bodyAt(fv.Elems[i].Tab, true)
+		if r.countRefused() {
+			return false
+		}
+		if sub.off != int(n) {
+			r.report.Malformed = true
+			r.m.Refill(fv.Elems[i].Tab)
+		}
 		r.off += int(n)
 		return true
 	}
@@ -1159,6 +1179,9 @@ func (r *wireReader) unionCell(cell *tabletext.Cell, f *ir.Field) bool {
 			payload := r.m.New(arm.Ref)
 			r.rt.builtArm(cell, payload)
 			sub.bodyAt(payload, true)
+			if r.countRefused() {
+				return false
+			}
 			if sub.off != length {
 				// a body whose terminator is not the last byte of its L is
 				// framing damage: the union reads None and the enclosing body
@@ -1432,3 +1455,14 @@ func bigInt64(v *big.Int) int64 {
 	}
 	return v.Int64()
 }
+
+// CountRefusal is the file reader's builder-path storage refusal (§2.9).
+// The caller must discard the partial value. Earlier report events stand;
+// meeting the cap itself adds no malformed event or other counter.
+type CountRefusal struct{}
+
+func (*CountRefusal) Error() string {
+	return "list count exceeds the int32 storage cap; discard the partial value"
+}
+
+func (r *wireReader) countRefused() bool { return r.countRefusal != nil && *r.countRefusal }

--- a/internal/tablewire/decode.go
+++ b/internal/tablewire/decode.go
@@ -150,7 +150,9 @@ func bodyExtent(body []byte, ids []uint64) (end int, terminated bool) {
 }
 
 type wireReader struct {
-	countRefusal *bool // shared by every nested file reader; not a malformed event
+	// Installed by decodeVariable and shared by its nested readers. Only
+	// value-only and framing/key scanners omit it; none can decode a list.
+	countRefusal *bool // a storage refusal, not a malformed event
 
 	buf    []byte
 	off    int
@@ -870,6 +872,10 @@ func (r *wireReader) arrayBody(fv *tabletext.Field, framed int) (ok, selected bo
 			if count > uint64(math.MaxInt32) {
 				if r.countRefusal != nil {
 					*r.countRefusal = true
+				} else {
+					// A reader without variable-root state cannot decode
+					// lists. Do not silently accept a misrouted internal read.
+					r.report.Malformed = true
 				}
 				r.off = end
 				return false, false
@@ -1076,6 +1082,13 @@ func (r *wireReader) keyed(fv *tabletext.Field) bool {
 				r.m.Refill(fv.Elems[slot].Tab)
 			}
 			elem.bodyAt(fv.Elems[slot].Tab, true)
+			if r.countRefused() {
+				return false
+			}
+			if elem.off != int(elemLen) {
+				r.report.Malformed = true
+				r.m.Refill(fv.Elems[slot].Tab)
+			}
 		default:
 			elem.scalarAt(&fv.Elems[slot], f, int(elemKind))
 		}

--- a/internal/tablewire/decodenodes.go
+++ b/internal/tablewire/decodenodes.go
@@ -88,6 +88,7 @@ func (r *wireReader) resolveCell(cell *tabletext.Cell, f *ir.Field, index uint64
 // all, then the records, then every body.
 func decodeVariable(m *tabletext.Model, inst *tabletext.Instance, data []byte, ids []uint64, report *tabletext.Report, rt *retainState) (bool, error) {
 	st := &decodeState{root: inst}
+	countRefusal := false
 
 	payload, present, framed := nodeTableBytes(data, ids, report)
 	records, scanned := []nodeRecord(nil), true
@@ -180,11 +181,17 @@ func decodeVariable(m *tabletext.Model, inst *tabletext.Instance, data []byte, i
 		if st.nodes[i].Inst == nil {
 			continue
 		}
-		sub := &wireReader{buf: rec.Body, report: report, m: m, ids: ids, st: st, rt: rt}
+		sub := &wireReader{buf: rec.Body, report: report, m: m, ids: ids, st: st, rt: rt, countRefusal: &countRefusal}
 		sub.bodyAt(st.nodes[i].Inst, true)
+		if countRefusal {
+			return false, &CountRefusal{}
+		}
 	}
 
-	r := &wireReader{buf: data, report: report, m: m, ids: ids, st: st, rt: rt}
+	r := &wireReader{buf: data, report: report, m: m, ids: ids, st: st, rt: rt, countRefusal: &countRefusal}
 	ok := r.body(inst)
+	if countRefusal {
+		return false, &CountRefusal{}
+	}
 	return ok, nil
 }

--- a/internal/tablewire/message.go
+++ b/internal/tablewire/message.go
@@ -393,7 +393,12 @@ func decodeVocabulary(in []byte) ([]ir.TableVocabularyEntry, bool) {
 // produce an answer: nothing was decoded, no counter moved, and no damage is
 // reported (docs/SPEC-TABLES.md §3, §3.3). The refusal is the answer, so a
 // caller reports it and carries on rather than propagating an error.
+// A CountRefusal instead keeps earlier events and requires discarding the
+// partial builder value; meeting the count cap adds no event (§2.9).
 func Refused(err error) bool {
+	if _, count := errors.AsType[*CountRefusal](err); count {
+		return true
+	}
 	if _, form := errors.AsType[*FormRefusal](err); form {
 		return true
 	}

--- a/internal/tablewire/message.go
+++ b/internal/tablewire/message.go
@@ -393,12 +393,7 @@ func decodeVocabulary(in []byte) ([]ir.TableVocabularyEntry, bool) {
 // produce an answer: nothing was decoded, no counter moved, and no damage is
 // reported (docs/SPEC-TABLES.md §3, §3.3). The refusal is the answer, so a
 // caller reports it and carries on rather than propagating an error.
-// A CountRefusal instead keeps earlier events and requires discarding the
-// partial builder value; meeting the count cap adds no event (§2.9).
 func Refused(err error) bool {
-	if _, count := errors.AsType[*CountRefusal](err); count {
-		return true
-	}
 	if _, form := errors.AsType[*FormRefusal](err); form {
 		return true
 	}

--- a/ir/wire.go
+++ b/ir/wire.go
@@ -32,8 +32,7 @@ func MaxBytes(bits int64) int64 {
 // implementation, so the widths the backends advertise and the bytes the data
 // compiler packs cannot drift apart.
 func CompressedFloatParams(fmin, fmax, res float64) (maxIntegerValue uint64, wireBits int64) {
-	delta := float32(fmax) - float32(fmin)
-	values := delta / float32(res)
+	values := compressedFloatValues(fmin, fmax, res)
 	if !(values >= 1.0) { // the runtime's own form — it also catches NaN
 		values = 1.0
 	}
@@ -42,6 +41,19 @@ func CompressedFloatParams(fmin, fmax, res float64) (maxIntegerValue uint64, wir
 	}
 	maxIntegerValue = uint64(math.Ceil(float64(values)))
 	return maxIntegerValue, int64(bits.Len64(maxIntegerValue))
+}
+
+// ValidCompressedFloatParams rejects a triple whose runtime derivation loses
+// its range to overflow or to the upper clamp. A fractional count below one
+// legitimately uses one step. The same float32 operations feed the codec.
+func ValidCompressedFloatParams(fmin, fmax, res float64) bool {
+	values := compressedFloatValues(fmin, fmax, res)
+	return values > 0 && values <= 4294967040.0
+}
+
+func compressedFloatValues(fmin, fmax, res float64) float32 {
+	delta := float32(fmax) - float32(fmin)
+	return delta / float32(res)
 }
 
 // CompressedFloatBits is the wire width alone.

--- a/testdata/golden/c/ClausesWire.h
+++ b/testdata/golden/c/ClausesWire.h
@@ -90,7 +90,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -134,7 +134,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/testdata/golden/c/JoinsWire.h
+++ b/testdata/golden/c/JoinsWire.h
@@ -90,7 +90,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -134,7 +134,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -91,7 +91,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -135,7 +135,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/testdata/golden/cpp/ClausesWire.h
+++ b/testdata/golden/cpp/ClausesWire.h
@@ -91,7 +91,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -135,7 +135,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/testdata/golden/cpp/JoinsWire.h
+++ b/testdata/golden/cpp/JoinsWire.h
@@ -92,7 +92,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -136,7 +136,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/testdata/golden/cpp/WireWire.h
+++ b/testdata/golden/cpp/WireWire.h
@@ -92,7 +92,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -136,7 +136,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/testdata/golden/packet-wide/c/WideTextWire.h
+++ b/testdata/golden/packet-wide/c/WideTextWire.h
@@ -89,7 +89,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
         {
             return 0;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return 0;
         }
@@ -133,7 +133,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )

--- a/testdata/golden/packet-wide/cpp/WideTextWire.h
+++ b/testdata/golden/packet-wide/cpp/WideTextWire.h
@@ -90,7 +90,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -134,7 +134,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -5872,6 +5872,7 @@ inline bool LeafSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 inline bool LeafLoadBody( TableReader & r, const TableNodeMap & nodes, Leaf & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     LeafReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6257,6 +6258,7 @@ inline bool HolderSaveBody( const Ctx & ctx, const TableNumbering & numbering, T
 
 inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder & value )
 {
+    if ( nodes.refused ) { return false; }
     HolderReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6315,6 +6317,7 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
                             }
                             value.carry.type = CarryType::Leaf;
                             LeafLoadBody( sub, nodes, value.carry.leaf );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.carry.type = CarryType::None; r.report->malformed = true; break; }
                             break;
                         }
@@ -6909,6 +6912,7 @@ inline bool HandSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & value )
 {
+    if ( nodes.refused ) { return false; }
     HandReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6993,6 +6997,7 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
                                         }
                                         value.entries[(int32_t) i].type = CarryType::Leaf;
                                         LeafLoadBody( elem_arm, nodes, value.entries[(int32_t) i].leaf );
+                                        if ( nodes.refused ) { return false; }
                                         if ( elem_arm.offset != elem_arm.size ) { value.entries[(int32_t) i].type = CarryType::None; r.report->malformed = true; break; }
                                         break;
                                     }
@@ -7554,6 +7559,7 @@ inline bool ChainSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & value )
 {
+    if ( nodes.refused ) { return false; }
     ChainReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7643,6 +7649,7 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
                                                 }
                                                 ( *slot ).type = CarryType::Leaf;
                                                 LeafLoadBody( elem_arm_links, nodes, ( *slot ).leaf );
+                                                if ( nodes.refused ) { return false; }
                                                 if ( elem_arm_links.offset != elem_arm_links.size ) { ( *slot ).type = CarryType::None; r.report->malformed = true; break; }
                                                 break;
                                             }
@@ -9740,6 +9747,7 @@ inline bool LeafLoadBuilder( LeafBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 LeafNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10638,6 +10646,7 @@ inline bool HolderLoadBuilder( HolderBuilder & builder, const uint8_t * wire_fil
             {
                 TableReader sub( body, length, out, &ids_table );
                 HolderNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -11536,6 +11545,7 @@ inline bool HandLoadBuilder( HandBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 HandNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12434,6 +12444,7 @@ inline bool ChainLoadBuilder( ChainBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 ChainNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12510,6 +12521,7 @@ inline bool LeafSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 inline bool LeafLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Leaf & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     LeafReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -12839,6 +12851,7 @@ inline bool HolderSaveBodyRetain( const Ctx & ctx, const TableNumbering & number
 
 inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Holder & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     HolderReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -12903,6 +12916,7 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
                             }
                             value.carry.type = CarryType::Leaf;
                             LeafLoadBodyRetain( sub, nodes, value.carry.leaf, retain, TableRetainStepInto( path, 0, (uint32_t) ( 0 ) ) );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.carry.type = CarryType::None; r.report->malformed = true; break; }
                             break;
                         }
@@ -13376,6 +13390,7 @@ inline bool HandSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Hand & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     HandReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -13468,6 +13483,7 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
                                         }
                                         value.entries[(int32_t) i].type = CarryType::Leaf;
                                         LeafLoadBodyRetain( elem_arm, nodes, value.entries[(int32_t) i].leaf, retain, TableRetainStepInto( TableRetainStepInto( path, 0, (uint32_t) ( i ) ), 0, (uint32_t) ( 0 ) ) );
+                                        if ( nodes.refused ) { return false; }
                                         if ( elem_arm.offset != elem_arm.size ) { value.entries[(int32_t) i].type = CarryType::None; r.report->malformed = true; break; }
                                         break;
                                     }
@@ -13909,6 +13925,7 @@ inline bool ChainSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Chain & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     ChainReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -14006,6 +14023,7 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                                                 }
                                                 ( *slot ).type = CarryType::Leaf;
                                                 LeafLoadBodyRetain( elem_arm_links, nodes, ( *slot ).leaf, retain, TableRetainStepInto( TableRetainStepInto( path, 0, (uint32_t) ( i ) ), 0, (uint32_t) ( 0 ) ) );
+                                                if ( nodes.refused ) { return false; }
                                                 if ( elem_arm_links.offset != elem_arm_links.size ) { ( *slot ).type = CarryType::None; r.report->malformed = true; break; }
                                                 break;
                                             }

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -6225,6 +6225,7 @@ inline bool GateSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & value )
 {
+    if ( nodes.refused ) { return false; }
     GateReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7939,6 +7940,7 @@ inline bool GateLoadBuilder( GateBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 GateNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8264,6 +8266,7 @@ inline bool GateSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gate & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     GateReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -5865,6 +5865,7 @@ inline bool TwigSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & value )
 {
+    if ( nodes.refused ) { return false; }
     TwigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -5923,6 +5924,7 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
                             }
                             value.inner.type = InnerType::Leaf;
                             LeafLoadBody( sub, nodes, value.inner.leaf );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.inner.type = InnerType::None; r.report->malformed = true; break; }
                             break;
                         }
@@ -6398,6 +6400,7 @@ inline bool NestSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & value )
 {
+    if ( nodes.refused ) { return false; }
     NestReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6478,6 +6481,7 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                                             }
                                             value.outer.inner.type = InnerType::Leaf;
                                             LeafLoadBody( arm_inner, nodes, value.outer.inner.leaf );
+                                            if ( nodes.refused ) { return false; }
                                             if ( arm_inner.offset != arm_inner.size ) { value.outer.inner.type = InnerType::None; r.report->malformed = true; break; }
                                             break;
                                         }
@@ -8431,6 +8435,7 @@ inline bool TwigLoadBuilder( TwigBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 TwigNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9329,6 +9334,7 @@ inline bool NestLoadBuilder( NestBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 NestNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9431,6 +9437,7 @@ inline bool TwigSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twig & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     TwigReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9495,6 +9502,7 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
                             }
                             value.inner.type = InnerType::Leaf;
                             LeafLoadBodyRetain( sub, nodes, value.inner.leaf, retain, TableRetainStepInto( path, 0, (uint32_t) ( 0 ) ) );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.inner.type = InnerType::None; r.report->malformed = true; break; }
                             break;
                         }
@@ -9885,6 +9893,7 @@ inline bool NestSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nest & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     NestReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9971,6 +9980,7 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                                             }
                                             value.outer.inner.type = InnerType::Leaf;
                                             LeafLoadBodyRetain( arm_inner, nodes, value.outer.inner.leaf, retain, TableRetainStepInto( path, 0, (uint32_t) ( 0 ) ) );
+                                            if ( nodes.refused ) { return false; }
                                             if ( arm_inner.offset != arm_inner.size ) { value.outer.inner.type = InnerType::None; r.report->malformed = true; break; }
                                             break;
                                         }

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -6373,6 +6373,7 @@ inline bool RingSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & value )
 {
+    if ( nodes.refused ) { return false; }
     RingReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7063,6 +7064,7 @@ inline bool RackSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & value )
 {
+    if ( nodes.refused ) { return false; }
     RackReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7784,6 +7786,7 @@ inline bool TraySaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & value )
 {
+    if ( nodes.refused ) { return false; }
     TrayReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -10038,6 +10041,7 @@ inline bool RingLoadBuilder( RingBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 RingNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10940,6 +10944,7 @@ inline bool RackLoadBuilder( RackBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 RackNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -11838,6 +11843,7 @@ inline bool TrayLoadBuilder( TrayBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 TrayNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12194,6 +12200,7 @@ inline bool RingSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ring & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     RingReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -12767,6 +12774,7 @@ inline bool RackSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rack & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     RackReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -13371,6 +13379,7 @@ inline bool TraySaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tray & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     TrayReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -5201,8 +5201,8 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -5736,8 +5736,8 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8493,8 +8493,8 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8938,8 +8938,8 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -5198,7 +5198,13 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -5727,7 +5733,13 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -8478,7 +8490,13 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -8917,7 +8935,13 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -299,7 +299,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -2763,7 +2763,13 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 15 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 15 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -3754,6 +3760,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             PaddedRowLoadBody( elem, value.rows[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; PaddedRowReset( value.rows[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -2766,8 +2766,8 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -10674,6 +10674,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderCameraLoadBody( elem, value.cameras[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderCameraReset( value.cameras[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10727,6 +10728,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderShipLoadBody( elem, value.ships[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderShipReset( value.ships[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10780,6 +10782,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderTurretLoadBody( elem, value.turrets[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderTurretReset( value.turrets[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10833,6 +10836,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderMissileLoadBody( elem, value.missiles[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderMissileReset( value.missiles[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10886,6 +10890,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderDynamicPropLoadBody( elem, value.dynamic_props[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderDynamicPropReset( value.dynamic_props[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10939,6 +10944,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderStaticPropLoadBody( elem, value.static_props[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderStaticPropReset( value.static_props[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -10992,6 +10998,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderCosmeticPropLoadBody( elem, value.cosmetic_props[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderCosmeticPropReset( value.cosmetic_props[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -11045,6 +11052,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderLaserLoadBody( elem, value.lasers[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderLaserReset( value.lasers[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -11098,6 +11106,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RenderExplosionLoadBody( elem, value.explosions[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RenderExplosionReset( value.explosions[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -3737,6 +3737,7 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             FiringGroupLoadBody( elem, value.firing_groups[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; FiringGroupReset( value.firing_groups[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -3790,6 +3791,7 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             FiringGroupLoadBody( elem, value.missile_groups[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; FiringGroupReset( value.missile_groups[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -2926,6 +2926,7 @@ BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & valu
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             PartRowLoadBody( elem, value.parts[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; PartRowReset( value.parts[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -299,7 +299,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -298,7 +298,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -2693,7 +2693,13 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.note[0] = 0; value.note_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.note, 0, sizeof( value.note ) );
+    value.note_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.note, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -2696,8 +2696,8 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.note, 0, sizeof( value.note ) );
-    value.note_length = 0;
+                    memset( value.note, 0, sizeof( value.note ) );
+                    value.note_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -2855,8 +2855,8 @@ TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & va
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.banner, 0, sizeof( value.banner ) );
-    value.banner_length = 0;
+                    memset( value.banner, 0, sizeof( value.banner ) );
+                    value.banner_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -4125,6 +4125,7 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             TurretConfigLoadBody( elem, value.turrets.slots[int32_t( slot ) - 1] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; TurretConfigReset( value.turrets.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -4729,6 +4730,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             TeamConfigLoadBody( elem, value.teams.slots[int32_t( slot ) - 1] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; TeamConfigReset( value.teams.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -4782,6 +4784,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             HullConfigLoadBody( elem, value.hulls.slots[int32_t( slot ) - 1] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; HullConfigReset( value.hulls.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -2852,7 +2852,13 @@ TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & va
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.banner[0] = 0; value.banner_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.banner, 0, sizeof( value.banner ) );
+    value.banner_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.banner, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -2783,7 +2783,13 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.callsign[0] = 0; value.callsign_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.callsign, 0, sizeof( value.callsign ) );
+    value.callsign_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 24 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 24 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.callsign, r.buffer + r.offset, (size_t) keep );
@@ -3209,7 +3215,13 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.display_name[0] = 0; value.display_name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.display_name, 0, sizeof( value.display_name ) );
+    value.display_name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.display_name, r.buffer + r.offset, (size_t) keep );
@@ -3970,7 +3982,13 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.build_note[0] = 0; value.build_note_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.build_note, 0, sizeof( value.build_note ) );
+    value.build_note_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 48 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 48 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.build_note, r.buffer + r.offset, (size_t) keep );
@@ -4887,6 +4905,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ShipEntryLoadBody( elem, value.reserves[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ShipEntryReset( value.reserves[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -2786,8 +2786,8 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.callsign, 0, sizeof( value.callsign ) );
-    value.callsign_length = 0;
+                    memset( value.callsign, 0, sizeof( value.callsign ) );
+                    value.callsign_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -3218,8 +3218,8 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.display_name, 0, sizeof( value.display_name ) );
-    value.display_name_length = 0;
+                    memset( value.display_name, 0, sizeof( value.display_name ) );
+                    value.display_name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -3985,8 +3985,8 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.build_note, 0, sizeof( value.build_note ) );
-    value.build_note_length = 0;
+                    memset( value.build_note, 0, sizeof( value.build_note ) );
+                    value.build_note_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -4756,6 +4756,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ShipEntryLoadBody( elem, value.ships.slots[int32_t( slot ) - 1] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ShipEntryReset( value.ships.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -3929,6 +3929,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             WeaponConfigLoadBody( elem, value.backups[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; WeaponConfigReset( value.backups[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -3980,6 +3981,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             AttachmentLoadBody( elem, value.attachments[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; AttachmentReset( value.attachments[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -4745,7 +4747,13 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -6000,7 +6008,13 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.version_note[0] = 0; value.version_note_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.version_note, 0, sizeof( value.version_note ) );
+    value.version_note_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.version_note, r.buffer + r.offset, (size_t) keep );
@@ -6052,6 +6066,7 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             WeaponConfigLoadBody( elem, value.weapons[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; WeaponConfigReset( value.weapons[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -6105,6 +6120,7 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ProfileConfigLoadBody( elem, value.profiles[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ProfileConfigReset( value.profiles[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -4750,8 +4750,8 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6011,8 +6011,8 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.version_note, 0, sizeof( value.version_note ) );
-    value.version_note_length = 0;
+                    memset( value.version_note, 0, sizeof( value.version_note ) );
+                    value.version_note_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -2574,8 +2574,8 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -2571,7 +2571,13 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 70000 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 70000 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -6694,7 +6694,7 @@ inline SquadRosterEntryKeyRead SquadRosterEntryReadKey( const uint8_t * body, in
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7166,6 +7166,7 @@ inline bool RowSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tabl
 inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7237,6 +7238,7 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
                                 {
                                     TableReader elem_items( sub.buffer + sub.offset, (int64_t) elem_len_items, r.report, r.ids );
                                     SampleLoadBody( elem_items, ( *slot ) );
+                                    if ( elem_items.offset != elem_items.size ) { r.report->malformed = true; SampleReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_items;
                                 landed = true;
@@ -7581,6 +7583,7 @@ inline bool SheetSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & value )
 {
+    if ( nodes.refused ) { return false; }
     SheetReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7652,6 +7655,8 @@ inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & 
                                 {
                                     TableReader elem_rows( sub.buffer + sub.offset, (int64_t) elem_len_rows, r.report, r.ids );
                                     RowLoadBody( elem_rows, nodes, ( *slot ) );
+                                    if ( nodes.refused ) { return false; }
+                                    if ( elem_rows.offset != elem_rows.size ) { r.report->malformed = true; RowReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_rows;
                                 landed = true;
@@ -8509,6 +8514,7 @@ inline bool SquadSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SquadReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8969,6 +8975,7 @@ inline bool ArmySaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & value )
 {
+    if ( nodes.refused ) { return false; }
     ArmyReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -9040,6 +9047,8 @@ inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & va
                                 {
                                     TableReader elem_squads( sub.buffer + sub.offset, (int64_t) elem_len_squads, r.report, r.ids );
                                     SquadLoadBody( elem_squads, nodes, ( *slot ) );
+                                    if ( nodes.refused ) { return false; }
+                                    if ( elem_squads.offset != elem_squads.size ) { r.report->malformed = true; SquadReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_squads;
                                 landed = true;
@@ -9360,6 +9369,7 @@ inline bool DeckSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & value )
 {
+    if ( nodes.refused ) { return false; }
     DeckReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -9426,6 +9436,8 @@ inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & va
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RowLoadBody( elem, nodes, value.hands[(int32_t) i] );
+                            if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RowReset( value.hands[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -11537,6 +11549,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
             {
                 TableReader sub( body, length, out, &ids_table );
                 RowNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12445,6 +12458,7 @@ inline bool SheetLoadBuilder( SheetBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 SheetNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -13343,6 +13357,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 SquadNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -14241,6 +14256,7 @@ inline bool ArmyLoadBuilder( ArmyBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 ArmyNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -15139,6 +15155,7 @@ inline bool DeckLoadBuilder( DeckBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 DeckNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -15414,6 +15431,7 @@ inline bool RowSaveBodyRetain( const Ctx & ctx, const TableNumbering & numbering
 inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RowReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -15493,6 +15511,7 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
                                 {
                                     TableReader elem_items( sub.buffer + sub.offset, (int64_t) elem_len_items, r.report, r.ids );
                                     SampleLoadBodyRetain( elem_items, ( *slot ), retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                                    if ( elem_items.offset != elem_items.size ) { r.report->malformed = true; SampleReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_items;
                                 landed = true;
@@ -15764,6 +15783,7 @@ inline bool SheetSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sheet & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     SheetReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -15843,6 +15863,8 @@ inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sh
                                 {
                                     TableReader elem_rows( sub.buffer + sub.offset, (int64_t) elem_len_rows, r.report, r.ids );
                                     RowLoadBodyRetain( elem_rows, nodes, ( *slot ), retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                                    if ( nodes.refused ) { return false; }
+                                    if ( elem_rows.offset != elem_rows.size ) { r.report->malformed = true; RowReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_rows;
                                 landed = true;
@@ -16437,6 +16459,7 @@ inline bool SquadSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Squad & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SquadReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -16830,6 +16853,7 @@ inline bool ArmySaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Army & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     ArmyReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -16909,6 +16933,8 @@ inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Arm
                                 {
                                     TableReader elem_squads( sub.buffer + sub.offset, (int64_t) elem_len_squads, r.report, r.ids );
                                     SquadLoadBodyRetain( elem_squads, nodes, ( *slot ), retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                                    if ( nodes.refused ) { return false; }
+                                    if ( elem_squads.offset != elem_squads.size ) { r.report->malformed = true; SquadReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_squads;
                                 landed = true;
@@ -17155,6 +17181,7 @@ inline bool DeckSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Deck & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     DeckReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -17229,6 +17256,8 @@ inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Dec
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             RowLoadBodyRetain( elem, nodes, value.hands[(int32_t) i], retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                            if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; RowReset( value.hands[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -6914,6 +6914,7 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBody( TableReader & r, Bounded & value )
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             UnitLoadBody( elem, value.items[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; UnitReset( value.items[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -7327,6 +7328,7 @@ inline bool UnboundedSaveBody( const Ctx & ctx, const TableNumbering & numbering
 inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbounded & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     UnboundedReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7398,6 +7400,7 @@ inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbo
                                 {
                                     TableReader elem_items( sub.buffer + sub.offset, (int64_t) elem_len_items, r.report, r.ids );
                                     UnitLoadBody( elem_items, ( *slot ) );
+                                    if ( elem_items.offset != elem_items.size ) { r.report->malformed = true; UnitReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_items;
                                 landed = true;
@@ -8689,6 +8692,7 @@ inline bool UnboundedLoadBuilder( UnboundedBuilder & builder, const uint8_t * wi
             {
                 TableReader sub( body, length, out, &ids_table );
                 UnboundedNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9019,6 +9023,7 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBodyRetain( TableReader & r, Bounded & val
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             UnitLoadBodyRetain( elem, value.items[(int32_t) i], retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; UnitReset( value.items[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -9271,6 +9276,7 @@ inline bool UnboundedSaveBodyRetain( const Ctx & ctx, const TableNumbering & num
 inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Unbounded & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     UnboundedReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9350,6 +9356,7 @@ inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes
                                 {
                                     TableReader elem_items( sub.buffer + sub.offset, (int64_t) elem_len_items, r.report, r.ids );
                                     UnitLoadBodyRetain( elem_items, ( *slot ), retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                                    if ( elem_items.offset != elem_items.size ) { r.report->malformed = true; UnitReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_items;
                                 landed = true;

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -6525,6 +6525,7 @@ inline bool BytesSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool BytesLoadBody( TableReader & r, const TableNodeMap & nodes, Bytes & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     BytesReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6914,6 +6915,7 @@ inline bool IntsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 inline bool IntsLoadBody( TableReader & r, const TableNodeMap & nodes, Ints & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     IntsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7335,6 +7337,7 @@ inline bool FloatsSaveBody( const Ctx & ctx, const TableNumbering & numbering, T
 inline bool FloatsLoadBody( TableReader & r, const TableNodeMap & nodes, Floats & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     FloatsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -9021,6 +9024,7 @@ inline bool BytesLoadBuilder( BytesBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 BytesNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9919,6 +9923,7 @@ inline bool IntsLoadBuilder( IntsBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 IntsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10817,6 +10822,7 @@ inline bool FloatsLoadBuilder( FloatsBuilder & builder, const uint8_t * wire_fil
             {
                 TableReader sub( body, length, out, &ids_table );
                 FloatsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10899,6 +10905,7 @@ inline bool BytesSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool BytesLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Bytes & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     BytesReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -11219,6 +11226,7 @@ inline bool IntsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 inline bool IntsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ints & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     IntsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -11574,6 +11582,7 @@ inline bool FloatsSaveBodyRetain( const Ctx & ctx, const TableNumbering & number
 inline bool FloatsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Floats & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     FloatsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -7579,6 +7579,7 @@ inline bool SaveSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & value )
 {
+    if ( nodes.refused ) { return false; }
     SaveReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7650,6 +7651,7 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
                                 {
                                     TableReader elem_placements( sub.buffer + sub.offset, (int64_t) elem_len_placements, r.report, r.ids );
                                     PlacementLoadBody( elem_placements, ( *slot ) );
+                                    if ( elem_placements.offset != elem_placements.size ) { r.report->malformed = true; PlacementReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_placements;
                                 landed = true;
@@ -8784,6 +8786,7 @@ inline bool MixedSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     MixedReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -11317,6 +11320,7 @@ inline bool SaveLoadBuilder( SaveBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 SaveNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12215,6 +12219,7 @@ inline bool MixedLoadBuilder( MixedBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 MixedNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12816,6 +12821,7 @@ inline bool SaveSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Save & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     SaveReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -12895,6 +12901,7 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
                                 {
                                     TableReader elem_placements( sub.buffer + sub.offset, (int64_t) elem_len_placements, r.report, r.ids );
                                     PlacementLoadBodyRetain( elem_placements, ( *slot ), retain, TableRetainStepInto( path, 0, (uint32_t) ( i ) ) );
+                                    if ( elem_placements.offset != elem_placements.size ) { r.report->malformed = true; PlacementReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_placements;
                                 landed = true;
@@ -13728,6 +13735,7 @@ inline bool MixedSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mixed & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     MixedReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -6949,6 +6949,7 @@ inline bool AlbumSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & value )
 {
+    if ( nodes.refused ) { return false; }
     AlbumReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8546,6 +8547,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 AlbumNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8900,6 +8902,7 @@ inline bool AlbumSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Album & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     AlbumReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -6770,8 +6770,8 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBody( TableReader & r, CellsRowsEntr
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8749,8 +8749,8 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBodyRetain( TableReader & r, CellsRo
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -6636,7 +6636,7 @@ inline CellsRowsEntryKeyRead CellsRowsEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6767,7 +6767,13 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBody( TableReader & r, CellsRowsEntr
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -7131,6 +7137,7 @@ inline bool CellsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool CellsLoadBody( TableReader & r, const TableNodeMap & nodes, Cells & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     CellsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8624,6 +8631,7 @@ inline bool CellsLoadBuilder( CellsBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 CellsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8738,7 +8746,13 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBodyRetain( TableReader & r, CellsRo
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -9060,6 +9074,7 @@ inline bool CellsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool CellsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cells & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     CellsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -6634,7 +6634,7 @@ inline ChunksBlobsEntryKeyRead ChunksBlobsEntryReadKey( const uint8_t * body, in
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6732,6 +6732,7 @@ inline bool ChunksBlobsEntrySaveBody( const Ctx & ctx, const TableNumbering & nu
 
 inline bool ChunksBlobsEntryLoadBody( TableReader & r, const TableNodeMap & nodes, ChunksBlobsEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     ChunksBlobsEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7040,6 +7041,7 @@ inline bool ChunksSaveBody( const Ctx & ctx, const TableNumbering & numbering, T
 
 inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks & value )
 {
+    if ( nodes.refused ) { return false; }
     ChunksReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7141,6 +7143,7 @@ inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             ChunksBlobsEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8712,6 +8715,7 @@ inline bool ChunksLoadBuilder( ChunksBuilder & builder, const uint8_t * wire_fil
             {
                 TableReader sub( body, length, out, &ids_table );
                 ChunksNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8784,6 +8788,7 @@ inline bool ChunksBlobsEntrySaveBodyRetain( const Ctx & ctx, const TableNumberin
 
 inline bool ChunksBlobsEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, ChunksBlobsEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     ChunksBlobsEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9058,6 +9063,7 @@ inline bool ChunksSaveBodyRetain( const Ctx & ctx, const TableNumbering & number
 
 inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Chunks & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     ChunksReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9167,6 +9173,7 @@ inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, C
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             ChunksBlobsEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -6633,7 +6633,7 @@ inline CrewsMembersEntryKeyRead CrewsMembersEntryReadKey( const uint8_t * body, 
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6752,6 +6752,7 @@ inline bool CrewsMembersEntrySaveBody( const Ctx & ctx, const TableNumbering & n
 
 inline bool CrewsMembersEntryLoadBody( TableReader & r, const TableNodeMap & nodes, CrewsMembersEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     CrewsMembersEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7099,6 +7100,7 @@ inline bool CrewsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & value )
 {
+    if ( nodes.refused ) { return false; }
     CrewsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7200,6 +7202,7 @@ inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             CrewsMembersEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8798,6 +8801,7 @@ inline bool CrewsLoadBuilder( CrewsBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 CrewsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8891,6 +8895,7 @@ inline bool CrewsMembersEntrySaveBodyRetain( const Ctx & ctx, const TableNumberi
 
 inline bool CrewsMembersEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, CrewsMembersEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     CrewsMembersEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9204,6 +9209,7 @@ inline bool CrewsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Crews & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     CrewsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9313,6 +9319,7 @@ inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cr
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             CrewsMembersEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -7762,6 +7762,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBody( elem, nodes, value.keyed.slots[int32_t( slot ) - 1] );
                             if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; SquadReset( value.keyed.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -11573,6 +11574,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBodyRetain( elem, nodes, value.keyed.slots[int32_t( slot ) - 1], retain, TableRetainStepInto( path, 2, (uint32_t) ( int32_t( slot ) - 1 ) ) );
                             if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; SquadReset( value.keyed.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -6767,7 +6767,7 @@ inline SquadRosterEntryKeyRead SquadRosterEntryReadKey( const uint8_t * body, in
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7103,6 +7103,7 @@ inline bool SquadSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SquadReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7610,6 +7611,7 @@ inline bool DepthSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & value )
 {
+    if ( nodes.refused ) { return false; }
     DepthReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7648,6 +7650,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
                     SquadLoadBody( sub, nodes, value.one );
+                    if ( nodes.refused ) { return false; }
                     if ( sub.offset != sub.size )
                     {
                         r.report->malformed = true;
@@ -7700,6 +7703,8 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBody( elem, nodes, value.many[(int32_t) i] );
+                            if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; SquadReset( value.many[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -7756,6 +7761,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBody( elem, nodes, value.keyed.slots[int32_t( slot ) - 1] );
+                            if ( nodes.refused ) { return false; }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -7798,6 +7804,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                             }
                             value.arm.type = ForceType::Squad;
                             SquadLoadBody( sub, nodes, value.arm.squad );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.arm.type = ForceType::None; r.report->malformed = true; break; }
                             break;
                         }
@@ -9766,6 +9773,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 SquadNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10664,6 +10672,7 @@ inline bool DepthLoadBuilder( DepthBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 DepthNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10953,6 +10962,7 @@ inline bool SquadSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Squad & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SquadReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -11403,6 +11413,7 @@ inline bool DepthSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Depth & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     DepthReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -11447,6 +11458,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
                     SquadLoadBodyRetain( sub, nodes, value.one, retain, TableRetainStepInto( path, 0, (uint32_t) ( 0 ) ) );
+                    if ( nodes.refused ) { return false; }
                     if ( sub.offset != sub.size )
                     {
                         r.report->malformed = true;
@@ -11502,6 +11514,8 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBodyRetain( elem, nodes, value.many[(int32_t) i], retain, TableRetainStepInto( path, 1, (uint32_t) ( i ) ) );
+                            if ( nodes.refused ) { return false; }
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; SquadReset( value.many[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -11558,6 +11572,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SquadLoadBodyRetain( elem, nodes, value.keyed.slots[int32_t( slot ) - 1], retain, TableRetainStepInto( path, 2, (uint32_t) ( int32_t( slot ) - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -11601,6 +11616,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                             }
                             value.arm.type = ForceType::Squad;
                             SquadLoadBodyRetain( sub, nodes, value.arm.squad, retain, TableRetainStepInto( path, 3, (uint32_t) ( 0 ) ) );
+                            if ( nodes.refused ) { return false; }
                             if ( sub.offset != sub.size ) { value.arm.type = ForceType::None; r.report->malformed = true; break; }
                             break;
                         }

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -6644,7 +6644,7 @@ inline DocsPagesEntryKeyRead DocsPagesEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6742,6 +6742,7 @@ inline bool DocsPagesEntrySaveBody( const Ctx & ctx, const TableNumbering & numb
 
 inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes, DocsPagesEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     DocsPagesEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6779,7 +6780,13 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -7028,6 +7035,7 @@ inline bool DocsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 
 inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & value )
 {
+    if ( nodes.refused ) { return false; }
     DocsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7129,6 +7137,7 @@ inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & va
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             DocsPagesEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; last_length = read.length; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8720,6 +8729,7 @@ inline bool DocsLoadBuilder( DocsBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 DocsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8795,6 +8805,7 @@ inline bool DocsPagesEntrySaveBodyRetain( const Ctx & ctx, const TableNumbering 
 
 inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, DocsPagesEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     DocsPagesEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -8837,7 +8848,13 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -9041,6 +9058,7 @@ inline bool DocsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 
 inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Docs & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     DocsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9150,6 +9168,7 @@ inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Doc
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             DocsPagesEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; last_length = read.length; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -6783,8 +6783,8 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8851,8 +8851,8 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -7545,8 +7545,8 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBody( TableReader & r, ShipConfig & valu
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8281,8 +8281,8 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBody( TableReader & r, FleetShipsEn
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -9072,8 +9072,8 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -13083,8 +13083,8 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBodyRetain( TableReader & r, ShipConfig 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -13516,8 +13516,8 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBodyRetain( TableReader & r, FleetS
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -14215,8 +14215,8 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -7061,7 +7061,7 @@ inline FleetLoadoutsEntryValueEntryKeyRead FleetLoadoutsEntryValueEntryReadKey( 
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7143,7 +7143,7 @@ inline FleetShipsEntryKeyRead FleetShipsEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7219,7 +7219,7 @@ inline FleetByIdEntryKeyRead FleetByIdEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7312,7 +7312,7 @@ inline FleetLoadoutsEntryKeyRead FleetLoadoutsEntryReadKey( const uint8_t * body
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7386,7 +7386,7 @@ inline FleetTiersEntryKeyRead FleetTiersEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7542,7 +7542,13 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBody( TableReader & r, ShipConfig & valu
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 64 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 64 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -8272,7 +8278,13 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBody( TableReader & r, FleetShipsEn
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -8490,6 +8502,7 @@ inline bool FleetByIdEntrySaveBody( const Ctx & ctx, const TableNumbering & numb
 
 inline bool FleetByIdEntryLoadBody( TableReader & r, const TableNodeMap & nodes, FleetByIdEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     FleetByIdEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -9018,6 +9031,7 @@ inline bool FleetLoadoutsEntrySaveBody( const Ctx & ctx, const TableNumbering & 
 inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & nodes, FleetLoadoutsEntry & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     FleetLoadoutsEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -9055,7 +9069,13 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -9865,6 +9885,7 @@ inline bool FleetSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & value )
 {
+    if ( nodes.refused ) { return false; }
     FleetReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -10053,6 +10074,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             FleetByIdEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -10160,6 +10182,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             FleetLoadoutsEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; last_length = read.length; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -12965,6 +12988,7 @@ inline bool FleetLoadBuilder( FleetBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 FleetNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -13056,7 +13080,13 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBodyRetain( TableReader & r, ShipConfig 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 64 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 64 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -13483,7 +13513,13 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBodyRetain( TableReader & r, FleetS
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -13664,6 +13700,7 @@ inline bool FleetByIdEntrySaveBodyRetain( const Ctx & ctx, const TableNumbering 
 
 inline bool FleetByIdEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, FleetByIdEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     FleetByIdEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -14132,6 +14169,7 @@ inline bool FleetLoadoutsEntrySaveBodyRetain( const Ctx & ctx, const TableNumber
 inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, FleetLoadoutsEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     FleetLoadoutsEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -14174,7 +14212,13 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -14880,6 +14924,7 @@ inline bool FleetSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fleet & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     FleetReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -15079,6 +15124,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             FleetByIdEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 1, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -15189,6 +15235,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             FleetLoadoutsEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 3, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; last_length = read.length; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -6630,7 +6630,7 @@ inline PairsSlotsEntryKeyRead PairsSlotsEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6755,6 +6755,7 @@ inline bool PairsSlotsEntrySaveBody( const Ctx & ctx, const TableNumbering & num
 
 inline bool PairsSlotsEntryLoadBody( TableReader & r, const TableNodeMap & nodes, PairsSlotsEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     PairsSlotsEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7102,6 +7103,7 @@ inline bool PairsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 
 inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & value )
 {
+    if ( nodes.refused ) { return false; }
     PairsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7203,6 +7205,7 @@ inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             PairsSlotsEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8801,6 +8804,7 @@ inline bool PairsLoadBuilder( PairsBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 PairsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8900,6 +8904,7 @@ inline bool PairsSlotsEntrySaveBodyRetain( const Ctx & ctx, const TableNumbering
 
 inline bool PairsSlotsEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, PairsSlotsEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     PairsSlotsEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9209,6 +9214,7 @@ inline bool PairsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 
 inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pairs & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     PairsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9318,6 +9324,7 @@ inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pa
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             PairsSlotsEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -7308,8 +7308,8 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBody( TableReader & r, RowEntriesEn
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8735,8 +8735,8 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBody( TableReader & r, EdgeRowNam
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -13439,8 +13439,8 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBodyRetain( TableReader & r, RowEnt
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -14674,8 +14674,8 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBodyRetain( TableReader & r, Edge
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -6919,7 +6919,7 @@ inline RowEntriesEntryKeyRead RowEntriesEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6993,7 +6993,7 @@ inline WideRowEntriesEntryKeyRead WideRowEntriesEntryReadKey( const uint8_t * bo
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7084,7 +7084,7 @@ inline EdgeRowNamesEntryKeyRead EdgeRowNamesEntryReadKey( const uint8_t * body, 
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7158,7 +7158,7 @@ inline EdgeRowIdsEntryKeyRead EdgeRowIdsEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7305,7 +7305,13 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBody( TableReader & r, RowEntriesEn
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -7545,6 +7551,7 @@ inline bool RowSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tabl
 inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8258,6 +8265,7 @@ inline bool WideRowSaveBody( const Ctx & ctx, const TableNumbering & numbering, 
 inline bool WideRowLoadBody( TableReader & r, const TableNodeMap & nodes, WideRow & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     WideRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8724,7 +8732,13 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBody( TableReader & r, EdgeRowNam
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 300 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 300 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -9257,6 +9271,7 @@ inline bool EdgeRowSaveBody( const Ctx & ctx, const TableNumbering & numbering, 
 inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRow & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     EdgeRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -11517,6 +11532,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
             {
                 TableReader sub( body, length, out, &ids_table );
                 RowNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -12415,6 +12431,7 @@ inline bool WideRowLoadBuilder( WideRowBuilder & builder, const uint8_t * wire_f
             {
                 TableReader sub( body, length, out, &ids_table );
                 WideRowNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -13313,6 +13330,7 @@ inline bool EdgeRowLoadBuilder( EdgeRowBuilder & builder, const uint8_t * wire_f
             {
                 TableReader sub( body, length, out, &ids_table );
                 EdgeRowNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -13418,7 +13436,13 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBodyRetain( TableReader & r, RowEnt
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -13621,6 +13645,7 @@ inline bool RowSaveBodyRetain( const Ctx & ctx, const TableNumbering & numbering
 inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RowReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -14241,6 +14266,7 @@ inline bool WideRowSaveBodyRetain( const Ctx & ctx, const TableNumbering & numbe
 inline bool WideRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, WideRow & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     WideRowReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -14645,7 +14671,13 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBodyRetain( TableReader & r, Edge
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 300 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 300 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -15115,6 +15147,7 @@ inline bool EdgeRowSaveBodyRetain( const Ctx & ctx, const TableNumbering & numbe
 inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, EdgeRow & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     EdgeRowReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -6627,7 +6627,7 @@ inline RunsSpansEntryKeyRead RunsSpansEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6822,6 +6822,7 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBody( TableReader & r, RunsSpansEntr
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ItemLoadBody( elem, value.value[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ItemReset( value.value[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -7071,6 +7072,7 @@ inline bool RunsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 inline bool RunsLoadBody( TableReader & r, const TableNodeMap & nodes, Runs & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RunsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8561,6 +8563,7 @@ inline bool RunsLoadBuilder( RunsBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 RunsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8739,6 +8742,7 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBodyRetain( TableReader & r, RunsSpa
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ItemLoadBodyRetain( elem, value.value[(int32_t) i], retain, TableRetainStepInto( path, 1, (uint32_t) ( i ) ) );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ItemReset( value.value[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -8951,6 +8955,7 @@ inline bool RunsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 inline bool RunsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Runs & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     RunsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -6692,7 +6692,7 @@ inline SlotsSeatsEntryKeyRead SlotsSeatsEntryReadKey( const uint8_t * body, int6
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7244,6 +7244,7 @@ inline bool SlotsSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool SlotsLoadBody( TableReader & r, const TableNodeMap & nodes, Slots & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SlotsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -8734,6 +8735,7 @@ inline bool SlotsLoadBuilder( SlotsBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 SlotsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9201,6 +9203,7 @@ inline bool SlotsSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool SlotsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Slots & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SlotsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -6631,7 +6631,7 @@ inline SpansTracksEntryKeyRead SpansTracksEntryReadKey( const uint8_t * body, in
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6745,6 +6745,7 @@ inline bool SpansTracksEntrySaveBody( const Ctx & ctx, const TableNumbering & nu
 inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & nodes, SpansTracksEntry & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SpansTracksEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -6831,6 +6832,7 @@ inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & node
                                 {
                                     TableReader elem_value( sub.buffer + sub.offset, (int64_t) elem_len_value, r.report, r.ids );
                                     ItemLoadBody( elem_value, ( *slot ) );
+                                    if ( elem_value.offset != elem_value.size ) { r.report->malformed = true; ItemReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_value;
                                 landed = true;
@@ -7105,6 +7107,7 @@ inline bool SpansSaveBody( const Ctx & ctx, const TableNumbering & numbering, Ta
 inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SpansReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7206,6 +7209,7 @@ inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             SpansTracksEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8762,6 +8766,7 @@ inline bool SpansLoadBuilder( SpansBuilder & builder, const uint8_t * wire_file,
             {
                 TableReader sub( body, length, out, &ids_table );
                 SpansNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -8859,6 +8864,7 @@ inline bool SpansTracksEntrySaveBodyRetain( const Ctx & ctx, const TableNumberin
 inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, SpansTracksEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SpansTracksEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -8953,6 +8959,7 @@ inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                                 {
                                     TableReader elem_value( sub.buffer + sub.offset, (int64_t) elem_len_value, r.report, r.ids );
                                     ItemLoadBodyRetain( elem_value, ( *slot ), retain, TableRetainStepInto( path, 1, (uint32_t) ( i ) ) );
+                                    if ( elem_value.offset != elem_value.size ) { r.report->malformed = true; ItemReset( ( *slot ) ); }
                                 }
                                 sub.offset += (int64_t) elem_len_value;
                                 landed = true;
@@ -9154,6 +9161,7 @@ inline bool SpansSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberi
 inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Spans & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     SpansReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9263,6 +9271,7 @@ inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sp
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             SpansTracksEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -6800,7 +6800,7 @@ inline TextNamesEntryKeyRead TextNamesEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6878,7 +6878,7 @@ inline TextWideEntryKeyRead TextWideEntryReadKey( const uint8_t * body, int64_t 
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6959,7 +6959,7 @@ inline TextBlobsEntryKeyRead TextBlobsEntryReadKey( const uint8_t * body, int64_
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -7081,7 +7081,13 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -7104,7 +7110,13 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.value[0] = 0; value.value_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.value, 0, sizeof( value.value ) );
+    value.value_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.value, r.buffer + r.offset, (size_t) keep );
@@ -7975,6 +7987,7 @@ inline bool TextSaveBody( const Ctx & ctx, const TableNumbering & numbering, Tab
 inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & value )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     TextReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -10100,6 +10113,7 @@ inline bool TextLoadBuilder( TextBuilder & builder, const uint8_t * wire_file, i
             {
                 TableReader sub( body, length, out, &ids_table );
                 TextNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -10194,7 +10208,13 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.key[0] = 0; value.key_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.key, 0, sizeof( value.key ) );
+    value.key_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.key, r.buffer + r.offset, (size_t) keep );
@@ -10217,7 +10237,13 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.value[0] = 0; value.value_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.value, 0, sizeof( value.value ) );
+    value.value_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.value, r.buffer + r.offset, (size_t) keep );
@@ -11002,6 +11028,7 @@ inline bool TextSaveBodyRetain( const Ctx & ctx, const TableNumbering & numberin
 inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Text & value, TableRetain * retain, const TableRetainPath & path )
 {
     (void) nodes;
+    if ( nodes.refused ) { return false; }
     TextReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -7084,8 +7084,8 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -7113,8 +7113,8 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.value, 0, sizeof( value.value ) );
-    value.value_length = 0;
+                    memset( value.value, 0, sizeof( value.value ) );
+                    value.value_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -10211,8 +10211,8 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.key, 0, sizeof( value.key ) );
-    value.key_length = 0;
+                    memset( value.key, 0, sizeof( value.key ) );
+                    value.key_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -10240,8 +10240,8 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.value, 0, sizeof( value.value ) );
-    value.value_length = 0;
+                    memset( value.value, 0, sizeof( value.value ) );
+                    value.value_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -6632,7 +6632,7 @@ inline TrailsStepsEntryKeyRead TrailsStepsEntryReadKey( const uint8_t * body, in
     {
         uint64_t field_ref = 0;
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
-        if ( field_ref == 0 ) { return out; } // the terminator: no key field is the key's DEFAULT
+        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
         const uint64_t field_id = ids->at( field_ref );
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
@@ -6758,6 +6758,7 @@ inline bool TrailsStepsEntrySaveBody( const Ctx & ctx, const TableNumbering & nu
 
 inline bool TrailsStepsEntryLoadBody( TableReader & r, const TableNodeMap & nodes, TrailsStepsEntry & value )
 {
+    if ( nodes.refused ) { return false; }
     TrailsStepsEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7141,6 +7142,7 @@ inline bool TrailsSaveBody( const Ctx & ctx, const TableNumbering & numbering, T
 
 inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails & value )
 {
+    if ( nodes.refused ) { return false; }
     TrailsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
@@ -7242,6 +7244,7 @@ inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails 
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             TrailsStepsEntryLoadBody( elem, nodes, *slot );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;
@@ -8924,6 +8927,7 @@ inline bool TrailsLoadBuilder( TrailsBuilder & builder, const uint8_t * wire_fil
             {
                 TableReader sub( body, length, out, &ids_table );
                 TrailsNodeBody( type_id, sub, nodes, TableArenaAt( builder.arena, (uint32_t) directory[k + 1].offset ) );
+                if ( nodes.refused ) { break; }
             }
             k++;
         }
@@ -9024,6 +9028,7 @@ inline bool TrailsStepsEntrySaveBodyRetain( const Ctx & ctx, const TableNumberin
 
 inline bool TrailsStepsEntryLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, TrailsStepsEntry & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     TrailsStepsEntryReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9338,6 +9343,7 @@ inline bool TrailsSaveBodyRetain( const Ctx & ctx, const TableNumbering & number
 
 inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Trails & value, TableRetain * retain, const TableRetainPath & path )
 {
+    if ( nodes.refused ) { return false; }
     TrailsReset( value ); // prefill declared defaults in place, then overlay
     // A RETAINED RECORD DIES WITH THE BODY OCCURRENCE THAT CARRIED IT
     // (docs/SPEC-TABLES.md §6.6): this body is being established, so
@@ -9447,6 +9453,7 @@ inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, T
                         {
                             TableReader elem( elem_body, (int64_t) elem_len, r.report, r.ids );
                             TrailsStepsEntryLoadBodyRetain( elem, nodes, *slot, retain, TableRetainStepInto( path, 0, (uint32_t) ( fill.map->count - 1 ) ) );
+                            if ( nodes.refused ) { return false; }
                         }
                         last_key = read.key; // the WIRE keys of the entries that LAND
                         landed = true;

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -2789,8 +2789,8 @@ MESSAGEDEMO_TABLE_INLINE bool UserLoadBody( TableReader & r, User & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -3113,8 +3113,8 @@ MESSAGEDEMO_TABLE_INLINE bool ScriptLoadBody( TableReader & r, Script & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.path, 0, sizeof( value.path ) );
-    value.path_length = 0;
+                    memset( value.path, 0, sizeof( value.path ) );
+                    value.path_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -4261,8 +4261,8 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.text, 0, sizeof( value.text ) );
-    value.text_length = 0;
+                    memset( value.text, 0, sizeof( value.text ) );
+                    value.text_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6773,8 +6773,8 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.path, 0, sizeof( value.path ) );
-    value.path_length = 0;
+                    memset( value.path, 0, sizeof( value.path ) );
+                    value.path_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -7211,8 +7211,8 @@ MESSAGEDEMO_TABLE_INLINE bool SaveDocumentLoadBody( TableReader & r, SaveDocumen
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.path, 0, sizeof( value.path ) );
-    value.path_length = 0;
+                    memset( value.path, 0, sizeof( value.path ) );
+                    value.path_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -7926,8 +7926,8 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.reason, 0, sizeof( value.reason ) );
-    value.reason_length = 0;
+                    memset( value.reason, 0, sizeof( value.reason ) );
+                    value.reason_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -2786,7 +2786,13 @@ MESSAGEDEMO_TABLE_INLINE bool UserLoadBody( TableReader & r, User & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -3104,7 +3110,13 @@ MESSAGEDEMO_TABLE_INLINE bool ScriptLoadBody( TableReader & r, Script & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.path[0] = 0; value.path_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.path, 0, sizeof( value.path ) );
+    value.path_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 64 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 64 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.path, r.buffer + r.offset, (size_t) keep );
@@ -4246,7 +4258,13 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.text[0] = 0; value.text_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.text, 0, sizeof( value.text ) );
+    value.text_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 32 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 32 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.text, r.buffer + r.offset, (size_t) keep );
@@ -6752,7 +6770,13 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.path[0] = 0; value.path_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.path, 0, sizeof( value.path ) );
+    value.path_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 64 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 64 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.path, r.buffer + r.offset, (size_t) keep );
@@ -7184,7 +7208,13 @@ MESSAGEDEMO_TABLE_INLINE bool SaveDocumentLoadBody( TableReader & r, SaveDocumen
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.path[0] = 0; value.path_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.path, 0, sizeof( value.path ) );
+    value.path_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 64 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 64 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.path, r.buffer + r.offset, (size_t) keep );
@@ -7893,7 +7923,13 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.reason[0] = 0; value.reason_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.reason, 0, sizeof( value.reason ) );
+    value.reason_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.reason, r.buffer + r.offset, (size_t) keep );
@@ -7945,6 +7981,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             EditLoadBody( elem, value.edits[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; EditReset( value.edits[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -8269,6 +8306,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             SelectionLoadBody( elem, value.snapshots[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; SelectionReset( value.snapshots[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -10711,6 +10749,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             ScriptLoadBody( elem, value.trace[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; ScriptReset( value.trace[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -306,7 +306,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -304,7 +304,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -304,7 +304,7 @@ static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int6
     return r;
 }
 
-static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return r->offset + bytes <= r->size; }
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE uint16_t table_reader_get16( TableReader * r )
 {

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -5691,8 +5691,8 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.tag, 0, sizeof( value.tag ) );
-    value.tag_length = 0;
+                    memset( value.tag, 0, sizeof( value.tag ) );
+                    value.tag_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6105,8 +6105,8 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6529,8 +6529,8 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6889,8 +6889,8 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -7672,8 +7672,8 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8511,8 +8511,8 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -8569,6 +8569,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LayerLoadBody( elem, nodes, value.banks.slots[int32_t( slot ) - 1] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LayerReset( value.banks.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -9068,8 +9069,8 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -15726,8 +15727,8 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBodyRetain( TableReader & r, Meta & value, T
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.tag, 0, sizeof( value.tag ) );
-    value.tag_length = 0;
+                    memset( value.tag, 0, sizeof( value.tag ) );
+                    value.tag_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -15971,8 +15972,8 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBodyRetain( TableReader & r, Settings & 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -16245,8 +16246,8 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -16555,8 +16556,8 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -17244,8 +17245,8 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -17922,8 +17923,8 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -17980,6 +17981,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LayerLoadBodyRetain( elem, nodes, value.banks.slots[int32_t( slot ) - 1], retain, TableRetainStepInto( path, 1, (uint32_t) ( int32_t( slot ) - 1 ) ) );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LayerReset( value.banks.slots[int32_t( slot ) - 1] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                     }
@@ -18369,8 +18371,8 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -5688,7 +5688,13 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.tag[0] = 0; value.tag_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.tag, r.buffer + r.offset, (size_t) keep );
@@ -6096,7 +6102,13 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -6514,7 +6526,13 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -6868,7 +6886,13 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -7645,7 +7669,13 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 24 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 24 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -7831,6 +7861,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LayerLoadBody( elem, nodes, value.layers[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LayerReset( value.layers[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -8477,7 +8508,13 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -9028,7 +9065,13 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -15680,7 +15723,13 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBodyRetain( TableReader & r, Meta & value, T
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.tag[0] = 0; value.tag_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.tag, r.buffer + r.offset, (size_t) keep );
@@ -15919,7 +15968,13 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBodyRetain( TableReader & r, Settings & 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -16187,7 +16242,13 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -16491,7 +16552,13 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -17174,7 +17241,13 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 24 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 24 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -17364,6 +17437,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LayerLoadBodyRetain( elem, nodes, value.layers[(int32_t) i], retain, TableRetainStepInto( path, 7, (uint32_t) ( i ) ) );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LayerReset( value.layers[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;
@@ -17845,7 +17919,13 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 12 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 12 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -18286,7 +18366,13 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -5654,7 +5654,13 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );
@@ -7097,7 +7103,13 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.label[0] = 0; value.label_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.label, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -5657,8 +5657,8 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -7106,8 +7106,8 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.label, 0, sizeof( value.label ) );
-    value.label_length = 0;
+                    memset( value.label, 0, sizeof( value.label ) );
+                    value.label_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -5212,7 +5212,13 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.tag[0] = 0; value.tag_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.tag, r.buffer + r.offset, (size_t) keep );
@@ -6009,7 +6015,13 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBodyRetain( TableReader & r, Stamp & value,
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.tag[0] = 0; value.tag_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 8 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 8 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.tag, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -5215,8 +5215,8 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.tag, 0, sizeof( value.tag ) );
-    value.tag_length = 0;
+                    memset( value.tag, 0, sizeof( value.tag ) );
+                    value.tag_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -6018,8 +6018,8 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBodyRetain( TableReader & r, Stamp & value,
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.tag, 0, sizeof( value.tag ) );
-    value.tag_length = 0;
+                    memset( value.tag, 0, sizeof( value.tag ) );
+                    value.tag_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -5211,8 +5211,8 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBody( TableReader & r, Header & value )
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;
@@ -9083,8 +9083,8 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBodyRetain( TableReader & r, Header & val
                 if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
                 {
                     r.report->malformed = true;
-    memset( value.name, 0, sizeof( value.name ) );
-    value.name_length = 0;
+                    memset( value.name, 0, sizeof( value.name ) );
+                    value.name_length = 0;
                     r.offset += (int64_t) len; break;
                 }
                 uint64_t keep = len;

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -5208,7 +5208,13 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBody( TableReader & r, Header & value )
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );
@@ -9074,7 +9080,13 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBodyRetain( TableReader & r, Header & val
                 if ( !r.getleb( len ) || !r.room( len ) ) { r.report->malformed = true; return false; }
                 // ILL-FORMED TEXT IS DAMAGE (§3, §4): the field reads its declared
                 // default, one malformed counts, and the parent reads on past L
-                if ( !TableUtf8Valid( r.buffer + r.offset, len ) ) { r.report->malformed = true; value.name[0] = 0; value.name_length = 0; r.offset += (int64_t) len; break; }
+                if ( !TableUtf8Valid( r.buffer + r.offset, len ) )
+                {
+                    r.report->malformed = true;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+                    r.offset += (int64_t) len; break;
+                }
                 uint64_t keep = len;
                 if ( keep > 16 ) { keep = (uint64_t) TableUtf8Clamp( r.buffer + r.offset, len, 16 ); r.report->clamped++; } // at a code point boundary (§3)
                 memcpy( value.name, r.buffer + r.offset, (size_t) keep );

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -2575,6 +2575,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LineLoadBody( elem, value.lines[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LineReset( value.lines[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -2575,6 +2575,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                         {
                             TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );
                             LineLoadBody( elem, value.lines[(int32_t) i] );
+                            if ( elem.offset != elem.size ) { r.report->malformed = true; LineReset( value.lines[(int32_t) i] ); }
                         }
                         sub.offset += (int64_t) elem_len;
                         decoded = i + 1;

--- a/testdata/golden/wide/cpp/WideTextWire.h
+++ b/testdata/golden/wide/cpp/WideTextWire.h
@@ -90,7 +90,7 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
         {
             return false;
         }
-        if ( i + continuations >= length )
+        if ( continuations >= length - i )
         {
             return false;
         }
@@ -134,7 +134,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     int32_t i = 0;
     if ( length >= 8 )
     {
-        for ( ; i + 8 <= length; i += 8 )
+        for ( ; i <= length - 8; i += 8 )
         {
             memcpy( &word, bytes + i, 8 );
             if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )


### PR DESCRIPTION
Repairs the confirmed defects in #710: C/C++ packet string bounds checks, string/float32 defaults, expanded unpack path confinement, cook range arithmetic, declared text defaults on table damage, and kind-13 collection framing. It also aligns Go and C++ nested list-cap refusals without adding a malformed event, fixes the two tutorial receive buffers, uses overflow-safe C table bounds checks, and parses leading-zero decimal integers according to the grammar.

Two findings need qualification. F-08's list directory loop is unreachable through `pack`: variable roots already require one `Root.json`; the regression preserves that refusal. F-10's region path already rejects oversized lists at `LoadMeasure`; the repaired discrepancy is the allocating decoder's refusal/report handling, including nested bodies and enum-keyed slots. A malformed map entry is rejected during the key scan, preserving the ascending prefix rather than resetting its key.

F-02 does not establish an ID collision: the projection includes all three parameters. The historical float64 `steps` token is preserved to keep existing IDs; codec widths retain the shared float32 arithmetic. The checker now refuses a triple whose runtime derivation overflows or requires the upper clamp. Arbitrary JSON keys remain legal in JSON; expanded unpack refuses unsafe path components and points to `--one-file`. Both unpack and generated output use `os.Root` to confine writes through existing symlinks.

Validation: focused Go suites and compiled C++ recovery/refusal regressions pass; actual INT32_MAX C and C++ string helper checks pass under ASan/UBSan. Source and conformance pins regenerated with no wire binary changes. The broad local Go suite passed except existing tests sensitive to a noncanonical TMPDIR spelling or spaces in temporary manifest paths; the baseline test passes with a canonical TMPDIR. All 61 PR CI jobs pass at c7ba9a8520c6536179169e8e695110312b6a8b64, including the clean-path whole Go suite and nine language conformance legs. The pinned modernizer and go vet pass; small regression tests fail against the original implementation through a Go overlay. Local make test explicitly refuses missing pinned toolchains; full certification is dispatched on the current head. Rowan reviewed the dispositions and agrees with the qualified F-02/F-10 decisions after checking the source and spec. His independent cold review identified a missing enum-keyed recovery check and an ineffective automated overflow regression; both are corrected. Sanitizers are now unconditional, and reverting either original helper makes its actual-limit test fail in C and C++. Reverting either keyed-slot implementation also fails its regression. A missing shared fixture dependency in the standalone map negative control is repaired. The review delta is with Rowan.

Compatibility: valid wire encoding and existing packet IDs are unchanged. Newly refused schema defaults/triples were unrepresentable or clamped; decimal `010` now means ten, as specified, and its resolved value is reflected in its protocol ID. Malformed-input recovery changes intentionally. No runtime pins were changed.
