### PR TITLE
Add C keyed past-Max refusal under -DNDEBUG

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -273,7 +273,7 @@ enum answered `undefined` before the guard was made symmetric.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-negative-control` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `test/cs-tables/src/Program.cs:1672` (None refused; past Max is the CLR's, always on) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
+| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ✅ `TestCTableKeyedBounds` `tables-c-keyed-none-refusal-ndebug` `tables-c-keyed-max-refusal-ndebug` | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `test/cs-tables/src/Program.cs:1672` (None refused; past Max is the CLR's, always on) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
 
 ### M6 — The variable class on the wire: a flat node table and an identity map
 

--- a/make/c.mk
+++ b/make/c.mk
@@ -293,6 +293,8 @@ tables-c: tables-c-wire-fuzz build/conformance-c build/conformance-c-asan tables
 	$(MAKE) tables-js-fuzz
 	$(MAKE) tables-c-keyed-none-refusal-ndebug
 	$(MAKE) tables-c-keyed-none-refusal-negative-control
+	$(MAKE) tables-c-keyed-max-refusal-ndebug
+	$(MAKE) tables-c-keyed-max-refusal-negative-control
 	$(MAKE) tables-c-soak SOAK_SECONDS=20
 	$(MAKE) tables-c-soak-negative-control
 
@@ -490,6 +492,42 @@ tables-c-keyed-none-refusal-negative-control: bin/schema test/c-tables/keyed_non
 		  cat build/c-keyed-sabotage/log; exit 1; }
 	@echo "negative control: deleting the C accessor's abort turns the None-refusal gate RED"
 
+# THE OTHER END OF THE SAME REFUSAL, C side (docs/SPEC-TABLES.md §2.4). C++ has
+# tables-keyed-max-refusal-ndebug; C had only TestCTableKeyedBounds (longjmp).
+# A shipped -DNDEBUG build must still die on a key past Max.
+.PHONY: tables-c-keyed-max-refusal-ndebug
+tables-c-keyed-max-refusal-ndebug: build/tables-generated-c/.stamp test/c-tables/keyed_max_ndebug_main.c
+	@mkdir -p build
+	$(CC) $(TABLES_CFLAGS) -DNDEBUG -Ibuild/tables-generated-c/examples \
+		test/c-tables/keyed_max_ndebug_main.c -o build/schema_test_c_keyed_max_ndebug -lm
+	./build/schema_test_c_keyed_max_ndebug
+
+# and its NEGATIVE CONTROL: put the accessor back to the None-ONLY compare —
+# what it refused before both ends stood — and the gate above must go RED.
+.PHONY: tables-c-keyed-max-refusal-negative-control
+tables-c-keyed-max-refusal-negative-control: bin/schema test/c-tables/keyed_max_ndebug_main.c
+	@rm -rf build/c-keyed-max-sabotage && mkdir -p build/c-keyed-max-sabotage
+	@sed 's|    if ( (uint32_t) key - 1u >= count )|    if ( key == 0 ) /* SABOTAGED: the None-only compare again */|' \
+		internal/codegen/ctable/ctable.go > build/c-keyed-max-sabotage/ctable.go.txt
+	@cmp -s internal/codegen/ctable/ctable.go build/c-keyed-max-sabotage/ctable.go.txt && \
+		{ echo "NEGATIVE CONTROL: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/ctable/ctable.go":"%s/build/c-keyed-max-sabotage/ctable.go.txt"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/c-keyed-max-sabotage/overlay.json
+	go build -overlay build/c-keyed-max-sabotage/overlay.json -o build/c-keyed-max-sabotage/schema ./cmd/schema
+	build/c-keyed-max-sabotage/schema generate --lang c --out build/c-keyed-max-sabotage/generated tables/examples
+	@grep -q "SABOTAGED" build/c-keyed-max-sabotage/generated/KeyedTable.h || \
+		{ echo "NEGATIVE CONTROL: the sabotaged emitter emitted an unsabotaged accessor"; exit 1; }
+	$(CC) $(TABLES_CFLAGS) -Wno-error -DNDEBUG -Ibuild/c-keyed-max-sabotage/generated \
+		test/c-tables/keyed_max_ndebug_main.c -o build/c-keyed-max-sabotage/probe -lm
+	@if ./build/c-keyed-max-sabotage/probe > build/c-keyed-max-sabotage/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a None-only compare left the past-Max gate GREEN"; \
+		cat build/c-keyed-max-sabotage/log; exit 1; \
+	fi
+	@grep -q "the refusal was compiled out" build/c-keyed-max-sabotage/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on the refusal"; \
+		  cat build/c-keyed-max-sabotage/log; exit 1; }
+	@echo "negative control: the None-only compare turns the C past-Max refusal gate red"
+
 # THE VARIABLE-LENGTH CLASS, end to end (docs/SPEC-TABLES.md §2, §6, §9). The
 # conformance corpus reaches every FIXED surface and none of this one: its
 # instances are all fixed, because the harness's wire goldens are. So the
@@ -650,6 +688,8 @@ test-c: build/schema_test_c build/schema_test_c_ludicrous build/schema_test_benc
 	$(MAKE) tables-c-variable
 	$(MAKE) tables-c-keyed-none-refusal-ndebug
 	$(MAKE) tables-c-keyed-none-refusal-negative-control
+	$(MAKE) tables-c-keyed-max-refusal-ndebug
+	$(MAKE) tables-c-keyed-max-refusal-negative-control
 	$(MAKE) tables-c-soak SOAK_SECONDS=2
 	$(MAKE) tables-c-soak-negative-control
 	# and the whole matrix again under ASan + UBSan: the sanitized run is the

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -209,6 +209,7 @@
         "tables-blob-span-negative-control",
         "tables-c-fuzz-negative-control",
         "tables-c-keyed-none-refusal-negative-control",
+        "tables-c-keyed-max-refusal-negative-control",
         "tables-c-soak-negative-control",
         "tables-cook-fuzz-negative-control",
         "tables-cook-open-lengths-negative-control",

--- a/test/c-tables/keyed_max_ndebug_main.c
+++ b/test/c-tables/keyed_max_ndebug_main.c
@@ -1,0 +1,65 @@
+/* THE OTHER END OF THE SAME REFUSAL, HELD IN THE CONFIGURATION THAT WOULD DROP
+ * IT — the C leg's twin of test/tables/keyed_max_ndebug_main.cpp
+ * (docs/SPEC-TABLES.md §2.4).
+ *
+ * An enum-keyed array holds one slot per NAMED variant, so a key past Max names
+ * a variant this enum does not have: the same program error as None, refused
+ * the same way in EVERY build. A build that let it through would read past the
+ * end of the storage.
+ *
+ * This translation unit is compiled -DNDEBUG, which is exactly the
+ * configuration a game ships and exactly the one that removes an assert. The
+ * child must still die. Its Makefile gate requires that.
+ *
+ * C's accessor is a macro over table_keyed_slot rather than an operator[]; the
+ * refusal inside it is the same unsigned compare plus the same abort.
+ */
+
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "KeyedTable.h"
+
+int main( void )
+{
+#ifndef NDEBUG
+    printf( "FAILED: this gate is meaningless without -DNDEBUG\n" );
+    return 1;
+#else
+    pid_t child;
+    int status = 0;
+    fflush( stdout );
+    child = fork();
+    if ( child == 0 )
+    {
+        FILE * quiet = freopen( "/dev/null", "w", stderr );
+        KeyedConfig cfg;
+        Team key = (Team) ( (int32_t) TEAM_MAX + 1 );
+        (void) quiet;
+        keyed_config_reset( &cfg );
+        SCHEMA_TABLE_KEYED_AT( cfg.teams, key, TEAM_MAX ).spawn_count = 1; /* never reached */
+        _exit( 0 );
+    }
+    if ( child < 0 )
+    {
+        printf( "FAILED: fork\n" );
+        return 1;
+    }
+    if ( waitpid( child, &status, 0 ) != child )
+    {
+        printf( "FAILED: waitpid\n" );
+        return 1;
+    }
+    if ( !WIFSIGNALED( status ) )
+    {
+        printf( "FAILED: under -DNDEBUG a key past Max did NOT end the program — "
+                "the refusal was compiled out, and a shipped build would read "
+                "past the end of the storage (docs/SPEC-TABLES.md §2.4)\n" );
+        return 1;
+    }
+    printf( "keyed past-Max refusal under -DNDEBUG, C: the index ended the program (signal %d)\n",
+            WTERMSIG( status ) );
+    return 0;
+#endif
+}


### PR DESCRIPTION
Johnny Grok. Remaining table-wire hole from the compare: C had no process-death twin of C++ \`tables-keyed-max-refusal-ndebug\`.

\`tables-c-keyed-max-refusal-ndebug\` compiles the C accessor \`-DNDEBUG\` and requires \`TEAM_MAX+1\` to abort. The negative control puts the None-only compare back and requires that gate to go red.

\`TestCTableKeyedBounds\` still holds both ends via longjmp. This is the shipped-build half.