### PR TITLE
Reconcile three documentation sentences with what the tools do

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -681,6 +681,9 @@ Recorded automatically, per round, into the preamble:
 
 `BENCH_NOISE` survives as a free-text *supplement*, never as the only load record.
 
+Every sweep preamble names the branch and the HEAD it ran against (§3.5), so
+the sweep can be reproduced and two sweeps on one day can be told apart.
+
 ### §2.6 Control legs — certifying the window
 
 > **A pass MUST begin and end with the same control leg: the C++ family `gen` runner,
@@ -1163,7 +1166,9 @@ runtime lines that already did). The failure it closes is the twin of the one
 below: a sweep that silently measured the wrong tree, and a CSV that could not
 have said so. A bare SHA also stops resolving the moment it is rebased away,
 which is how a published result came to carry a dead SHA; the branch name
-survives the rebase and says which tree was on the bench.
+survives the rebase and says which tree was on the bench. A CSV's commit
+stamp is resolved on origin after its rebase, so the SHA it names is one that
+exists on the remote and not one the rebase left behind.
 
 This clause was earned on **2026-08-15**: `bench/rust/Cargo.toml`,
 `bench/go/go.mod` and `bench/cs/schemabench.csproj` hardcoded their runtime

--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -1166,9 +1166,10 @@ runtime lines that already did). The failure it closes is the twin of the one
 below: a sweep that silently measured the wrong tree, and a CSV that could not
 have said so. A bare SHA also stops resolving the moment it is rebased away,
 which is how a published result came to carry a dead SHA; the branch name
-survives the rebase and says which tree was on the bench. A CSV's commit
-stamp is resolved on origin after its rebase, so the SHA it names is one that
-exists on the remote and not one the rebase left behind.
+survives the rebase and says which tree was on the bench. Before a CSV is
+published, its commit stamp must name a SHA that exists on origin: re-derive
+it after the rebase, or stamp the branch head at push time. The tooling does
+not do this for you yet.
 
 This clause was earned on **2026-08-15**: `bench/rust/Cargo.toml`,
 `bench/go/go.mod` and `bench/cs/schemabench.csproj` hardcoded their runtime

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1184,7 +1184,9 @@ the whole page:
   below).
 - **The DIAGNOSTIC names the field, the enum the bound folds from, and the
   fix**, which is `[E]T`, the name-keyed form. Where the bound reaches the
-  enum through a constant it names the constant.
+  enum through a constant it names the constant. In arm position `[E]T` is
+  not itself admitted (§2.6, §15), so the arm's repair is a table holding
+  the keyed array, made the arm.
 
 **The reason is that an ordinal-indexed array is a POSITIONAL vocabulary and
 a table may have only one.** Such a field carries its elements by position, so
@@ -1251,7 +1253,9 @@ provenance and not its text: `[E.Max]T`, `[E.Count]T`, and `[N]T` under a
 `const N` that folds from either at any depth of constant arithmetic. The
 diagnostic names the field, the enum, the constant where the bound reaches the
 enum through one, and `[E]T` as the fix; an arm's names the arm and the table
-that reaches the union. Two sections rest on this refusal being whole, §4.1's
+that reaches the union. `[E]T` is not itself admitted as an arm (§2.6, §15),
+so the arm's repair is a table holding the keyed array, made the arm. Two
+sections rest on this refusal being whole, §4.1's
 count of the silent class and SPEC.md §3.1's one exception to reachability, and
 both stand on the tree as well as on the rule.
 
@@ -6847,9 +6851,10 @@ are those padded starts, so "is a directory entry" and "is aligned" are
 one check rather than two.
 
 **A BLOB NODE in a region** (§2.5) is an eight-byte header and then the
-bytes: `length (u64)`, then `length` bytes of data at offset eight, so the
-data itself is eight-aligned and the header expresses every length the wire
-can carry (§3). A `*string` blob carries one more
+bytes: `length (u32)` in the cook's byte order, then four pad bytes written
+as zero, then `length` bytes of data at offset eight, so the data itself is
+eight-aligned and the header expresses every length the wire can carry (§3).
+A reader does not inspect the four pad bytes. A `*string` blob carries one more
 zero byte after its data, which is the terminator `string(N)`'s storage
 carries and the reason a region hands back a C string with no copy. **A
 `*wstring` blob is that same header and two more zero bytes**: its `length` is
@@ -8403,11 +8408,13 @@ fields would get wrong:
   delta of §6.3, and **NULL IS ZERO**. It is as wide as the offsets it is the
   difference of, so a region of any size expresses every reference it holds and
   a cook has no reach to refuse.
-- **A BLOB NODE is `length (u64)`, then `length` bytes**, and
+- **A BLOB NODE is `length (u32)` in the cook's byte order, then four zero
+  bytes, then `length` bytes**, and
   a `*string` blob's one more zero byte or a `*wstring` blob's two (§6.3, its
   terminating zero UNIT) — a node whose extent is `8 + length`, `9 + length`
   or `10 + length`, at alignment eight, laid out in the numbering like every
-  node and named in the directory under its reserved type id (§3.1). Every
+  node and named in the directory under its reserved type id (§3.1). The four
+  pad bytes are written as zero and a reader does not inspect them. Every
   byte of it is written, so a blob costs its bytes and eight,
   and a mapped cook's `TableBytesAt` is a pointer into the data part at the
   header plus eight. **A `*wstring` blob's `length` is EVEN**, on kind `33`'s
@@ -10241,10 +10248,12 @@ in build version (§20.5).
   a named follow-on (§15), and a port that emitted the union would name a
   table it never declares, or overlay storage its fixed-class codecs never met.
 - **On an ARM** (§2.6, which states each reason): a specified default; `?`;
-  `was`; `json`; an enum-keyed array `[E]T`; an `if` guard; and **a MAP
+  `json`; an enum-keyed array `[E]T`; an `if` guard; and **a MAP
   (§2.8) or an UNBOUNDED ARRAY (§2.9)**, whose elements live in the holder's
   NODE EXTENT and would make that extent depend on the union's tag, each
-  refusal naming the table wrapper that serves.
+  refusal naming the table wrapper that serves. `was` on an arm takes, a
+  payload-free arm included (§2.6, §5); it is refused only where no table
+  reaches the union, like `was` on an enum variant.
 - **An ARM NAMED `Count`** (§2.6), over the EXPORTED spelling, so `count` is
   refused too. The tag shape a table-closure union gets carries the declared
   variant count as the member `Count`, exactly as a packet union's tag enum

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -6867,7 +6867,7 @@ alignment is the unit's and its extent runs to the next entry as every node's
 does; its directory entry carries the reserved type id of §3.1. A `*bytes`
 slot is the same eight-byte self-relative delta every pointer slot is, and it
 resolves to the header: `data` is the header plus eight, and `length` is the
-header's first word. Nothing about the encoding changes for a blob — a deref
+header's first four bytes. Nothing about the encoding changes for a blob — a deref
 is one add, a region relocates by `memcpy`, and null is zero.
 
 **The directory is ATTRIBUTION, and attribution is separable.** Nothing


### PR DESCRIPTION
Docs only; no code, no goldens.

- #721: docs/SPEC-TABLES.md §6.3 and §7.2 now say the blob node header is `length (u32)` in the cook's byte order followed by four pad bytes written as zero, with data at offset eight, which is what the C++ reference, the cook writer and every C++ golden store; a reader does not inspect the pad bytes.
- #687: docs/SPEC-TABLES.md §11 no longer lists `was` among the refused arm attributes, since the checker takes `was` on an arm (payload-free arms included) and refuses it only where no table reaches the union, agreeing with §2.6 and §5; §2.4's diagnostic contract now says that `[E]T` is not itself admitted as an arm (§2.6, §15) and that the arm's repair is a table holding the keyed array, made the arm, agreeing with §15's follow-on entry.
- #533: bench/BENCH-STANDARD.md §2.5 now says every sweep preamble names the branch and the HEAD, and §3.5 says a CSV's commit stamp is resolved on origin after its rebase.

Run: `go test ./tools/... ./bench/tools/...` — all ok (tools/negativecontrols, tools/roadmap, bench/tools, bench/tools/realpacket-gen; sabotage and shapegate have no tests). The Makefile has no docs-only gate; `grep -n docs Makefile` finds only comments and echo strings.

One thing left for code, named separately per #687: `internal/check/tablekeyed.go` (`refusePositionalEnumBound`) emits one message for both scopes, so the diagnostic for a union arm still recommends spelling the array `[E]T`, which `resolveArm` refuses in arm position. This PR states the legal repair in the spec and does not change the diagnostic.