### PR TITLE
Refuse an incomplete C++ table allocator before the first callback

### DIFF
--- a/internal/codegen/cpptable/arena.go
+++ b/internal/codegen/cpptable/arena.go
@@ -142,6 +142,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -290,7 +306,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -325,13 +341,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -372,7 +388,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -543,7 +559,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -590,7 +606,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -598,7 +614,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -789,7 +805,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -817,12 +833,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;

--- a/internal/codegen/cpptable/cookwrite.go
+++ b/internal/codegen/cpptable/cookwrite.go
@@ -649,7 +649,7 @@ func (g *tableGen) emitCookWriteVariableRoot(st *ir.Struct) {
 	g.pf("    TableCookRegion region;\n")
 	g.pf("    bool ok = %sNumberFrom( ctx, numbering, root );\n", n)
 	g.pf("    if ( ok )\n    {\n")
-	g.pf("        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );\n")
+	g.pf("        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );\n")
 	if g.anyExtent {
 		g.pf("        ok = region.offsets != NULL && %sCookLayout( ctx, root, numbering, region );\n", n)
 	} else {
@@ -728,7 +728,7 @@ func (g *tableGen) emitCookWriteVariableRoot(st *ir.Struct) {
 	g.pf("            }\n")
 	g.pf("        }\n")
 	g.pf("    }\n")
-	g.pf("    allocator.free( allocator.context, region.offsets );\n")
+	g.pf("    table_release( allocator, region.offsets );\n")
 	g.pf("    TableNumberingShutdown( numbering );\n")
 	g.pf("    return ok;\n}\n\n")
 

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -3211,7 +3211,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -3241,7 +3241,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -3249,7 +3249,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/internal/codegen/cpptable/maps.go
+++ b/internal/codegen/cpptable/maps.go
@@ -396,7 +396,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -412,7 +412,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -429,7 +429,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -912,7 +912,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("        TableSlot<%s> slot = main.Alloc<%s>();\n", n, n)
 	g.pf("        root_ref = slot.ref;\n")
 	g.pf("    }\n")
-	g.pf("    ~%sBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }\n", n)
+	g.pf("    ~%sBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }\n", n)
 	g.pf("    %sBuilder( const %sBuilder & ) = delete;\n", n, n)
 	g.pf("    %sBuilder & operator=( const %sBuilder & ) = delete;\n\n", n, n)
 	g.pf("    // Alloc a node in THIS thread's slab: no lock, no atomic per node.\n")
@@ -969,7 +969,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    // the AUTHORING path may allocate (§6.5), and it does so through the\n")
 	g.pf("    // builder's own pair. The region comes back ZEROED, which is the\n")
 	g.pf("    // allocator's contract: a packed region carries node padding.\n")
-	g.pf("    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );\n")
+	g.pf("    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );\n")
 	g.pf("    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }\n")
 	if g.anyExtent {
 		g.pf("    int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( %s ) ) + root_extent );\n", n)
@@ -986,7 +986,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||\n")
 	g.pf("         !%sPack( ctx, seen, root, *destination, packed, total, used ) || used != total )\n    {\n", n)
 	g.pf("        TablePackMapShutdown( seen );\n")
-	g.pf("        arena.allocator.free( arena.allocator.context, packed );\n        return false;\n    }\n")
+	g.pf("        table_release( arena.allocator, packed );\n        return false;\n    }\n")
 	g.pf("    TablePackMapShutdown( seen );\n")
 	g.pf("    region = packed;\n")
 	g.pf("    region_bytes = total;\n")
@@ -1113,7 +1113,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    // It goes through the builder's own pair, like everything else the\n")
 	g.pf("    // builder reaches, and the entries come back zeroed.\n")
 	g.pf("    const TableAllocator allocator = builder.arena.allocator;\n")
-	g.pf("    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );\n")
+	g.pf("    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );\n")
 	g.pf("    if ( directory == NULL ) { out->malformed = true; return false; }\n")
 	g.pf("    directory[0].offset = (uint64_t) builder.root_ref.value;\n")
 	g.pf("    directory[0].type_id = 0x%016xull;\n", ir.TableWireId(st.WireName()))
@@ -1178,7 +1178,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 		g.pf("    // holds what it held when the count was met\n")
 		g.pf("    ok = ok && !nodes.refused;\n")
 	}
-	g.pf("    allocator.free( allocator.context, directory );\n")
+	g.pf("    table_release( allocator, directory );\n")
 	g.pf("    return ok;\n}\n\n")
 }
 

--- a/test/tables/hooks_main.cpp
+++ b/test/tables/hooks_main.cpp
@@ -210,6 +210,42 @@ static void test_allocator_sees_everything()
     CHECK( g_fallback_frees == 0 );
 }
 
+// An incomplete pair refuses before the first callback (C's table_allocate).
+static void test_incomplete_pair_refuses_before_callback()
+{
+    g_fallback_allocs = 0;
+    g_fallback_frees = 0;
+
+    Counters counters = { 0, 0, 0 };
+    graphdemo::TableAllocator alloc_only;
+    alloc_only.alloc = counting_alloc;
+    alloc_only.free = NULL;
+    alloc_only.context = &counters;
+    {
+        graphdemo::SceneBuilder builder( alloc_only );
+        CHECK( counters.allocs == 0 );
+        CHECK( builder.GetRoot() == NULL );
+        CHECK( !builder.Lock() );
+        CHECK( counters.allocs == 0 );
+        CHECK( counters.frees == 0 );
+    }
+    CHECK( counters.allocs == 0 );
+
+    graphdemo::TableAllocator free_only;
+    free_only.alloc = NULL;
+    free_only.free = counting_free;
+    free_only.context = &counters;
+    {
+        graphdemo::SceneBuilder builder( free_only );
+        CHECK( counters.allocs == 0 );
+        CHECK( builder.GetRoot() == NULL );
+        CHECK( !builder.Lock() );
+        CHECK( counters.frees == 0 );
+    }
+    CHECK( g_fallback_allocs == 0 );
+    CHECK( g_fallback_frees == 0 );
+}
+
 // ---- the BYTE BUFFER's two allocation claims, at run time ----
 //
 // THE BUILDER'S BLOBS GO THROUGH THE PAIR — a small blob inside a slab and a
@@ -290,6 +326,7 @@ int main()
 {
     test_refusal_reaches_the_caller();
     test_allocator_sees_everything();
+    test_incomplete_pair_refuses_before_callback();
     test_blob_read_path_allocates_nothing();
     if ( failures != 0 )
     {

--- a/testdata/golden/tables/arms/CarryTable.cpp
+++ b/testdata/golden/tables/arms/CarryTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -2033,6 +2033,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2181,7 +2197,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2216,13 +2232,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2263,7 +2279,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2462,7 +2478,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2509,7 +2525,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2517,7 +2533,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2708,7 +2724,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2736,12 +2752,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -8933,7 +8949,7 @@ struct LeafBuilder
         TableSlot<Leaf> slot = main.Alloc<Leaf>();
         root_ref = slot.ref;
     }
-    ~LeafBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~LeafBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     LeafBuilder( const LeafBuilder & ) = delete;
     LeafBuilder & operator=( const LeafBuilder & ) = delete;
 
@@ -8991,7 +9007,7 @@ inline bool LeafBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Leaf ) ) + root_extent );
     Leaf * destination = new ( packed ) Leaf; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9005,7 +9021,7 @@ inline bool LeafBuilder::Lock()
          !LeafPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -9742,7 +9758,7 @@ inline bool LeafLoadBuilder( LeafBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xa5c085b4bb73d1b5ull;
@@ -9799,7 +9815,7 @@ inline bool LeafLoadBuilder( LeafBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9832,7 +9848,7 @@ struct HolderBuilder
         TableSlot<Holder> slot = main.Alloc<Holder>();
         root_ref = slot.ref;
     }
-    ~HolderBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~HolderBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     HolderBuilder( const HolderBuilder & ) = delete;
     HolderBuilder & operator=( const HolderBuilder & ) = delete;
 
@@ -9890,7 +9906,7 @@ inline bool HolderBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Holder ) ) + root_extent );
     Holder * destination = new ( packed ) Holder; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9904,7 +9920,7 @@ inline bool HolderBuilder::Lock()
          !HolderPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10641,7 +10657,7 @@ inline bool HolderLoadBuilder( HolderBuilder & builder, const uint8_t * wire_fil
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xa1f526c44ead452full;
@@ -10698,7 +10714,7 @@ inline bool HolderLoadBuilder( HolderBuilder & builder, const uint8_t * wire_fil
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10731,7 +10747,7 @@ struct HandBuilder
         TableSlot<Hand> slot = main.Alloc<Hand>();
         root_ref = slot.ref;
     }
-    ~HandBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~HandBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     HandBuilder( const HandBuilder & ) = delete;
     HandBuilder & operator=( const HandBuilder & ) = delete;
 
@@ -10789,7 +10805,7 @@ inline bool HandBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Hand ) ) + root_extent );
     Hand * destination = new ( packed ) Hand; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10803,7 +10819,7 @@ inline bool HandBuilder::Lock()
          !HandPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11540,7 +11556,7 @@ inline bool HandLoadBuilder( HandBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x58ba95d8757c67c0ull;
@@ -11597,7 +11613,7 @@ inline bool HandLoadBuilder( HandBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11630,7 +11646,7 @@ struct ChainBuilder
         TableSlot<Chain> slot = main.Alloc<Chain>();
         root_ref = slot.ref;
     }
-    ~ChainBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~ChainBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     ChainBuilder( const ChainBuilder & ) = delete;
     ChainBuilder & operator=( const ChainBuilder & ) = delete;
 
@@ -11688,7 +11704,7 @@ inline bool ChainBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Chain ) ) + root_extent );
     Chain * destination = new ( packed ) Chain; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11702,7 +11718,7 @@ inline bool ChainBuilder::Lock()
          !ChainPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12439,7 +12455,7 @@ inline bool ChainLoadBuilder( ChainBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x670377dcbe2f82b6ull;
@@ -12496,7 +12512,7 @@ inline bool ChainLoadBuilder( ChainBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -16667,7 +16683,7 @@ inline bool LeafCookFrom( const Ctx & ctx, const Leaf & root, void * out, uint64
     bool ok = LeafNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && LeafCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16708,7 +16724,7 @@ inline bool LeafCookFrom( const Ctx & ctx, const Leaf & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -16830,7 +16846,7 @@ inline bool HolderCookFrom( const Ctx & ctx, const Holder & root, void * out, ui
     bool ok = HolderNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && HolderCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16871,7 +16887,7 @@ inline bool HolderCookFrom( const Ctx & ctx, const Holder & root, void * out, ui
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -16993,7 +17009,7 @@ inline bool HandCookFrom( const Ctx & ctx, const Hand & root, void * out, uint64
     bool ok = HandNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && HandCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -17034,7 +17050,7 @@ inline bool HandCookFrom( const Ctx & ctx, const Hand & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -17156,7 +17172,7 @@ inline bool ChainCookFrom( const Ctx & ctx, const Chain & root, void * out, uint
     bool ok = ChainNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && ChainCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -17197,7 +17213,7 @@ inline bool ChainCookFrom( const Ctx & ctx, const Chain & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/arms/GateTable.cpp
+++ b/testdata/golden/tables/arms/GateTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -2033,6 +2033,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2181,7 +2197,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2216,13 +2232,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2263,7 +2279,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2462,7 +2478,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2509,7 +2525,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2517,7 +2533,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2708,7 +2724,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2736,12 +2752,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -7079,7 +7095,7 @@ struct GateBuilder
         TableSlot<Gate> slot = main.Alloc<Gate>();
         root_ref = slot.ref;
     }
-    ~GateBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~GateBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     GateBuilder( const GateBuilder & ) = delete;
     GateBuilder & operator=( const GateBuilder & ) = delete;
 
@@ -7137,7 +7153,7 @@ inline bool GateBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Gate ) ) + root_extent );
     Gate * destination = new ( packed ) Gate; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7151,7 +7167,7 @@ inline bool GateBuilder::Lock()
          !GatePack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -7897,7 +7913,7 @@ inline bool GateLoadBuilder( GateBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xb5877a7e05bbfed2ull;
@@ -7962,7 +7978,7 @@ inline bool GateLoadBuilder( GateBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9453,7 +9469,7 @@ inline bool GateCookFrom( const Ctx & ctx, const Gate & root, void * out, uint64
     bool ok = GateNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && GateCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -9511,7 +9527,7 @@ inline bool GateCookFrom( const Ctx & ctx, const Gate & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/arms/NestTable.cpp
+++ b/testdata/golden/tables/arms/NestTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -2034,6 +2034,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2182,7 +2198,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2217,13 +2233,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2264,7 +2280,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2463,7 +2479,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2510,7 +2526,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2518,7 +2534,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2709,7 +2725,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2737,12 +2753,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -7591,7 +7607,7 @@ struct TwigBuilder
         TableSlot<Twig> slot = main.Alloc<Twig>();
         root_ref = slot.ref;
     }
-    ~TwigBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~TwigBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     TwigBuilder( const TwigBuilder & ) = delete;
     TwigBuilder & operator=( const TwigBuilder & ) = delete;
 
@@ -7649,7 +7665,7 @@ inline bool TwigBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Twig ) ) + root_extent );
     Twig * destination = new ( packed ) Twig; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7663,7 +7679,7 @@ inline bool TwigBuilder::Lock()
          !TwigPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8400,7 +8416,7 @@ inline bool TwigLoadBuilder( TwigBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x9f8e22fb612a2f78ull;
@@ -8457,7 +8473,7 @@ inline bool TwigLoadBuilder( TwigBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -8490,7 +8506,7 @@ struct NestBuilder
         TableSlot<Nest> slot = main.Alloc<Nest>();
         root_ref = slot.ref;
     }
-    ~NestBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~NestBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     NestBuilder( const NestBuilder & ) = delete;
     NestBuilder & operator=( const NestBuilder & ) = delete;
 
@@ -8548,7 +8564,7 @@ inline bool NestBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Nest ) ) + root_extent );
     Nest * destination = new ( packed ) Nest; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8562,7 +8578,7 @@ inline bool NestBuilder::Lock()
          !NestPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -9299,7 +9315,7 @@ inline bool NestLoadBuilder( NestBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x0fe46fc6a1b583abull;
@@ -9356,7 +9372,7 @@ inline bool NestLoadBuilder( NestBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11644,7 +11660,7 @@ inline bool TwigCookFrom( const Ctx & ctx, const Twig & root, void * out, uint64
     bool ok = TwigNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && TwigCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -11685,7 +11701,7 @@ inline bool TwigCookFrom( const Ctx & ctx, const Twig & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -11807,7 +11823,7 @@ inline bool NestCookFrom( const Ctx & ctx, const Nest & root, void * out, uint64
     bool ok = NestNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && NestCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -11848,7 +11864,7 @@ inline bool NestCookFrom( const Ctx & ctx, const Nest & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/arms/RingTable.cpp
+++ b/testdata/golden/tables/arms/RingTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -2033,6 +2033,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2181,7 +2197,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2216,13 +2232,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2263,7 +2279,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2462,7 +2478,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2509,7 +2525,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2517,7 +2533,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2708,7 +2724,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2736,12 +2752,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -9197,7 +9213,7 @@ struct RingBuilder
         TableSlot<Ring> slot = main.Alloc<Ring>();
         root_ref = slot.ref;
     }
-    ~RingBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~RingBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     RingBuilder( const RingBuilder & ) = delete;
     RingBuilder & operator=( const RingBuilder & ) = delete;
 
@@ -9255,7 +9271,7 @@ inline bool RingBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Ring ) ) + root_extent );
     Ring * destination = new ( packed ) Ring; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9269,7 +9285,7 @@ inline bool RingBuilder::Lock()
          !RingPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10010,7 +10026,7 @@ inline bool RingLoadBuilder( RingBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xdcea4d2bfa11ceebull;
@@ -10067,7 +10083,7 @@ inline bool RingLoadBuilder( RingBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10100,7 +10116,7 @@ struct RackBuilder
         TableSlot<Rack> slot = main.Alloc<Rack>();
         root_ref = slot.ref;
     }
-    ~RackBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~RackBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     RackBuilder( const RackBuilder & ) = delete;
     RackBuilder & operator=( const RackBuilder & ) = delete;
 
@@ -10158,7 +10174,7 @@ inline bool RackBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Rack ) ) + root_extent );
     Rack * destination = new ( packed ) Rack; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10172,7 +10188,7 @@ inline bool RackBuilder::Lock()
          !RackPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10913,7 +10929,7 @@ inline bool RackLoadBuilder( RackBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x986d012bd380b0b2ull;
@@ -10970,7 +10986,7 @@ inline bool RackLoadBuilder( RackBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11003,7 +11019,7 @@ struct TrayBuilder
         TableSlot<Tray> slot = main.Alloc<Tray>();
         root_ref = slot.ref;
     }
-    ~TrayBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~TrayBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     TrayBuilder( const TrayBuilder & ) = delete;
     TrayBuilder & operator=( const TrayBuilder & ) = delete;
 
@@ -11061,7 +11077,7 @@ inline bool TrayBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Tray ) ) + root_extent );
     Tray * destination = new ( packed ) Tray; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11075,7 +11091,7 @@ inline bool TrayBuilder::Lock()
          !TrayPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11812,7 +11828,7 @@ inline bool TrayLoadBuilder( TrayBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x85a6b5fb5284964dull;
@@ -11869,7 +11885,7 @@ inline bool TrayLoadBuilder( TrayBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -15722,7 +15738,7 @@ inline bool RingCookFrom( const Ctx & ctx, const Ring & root, void * out, uint64
     bool ok = RingNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && RingCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -15773,7 +15789,7 @@ inline bool RingCookFrom( const Ctx & ctx, const Ring & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -15896,7 +15912,7 @@ inline bool RackCookFrom( const Ctx & ctx, const Rack & root, void * out, uint64
     bool ok = RackNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && RackCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -15947,7 +15963,7 @@ inline bool RackCookFrom( const Ctx & ctx, const Rack & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -16070,7 +16086,7 @@ inline bool TrayCookFrom( const Ctx & ctx, const Tray & root, void * out, uint64
     bool ok = TrayNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && TrayCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16121,7 +16137,7 @@ inline bool TrayCookFrom( const Ctx & ctx, const Tray & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/blobs/AssetsTable.cpp
+++ b/testdata/golden/tables/blobs/AssetsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -1990,6 +1990,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2138,7 +2154,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2173,13 +2189,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2220,7 +2236,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2391,7 +2407,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2438,7 +2454,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2446,7 +2462,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2637,7 +2653,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2665,12 +2681,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -6665,7 +6681,7 @@ struct AssetBuilder
         TableSlot<Asset> slot = main.Alloc<Asset>();
         root_ref = slot.ref;
     }
-    ~AssetBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~AssetBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     AssetBuilder( const AssetBuilder & ) = delete;
     AssetBuilder & operator=( const AssetBuilder & ) = delete;
 
@@ -6721,7 +6737,7 @@ inline bool AssetBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Asset ) );
     Asset * destination = new ( packed ) Asset; // lifetime only: the Pack below memcpy's the whole node over it
@@ -6735,7 +6751,7 @@ inline bool AssetBuilder::Lock()
          !AssetPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -7427,7 +7443,7 @@ inline bool AssetLoadBuilder( AssetBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x8e4e6dccfe5f64fbull;
@@ -7483,7 +7499,7 @@ inline bool AssetLoadBuilder( AssetBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = AssetLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -7516,7 +7532,7 @@ struct CatalogBuilder
         TableSlot<Catalog> slot = main.Alloc<Catalog>();
         root_ref = slot.ref;
     }
-    ~CatalogBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~CatalogBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     CatalogBuilder( const CatalogBuilder & ) = delete;
     CatalogBuilder & operator=( const CatalogBuilder & ) = delete;
 
@@ -7572,7 +7588,7 @@ inline bool CatalogBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Catalog ) );
     Catalog * destination = new ( packed ) Catalog; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7586,7 +7602,7 @@ inline bool CatalogBuilder::Lock()
          !CatalogPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8278,7 +8294,7 @@ inline bool CatalogLoadBuilder( CatalogBuilder & builder, const uint8_t * wire_f
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x1f1750c1bc916638ull;
@@ -8334,7 +8350,7 @@ inline bool CatalogLoadBuilder( CatalogBuilder & builder, const uint8_t * wire_f
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = CatalogLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10257,7 +10273,7 @@ inline bool AssetCookFrom( const Ctx & ctx, const Asset & root, void * out, uint
     bool ok = AssetNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && AssetCookLayout( numbering, region );
     }
     if ( ok )
@@ -10322,7 +10338,7 @@ inline bool AssetCookFrom( const Ctx & ctx, const Asset & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -10441,7 +10457,7 @@ inline bool CatalogCookFrom( const Ctx & ctx, const Catalog & root, void * out, 
     bool ok = CatalogNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && CatalogCookLayout( numbering, region );
     }
     if ( ok )
@@ -10506,7 +10522,7 @@ inline bool CatalogCookFrom( const Ctx & ctx, const Catalog & root, void * out, 
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/lists/HoldersTable.cpp
+++ b/testdata/golden/tables/lists/HoldersTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -2063,6 +2063,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2211,7 +2227,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2246,13 +2262,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2293,7 +2309,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2492,7 +2508,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2539,7 +2555,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2547,7 +2563,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2738,7 +2754,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2766,12 +2782,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5034,7 +5050,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5050,7 +5066,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5067,7 +5083,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -10717,7 +10733,7 @@ struct RowBuilder
         TableSlot<Row> slot = main.Alloc<Row>();
         root_ref = slot.ref;
     }
-    ~RowBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~RowBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     RowBuilder( const RowBuilder & ) = delete;
     RowBuilder & operator=( const RowBuilder & ) = delete;
 
@@ -10775,7 +10791,7 @@ inline bool RowBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Row ) ) + root_extent );
     Row * destination = new ( packed ) Row; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10789,7 +10805,7 @@ inline bool RowBuilder::Lock()
          !RowPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11526,7 +11542,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xa013e119fec906fbull;
@@ -11583,7 +11599,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11616,7 +11632,7 @@ struct SheetBuilder
         TableSlot<Sheet> slot = main.Alloc<Sheet>();
         root_ref = slot.ref;
     }
-    ~SheetBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SheetBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SheetBuilder( const SheetBuilder & ) = delete;
     SheetBuilder & operator=( const SheetBuilder & ) = delete;
 
@@ -11674,7 +11690,7 @@ inline bool SheetBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Sheet ) ) + root_extent );
     Sheet * destination = new ( packed ) Sheet; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11688,7 +11704,7 @@ inline bool SheetBuilder::Lock()
          !SheetPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12435,7 +12451,7 @@ inline bool SheetLoadBuilder( SheetBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x0cc9e0af9a85fbc8ull;
@@ -12492,7 +12508,7 @@ inline bool SheetLoadBuilder( SheetBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -12525,7 +12541,7 @@ struct SquadBuilder
         TableSlot<Squad> slot = main.Alloc<Squad>();
         root_ref = slot.ref;
     }
-    ~SquadBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SquadBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SquadBuilder( const SquadBuilder & ) = delete;
     SquadBuilder & operator=( const SquadBuilder & ) = delete;
 
@@ -12583,7 +12599,7 @@ inline bool SquadBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Squad ) ) + root_extent );
     Squad * destination = new ( packed ) Squad; // lifetime only: the Pack below memcpy's the whole node over it
@@ -12597,7 +12613,7 @@ inline bool SquadBuilder::Lock()
          !SquadPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -13334,7 +13350,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xec07a2f760550a91ull;
@@ -13391,7 +13407,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -13424,7 +13440,7 @@ struct ArmyBuilder
         TableSlot<Army> slot = main.Alloc<Army>();
         root_ref = slot.ref;
     }
-    ~ArmyBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~ArmyBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     ArmyBuilder( const ArmyBuilder & ) = delete;
     ArmyBuilder & operator=( const ArmyBuilder & ) = delete;
 
@@ -13482,7 +13498,7 @@ inline bool ArmyBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Army ) ) + root_extent );
     Army * destination = new ( packed ) Army; // lifetime only: the Pack below memcpy's the whole node over it
@@ -13496,7 +13512,7 @@ inline bool ArmyBuilder::Lock()
          !ArmyPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -14233,7 +14249,7 @@ inline bool ArmyLoadBuilder( ArmyBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x06e2378b553a9e84ull;
@@ -14290,7 +14306,7 @@ inline bool ArmyLoadBuilder( ArmyBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -14323,7 +14339,7 @@ struct DeckBuilder
         TableSlot<Deck> slot = main.Alloc<Deck>();
         root_ref = slot.ref;
     }
-    ~DeckBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~DeckBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     DeckBuilder( const DeckBuilder & ) = delete;
     DeckBuilder & operator=( const DeckBuilder & ) = delete;
 
@@ -14381,7 +14397,7 @@ inline bool DeckBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Deck ) ) + root_extent );
     Deck * destination = new ( packed ) Deck; // lifetime only: the Pack below memcpy's the whole node over it
@@ -14395,7 +14411,7 @@ inline bool DeckBuilder::Lock()
          !DeckPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -15132,7 +15148,7 @@ inline bool DeckLoadBuilder( DeckBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xd043187343bfcfe8ull;
@@ -15189,7 +15205,7 @@ inline bool DeckLoadBuilder( DeckBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -20494,7 +20510,7 @@ inline bool RowCookFrom( const Ctx & ctx, const Row & root, void * out, uint64_t
     bool ok = RowNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && RowCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -20535,7 +20551,7 @@ inline bool RowCookFrom( const Ctx & ctx, const Row & root, void * out, uint64_t
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -20664,7 +20680,7 @@ inline bool SheetCookFrom( const Ctx & ctx, const Sheet & root, void * out, uint
     bool ok = SheetNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SheetCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -20715,7 +20731,7 @@ inline bool SheetCookFrom( const Ctx & ctx, const Sheet & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -20889,7 +20905,7 @@ inline bool SquadCookFrom( const Ctx & ctx, const Squad & root, void * out, uint
     bool ok = SquadNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SquadCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -20930,7 +20946,7 @@ inline bool SquadCookFrom( const Ctx & ctx, const Squad & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -21052,7 +21068,7 @@ inline bool ArmyCookFrom( const Ctx & ctx, const Army & root, void * out, uint64
     bool ok = ArmyNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && ArmyCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -21093,7 +21109,7 @@ inline bool ArmyCookFrom( const Ctx & ctx, const Army & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -21215,7 +21231,7 @@ inline bool DeckCookFrom( const Ctx & ctx, const Deck & root, void * out, uint64
     bool ok = DeckNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && DeckCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -21256,7 +21272,7 @@ inline bool DeckCookFrom( const Ctx & ctx, const Deck & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/lists/MigrateTable.cpp
+++ b/testdata/golden/tables/lists/MigrateTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -2063,6 +2063,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2211,7 +2227,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2246,13 +2262,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2293,7 +2309,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2492,7 +2508,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2539,7 +2555,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2547,7 +2563,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2738,7 +2754,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2766,12 +2782,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5034,7 +5050,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5050,7 +5066,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5067,7 +5083,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7858,7 +7874,7 @@ struct UnboundedBuilder
         TableSlot<Unbounded> slot = main.Alloc<Unbounded>();
         root_ref = slot.ref;
     }
-    ~UnboundedBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~UnboundedBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     UnboundedBuilder( const UnboundedBuilder & ) = delete;
     UnboundedBuilder & operator=( const UnboundedBuilder & ) = delete;
 
@@ -7916,7 +7932,7 @@ inline bool UnboundedBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Unbounded ) ) + root_extent );
     Unbounded * destination = new ( packed ) Unbounded; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7930,7 +7946,7 @@ inline bool UnboundedBuilder::Lock()
          !UnboundedPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8667,7 +8683,7 @@ inline bool UnboundedLoadBuilder( UnboundedBuilder & builder, const uint8_t * wi
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x2ec2f34386026d8bull;
@@ -8724,7 +8740,7 @@ inline bool UnboundedLoadBuilder( UnboundedBuilder & builder, const uint8_t * wi
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10462,7 +10478,7 @@ inline bool UnboundedCookFrom( const Ctx & ctx, const Unbounded & root, void * o
     bool ok = UnboundedNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && UnboundedCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10503,7 +10519,7 @@ inline bool UnboundedCookFrom( const Ctx & ctx, const Unbounded & root, void * o
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/lists/ReportTable.cpp
+++ b/testdata/golden/tables/lists/ReportTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -2063,6 +2063,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2211,7 +2227,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2246,13 +2262,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2293,7 +2309,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2492,7 +2508,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2539,7 +2555,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2547,7 +2563,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2738,7 +2754,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2766,12 +2782,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5034,7 +5050,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5050,7 +5066,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5067,7 +5083,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -8186,7 +8202,7 @@ struct BytesBuilder
         TableSlot<Bytes> slot = main.Alloc<Bytes>();
         root_ref = slot.ref;
     }
-    ~BytesBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~BytesBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     BytesBuilder( const BytesBuilder & ) = delete;
     BytesBuilder & operator=( const BytesBuilder & ) = delete;
 
@@ -8244,7 +8260,7 @@ inline bool BytesBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Bytes ) ) + root_extent );
     Bytes * destination = new ( packed ) Bytes; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8258,7 +8274,7 @@ inline bool BytesBuilder::Lock()
          !BytesPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8995,7 +9011,7 @@ inline bool BytesLoadBuilder( BytesBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xeeeea7adc131a244ull;
@@ -9052,7 +9068,7 @@ inline bool BytesLoadBuilder( BytesBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9085,7 +9101,7 @@ struct IntsBuilder
         TableSlot<Ints> slot = main.Alloc<Ints>();
         root_ref = slot.ref;
     }
-    ~IntsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~IntsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     IntsBuilder( const IntsBuilder & ) = delete;
     IntsBuilder & operator=( const IntsBuilder & ) = delete;
 
@@ -9143,7 +9159,7 @@ inline bool IntsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Ints ) ) + root_extent );
     Ints * destination = new ( packed ) Ints; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9157,7 +9173,7 @@ inline bool IntsBuilder::Lock()
          !IntsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -9894,7 +9910,7 @@ inline bool IntsLoadBuilder( IntsBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x2034c5d17c00ceb7ull;
@@ -9951,7 +9967,7 @@ inline bool IntsLoadBuilder( IntsBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9984,7 +10000,7 @@ struct FloatsBuilder
         TableSlot<Floats> slot = main.Alloc<Floats>();
         root_ref = slot.ref;
     }
-    ~FloatsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~FloatsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     FloatsBuilder( const FloatsBuilder & ) = delete;
     FloatsBuilder & operator=( const FloatsBuilder & ) = delete;
 
@@ -10042,7 +10058,7 @@ inline bool FloatsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Floats ) ) + root_extent );
     Floats * destination = new ( packed ) Floats; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10056,7 +10072,7 @@ inline bool FloatsBuilder::Lock()
          !FloatsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10793,7 +10809,7 @@ inline bool FloatsLoadBuilder( FloatsBuilder & builder, const uint8_t * wire_fil
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x91638659f8f6ad42ull;
@@ -10850,7 +10866,7 @@ inline bool FloatsLoadBuilder( FloatsBuilder & builder, const uint8_t * wire_fil
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -13563,7 +13579,7 @@ inline bool BytesCookFrom( const Ctx & ctx, const Bytes & root, void * out, uint
     bool ok = BytesNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && BytesCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -13604,7 +13620,7 @@ inline bool BytesCookFrom( const Ctx & ctx, const Bytes & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -13726,7 +13742,7 @@ inline bool IntsCookFrom( const Ctx & ctx, const Ints & root, void * out, uint64
     bool ok = IntsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && IntsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -13767,7 +13783,7 @@ inline bool IntsCookFrom( const Ctx & ctx, const Ints & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -13889,7 +13905,7 @@ inline bool FloatsCookFrom( const Ctx & ctx, const Floats & root, void * out, ui
     bool ok = FloatsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && FloatsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -13930,7 +13946,7 @@ inline bool FloatsCookFrom( const Ctx & ctx, const Floats & root, void * out, ui
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/lists/SaveTable.cpp
+++ b/testdata/golden/tables/lists/SaveTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -2063,6 +2063,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2211,7 +2227,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2246,13 +2262,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2293,7 +2309,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2492,7 +2508,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2539,7 +2555,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2547,7 +2563,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2738,7 +2754,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2766,12 +2782,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5034,7 +5050,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5050,7 +5066,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5067,7 +5083,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -10508,7 +10524,7 @@ struct SaveBuilder
         TableSlot<Save> slot = main.Alloc<Save>();
         root_ref = slot.ref;
     }
-    ~SaveBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SaveBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SaveBuilder( const SaveBuilder & ) = delete;
     SaveBuilder & operator=( const SaveBuilder & ) = delete;
 
@@ -10566,7 +10582,7 @@ inline bool SaveBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Save ) ) + root_extent );
     Save * destination = new ( packed ) Save; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10580,7 +10596,7 @@ inline bool SaveBuilder::Lock()
          !SavePack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11321,7 +11337,7 @@ inline bool SaveLoadBuilder( SaveBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x33f85f24c0f5f008ull;
@@ -11378,7 +11394,7 @@ inline bool SaveLoadBuilder( SaveBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11411,7 +11427,7 @@ struct MixedBuilder
         TableSlot<Mixed> slot = main.Alloc<Mixed>();
         root_ref = slot.ref;
     }
-    ~MixedBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~MixedBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     MixedBuilder( const MixedBuilder & ) = delete;
     MixedBuilder & operator=( const MixedBuilder & ) = delete;
 
@@ -11469,7 +11485,7 @@ inline bool MixedBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Mixed ) ) + root_extent );
     Mixed * destination = new ( packed ) Mixed; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11483,7 +11499,7 @@ inline bool MixedBuilder::Lock()
          !MixedPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12220,7 +12236,7 @@ inline bool MixedLoadBuilder( MixedBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xbb86c6c96f598bb8ull;
@@ -12277,7 +12293,7 @@ inline bool MixedLoadBuilder( MixedBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -16054,7 +16070,7 @@ inline bool SaveCookFrom( const Ctx & ctx, const Save & root, void * out, uint64
     bool ok = SaveNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SaveCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16105,7 +16121,7 @@ inline bool SaveCookFrom( const Ctx & ctx, const Save & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -16279,7 +16295,7 @@ inline bool MixedCookFrom( const Ctx & ctx, const Mixed & root, void * out, uint
     bool ok = MixedNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && MixedCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16320,7 +16336,7 @@ inline bool MixedCookFrom( const Ctx & ctx, const Mixed & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/lists/SharedTable.cpp
+++ b/testdata/golden/tables/lists/SharedTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -2063,6 +2063,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2211,7 +2227,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2246,13 +2262,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2293,7 +2309,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2492,7 +2508,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2539,7 +2555,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2547,7 +2563,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2738,7 +2754,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2766,12 +2782,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5034,7 +5050,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5050,7 +5066,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5067,7 +5083,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7705,7 +7721,7 @@ struct AlbumBuilder
         TableSlot<Album> slot = main.Alloc<Album>();
         root_ref = slot.ref;
     }
-    ~AlbumBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~AlbumBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     AlbumBuilder( const AlbumBuilder & ) = delete;
     AlbumBuilder & operator=( const AlbumBuilder & ) = delete;
 
@@ -7763,7 +7779,7 @@ inline bool AlbumBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Album ) ) + root_extent );
     Album * destination = new ( packed ) Album; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7777,7 +7793,7 @@ inline bool AlbumBuilder::Lock()
          !AlbumPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8518,7 +8534,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xd858c2cb7f1514ccull;
@@ -8575,7 +8591,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9907,7 +9923,7 @@ inline bool AlbumCookFrom( const Ctx & ctx, const Album & root, void * out, uint
     bool ok = AlbumNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && AlbumCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -9958,7 +9974,7 @@ inline bool AlbumCookFrom( const Ctx & ctx, const Album & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/CellsTable.cpp
+++ b/testdata/golden/tables/maps/CellsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -2180,6 +2180,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2328,7 +2344,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2363,13 +2379,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2410,7 +2426,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2609,7 +2625,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2656,7 +2672,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2664,7 +2680,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2855,7 +2871,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2883,12 +2899,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5155,7 +5171,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5171,7 +5187,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5188,7 +5204,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7795,7 +7811,7 @@ struct CellsBuilder
         TableSlot<Cells> slot = main.Alloc<Cells>();
         root_ref = slot.ref;
     }
-    ~CellsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~CellsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     CellsBuilder( const CellsBuilder & ) = delete;
     CellsBuilder & operator=( const CellsBuilder & ) = delete;
 
@@ -7853,7 +7869,7 @@ inline bool CellsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Cells ) ) + root_extent );
     Cells * destination = new ( packed ) Cells; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7867,7 +7883,7 @@ inline bool CellsBuilder::Lock()
          !CellsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8604,7 +8620,7 @@ inline bool CellsLoadBuilder( CellsBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x1f781dc01a2b5152ull;
@@ -8661,7 +8677,7 @@ inline bool CellsLoadBuilder( CellsBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10069,7 +10085,7 @@ inline bool CellsCookFrom( const Ctx & ctx, const Cells & root, void * out, uint
     bool ok = CellsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && CellsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10110,7 +10126,7 @@ inline bool CellsCookFrom( const Ctx & ctx, const Cells & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/ChunksTable.cpp
+++ b/testdata/golden/tables/maps/ChunksTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -2180,6 +2180,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2328,7 +2344,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2363,13 +2379,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2410,7 +2426,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2609,7 +2625,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2656,7 +2672,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2664,7 +2680,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2855,7 +2871,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2883,12 +2899,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5155,7 +5171,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5171,7 +5187,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5188,7 +5204,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7880,7 +7896,7 @@ struct ChunksBuilder
         TableSlot<Chunks> slot = main.Alloc<Chunks>();
         root_ref = slot.ref;
     }
-    ~ChunksBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~ChunksBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     ChunksBuilder( const ChunksBuilder & ) = delete;
     ChunksBuilder & operator=( const ChunksBuilder & ) = delete;
 
@@ -7938,7 +7954,7 @@ inline bool ChunksBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Chunks ) ) + root_extent );
     Chunks * destination = new ( packed ) Chunks; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7952,7 +7968,7 @@ inline bool ChunksBuilder::Lock()
          !ChunksPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8687,7 +8703,7 @@ inline bool ChunksLoadBuilder( ChunksBuilder & builder, const uint8_t * wire_fil
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x816c207ba6213983ull;
@@ -8744,7 +8760,7 @@ inline bool ChunksLoadBuilder( ChunksBuilder & builder, const uint8_t * wire_fil
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10064,7 +10080,7 @@ inline bool ChunksCookFrom( const Ctx & ctx, const Chunks & root, void * out, ui
     bool ok = ChunksNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && ChunksCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10121,7 +10137,7 @@ inline bool ChunksCookFrom( const Ctx & ctx, const Chunks & root, void * out, ui
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/CrewsTable.cpp
+++ b/testdata/golden/tables/maps/CrewsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7964,7 +7980,7 @@ struct CrewsBuilder
         TableSlot<Crews> slot = main.Alloc<Crews>();
         root_ref = slot.ref;
     }
-    ~CrewsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~CrewsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     CrewsBuilder( const CrewsBuilder & ) = delete;
     CrewsBuilder & operator=( const CrewsBuilder & ) = delete;
 
@@ -8022,7 +8038,7 @@ inline bool CrewsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Crews ) ) + root_extent );
     Crews * destination = new ( packed ) Crews; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8036,7 +8052,7 @@ inline bool CrewsBuilder::Lock()
          !CrewsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8777,7 +8793,7 @@ inline bool CrewsLoadBuilder( CrewsBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xc85b940060088651ull;
@@ -8834,7 +8850,7 @@ inline bool CrewsLoadBuilder( CrewsBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10216,7 +10232,7 @@ inline bool CrewsCookFrom( const Ctx & ctx, const Crews & root, void * out, uint
     bool ok = CrewsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && CrewsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10267,7 +10283,7 @@ inline bool CrewsCookFrom( const Ctx & ctx, const Crews & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/DepthTable.cpp
+++ b/testdata/golden/tables/maps/DepthTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -8942,7 +8958,7 @@ struct SquadBuilder
         TableSlot<Squad> slot = main.Alloc<Squad>();
         root_ref = slot.ref;
     }
-    ~SquadBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SquadBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SquadBuilder( const SquadBuilder & ) = delete;
     SquadBuilder & operator=( const SquadBuilder & ) = delete;
 
@@ -9000,7 +9016,7 @@ inline bool SquadBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Squad ) ) + root_extent );
     Squad * destination = new ( packed ) Squad; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9014,7 +9030,7 @@ inline bool SquadBuilder::Lock()
          !SquadPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -9751,7 +9767,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xec07a2f760550a91ull;
@@ -9808,7 +9824,7 @@ inline bool SquadLoadBuilder( SquadBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9841,7 +9857,7 @@ struct DepthBuilder
         TableSlot<Depth> slot = main.Alloc<Depth>();
         root_ref = slot.ref;
     }
-    ~DepthBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~DepthBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     DepthBuilder( const DepthBuilder & ) = delete;
     DepthBuilder & operator=( const DepthBuilder & ) = delete;
 
@@ -9899,7 +9915,7 @@ inline bool DepthBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Depth ) ) + root_extent );
     Depth * destination = new ( packed ) Depth; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9913,7 +9929,7 @@ inline bool DepthBuilder::Lock()
          !DepthPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10650,7 +10666,7 @@ inline bool DepthLoadBuilder( DepthBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x3231d0dc6fe30d4aull;
@@ -10707,7 +10723,7 @@ inline bool DepthLoadBuilder( DepthBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -13227,7 +13243,7 @@ inline bool SquadCookFrom( const Ctx & ctx, const Squad & root, void * out, uint
     bool ok = SquadNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SquadCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -13268,7 +13284,7 @@ inline bool SquadCookFrom( const Ctx & ctx, const Squad & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -13390,7 +13406,7 @@ inline bool DepthCookFrom( const Ctx & ctx, const Depth & root, void * out, uint
     bool ok = DepthNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && DepthCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -13431,7 +13447,7 @@ inline bool DepthCookFrom( const Ctx & ctx, const Depth & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/DocsTable.cpp
+++ b/testdata/golden/tables/maps/DocsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -2180,6 +2180,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2328,7 +2344,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2363,13 +2379,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2410,7 +2426,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2609,7 +2625,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2656,7 +2672,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2664,7 +2680,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2855,7 +2871,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2883,12 +2899,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5155,7 +5171,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5171,7 +5187,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5188,7 +5204,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7878,7 +7894,7 @@ struct DocsBuilder
         TableSlot<Docs> slot = main.Alloc<Docs>();
         root_ref = slot.ref;
     }
-    ~DocsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~DocsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     DocsBuilder( const DocsBuilder & ) = delete;
     DocsBuilder & operator=( const DocsBuilder & ) = delete;
 
@@ -7936,7 +7952,7 @@ inline bool DocsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Docs ) ) + root_extent );
     Docs * destination = new ( packed ) Docs; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7950,7 +7966,7 @@ inline bool DocsBuilder::Lock()
          !DocsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8694,7 +8710,7 @@ inline bool DocsLoadBuilder( DocsBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x036ffe7360826852ull;
@@ -8759,7 +8775,7 @@ inline bool DocsLoadBuilder( DocsBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10071,7 +10087,7 @@ inline bool DocsCookFrom( const Ctx & ctx, const Docs & root, void * out, uint64
     bool ok = DocsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && DocsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10128,7 +10144,7 @@ inline bool DocsCookFrom( const Ctx & ctx, const Docs & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/FleetTable.cpp
+++ b/testdata/golden/tables/maps/FleetTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -2180,6 +2180,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2328,7 +2344,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2363,13 +2379,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2410,7 +2426,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2609,7 +2625,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2656,7 +2672,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2664,7 +2680,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2855,7 +2871,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2883,12 +2899,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5155,7 +5171,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5171,7 +5187,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5188,7 +5204,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -12154,7 +12170,7 @@ struct FleetBuilder
         TableSlot<Fleet> slot = main.Alloc<Fleet>();
         root_ref = slot.ref;
     }
-    ~FleetBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~FleetBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     FleetBuilder( const FleetBuilder & ) = delete;
     FleetBuilder & operator=( const FleetBuilder & ) = delete;
 
@@ -12212,7 +12228,7 @@ inline bool FleetBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Fleet ) ) + root_extent );
     Fleet * destination = new ( packed ) Fleet; // lifetime only: the Pack below memcpy's the whole node over it
@@ -12226,7 +12242,7 @@ inline bool FleetBuilder::Lock()
          !FleetPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12967,7 +12983,7 @@ inline bool FleetLoadBuilder( FleetBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x0a53e00afba279afull;
@@ -13024,7 +13040,7 @@ inline bool FleetLoadBuilder( FleetBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -16809,7 +16825,7 @@ inline bool FleetCookFrom( const Ctx & ctx, const Fleet & root, void * out, uint
     bool ok = FleetNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && FleetCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -16860,7 +16876,7 @@ inline bool FleetCookFrom( const Ctx & ctx, const Fleet & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/PairsTable.cpp
+++ b/testdata/golden/tables/maps/PairsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7963,7 +7979,7 @@ struct PairsBuilder
         TableSlot<Pairs> slot = main.Alloc<Pairs>();
         root_ref = slot.ref;
     }
-    ~PairsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~PairsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     PairsBuilder( const PairsBuilder & ) = delete;
     PairsBuilder & operator=( const PairsBuilder & ) = delete;
 
@@ -8021,7 +8037,7 @@ inline bool PairsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Pairs ) ) + root_extent );
     Pairs * destination = new ( packed ) Pairs; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8035,7 +8051,7 @@ inline bool PairsBuilder::Lock()
          !PairsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8776,7 +8792,7 @@ inline bool PairsLoadBuilder( PairsBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x1404200dab337086ull;
@@ -8833,7 +8849,7 @@ inline bool PairsLoadBuilder( PairsBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10212,7 +10228,7 @@ inline bool PairsCookFrom( const Ctx & ctx, const Pairs & root, void * out, uint
     bool ok = PairsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && PairsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10263,7 +10279,7 @@ inline bool PairsCookFrom( const Ctx & ctx, const Pairs & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/RowsTable.cpp
+++ b/testdata/golden/tables/maps/RowsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -10700,7 +10716,7 @@ struct RowBuilder
         TableSlot<Row> slot = main.Alloc<Row>();
         root_ref = slot.ref;
     }
-    ~RowBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~RowBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     RowBuilder( const RowBuilder & ) = delete;
     RowBuilder & operator=( const RowBuilder & ) = delete;
 
@@ -10758,7 +10774,7 @@ inline bool RowBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Row ) ) + root_extent );
     Row * destination = new ( packed ) Row; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10772,7 +10788,7 @@ inline bool RowBuilder::Lock()
          !RowPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11509,7 +11525,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xa013e119fec906fbull;
@@ -11566,7 +11582,7 @@ inline bool RowLoadBuilder( RowBuilder & builder, const uint8_t * wire_file, int
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11599,7 +11615,7 @@ struct WideRowBuilder
         TableSlot<WideRow> slot = main.Alloc<WideRow>();
         root_ref = slot.ref;
     }
-    ~WideRowBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~WideRowBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     WideRowBuilder( const WideRowBuilder & ) = delete;
     WideRowBuilder & operator=( const WideRowBuilder & ) = delete;
 
@@ -11657,7 +11673,7 @@ inline bool WideRowBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( WideRow ) ) + root_extent );
     WideRow * destination = new ( packed ) WideRow; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11671,7 +11687,7 @@ inline bool WideRowBuilder::Lock()
          !WideRowPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12408,7 +12424,7 @@ inline bool WideRowLoadBuilder( WideRowBuilder & builder, const uint8_t * wire_f
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xb413964e3571a316ull;
@@ -12465,7 +12481,7 @@ inline bool WideRowLoadBuilder( WideRowBuilder & builder, const uint8_t * wire_f
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -12498,7 +12514,7 @@ struct EdgeRowBuilder
         TableSlot<EdgeRow> slot = main.Alloc<EdgeRow>();
         root_ref = slot.ref;
     }
-    ~EdgeRowBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~EdgeRowBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     EdgeRowBuilder( const EdgeRowBuilder & ) = delete;
     EdgeRowBuilder & operator=( const EdgeRowBuilder & ) = delete;
 
@@ -12556,7 +12572,7 @@ inline bool EdgeRowBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( EdgeRow ) ) + root_extent );
     EdgeRow * destination = new ( packed ) EdgeRow; // lifetime only: the Pack below memcpy's the whole node over it
@@ -12570,7 +12586,7 @@ inline bool EdgeRowBuilder::Lock()
          !EdgeRowPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -13307,7 +13323,7 @@ inline bool EdgeRowLoadBuilder( EdgeRowBuilder & builder, const uint8_t * wire_f
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xe8130af045a036f8ull;
@@ -13364,7 +13380,7 @@ inline bool EdgeRowLoadBuilder( EdgeRowBuilder & builder, const uint8_t * wire_f
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -17473,7 +17489,7 @@ inline bool RowCookFrom( const Ctx & ctx, const Row & root, void * out, uint64_t
     bool ok = RowNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && RowCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -17514,7 +17530,7 @@ inline bool RowCookFrom( const Ctx & ctx, const Row & root, void * out, uint64_t
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -17636,7 +17652,7 @@ inline bool WideRowCookFrom( const Ctx & ctx, const WideRow & root, void * out, 
     bool ok = WideRowNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && WideRowCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -17677,7 +17693,7 @@ inline bool WideRowCookFrom( const Ctx & ctx, const WideRow & root, void * out, 
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -17799,7 +17815,7 @@ inline bool EdgeRowCookFrom( const Ctx & ctx, const EdgeRow & root, void * out, 
     bool ok = EdgeRowNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && EdgeRowCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -17840,7 +17856,7 @@ inline bool EdgeRowCookFrom( const Ctx & ctx, const EdgeRow & root, void * out, 
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/RunsTable.cpp
+++ b/testdata/golden/tables/maps/RunsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7730,7 +7746,7 @@ struct RunsBuilder
         TableSlot<Runs> slot = main.Alloc<Runs>();
         root_ref = slot.ref;
     }
-    ~RunsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~RunsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     RunsBuilder( const RunsBuilder & ) = delete;
     RunsBuilder & operator=( const RunsBuilder & ) = delete;
 
@@ -7788,7 +7804,7 @@ inline bool RunsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Runs ) ) + root_extent );
     Runs * destination = new ( packed ) Runs; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7802,7 +7818,7 @@ inline bool RunsBuilder::Lock()
          !RunsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8539,7 +8555,7 @@ inline bool RunsLoadBuilder( RunsBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xea7bdd2b70c8c2bbull;
@@ -8596,7 +8612,7 @@ inline bool RunsLoadBuilder( RunsBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -9957,7 +9973,7 @@ inline bool RunsCookFrom( const Ctx & ctx, const Runs & root, void * out, uint64
     bool ok = RunsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && RunsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -9998,7 +10014,7 @@ inline bool RunsCookFrom( const Ctx & ctx, const Runs & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/SlotsTable.cpp
+++ b/testdata/golden/tables/maps/SlotsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7898,7 +7914,7 @@ struct SlotsBuilder
         TableSlot<Slots> slot = main.Alloc<Slots>();
         root_ref = slot.ref;
     }
-    ~SlotsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SlotsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SlotsBuilder( const SlotsBuilder & ) = delete;
     SlotsBuilder & operator=( const SlotsBuilder & ) = delete;
 
@@ -7956,7 +7972,7 @@ inline bool SlotsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Slots ) ) + root_extent );
     Slots * destination = new ( packed ) Slots; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7970,7 +7986,7 @@ inline bool SlotsBuilder::Lock()
          !SlotsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8707,7 +8723,7 @@ inline bool SlotsLoadBuilder( SlotsBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xf96b15cd3921d4a6ull;
@@ -8764,7 +8780,7 @@ inline bool SlotsLoadBuilder( SlotsBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10196,7 +10212,7 @@ inline bool SlotsCookFrom( const Ctx & ctx, const Slots & root, void * out, uint
     bool ok = SlotsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SlotsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10237,7 +10253,7 @@ inline bool SlotsCookFrom( const Ctx & ctx, const Slots & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/SpansTable.cpp
+++ b/testdata/golden/tables/maps/SpansTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -7930,7 +7946,7 @@ struct SpansBuilder
         TableSlot<Spans> slot = main.Alloc<Spans>();
         root_ref = slot.ref;
     }
-    ~SpansBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SpansBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SpansBuilder( const SpansBuilder & ) = delete;
     SpansBuilder & operator=( const SpansBuilder & ) = delete;
 
@@ -7988,7 +8004,7 @@ inline bool SpansBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Spans ) ) + root_extent );
     Spans * destination = new ( packed ) Spans; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8002,7 +8018,7 @@ inline bool SpansBuilder::Lock()
          !SpansPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8739,7 +8755,7 @@ inline bool SpansLoadBuilder( SpansBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x033de3f1246bba76ull;
@@ -8796,7 +8812,7 @@ inline bool SpansLoadBuilder( SpansBuilder & builder, const uint8_t * wire_file,
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10175,7 +10191,7 @@ inline bool SpansCookFrom( const Ctx & ctx, const Spans & root, void * out, uint
     bool ok = SpansNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SpansCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10216,7 +10232,7 @@ inline bool SpansCookFrom( const Ctx & ctx, const Spans & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/TextTable.cpp
+++ b/testdata/golden/tables/maps/TextTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -2180,6 +2180,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2328,7 +2344,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2363,13 +2379,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2410,7 +2426,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2609,7 +2625,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2656,7 +2672,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2664,7 +2680,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2855,7 +2871,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2883,12 +2899,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5155,7 +5171,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5171,7 +5187,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5188,7 +5204,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -9279,7 +9295,7 @@ struct TextBuilder
         TableSlot<Text> slot = main.Alloc<Text>();
         root_ref = slot.ref;
     }
-    ~TextBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~TextBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     TextBuilder( const TextBuilder & ) = delete;
     TextBuilder & operator=( const TextBuilder & ) = delete;
 
@@ -9337,7 +9353,7 @@ inline bool TextBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Text ) ) + root_extent );
     Text * destination = new ( packed ) Text; // lifetime only: the Pack below memcpy's the whole node over it
@@ -9351,7 +9367,7 @@ inline bool TextBuilder::Lock()
          !TextPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -10088,7 +10104,7 @@ inline bool TextLoadBuilder( TextBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x2492f5fb1b05b45eull;
@@ -10145,7 +10161,7 @@ inline bool TextLoadBuilder( TextBuilder & builder, const uint8_t * wire_file, i
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -12421,7 +12437,7 @@ inline bool TextCookFrom( const Ctx & ctx, const Text & root, void * out, uint64
     bool ok = TextNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && TextCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -12462,7 +12478,7 @@ inline bool TextCookFrom( const Ctx & ctx, const Text & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/maps/TrailsTable.cpp
+++ b/testdata/golden/tables/maps/TrailsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -2181,6 +2181,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2329,7 +2345,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2364,13 +2380,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2411,7 +2427,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2610,7 +2626,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2657,7 +2673,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2665,7 +2681,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2856,7 +2872,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2884,12 +2900,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -5156,7 +5172,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     if ( map.entries.value == 0 || map.count <= 0 ) { cursor.ok = map.count == 0; cursor.count = 0; return cursor; }
     const TableMapHead * head = (const TableMapHead *) TableArenaAt( arena, (uint32_t) map.entries.value );
     if ( head->live != map.count ) { return cursor; } // the slot and the head disagree: refused, never guessed
-    const Entry ** order = (const Entry **) arena.allocator.alloc( arena.allocator.context, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
+    const Entry ** order = (const Entry **) table_allocate( arena.allocator, (int64_t) map.count * (int64_t) sizeof( const Entry * ) );
     if ( order == NULL ) { return cursor; }
     int32_t at = 0;
     TableRef segment_ref = head->first;
@@ -5172,7 +5188,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArena & arena, const Tabl
     }
     if ( at != map.count )
     {
-        arena.allocator.free( arena.allocator.context, order );
+        table_release( arena.allocator, order );
         return cursor;
     }
     TableMapSort( order, map.count );
@@ -5189,7 +5205,7 @@ inline TableMapCursor<Entry> TableMapOrder( const TableArenaCtx & ctx, const Tab
 
 template <typename Entry> inline void TableMapRelease( TableMapCursor<Entry> & cursor )
 {
-    if ( cursor.order != NULL ) { cursor.allocator.free( cursor.allocator.context, (void *) cursor.order ); }
+    if ( cursor.order != NULL ) { table_release( cursor.allocator, (void *) cursor.order ); }
     cursor.order = NULL;
 }
 
@@ -8086,7 +8102,7 @@ struct TrailsBuilder
         TableSlot<Trails> slot = main.Alloc<Trails>();
         root_ref = slot.ref;
     }
-    ~TrailsBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~TrailsBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     TrailsBuilder( const TrailsBuilder & ) = delete;
     TrailsBuilder & operator=( const TrailsBuilder & ) = delete;
 
@@ -8144,7 +8160,7 @@ inline bool TrailsBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( TableAlignUp64( (int64_t) sizeof( Trails ) ) + root_extent );
     Trails * destination = new ( packed ) Trails; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8158,7 +8174,7 @@ inline bool TrailsBuilder::Lock()
          !TrailsPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8899,7 +8915,7 @@ inline bool TrailsLoadBuilder( TrailsBuilder & builder, const uint8_t * wire_fil
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xb4578774a78fb150ull;
@@ -8956,7 +8972,7 @@ inline bool TrailsLoadBuilder( TrailsBuilder & builder, const uint8_t * wire_fil
     // §2.9): the partial builder is the caller's to discard, and the report
     // holds what it held when the count was met
     ok = ok && !nodes.refused;
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -10358,7 +10374,7 @@ inline bool TrailsCookFrom( const Ctx & ctx, const Trails & root, void * out, ui
     bool ok = TrailsNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && TrailsCookLayout( ctx, root, numbering, region );
     }
     if ( ok )
@@ -10409,7 +10425,7 @@ inline bool TrailsCookFrom( const Ctx & ctx, const Trails & root, void * out, ui
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/pointers/GraphTable.cpp
+++ b/testdata/golden/tables/pointers/GraphTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -2145,6 +2145,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2293,7 +2309,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2328,13 +2344,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2375,7 +2391,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2546,7 +2562,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2593,7 +2609,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2601,7 +2617,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2792,7 +2808,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2820,12 +2836,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -10656,7 +10672,7 @@ struct ListNodeBuilder
         TableSlot<ListNode> slot = main.Alloc<ListNode>();
         root_ref = slot.ref;
     }
-    ~ListNodeBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~ListNodeBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     ListNodeBuilder( const ListNodeBuilder & ) = delete;
     ListNodeBuilder & operator=( const ListNodeBuilder & ) = delete;
 
@@ -10712,7 +10728,7 @@ inline bool ListNodeBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( ListNode ) );
     ListNode * destination = new ( packed ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
@@ -10726,7 +10742,7 @@ inline bool ListNodeBuilder::Lock()
          !ListNodePack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -11404,7 +11420,7 @@ inline bool ListNodeLoadBuilder( ListNodeBuilder & builder, const uint8_t * wire
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xf60ec899a5a69fa9ull;
@@ -11452,7 +11468,7 @@ inline bool ListNodeLoadBuilder( ListNodeBuilder & builder, const uint8_t * wire
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = ListNodeLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11485,7 +11501,7 @@ struct TreeNodeBuilder
         TableSlot<TreeNode> slot = main.Alloc<TreeNode>();
         root_ref = slot.ref;
     }
-    ~TreeNodeBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~TreeNodeBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     TreeNodeBuilder( const TreeNodeBuilder & ) = delete;
     TreeNodeBuilder & operator=( const TreeNodeBuilder & ) = delete;
 
@@ -11541,7 +11557,7 @@ inline bool TreeNodeBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( TreeNode ) );
     TreeNode * destination = new ( packed ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
@@ -11555,7 +11571,7 @@ inline bool TreeNodeBuilder::Lock()
          !TreeNodePack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -12233,7 +12249,7 @@ inline bool TreeNodeLoadBuilder( TreeNodeBuilder & builder, const uint8_t * wire
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xb97e90a3784c431dull;
@@ -12281,7 +12297,7 @@ inline bool TreeNodeLoadBuilder( TreeNodeBuilder & builder, const uint8_t * wire
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = TreeNodeLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -12314,7 +12330,7 @@ struct LayerBuilder
         TableSlot<Layer> slot = main.Alloc<Layer>();
         root_ref = slot.ref;
     }
-    ~LayerBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~LayerBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     LayerBuilder( const LayerBuilder & ) = delete;
     LayerBuilder & operator=( const LayerBuilder & ) = delete;
 
@@ -12370,7 +12386,7 @@ inline bool LayerBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Layer ) );
     Layer * destination = new ( packed ) Layer; // lifetime only: the Pack below memcpy's the whole node over it
@@ -12384,7 +12400,7 @@ inline bool LayerBuilder::Lock()
          !LayerPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -13062,7 +13078,7 @@ inline bool LayerLoadBuilder( LayerBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x9d167ef77aed79b6ull;
@@ -13110,7 +13126,7 @@ inline bool LayerLoadBuilder( LayerBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = LayerLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -13143,7 +13159,7 @@ struct SceneBuilder
         TableSlot<Scene> slot = main.Alloc<Scene>();
         root_ref = slot.ref;
     }
-    ~SceneBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~SceneBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     SceneBuilder( const SceneBuilder & ) = delete;
     SceneBuilder & operator=( const SceneBuilder & ) = delete;
 
@@ -13199,7 +13215,7 @@ inline bool SceneBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Scene ) );
     Scene * destination = new ( packed ) Scene; // lifetime only: the Pack below memcpy's the whole node over it
@@ -13213,7 +13229,7 @@ inline bool SceneBuilder::Lock()
          !ScenePack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -13903,7 +13919,7 @@ inline bool SceneLoadBuilder( SceneBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x4a9a31623ab5f213ull;
@@ -13951,7 +13967,7 @@ inline bool SceneLoadBuilder( SceneBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = SceneLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -13984,7 +14000,7 @@ struct DepotBuilder
         TableSlot<Depot> slot = main.Alloc<Depot>();
         root_ref = slot.ref;
     }
-    ~DepotBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~DepotBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     DepotBuilder( const DepotBuilder & ) = delete;
     DepotBuilder & operator=( const DepotBuilder & ) = delete;
 
@@ -14040,7 +14056,7 @@ inline bool DepotBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Depot ) );
     Depot * destination = new ( packed ) Depot; // lifetime only: the Pack below memcpy's the whole node over it
@@ -14054,7 +14070,7 @@ inline bool DepotBuilder::Lock()
          !DepotPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -14732,7 +14748,7 @@ inline bool DepotLoadBuilder( DepotBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x327fe6dc702553fdull;
@@ -14780,7 +14796,7 @@ inline bool DepotLoadBuilder( DepotBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = DepotLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -14813,7 +14829,7 @@ struct AlbumBuilder
         TableSlot<Album> slot = main.Alloc<Album>();
         root_ref = slot.ref;
     }
-    ~AlbumBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~AlbumBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     AlbumBuilder( const AlbumBuilder & ) = delete;
     AlbumBuilder & operator=( const AlbumBuilder & ) = delete;
 
@@ -14869,7 +14885,7 @@ inline bool AlbumBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Album ) );
     Album * destination = new ( packed ) Album; // lifetime only: the Pack below memcpy's the whole node over it
@@ -14883,7 +14899,7 @@ inline bool AlbumBuilder::Lock()
          !AlbumPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -15573,7 +15589,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xd858c2cb7f1514ccull;
@@ -15621,7 +15637,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = AlbumLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -21811,7 +21827,7 @@ inline bool ListNodeCookFrom( const Ctx & ctx, const ListNode & root, void * out
     bool ok = ListNodeNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && ListNodeCookLayout( numbering, region );
     }
     if ( ok )
@@ -21862,7 +21878,7 @@ inline bool ListNodeCookFrom( const Ctx & ctx, const ListNode & root, void * out
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -21979,7 +21995,7 @@ inline bool TreeNodeCookFrom( const Ctx & ctx, const TreeNode & root, void * out
     bool ok = TreeNodeNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && TreeNodeCookLayout( numbering, region );
     }
     if ( ok )
@@ -22030,7 +22046,7 @@ inline bool TreeNodeCookFrom( const Ctx & ctx, const TreeNode & root, void * out
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -22147,7 +22163,7 @@ inline bool LayerCookFrom( const Ctx & ctx, const Layer & root, void * out, uint
     bool ok = LayerNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && LayerCookLayout( numbering, region );
     }
     if ( ok )
@@ -22198,7 +22214,7 @@ inline bool LayerCookFrom( const Ctx & ctx, const Layer & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -22317,7 +22333,7 @@ inline bool SceneCookFrom( const Ctx & ctx, const Scene & root, void * out, uint
     bool ok = SceneNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && SceneCookLayout( numbering, region );
     }
     if ( ok )
@@ -22370,7 +22386,7 @@ inline bool SceneCookFrom( const Ctx & ctx, const Scene & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -22487,7 +22503,7 @@ inline bool DepotCookFrom( const Ctx & ctx, const Depot & root, void * out, uint
     bool ok = DepotNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && DepotCookLayout( numbering, region );
     }
     if ( ok )
@@ -22538,7 +22554,7 @@ inline bool DepotCookFrom( const Ctx & ctx, const Depot & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -22657,7 +22673,7 @@ inline bool AlbumCookFrom( const Ctx & ctx, const Album & root, void * out, uint
     bool ok = AlbumNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && AlbumCookLayout( numbering, region );
     }
     if ( ok )
@@ -22710,7 +22726,7 @@ inline bool AlbumCookFrom( const Ctx & ctx, const Album & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/pointers/MarksTable.cpp
+++ b/testdata/golden/tables/pointers/MarksTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -2142,6 +2142,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2290,7 +2306,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2325,13 +2341,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2372,7 +2388,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2543,7 +2559,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2590,7 +2606,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2598,7 +2614,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2789,7 +2805,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2817,12 +2833,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -6019,7 +6035,7 @@ struct MarkerBuilder
         TableSlot<Marker> slot = main.Alloc<Marker>();
         root_ref = slot.ref;
     }
-    ~MarkerBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~MarkerBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     MarkerBuilder( const MarkerBuilder & ) = delete;
     MarkerBuilder & operator=( const MarkerBuilder & ) = delete;
 
@@ -6075,7 +6091,7 @@ inline bool MarkerBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Marker ) );
     Marker * destination = new ( packed ) Marker; // lifetime only: the Pack below memcpy's the whole node over it
@@ -6089,7 +6105,7 @@ inline bool MarkerBuilder::Lock()
          !MarkerPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -6769,7 +6785,7 @@ inline bool MarkerLoadBuilder( MarkerBuilder & builder, const uint8_t * wire_fil
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xd6458a3eef83d457ull;
@@ -6817,7 +6833,7 @@ inline bool MarkerLoadBuilder( MarkerBuilder & builder, const uint8_t * wire_fil
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = MarkerLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -7915,7 +7931,7 @@ inline bool MarkerCookFrom( const Ctx & ctx, const Marker & root, void * out, ui
     bool ok = MarkerNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && MarkerCookLayout( numbering, region );
     }
     if ( ok )
@@ -7966,7 +7982,7 @@ inline bool MarkerCookFrom( const Ctx & ctx, const Marker & root, void * out, ui
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }

--- a/testdata/golden/tables/pointers/PartsTable.cpp
+++ b/testdata/golden/tables/pointers/PartsTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -2142,6 +2142,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2290,7 +2306,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2325,13 +2341,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2372,7 +2388,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2543,7 +2559,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2590,7 +2606,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2598,7 +2614,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2789,7 +2805,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2817,12 +2833,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;

--- a/testdata/golden/tables/stream/StreamTable.cpp
+++ b/testdata/golden/tables/stream/StreamTable.cpp
@@ -2622,7 +2622,7 @@ inline void TableJsonGraphMapInit( TableJsonGraphMap & map, TableAllocator alloc
 
 inline void TableJsonGraphMapShutdown( TableJsonGraphMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TableJsonGraphMapInit( map, map.allocator );
 }
 
@@ -2652,7 +2652,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 64;
     grown.count = 0;
-    grown.entries = (TableJsonGraphEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
+    grown.entries = (TableJsonGraphEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TableJsonGraphEntry ) ); // zeroed, by the pair's contract
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2660,7 +2660,7 @@ inline bool TableJsonGraphMapGrow( TableJsonGraphMap & map )
         grown.entries[ TableJsonGraphMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -1995,6 +1995,22 @@ inline TableAllocator TableDefaultAllocator()
     return allocator;
 }
 
+// Both callbacks are required together. An incomplete pair refuses before the
+// first callback, the same way C's table_allocate does.
+inline bool table_allocator_complete( TableAllocator const & a )
+{
+    return a.alloc != NULL && a.free != NULL;
+}
+inline void * table_allocate( TableAllocator const & a, int64_t bytes )
+{
+    if ( !table_allocator_complete( a ) || bytes <= 0 ) return NULL;
+    return a.alloc( a.context, bytes );
+}
+inline void table_release( TableAllocator const & a, void * pointer )
+{
+    if ( a.free != NULL ) a.free( a.context, pointer );
+}
+
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
 //
 // Two encodings, one slot, and the FORM says which is in force:
@@ -2143,7 +2159,7 @@ inline void TableArenaShutdown( TableArena & arena )
     for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
     {
         uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
-        if ( segment != NULL ) { arena.allocator.free( arena.allocator.context, segment ); }
+        if ( segment != NULL ) { table_release( arena.allocator, segment ); }
     }
     arena.cursor.store( 0, std::memory_order_relaxed );
 }
@@ -2178,13 +2194,13 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
                 // at the segment or not at all. It costs nothing measurable: a
                 // fresh segment is untouched pages either way, and the default
                 // pair's calloc has the kernel hand them over zeroed.
-                uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, (int64_t) kTableSegmentSize );
+                uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, (int64_t) kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
                 {
                     // another worker published this segment first
-                    arena.allocator.free( arena.allocator.context, memory );
+                    table_release( arena.allocator, memory );
                 }
             }
             if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
@@ -2225,7 +2241,7 @@ inline uint32_t TableArenaGrabSpan( TableArena & arena, int64_t bytes )
         // first index, so a plain store suffices, and the block comes back
         // ZEROED like every segment — the blob's bytes and its tail are zeros
         // until written
-        uint8_t * memory = (uint8_t *) arena.allocator.alloc( arena.allocator.context, bytes );
+        uint8_t * memory = (uint8_t *) table_allocate( arena.allocator, bytes );
         if ( memory == NULL ) { return kTableAllocFailed; }
         arena.segments[start].store( memory, std::memory_order_release );
         return start << kTableSegmentBits;
@@ -2396,7 +2412,7 @@ inline void TablePackMapInit( TablePackMap & map, TableAllocator allocator )
 
 inline void TablePackMapShutdown( TablePackMap & map )
 {
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     TablePackMapInit( map, map.allocator );
 }
 
@@ -2443,7 +2459,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
     TablePackMap grown;
     grown.allocator = map.allocator;
     grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
-    grown.entries = (TablePackEntry *) map.allocator.alloc( map.allocator.context, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
+    grown.entries = (TablePackEntry *) table_allocate( map.allocator, grown.capacity * (int64_t) sizeof( TablePackEntry ) );
     if ( grown.entries == NULL ) { return false; }
     for ( int64_t i = 0; i < map.capacity; i++ )
     {
@@ -2451,7 +2467,7 @@ inline bool TablePackMapGrow( TablePackMap & map )
         grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
         grown.count++;
     }
-    map.allocator.free( map.allocator.context, map.entries );
+    table_release( map.allocator, map.entries );
     map = grown;
     return true;
 }
@@ -2642,7 +2658,7 @@ inline void TableNumberingShutdown( TableNumbering & n )
 {
     TableAllocator allocator = n.seen.allocator;
     TablePackMapShutdown( n.seen );
-    allocator.free( allocator.context, n.entries );
+    table_release( allocator, n.entries );
     n.entries = NULL;
     n.count = 0;
     n.capacity = 0;
@@ -2670,12 +2686,12 @@ inline bool TableNumberingAppend( TableNumbering & n, const TableNodeEntry & ent
         // entry and the growth is the same growth it always was.
         int64_t capacity = n.capacity != 0 ? n.capacity * 4 : 256;
         TableAllocator allocator = n.seen.allocator;
-        TableNodeEntry * grown = (TableNodeEntry *) allocator.alloc( allocator.context, capacity * (int64_t) sizeof( TableNodeEntry ) );
+        TableNodeEntry * grown = (TableNodeEntry *) table_allocate( allocator, capacity * (int64_t) sizeof( TableNodeEntry ) );
         if ( grown == NULL ) { return false; }
         if ( n.entries != NULL )
         {
             memcpy( grown, n.entries, (size_t) n.count * sizeof( TableNodeEntry ) );
-            allocator.free( allocator.context, n.entries );
+            table_release( allocator, n.entries );
         }
         n.entries = grown;
         n.capacity = capacity;
@@ -7392,7 +7408,7 @@ struct ChunkBuilder
         TableSlot<Chunk> slot = main.Alloc<Chunk>();
         root_ref = slot.ref;
     }
-    ~ChunkBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~ChunkBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     ChunkBuilder( const ChunkBuilder & ) = delete;
     ChunkBuilder & operator=( const ChunkBuilder & ) = delete;
 
@@ -7448,7 +7464,7 @@ inline bool ChunkBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Chunk ) );
     Chunk * destination = new ( packed ) Chunk; // lifetime only: the Pack below memcpy's the whole node over it
@@ -7462,7 +7478,7 @@ inline bool ChunkBuilder::Lock()
          !ChunkPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8140,7 +8156,7 @@ inline bool ChunkLoadBuilder( ChunkBuilder & builder, const uint8_t * wire_file,
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0xcf4368dcf951e082ull;
@@ -8188,7 +8204,7 @@ inline bool ChunkLoadBuilder( ChunkBuilder & builder, const uint8_t * wire_file,
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = ChunkLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -8221,7 +8237,7 @@ struct FeedBuilder
         TableSlot<Feed> slot = main.Alloc<Feed>();
         root_ref = slot.ref;
     }
-    ~FeedBuilder() { TableArenaShutdown( arena ); arena.allocator.free( arena.allocator.context, region ); }
+    ~FeedBuilder() { TableArenaShutdown( arena ); table_release( arena.allocator, region ); }
     FeedBuilder( const FeedBuilder & ) = delete;
     FeedBuilder & operator=( const FeedBuilder & ) = delete;
 
@@ -8277,7 +8293,7 @@ inline bool FeedBuilder::Lock()
     // the AUTHORING path may allocate (§6.5), and it does so through the
     // builder's own pair. The region comes back ZEROED, which is the
     // allocator's contract: a packed region carries node padding.
-    uint8_t * packed = (uint8_t *) arena.allocator.alloc( arena.allocator.context, total );
+    uint8_t * packed = (uint8_t *) table_allocate( arena.allocator, total );
     if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     int64_t used = TableAlignUp64( (int64_t) sizeof( Feed ) );
     Feed * destination = new ( packed ) Feed; // lifetime only: the Pack below memcpy's the whole node over it
@@ -8291,7 +8307,7 @@ inline bool FeedBuilder::Lock()
          !FeedPack( ctx, seen, root, *destination, packed, total, used ) || used != total )
     {
         TablePackMapShutdown( seen );
-        arena.allocator.free( arena.allocator.context, packed );
+        table_release( arena.allocator, packed );
         return false;
     }
     TablePackMapShutdown( seen );
@@ -8969,7 +8985,7 @@ inline bool FeedLoadBuilder( FeedBuilder & builder, const uint8_t * wire_file, i
     // It goes through the builder's own pair, like everything else the
     // builder reaches, and the entries come back zeroed.
     const TableAllocator allocator = builder.arena.allocator;
-    TableNodeDirEntry * directory = (TableNodeDirEntry *) allocator.alloc( allocator.context, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
+    TableNodeDirEntry * directory = (TableNodeDirEntry *) table_allocate( allocator, ( records + 1 ) * (int64_t) sizeof( TableNodeDirEntry ) );
     if ( directory == NULL ) { out->malformed = true; return false; }
     directory[0].offset = (uint64_t) builder.root_ref.value;
     directory[0].type_id = 0x3a8fe3852a245245ull;
@@ -9017,7 +9033,7 @@ inline bool FeedLoadBuilder( FeedBuilder & builder, const uint8_t * wire_file, i
     TableReader r( wire, wire_bytes, out, &ids_table );
     r.nested = false; // the ROOT body, the one that carries the node table
     bool ok = FeedLoadBody( r, nodes, *root );
-    allocator.free( allocator.context, directory );
+    table_release( allocator, directory );
     return ok;
 }
 
@@ -11544,7 +11560,7 @@ inline bool ChunkCookFrom( const Ctx & ctx, const Chunk & root, void * out, uint
     bool ok = ChunkNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && ChunkCookLayout( numbering, region );
     }
     if ( ok )
@@ -11595,7 +11611,7 @@ inline bool ChunkCookFrom( const Ctx & ctx, const Chunk & root, void * out, uint
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }
@@ -11712,7 +11728,7 @@ inline bool FeedCookFrom( const Ctx & ctx, const Feed & root, void * out, uint64
     bool ok = FeedNumberFrom( ctx, numbering, root );
     if ( ok )
     {
-        region.offsets = (int64_t *) allocator.alloc( allocator.context, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
+        region.offsets = (int64_t *) table_allocate( allocator, ( numbering.count + 1 ) * (int64_t) sizeof( int64_t ) );
         ok = region.offsets != NULL && FeedCookLayout( numbering, region );
     }
     if ( ok )
@@ -11763,7 +11779,7 @@ inline bool FeedCookFrom( const Ctx & ctx, const Feed & root, void * out, uint64
             }
         }
     }
-    allocator.free( allocator.context, region.offsets );
+    table_release( allocator, region.offsets );
     TableNumberingShutdown( numbering );
     return ok;
 }


### PR DESCRIPTION
Johnny Grok. Leftover from the table-wire compare: C copied the pair check into \`table_allocate\`; C++ Lock and the arena still trusted a half-filled \`TableAllocator\`.

Both callbacks are required together. An alloc-only or free-only pair returns NULL before the first callback. \`test_incomplete_pair_refuses_before_callback\` in \`hooks_main.cpp\` pins it.

Does not change the block-form allocator.