### PR TITLE
C# keyed arrays refuse None and past Max

### DIFF
--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -88,3 +88,55 @@ table Node
 		t.Errorf("--lang cpp refused a pointered unit: %v", err)
 	}
 }
+
+// TestCsKeyedAccessorCoversBothEnds: C# used to refuse only key 0 and let
+// Slots[key-1] throw IndexOutOfRangeException past Max, naming an index.
+// M5 is one unsigned compare covering None and past Max, naming the key.
+func TestCsKeyedAccessorCoversBothEnds(t *testing.T) {
+	u := unitFromSource(t, `package probe
+enum Slot { Alpha, Beta, Gamma }
+table Root { tokens [Slot]int32 }
+`)
+	files, err := New().Generate(u, "cs", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(files["ProbeTable.cs"])
+	if strings.Contains(src, "RefuseNone") {
+		t.Error("TableKeyed still has RefuseNone — past Max would be a CLR index exception")
+	}
+	for _, want := range []string{
+		"static void RefuseKey(int key)",
+		"(uint)(key - 1) >= (uint)SlotCount",
+		"neither does a key past Max",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("TableKeyed lacks %q", want)
+		}
+	}
+}
+
+// TestCsCarriesBlobs: #723 emits *bytes/*string; registerBuiltin must name
+// C# as a carrier so a non-carrier's refusal lists --lang cs beside c/cpp/go.
+func TestCsCarriesBlobs(t *testing.T) {
+	u := unitFromSource(t, "package probe\ntable Root { data *bytes\n text *string }\n")
+	files, err := New().Generate(u, "cs", Options{})
+	if err != nil {
+		t.Fatalf("--lang cs refused blobs: %v", err)
+	}
+	src := string(files["ProbeTable.cs"])
+	for _, want := range []string{"data", "text"} {
+		if !strings.Contains(src, want) {
+			t.Errorf("blob field %q missing from generated C#", want)
+		}
+	}
+	err = refuseBlobs(u, "rust")
+	if err == nil {
+		t.Fatal("refuseBlobs accepted a blob-bearing unit for rust")
+	}
+	for _, want := range []string{"*bytes and *string are c, cpp, cs and go only today", "--lang cs"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("blob-carrier refusal does not name %q: %v", want, err)
+		}
+	}
+}

--- a/compiler/target_cs.go
+++ b/compiler/target_cs.go
@@ -46,7 +46,7 @@ func (csTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 func init() {
 	registerPacketValueDefaultCarrier("cs")
 	registerWideTextCarrier("cs")
-	registerBuiltin(csTarget{}, true, true, true, false)
+	registerBuiltin(csTarget{}, true, true, true, true)
 	registerOptionalArrayCarrier("cs")
 	registerMapCarrier("cs")
 	registerListCarrier("cs")

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -273,7 +273,7 @@ enum answered `undefined` before the guard was made symmetric.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-negative-control` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `test/cs-tables/src/Program.cs:1672` (None refused; past Max is the CLR's, always on) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
+| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-negative-control` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `TestCsKeyedAccessorCoversBothEnds` `TestKeyedIndexerRefusesNone` (`RefuseKey`, both ends) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
 
 ### M6 — The variable class on the wire: a flat node table and an identity map
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -273,7 +273,7 @@ enum answered `undefined` before the guard was made symmetric.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-negative-control` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `TestCsKeyedAccessorCoversBothEnds` `TestKeyedIndexerRefusesNone` (`RefuseKey`, both ends) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
+| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-negative-control` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `TestCsKeyedAccessorCoversBothEnds` (`RefuseKey`, both ends) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
 
 ### M6 — The variable class on the wire: a flat node table and an identity map
 

--- a/internal/codegen/cstable/cstable.go
+++ b/internal/codegen/cstable/cstable.go
@@ -401,10 +401,9 @@ func unitHasKeyedArray(u *ir.Unit, closure map[string]bool) bool {
 // So the indexer takes the key's VALUE as an int and the caller writes the
 // cast: `hull.Turrets[(int)Weapon.Missile]`. The CAST is the port's; the SHIFT
 // is not — the indexer subtracts one exactly as C++'s does, so no call site in
-// any language spells it (§2.4). The None refusal survives as the runtime
-// guard, and it stands in EVERY build — as C++'s does (§2.4): the two ports
-// refuse the same key in the same configurations, differing only in how a
-// language ends a program.
+// any language spells it (§2.4). The refusal covers None and past Max in
+// EVERY build — as C++'s does (§2.4): the two ports refuse the same keys in
+// the same configurations, differing only in how a language ends a program.
 //
 // ITERATION carries over with the same RANGE and one difference in what it
 // hands out (§2.4): a struct enumerator over the whole storage, so `foreach`
@@ -434,8 +433,9 @@ const tableKeyedStorage = `// An ENUM-KEYED array's storage: E.Max slots, ONE PE
 // out of step with.
 //
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
-// key of 0 is malformed, and INDEXING BY IT IS AN ERROR — a throw from the
-// indexer, which stands in every build exactly as the C++ abort does.
+// key of 0 is malformed, and INDEXING BY IT IS AN ERROR. A key past Max is
+// the same error. The throw stands in every build exactly as the C++ abort
+// does, and one unsigned compare covers both ends.
 //
 // ITERATION is the surface a consumer of the WHOLE array wants: foreach walks
 // every stored slot and yields the KEY, 1..E.Max, beside the element, so no
@@ -448,8 +448,8 @@ const tableKeyedStorage = `// An ENUM-KEYED array's storage: E.Max slots, ONE PE
 // indexer is how they are written.
 //
 // Slots is public and is what the generated codecs walk, by STORAGE INDEX; the
-// indexer is for callers and takes the KEY, and it is the one place the None
-// key can be caught in C#.
+// indexer is for callers and takes the KEY, and it is the one place None and
+// past Max are caught in C#.
 public sealed class TableKeyed<T, E> where E : struct, System.Enum
 {
     // the extent is the enum's, derived here and named nowhere else. C# has no
@@ -469,22 +469,25 @@ public sealed class TableKeyed<T, E> where E : struct, System.Enum
     {
         get
         {
-            RefuseNone(key);
+            RefuseKey(key);
             return Slots[key - 1];
         }
         set
         {
-            RefuseNone(key);
+            RefuseKey(key);
             Slots[key - 1] = value;
         }
     }
 
-    static void RefuseNone(int key)
+    // Storage index is key-1: None wraps above SlotCount, a key past Max is
+    // >= SlotCount. The CLR would still throw past Max, naming an index;
+    // this names the key.
+    static void RefuseKey(int key)
     {
-        if (key == 0)
+        if ((uint)(key - 1) >= (uint)SlotCount)
         {
             throw new ArgumentOutOfRangeException("key",
-                "None is the null key of an enum-keyed array: it keys no slot");
+                "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max");
         }
     }
 

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -1524,47 +1524,33 @@ static partial class Program
 
     // ---- the keyed indexer refuses None and past Max at runtime (§2.4) ----
 
-    static void TestKeyedIndexerRefusesNone()
+    static void CheckKeyedRefuses(int key, string why)
     {
         Demo.KeyedConfig cfg = new Demo.KeyedConfig();
-        bool threw = false;
         try
         {
-            Demo.TeamConfig ignored = cfg.Teams[0];
-            Check(ignored == null, "unreachable");
+            Demo.TeamConfig ignored = cfg.Teams[key];
+            Check(ignored == null, why + ": should throw");
         }
-        catch (ArgumentOutOfRangeException)
+        catch (ArgumentOutOfRangeException e)
         {
-            threw = true;
+            Check(e.ParamName == "key", why + ": the exception names the key");
+            return;
         }
-        Check(threw, "keyed indexer: None is the null key and indexing it is an error");
+        Check(false, why + ": no exception");
+    }
 
-        threw = false;
-        try
-        {
-            Demo.TeamConfig ignored = cfg.Teams[(int)Demo.Team.Max + 1];
-            Check(ignored == null, "unreachable");
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            threw = true;
-        }
-        Check(threw, "keyed indexer: a key past Max is an error, named as a key");
+    static void TestKeyedIndexerRefusesNone()
+    {
+        CheckKeyedRefuses(0, "keyed indexer: None");
+        CheckKeyedRefuses((int)Demo.Team.Max + 1, "keyed indexer: past Max");
+        CheckKeyedRefuses(-1, "keyed indexer: minus one");
+        CheckKeyedRefuses(int.MinValue, "keyed indexer: int min");
+        CheckKeyedRefuses(int.MaxValue, "keyed indexer: int max");
 
-        threw = false;
-        try
-        {
-            Demo.TeamConfig ignored = cfg.Teams[-1];
-            Check(ignored == null, "unreachable");
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            threw = true;
-        }
-        Check(threw, "keyed indexer: a negative key is an error, named as a key");
-
-        // and a real slot is reachable through the same indexer
+        Demo.KeyedConfig cfg = new Demo.KeyedConfig();
         Check(cfg.Teams[(int)Demo.Team.Blue] != null, "keyed indexer: a named slot reads");
+        Check(cfg.Teams[(int)Demo.Team.Max] != null, "keyed indexer: Max is the last named slot");
     }
 
     // ---- iteration over the VALID slots (§2.4) ----

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -1522,7 +1522,7 @@ static partial class Program
             "reflection: a positional array carries no key vocabulary");
     }
 
-    // ---- the keyed indexer refuses the None key at runtime (§2.4) ----
+    // ---- the keyed indexer refuses None and past Max at runtime (§2.4) ----
 
     static void TestKeyedIndexerRefusesNone()
     {
@@ -1538,6 +1538,30 @@ static partial class Program
             threw = true;
         }
         Check(threw, "keyed indexer: None is the null key and indexing it is an error");
+
+        threw = false;
+        try
+        {
+            Demo.TeamConfig ignored = cfg.Teams[(int)Demo.Team.Max + 1];
+            Check(ignored == null, "unreachable");
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            threw = true;
+        }
+        Check(threw, "keyed indexer: a key past Max is an error, named as a key");
+
+        threw = false;
+        try
+        {
+            Demo.TeamConfig ignored = cfg.Teams[-1];
+            Check(ignored == null, "unreachable");
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            threw = true;
+        }
+        Check(threw, "keyed indexer: a negative key is an error, named as a key");
 
         // and a real slot is reachable through the same indexer
         Check(cfg.Teams[(int)Demo.Team.Blue] != null, "keyed indexer: a named slot reads");

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -29,8 +29,9 @@ namespace Blockdemo
     // out of step with.
     //
     // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
-    // key of 0 is malformed, and INDEXING BY IT IS AN ERROR — a throw from the
-    // indexer, which stands in every build exactly as the C++ abort does.
+    // key of 0 is malformed, and INDEXING BY IT IS AN ERROR. A key past Max is
+    // the same error. The throw stands in every build exactly as the C++ abort
+    // does, and one unsigned compare covers both ends.
     //
     // ITERATION is the surface a consumer of the WHOLE array wants: foreach walks
     // every stored slot and yields the KEY, 1..E.Max, beside the element, so no
@@ -43,8 +44,8 @@ namespace Blockdemo
     // indexer is how they are written.
     //
     // Slots is public and is what the generated codecs walk, by STORAGE INDEX; the
-    // indexer is for callers and takes the KEY, and it is the one place the None
-    // key can be caught in C#.
+    // indexer is for callers and takes the KEY, and it is the one place None and
+    // past Max are caught in C#.
     public sealed class TableKeyed<T, E> where E : struct, System.Enum
     {
         // the extent is the enum's, derived here and named nowhere else. C# has no
@@ -64,22 +65,25 @@ namespace Blockdemo
         {
             get
             {
-                RefuseNone(key);
+                RefuseKey(key);
                 return Slots[key - 1];
             }
             set
             {
-                RefuseNone(key);
+                RefuseKey(key);
                 Slots[key - 1] = value;
             }
         }
 
-        static void RefuseNone(int key)
+        // Storage index is key-1: None wraps above SlotCount, a key past Max is
+        // >= SlotCount. The CLR would still throw past Max, naming an index;
+        // this names the key.
+        static void RefuseKey(int key)
         {
-            if (key == 0)
+            if ((uint)(key - 1) >= (uint)SlotCount)
             {
                 throw new ArgumentOutOfRangeException("key",
-                    "None is the null key of an enum-keyed array: it keys no slot");
+                    "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max");
             }
         }
 

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -29,8 +29,9 @@ namespace Tabledemo
     // out of step with.
     //
     // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
-    // key of 0 is malformed, and INDEXING BY IT IS AN ERROR — a throw from the
-    // indexer, which stands in every build exactly as the C++ abort does.
+    // key of 0 is malformed, and INDEXING BY IT IS AN ERROR. A key past Max is
+    // the same error. The throw stands in every build exactly as the C++ abort
+    // does, and one unsigned compare covers both ends.
     //
     // ITERATION is the surface a consumer of the WHOLE array wants: foreach walks
     // every stored slot and yields the KEY, 1..E.Max, beside the element, so no
@@ -43,8 +44,8 @@ namespace Tabledemo
     // indexer is how they are written.
     //
     // Slots is public and is what the generated codecs walk, by STORAGE INDEX; the
-    // indexer is for callers and takes the KEY, and it is the one place the None
-    // key can be caught in C#.
+    // indexer is for callers and takes the KEY, and it is the one place None and
+    // past Max are caught in C#.
     public sealed class TableKeyed<T, E> where E : struct, System.Enum
     {
         // the extent is the enum's, derived here and named nowhere else. C# has no
@@ -64,22 +65,25 @@ namespace Tabledemo
         {
             get
             {
-                RefuseNone(key);
+                RefuseKey(key);
                 return Slots[key - 1];
             }
             set
             {
-                RefuseNone(key);
+                RefuseKey(key);
                 Slots[key - 1] = value;
             }
         }
 
-        static void RefuseNone(int key)
+        // Storage index is key-1: None wraps above SlotCount, a key past Max is
+        // >= SlotCount. The CLR would still throw past Max, naming an index;
+        // this names the key.
+        static void RefuseKey(int key)
         {
-            if (key == 0)
+            if ((uint)(key - 1) >= (uint)SlotCount)
             {
                 throw new ArgumentOutOfRangeException("key",
-                    "None is the null key of an enum-keyed array: it keys no slot");
+                    "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max");
             }
         }
 


### PR DESCRIPTION
Johnny Grok.

C# `TableKeyed` only refused key 0 (`RefuseNone`) and let `Slots[key-1]` throw `IndexOutOfRangeException` past Max, naming an index. SPEC-TABLES §2.4 / PORTING M5: the accessor refuses both ends, in every build, and names the key. C++ and C already use one unsigned `key-1 >= count` compare.

This patch:
- `RefuseKey` with `(uint)(key - 1) >= (uint)SlotCount`, same message as C++
- runtime test also hits past Max and −1
- `registerBuiltin(..., true)` so C# is named as a `*bytes`/`*string` carrier (the emitter already did this since #723; the registry bit was stale)
- PORTING M5 C# cell updated

`go test ./compiler -run 'TestCs|TestMapRefusal|TestWideText'` green. Goldens regenerated from the emitter. I do not have `dotnet` on PATH here, so `tables-cs-leg` was not run.

Not in this PR: C# counted-array tail reset (#725), M3 float inlining (#404).