### PR TITLE
Enumerate C and Go block-lead residues 1..63

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1075,7 +1075,7 @@ lead 1 answered open, wanted refuse".
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-block-fuzz` (the enumerated 1..63 pass, `test/tables/block_fuzz_main.cpp:939`) | ❌ #387 (a random lead one mutant in four) | ❌ #387 (enumerated in the unreached `tables-rust-fuzz`) | ❌ #387 (a random lead; the oracle cannot see the check go missing) | ✅ `tables-block-fuzz` (`test/cs-block/src/Fuzz.cs:749-753`) | ❌ #387 (every `open` in the leg passes offset 0) | ❌ #387 (the block battery's pointer column is 0) | ❌ #387 (same) | ✅ `tables-elixir-block-lead` `tables-elixir-block-lead-negative-control` |
+| ✅ `tables-block-fuzz` (the enumerated 1..63 pass, `test/tables/block_fuzz_main.cpp:939`) | ✅ `tables-c-fuzz` (the enumerated 1..63 pass, `test/c-tables/fuzz_main.c:165`) | ❌ #387 (enumerated in the unreached `tables-rust-fuzz`) | ✅ `tables-go-fuzz` (the enumerated 1..63 pass, `test/go-tables/fuzz_test.go:205`) | ✅ `tables-block-fuzz` (`test/cs-block/src/Fuzz.cs:749-753`) | ❌ #387 (every `open` in the leg passes offset 0) | ❌ #387 (the block battery's pointer column is 0) | ❌ #387 (same) | ✅ `tables-elixir-block-lead` `tables-elixir-block-lead-negative-control` |
 
 ### I6 — Claimed names, both ways, with a control
 

--- a/test/c-tables/fuzz_main.c
+++ b/test/c-tables/fuzz_main.c
@@ -25,7 +25,11 @@
  * The extent and the base are fuzzed too, because both are caller facts a file
  * cannot carry: a claim shorter than the file is a truncation, a claim longer
  * is a caller that lied, and an unaligned base is the one pointer fact the
- * conformance data grew a column for.
+ * conformance data grew a column for. Random leads cannot see the %64 check
+ * go missing — unaligned loads succeed on every host this repo builds on —
+ * so after the clean open, every block image is placed at leads 1..63 (must
+ * refuse) and 64 (aligned again, must open). Cook lead is the harness's
+ * cook_lead_1..63 rows; this is the block's (docs/PORTING.md I5).
  *
  *   SEED=<n> N=<n> ./build/schema_test_c_fuzz
  */
@@ -148,6 +152,28 @@ int main( void )
         {
             fprintf( stderr, "fuzz: the clean %s %s does not open — the fuzzer would be damaging nothing\n",
                      subjects[s].kind, subjects[s].name );
+            return 1;
+        }
+    }
+
+    /* pass "lead": every residue. The random loop below plants a lead one
+       mutant in four; that cannot see the alignment check go missing. */
+    for ( s = 0; s < num_subjects; s++ )
+    {
+        int lead;
+        if ( strcmp( subjects[s].kind, "block" ) != 0 ) { continue; }
+        for ( lead = 1; lead < 64; lead++ )
+        {
+            if ( open_subject( &subjects[s], subjects[s].clean, subjects[s].bytes, -1, lead ) )
+            {
+                fprintf( stderr, "fuzz: %s at lead %d opened, wanted refuse — an unaligned base\n",
+                         subjects[s].name, lead );
+                return 1;
+            }
+        }
+        if ( !open_subject( &subjects[s], subjects[s].clean, subjects[s].bytes, -1, 64 ) )
+        {
+            fprintf( stderr, "fuzz: %s at lead 64 refused, wanted open\n", subjects[s].name );
             return 1;
         }
     }

--- a/test/go-tables/fuzz_test.go
+++ b/test/go-tables/fuzz_test.go
@@ -198,6 +198,29 @@ func TestBlockForgeryFuzz(t *testing.T) {
 		}
 		checkWhole(t, unit.name, "clean", 0, base, extent, facts, used, intact)
 
+		// pass "lead": every residue. Random leads cannot see the %64 check
+		// go missing — unaligned loads succeed on this host — so 1..63 must
+		// refuse by name. Lead 64 is aligned again and must open. Cook lead
+		// is the harness; this is the block's (docs/PORTING.md I5).
+		for lead := 1; lead < 64; lead++ {
+			base, extent, intact := place(image, int64(len(image)), lead)
+			opened, _, _ := unit.open(base, extent)
+			if opened {
+				t.Fatalf("%s: lead %d opened, wanted refuse — an unaligned base", unit.name, lead)
+			}
+			if !intact() {
+				t.Fatalf("%s: lead %d wrote past the extent", unit.name, lead)
+			}
+		}
+		{
+			base, extent, intact := place(image, int64(len(image)), 64)
+			opened, facts, used := unit.open(base, extent)
+			if !opened {
+				t.Fatalf("%s: lead 64 refused, wanted open", unit.name)
+			}
+			checkWhole(t, unit.name, "lead 64", 64, base, extent, facts, used, intact)
+		}
+
 		r := rand.New(rand.NewPCG(seed, uint64(len(unit.name))))
 		for i := 0; i < n; i++ {
 			mutant := make([]byte, len(image))


### PR DESCRIPTION
Johnny Grok. I5 / PORTING #387 carry for C and Go.

C and Go already refuse an unaligned block base (`(uintptr_t)base % 64` / `uintptr(base)%64`). Their fuzzers only planted a random lead, so deleting the check stayed green — unaligned loads succeed on every host this repo builds on.

This adds the enumerated pass C++ and C# already have, and asserts the verdict Elixir's `BlockLead` holds:

- clean image at lead 1..63 must refuse
- lead 64 is aligned again and must open
- cook lead stays the harness `cook_lead_1..63` rows

`make tables-c-fuzz N=2000` and `make tables-go-fuzz N=200` (including `-race`) are green. `go test ./compiler -run TestPortingRegister` is green.

Not #387's reference-leg forgery row (nonzero pointer in the pinned battery). That remains.