### PR TITLE
Hold Go blob spans with a slab-overlap negative control

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -655,7 +655,7 @@ reads it back after the nodes allocated behind it and the bytes are gone.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-blob-span-negative-control` | ✅ `internal/codegen/ctable/arena.go:312` `TestCTableWireBlobIdentity` | ❌ #259 | ❌ #259 | ✅ `tables-cs-leg` (large spans, descending addresses and failed blob allocation) | ❌ #259 | ❌ #259 | ❌ #259 | ❌ #259 |
+| ✅ `tables-blob-span-negative-control` | ✅ `internal/codegen/ctable/arena.go:312` `TestCTableWireBlobIdentity` | ❌ #259 | ✅ `TestBlobSpanHoldsAfterLaterAllocations` `tables-go-blob-span-negative-control` | ✅ `tables-cs-leg` (large spans, descending addresses and failed blob allocation) | ❌ #259 | ❌ #259 | ❌ #259 | ❌ #259 |
 
 
 ### M18 — A union arm is a field line

--- a/internal/codegen/gotable/blob_span_test.go
+++ b/internal/codegen/gotable/blob_span_test.go
@@ -1,0 +1,86 @@
+package gotable
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const blobSpanSchema = `package probe
+table Catalog {
+ thumb *bytes
+ note *string
+ extra *bytes
+}
+`
+
+const blobSpanTest = `package probe
+import("testing")
+func pattern(i int64) byte { return byte((i*31 + 7) & 0xff) }
+func TestBlobSpanHolds(t *testing.T) {
+ const big int64 = 66000
+ var b CatalogBuilder
+ if !b.Init() { t.Fatal("init") }
+ defer b.Shutdown()
+ root := b.GetRoot()
+ thumb := TableBytesEmplace(&b.Main, &root.Thumb, big)
+ if thumb == nil { t.Fatal("thumb") }
+ for i := int64(0); i < big; i++ { thumb[i] = pattern(i) }
+ if TableStringEmplace(&b.Main, &root.Note, []byte("tail")) == nil { t.Fatal("note") }
+ extra := TableBytesEmplace(&b.Main, &root.Extra, 24)
+ if extra == nil { t.Fatal("extra") }
+ for i := range extra { extra[i] = byte(i) }
+ live := TableBytesAt(&root.Thumb, &b.Arena)
+ if live.Length != big { t.Fatalf("live length %d", live.Length) }
+ for i := int64(0); i < big; i++ {
+  if live.Data[i] != pattern(i) { t.Fatalf("blob past the slab at %d", i) }
+ }
+ if !b.Lock() { t.Fatal("lock") }
+ locked := TableBytesAt(&b.AsConst().Thumb)
+ if locked.Length != big { t.Fatalf("locked length %d", locked.Length) }
+ for i := int64(0); i < big; i++ {
+  if locked.Data[i] != pattern(i) { t.Fatalf("blob past the slab after lock at %d", i) }
+ }
+}
+`
+
+func TestBlobSpanHoldsAfterLaterAllocations(t *testing.T) {
+	runGenerated(t, blobSpanSchema, blobSpanTest)
+}
+
+func TestBlobSpanNegativeControl(t *testing.T) {
+	out, err := runGeneratedEdited(t, blobSpanSchema, blobSpanTest, func(files map[string][]byte) {
+		patched := 0
+		for name, data := range files {
+			s := string(data)
+			repls := [][2]string{
+				{"span := bytes > tableArenaSlabBytes", "span := false /* SABOTAGED */"},
+				{"span:=bytes>tableArenaSlabBytes", "span:=false /* SABOTAGED */"},
+				{"if n > tableArenaSlabBytes {", "if false { /* SABOTAGED: no blob takes a span */"},
+				{"if n>tableArenaSlabBytes {", "if false { /* SABOTAGED: no blob takes a span */"},
+			}
+			n := 0
+			for _, pair := range repls {
+				next := strings.ReplaceAll(s, pair[0], pair[1])
+				if next != s {
+					n++
+					s = next
+				}
+			}
+			if n == 0 {
+				continue
+			}
+			files[name] = []byte(s)
+			patched += n
+		}
+		if patched == 0 {
+			t.Fatal("NEGATIVE CONTROL FAILED: the span sabotage patched nothing")
+		}
+	})
+	if err == nil {
+		t.Fatalf("NEGATIVE CONTROL FAILED: a blob bump-allocated in a slab it does not fit left the driver GREEN\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("blob past the slab")) {
+		t.Fatalf("NEGATIVE CONTROL FAILED: the driver went red, but not on the blob\n%s", out)
+	}
+}

--- a/make/go.mk
+++ b/make/go.mk
@@ -362,6 +362,17 @@ test-go: tables-go-retain
 tables-go-allocator:
 	@if [ "$${SCHEMA_GO_ALLOC_ANY_GO:-}" = 1 ]; then echo "Go allocation observation mode: NOT CERTIFIED"; fi
 	GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
+
+# THE SPAN, on its own (docs/SPEC-TABLES.md §2.5, M17). A blob larger than a
+# slab takes a span of the arena's address space. The negative control makes
+# grab() never span, so the blob is bump-allocated in a slab it does not fit
+# and later allocations overwrite it.
+.PHONY: tables-go-blob-span tables-go-blob-span-negative-control
+tables-go-blob-span:
+	go test ./internal/codegen/gotable -run '^TestBlobSpanHoldsAfterLaterAllocations$$' -count=1
+tables-go-blob-span-negative-control:
+	go test ./internal/codegen/gotable -run '^TestBlobSpanNegativeControl$$' -count=1
+test-go: tables-go-blob-span tables-go-blob-span-negative-control
 tables-go-allocator-negative-controls:
 	@set -e; for mode in original-slice pair frame; do sh test/conformance/go/ownership-negative-control $$mode; done
 tables-go-allocator-runtime-negative-control:

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -207,6 +207,7 @@
       "targets": [
         "tables-blob-read-hooks-negative-control",
         "tables-blob-span-negative-control",
+        "tables-go-blob-span-negative-control",
         "tables-c-fuzz-negative-control",
         "tables-c-keyed-none-refusal-negative-control",
         "tables-c-soak-negative-control",


### PR DESCRIPTION
Johnny Grok. Leftover from the table-wire compare: do not flip Go M17 without a blob-span negative control.

Go \`TableArena.grab\` already spans. This adds the missing control: sabotaging the span decision makes a 66KiB blob share a slab, and later allocations overwrite it. PORTING Go M17 is now ✅.

Does not flip rust/java/js/dart/elixir. Those still cite #259.