### PR TITLE
Reset C# counted-array tails after a shorter replacement

### DIFF
--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -88,3 +88,26 @@ table Node
 		t.Errorf("--lang cpp refused a pointered unit: %v", err)
 	}
 }
+
+// TestCsCountedArrayTailReset: a shorter counted-array replacement must restore
+// slots above the new count (#725). C++/C/Go already walk previous..decoded.
+func TestCsCountedArrayTailReset(t *testing.T) {
+	u := unitFromSource(t, `package probe
+table Child { n int32 = 7 }
+table Root { values [..8]Child }
+`)
+	files, err := New().Generate(u, "cs", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(files["ProbeTable.cs"])
+	for _, want := range []string{
+		"static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)",
+		"int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0",
+		"ResetCountedTail(value, f, previous, decoded)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("C# counted-array load lacks %q", want)
+		}
+	}
+}

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -3480,6 +3480,7 @@ namespace Benchtable
                     if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
                     int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
                     if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+                    int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
                     ulong walk = run >= 0 ? (ulong)kept : n;
                     for (ulong i = 0; i < walk; i++)
                     {
@@ -3487,7 +3488,7 @@ namespace Benchtable
                         if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
                     }
                     if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-                    if (f.Counted && value!=null) { f.SetCount(value, kept); }
+                    if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
                     if (f.Optional && value!=null) { f.SetPresent(value, true); }
                     return true;
                 }
@@ -4349,6 +4350,24 @@ namespace Benchtable
                 if (f.Counted) { f.SetCount(value, 0); }
                 if (f.Optional) { f.SetPresent(value, false); }
             }
+            // A shorter replacement, including a damaged one, must restore slots above
+            // the new count to the value-initialized element (#725).
+            static void ResetElement(object value, TableFieldInfo f, int i)
+            {
+                if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+                else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+                else if (f.Kind == 17) { f.SetChild(value, i, null); }
+                else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+                else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+            }
+            static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+            {
+                if (value == null || f.SetCount == null) { return; }
+                int end = previous;
+                if (end > f.ArrayBound) { end = f.ArrayBound; }
+                for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+                f.SetCount(value, decoded);
+            }
             static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
             {
                 if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -4483,6 +4502,7 @@ namespace Benchtable
                     {
                         int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                         if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                        int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                         int decoded = 0;
                         for (int i = 0; i < keep; i++)
                         {
@@ -4490,7 +4510,7 @@ namespace Benchtable
                             if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                             decoded++;
                         }
-                        if (f.Counted) { f.SetCount(value, decoded); }
+                        if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
                     }
                     return true;
                 }

--- a/internal/codegen/cstable/messageread.go
+++ b/internal/codegen/cstable/messageread.go
@@ -198,6 +198,7 @@ const tableMessageReadSource = `
             if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
             int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
             if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+            int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
             ulong walk = run >= 0 ? (ulong)kept : n;
             for (ulong i = 0; i < walk; i++)
             {
@@ -205,7 +206,7 @@ const tableMessageReadSource = `
                 if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
             }
             if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-            if (f.Counted && value!=null) { f.SetCount(value, kept); }
+            if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
             if (f.Optional && value!=null) { f.SetPresent(value, true); }
             return true;
         }

--- a/internal/codegen/cstable/region.go
+++ b/internal/codegen/cstable/region.go
@@ -152,6 +152,21 @@ const tableRegionSource = `
         }
         if(f.Optional) { value.SetPresent(f,false); }
     }
+    static unsafe void NativeResetElement(NativeValue value, TableFieldInfo f, int i)
+    {
+        if (value.Base == null) { return; }
+        if (f.Kind == 13) { NativeReset(value.Child(f, i), f.Table); }
+        else if (f.Kind == 15) { System.Runtime.InteropServices.NativeMemory.Clear(value.Slot(f, i), (nuint)f.NativeElementSize); }
+        else if (f.GetWide != null) { value.SetWide(f, i, f.DefaultWide); }
+        else { value.SetRaw(f, i, f.DefaultRaw); }
+    }
+    static unsafe void NativeResetCountedTail(NativeValue value, TableFieldInfo f, int previous, int decoded)
+    {
+        int end = previous;
+        if (end > f.ArrayBound) { end = f.ArrayBound; }
+        for (int i = decoded; i < end; i++) { NativeResetElement(value, f, i); }
+        value.SetCount(f, decoded);
+    }
     static unsafe bool NativeReserve(ref NativeState state,NativeValue value,TableFieldInfo f,ulong count,TableReport report)
     {
         if(state.Worker!=null)
@@ -493,6 +508,7 @@ const tableRegionSource = `
                 int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                 if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
                 if (f.Dynamic && !NativeReserve(ref state,value,f,count,report)) { return false; }
+                int previous = f.Counted ? value.Count(f) : 0;
                 int decoded = 0;
                 for (int i = 0; i < keep; i++)
                 {
@@ -500,7 +516,7 @@ const tableRegionSource = `
                     if (!NativeReadElement(ref state, ref array, value, f, i, elementKind, report, true)) { break; }
                     decoded++;
                 }
-                if (f.Counted) { value.SetCount(f,decoded); }
+                if (f.Counted) { NativeResetCountedTail(value, f, previous, decoded); }
             }
             return true;
         }

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -620,6 +620,24 @@ public static partial class TableWire
         if (f.Counted) { f.SetCount(value, 0); }
         if (f.Optional) { f.SetPresent(value, false); }
     }
+    // A shorter replacement, including a damaged one, must restore slots above
+    // the new count to the value-initialized element (#725).
+    static void ResetElement(object value, TableFieldInfo f, int i)
+    {
+        if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+        else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+        else if (f.Kind == 17) { f.SetChild(value, i, null); }
+        else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+        else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+    }
+    static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+    {
+        if (value == null || f.SetCount == null) { return; }
+        int end = previous;
+        if (end > f.ArrayBound) { end = f.ArrayBound; }
+        for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+        f.SetCount(value, decoded);
+    }
     static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
     {
         if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -754,6 +772,7 @@ public static partial class TableWire
             {
                 int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                 if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                 int decoded = 0;
                 for (int i = 0; i < keep; i++)
                 {
@@ -761,7 +780,7 @@ public static partial class TableWire
                     if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                     decoded++;
                 }
-                if (f.Counted) { f.SetCount(value, decoded); }
+                if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
             }
             return true;
         }

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -557,6 +557,54 @@ static partial class Program
         }
     }
 
+    // #725: a later counted-array occurrence that is shorter must restore
+    // slots above the new count to the declared default, not leave the first
+    // occurrence standing. Two RootConfig saves of the same fields share a
+    // vocabulary suffix; splicing the field streams yields two occurrences.
+    static byte[] SharedVocabSplice(byte[] first, byte[] second)
+    {
+        int suffix = 0;
+        int n = Math.Min(first.Length, second.Length);
+        while (suffix < n && first[first.Length - 1 - suffix] == second[second.Length - 1 - suffix])
+        {
+            suffix++;
+        }
+        Check(suffix > 8, "counted tail: files share a vocabulary suffix");
+        Check(first[first.Length - suffix - 1] == 0, "counted tail: first field stream ends at 0");
+        byte[] spliced = new byte[first.Length - suffix - 1 + second.Length];
+        Buffer.BlockCopy(first, 0, spliced, 0, first.Length - suffix - 1);
+        Buffer.BlockCopy(second, 0, spliced, first.Length - suffix - 1, second.Length);
+        return spliced;
+    }
+
+    static void TestCountedArrayShorterReplacement()
+    {
+        Demo.RootConfig three = new Demo.RootConfig();
+        three.WeaponsCount = 3;
+        three.Weapons[0].Damage = 5.0f;
+        three.Weapons[1].Damage = 99.0f;
+        three.Weapons[2].Damage = 88.0f;
+        long n = Demo.Schema.RootConfigMeasure(three);
+        byte[] a = new byte[n];
+        Check(Demo.Schema.RootConfigSave(three, a) == n, "counted tail: save three");
+
+        Demo.RootConfig one = new Demo.RootConfig();
+        one.WeaponsCount = 1;
+        one.Weapons[0].Damage = 5.0f;
+        long m = Demo.Schema.RootConfigMeasure(one);
+        byte[] b = new byte[m];
+        Check(Demo.Schema.RootConfigSave(one, b) == m, "counted tail: save one");
+
+        byte[] spliced = SharedVocabSplice(a, b);
+        Demo.RootConfig got = new Demo.RootConfig();
+        Demo.TableReport report = new Demo.TableReport();
+        Check(Demo.Schema.RootConfigLoad(got, spliced, report), "counted tail: load two occurrences");
+        Check(got.WeaponsCount == 1, "counted tail: later count wins");
+        Check(got.Weapons[0].Damage == 5.0f, "counted tail: live prefix kept");
+        Check(got.Weapons[1].Damage == 21.0f, "counted tail: slot 1 restored to default");
+        Check(got.Weapons[2].Damage == 21.0f, "counted tail: slot 2 restored to default");
+    }
+
     // ---- all-default: everything elides, decode restores every default ----
 
     static void TestAllDefault()
@@ -1727,6 +1775,7 @@ static partial class Program
         TestExactCapacity();
         TestStorageInvariants();
         TestBoundedElements();
+        TestCountedArrayShorterReplacement();
         TestAllDefault();
         TestGuard();
         TestEvolutionOldReaderNewData();

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -3508,6 +3508,7 @@ namespace Blockdemo
                     if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
                     int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
                     if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+                    int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
                     ulong walk = run >= 0 ? (ulong)kept : n;
                     for (ulong i = 0; i < walk; i++)
                     {
@@ -3515,7 +3516,7 @@ namespace Blockdemo
                         if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
                     }
                     if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-                    if (f.Counted && value!=null) { f.SetCount(value, kept); }
+                    if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
                     if (f.Optional && value!=null) { f.SetPresent(value, true); }
                     return true;
                 }
@@ -4377,6 +4378,24 @@ namespace Blockdemo
                 if (f.Counted) { f.SetCount(value, 0); }
                 if (f.Optional) { f.SetPresent(value, false); }
             }
+            // A shorter replacement, including a damaged one, must restore slots above
+            // the new count to the value-initialized element (#725).
+            static void ResetElement(object value, TableFieldInfo f, int i)
+            {
+                if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+                else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+                else if (f.Kind == 17) { f.SetChild(value, i, null); }
+                else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+                else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+            }
+            static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+            {
+                if (value == null || f.SetCount == null) { return; }
+                int end = previous;
+                if (end > f.ArrayBound) { end = f.ArrayBound; }
+                for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+                f.SetCount(value, decoded);
+            }
             static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
             {
                 if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -4511,6 +4530,7 @@ namespace Blockdemo
                     {
                         int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                         if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                        int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                         int decoded = 0;
                         for (int i = 0; i < keep; i++)
                         {
@@ -4518,7 +4538,7 @@ namespace Blockdemo
                             if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                             decoded++;
                         }
-                        if (f.Counted) { f.SetCount(value, decoded); }
+                        if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
                     }
                     return true;
                 }

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -3396,6 +3396,7 @@ namespace Blockhome
                     if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
                     int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
                     if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+                    int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
                     ulong walk = run >= 0 ? (ulong)kept : n;
                     for (ulong i = 0; i < walk; i++)
                     {
@@ -3403,7 +3404,7 @@ namespace Blockhome
                         if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
                     }
                     if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-                    if (f.Counted && value!=null) { f.SetCount(value, kept); }
+                    if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
                     if (f.Optional && value!=null) { f.SetPresent(value, true); }
                     return true;
                 }
@@ -4265,6 +4266,24 @@ namespace Blockhome
                 if (f.Counted) { f.SetCount(value, 0); }
                 if (f.Optional) { f.SetPresent(value, false); }
             }
+            // A shorter replacement, including a damaged one, must restore slots above
+            // the new count to the value-initialized element (#725).
+            static void ResetElement(object value, TableFieldInfo f, int i)
+            {
+                if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+                else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+                else if (f.Kind == 17) { f.SetChild(value, i, null); }
+                else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+                else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+            }
+            static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+            {
+                if (value == null || f.SetCount == null) { return; }
+                int end = previous;
+                if (end > f.ArrayBound) { end = f.ArrayBound; }
+                for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+                f.SetCount(value, decoded);
+            }
             static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
             {
                 if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -4399,6 +4418,7 @@ namespace Blockhome
                     {
                         int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                         if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                        int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                         int decoded = 0;
                         for (int i = 0; i < keep; i++)
                         {
@@ -4406,7 +4426,7 @@ namespace Blockhome
                             if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                             decoded++;
                         }
-                        if (f.Counted) { f.SetCount(value, decoded); }
+                        if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
                     }
                     return true;
                 }

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -3508,6 +3508,7 @@ namespace Tabledemo
                     if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
                     int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
                     if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+                    int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
                     ulong walk = run >= 0 ? (ulong)kept : n;
                     for (ulong i = 0; i < walk; i++)
                     {
@@ -3515,7 +3516,7 @@ namespace Tabledemo
                         if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
                     }
                     if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-                    if (f.Counted && value!=null) { f.SetCount(value, kept); }
+                    if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
                     if (f.Optional && value!=null) { f.SetPresent(value, true); }
                     return true;
                 }
@@ -4377,6 +4378,24 @@ namespace Tabledemo
                 if (f.Counted) { f.SetCount(value, 0); }
                 if (f.Optional) { f.SetPresent(value, false); }
             }
+            // A shorter replacement, including a damaged one, must restore slots above
+            // the new count to the value-initialized element (#725).
+            static void ResetElement(object value, TableFieldInfo f, int i)
+            {
+                if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+                else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+                else if (f.Kind == 17) { f.SetChild(value, i, null); }
+                else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+                else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+            }
+            static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+            {
+                if (value == null || f.SetCount == null) { return; }
+                int end = previous;
+                if (end > f.ArrayBound) { end = f.ArrayBound; }
+                for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+                f.SetCount(value, decoded);
+            }
             static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
             {
                 if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -4511,6 +4530,7 @@ namespace Tabledemo
                     {
                         int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                         if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                        int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                         int decoded = 0;
                         for (int i = 0; i < keep; i++)
                         {
@@ -4518,7 +4538,7 @@ namespace Tabledemo
                             if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                             decoded++;
                         }
-                        if (f.Counted) { f.SetCount(value, decoded); }
+                        if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
                     }
                     return true;
                 }

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -3396,6 +3396,7 @@ namespace Wide
                     if (f.Dynamic && (n > int.MaxValue || run!=0 && n > (ulong)((r.End - r.At) / Math.Max(1, run)))) { return false; }
                     int kept = (int)Math.Min(n, (ulong)f.ArrayBound);
                     if (n > (ulong)f.ArrayBound) { d.Report.Clamped++; }
+                    int previous = f.Counted && value != null && f.GetCount != null ? f.GetCount(value) : 0;
                     ulong walk = run >= 0 ? (ulong)kept : n;
                     for (ulong i = 0; i < walk; i++)
                     {
@@ -3403,7 +3404,7 @@ namespace Wide
                         if (!MessageReadElement(ref r, d, value, f, (int)i, shape.Elem, shape.Inner, i < (ulong)kept)) { return false; }
                     }
                     if (walk < n && !r.Skip((long)(n - walk) * run)) { return false; }
-                    if (f.Counted && value!=null) { f.SetCount(value, kept); }
+                    if (f.Counted && value!=null) { ResetCountedTail(value, f, previous, kept); }
                     if (f.Optional && value!=null) { f.SetPresent(value, true); }
                     return true;
                 }
@@ -4265,6 +4266,24 @@ namespace Wide
                 if (f.Counted) { f.SetCount(value, 0); }
                 if (f.Optional) { f.SetPresent(value, false); }
             }
+            // A shorter replacement, including a damaged one, must restore slots above
+            // the new count to the value-initialized element (#725).
+            static void ResetElement(object value, TableFieldInfo f, int i)
+            {
+                if (f.Kind == 13 && f.Table != null) { object child = f.GetChild(value, i); if (child != null) { f.Table.Reset(child); } }
+                else if (f.Kind == 15 && f.Arms != null) { f.Arms.SetTag(f.GetChild(value, i), 0); }
+                else if (f.Kind == 17) { f.SetChild(value, i, null); }
+                else if (f.SetWide != null) { f.SetWide(value, i, 0); }
+                else if (f.SetRaw != null) { f.SetRaw(value, i, f.DefaultRaw); }
+            }
+            static void ResetCountedTail(object value, TableFieldInfo f, int previous, int decoded)
+            {
+                if (value == null || f.SetCount == null) { return; }
+                int end = previous;
+                if (end > f.ArrayBound) { end = f.ArrayBound; }
+                for (int i = decoded; i < end; i++) { ResetElement(value, f, i); }
+                f.SetCount(value, decoded);
+            }
             static bool ReadArm(ref Reader r, object value, TableFieldInfo f, byte kind, TableReport report)
             {
                 if (f == null) { return r.Buffer.Length == 0 || Damage(report); }
@@ -4399,6 +4418,7 @@ namespace Wide
                     {
                         int keep = (int)Math.Min(count, (ulong)f.ArrayBound);
                         if (!f.Dynamic && count > (ulong)f.ArrayBound) { report.Clamped++; }
+                        int previous = f.Counted && f.GetCount != null ? f.GetCount(value) : 0;
                         int decoded = 0;
                         for (int i = 0; i < keep; i++)
                         {
@@ -4406,7 +4426,7 @@ namespace Wide
                             if (!ReadElement(ref array, value, f, i, elementKind, report, true)) { break; }
                             decoded++;
                         }
-                        if (f.Counted) { f.SetCount(value, decoded); }
+                        if (f.Counted) { ResetCountedTail(value, f, previous, decoded); }
                     }
                     return true;
                 }


### PR DESCRIPTION
Johnny Grok. Follow-up to the table-wire compare. #725.

A later counted-array occurrence that decodes a shorter prefix (including a damaged one) must restore slots above the new count to the value-initialized element. C++, C and Go already do this. C# only called `SetCount(decoded)`.

Managed file load, native region load, and the message counted-array path now capture the previous count and `ResetCountedTail` / `NativeResetCountedTail` before publishing the new count.

`TestCsCountedArrayTailReset` pins the generated helpers. Goldens for the three C# runtime homes updated. No `dotnet` on PATH here, so `tables-cs-leg` was not run.