### PR TITLE
Derive the tables goldens gate from the directory listing and make the bench's elixir leg require its pinned toolchain

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -208,7 +208,29 @@ DART_BIN="${DART:-$PWD/dist/dart-sdk-3.13.2/bin/dart}"
 BEAM_PATH="${BEAM_PATH:-$PWD/dist/otp-29.0.5/bin:$PWD/dist/elixir-1.20.4/bin}"
 JAVA_VERSION="$("$JAVA_BIN" --version 2>/dev/null | head -1 || true)"
 DART_VERSION="$("$DART_BIN" --version 2>/dev/null | head -1 || true)"
-ELIXIR_VERSION="$(PATH="$BEAM_PATH:$PATH" elixir --short-version 2>/dev/null | head -1 || true)"
+# beam_pinned: true only when an executable named $1 sits in one of
+# BEAM_PATH's OWN directories. The elixir leg REQUIRES the pin the way java
+# and dart require their absolute $JAVAC_BIN and $DART_BIN: a `command -v`
+# under PATH="$BEAM_PATH:$PATH" prepends rather than requires, so with dist/
+# absent and a Homebrew or asdf elixir on the caller's PATH the leg ran on
+# the system toolchain instead of skipping (#693).
+beam_pinned() {
+    local dir rest="$BEAM_PATH:"
+    while [ -n "$rest" ]; do
+        dir="${rest%%:*}"
+        rest="${rest#*:}"
+        if [ -n "$dir" ] && [ -x "$dir/$1" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+# the version line records the pin, or "not present" — never a system elixir
+# the leg would refuse to run on
+ELIXIR_VERSION=""
+if beam_pinned elixir && beam_pinned erl; then
+    ELIXIR_VERSION="$(PATH="$BEAM_PATH:$PATH" elixir --short-version 2>/dev/null | head -1 || true)"
+fi
 
 # Release flags: the schema repo's own flags (-std=c++17 -Wall -Wextra -Werror
 # -ffp-contract=off) plus the serialize repo's Release bench configuration
@@ -556,11 +578,14 @@ fi
 # ---- Elixir (generated codecs over the Bench corpus; pinned BEAM toolchain) ----
 if [ -z "$ONLY" ] || [ "$ONLY" = elixir ]; then
     if [ -f bench/elixir/main.exs ]; then
-        if PATH="$BEAM_PATH:$PATH" command -v elixir >/dev/null 2>&1; then
+        # both pinned binaries, tested on BEAM_PATH alone (beam_pinned above);
+        # the run still prepends, because the elixir launcher is a shell
+        # script that needs the system's coreutils beside the pinned erl
+        if beam_pinned elixir && beam_pinned erl; then
             echo "== elixir: run ==" >&2
             ( cd bench/elixir && $PIN env PATH="$BEAM_PATH:$PATH" elixir main.exs $RUNNER_ARGS ) >> "$OUT"
         else
-            skip_leg elixir "runner present but no elixir on $BEAM_PATH (populate dist/ per the Makefile, or set BEAM_PATH)"
+            skip_leg elixir "runner present but no pinned elixir+erl on $BEAM_PATH (populate dist/ per the Makefile, or set BEAM_PATH)"
         fi
     else
         skip_leg elixir "runner not landed yet (bench/elixir/main.exs)"

--- a/bench/tools/aggregate.go
+++ b/bench/tools/aggregate.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 )
@@ -150,8 +149,12 @@ func aggregateCmd(files []string) {
 	// a bench OR PATH missing from the lists would silently vanish from the
 	// pass, which is exactly what happened to round_trip when the gen
 	// bench_mixed rows went data-driven (#191).
-	// Printed keys are counted and any straggler REFUSES the aggregation.
-	printed := 0
+	// Printed keys are REMEMBERED and any straggler REFUSES the aggregation,
+	// named: the diagnostic walks the accumulated keys against the printed
+	// set, not against the lists, so a row on any unknown dimension — lang
+	// included, which the old bench-or-path filter named nothing for
+	// (#693) — is the one the message shows.
+	printed := map[key]bool{}
 	for _, l := range langs {
 		for _, b := range order {
 			for _, p := range paths {
@@ -161,7 +164,7 @@ func aggregateCmd(files []string) {
 					if !ok {
 						continue
 					}
-					printed++
+					printed[k] = true
 					rates := append([]float64{}, a.rates...)
 					sort.Float64s(rates)
 					n := len(rates)
@@ -184,10 +187,18 @@ func aggregateCmd(files []string) {
 			}
 		}
 	}
-	if printed != len(acc) {
-		fmt.Fprintf(os.Stderr, "aggregate: REFUSING: %d row key(s) accumulated but not printed — the bench or path lists do not know every row the rounds measured (bench: %s; path: %s):\n", len(acc)-printed, strings.Join(order, ", "), strings.Join(paths, ", "))
+	if len(printed) != len(acc) {
+		langKeys := make([]string, 0, len(langs))
+		for _, l := range langs {
+			langKeys = append(langKeys, l.key)
+		}
+		codecKeys := make([]string, 0, len(codecs))
+		for _, c := range codecs {
+			codecKeys = append(codecKeys, fmt.Sprintf("%q", c))
+		}
+		fmt.Fprintf(os.Stderr, "aggregate: REFUSING: %d row key(s) accumulated but not printed — the lang, bench, path or codec lists do not know every row the rounds measured (lang: %s; bench: %s; path: %s; codec: %s):\n", len(acc)-len(printed), strings.Join(langKeys, ", "), strings.Join(order, ", "), strings.Join(paths, ", "), strings.Join(codecKeys, ", "))
 		for _, k := range keys {
-			if !slices.Contains(order, k.bench) || !slices.Contains(paths, k.path) {
+			if !printed[k] {
 				fmt.Fprintf(os.Stderr, "    %s/%s/%s\n", k.lang, k.bench, k.path)
 			}
 		}

--- a/bench/tools/aggregate_test.go
+++ b/bench/tools/aggregate_test.go
@@ -140,6 +140,23 @@ func TestAggregateRefusesAPathTheListDoesNotKnow(t *testing.T) {
 	}
 }
 
+// The other negative control (#693): a row whose LANGUAGE the list does not
+// know is a straggler too, and the refusal must name it. The old diagnostic
+// loop filtered on bench and path alone, so a lang-only straggler produced
+// the "accumulated but not printed" heading over an empty list.
+func TestAggregateRefusesALanguageTheListDoesNotKnowByName(t *testing.T) {
+	dir := t.TempDir()
+	r0 := writeRound(t, dir, "round-0-zig.csv", "0",
+		"zig,bench_mixed,write,4000000,100,1,9000000,9000000,9000000,3759.77,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown")
+	out, errOut, code := runTool(t, "aggregate", r0)
+	if code != 2 {
+		t.Fatalf("aggregate accepted a row in an unknown language (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if !strings.Contains(errOut, "accumulated but not printed") || !strings.Contains(errOut, "zig/bench_mixed/write") {
+		t.Errorf("the straggler refusal did not fire naming the lang-only row:\n%s", errOut)
+	}
+}
+
 // bands reads its PRIOR files from its second argument onward. The same
 // shadow class that broke aggregate was recreated here by the first rename
 // (the loop kept reading `paths[1:]`, which had become the column list), so

--- a/internal/goldens/goldens_test.go
+++ b/internal/goldens/goldens_test.go
@@ -376,23 +376,168 @@ func pinDir(t *testing.T, dir string, files map[string][]byte) {
 	}
 }
 
-// pinnedUnits is every compilation unit this package pins, by the name its
-// golden files are stored under.
-var pinnedUnits = []struct {
-	name string
-	dir  string
-}{
-	{"examples", corpusDir},
-	{"examples128", corpus128Dir},
-	{"examples-wide", corpusWideDir},
-	{"tables-examples", "../../tables/examples"},
-	{"tables-pointers", "../../tables/pointers"},
-	{"tables-block", "../../tables/block"},
-	{"tables-blockhome", "../../tables/blockhome"},
-	{"tables-messages", "../../tables/messages"},
-	{"tables-stream", "../../tables/stream"},
-	{"tables-blobs", "../../tables/blobs"},
-	{"tables-scalars", "../../tables/scalars"},
+// tableGoldenDir is the tables units' Table-source pins: one directory per
+// (unit, target), written by `make update-goldens` from build/tables-generated
+// and its C and C# siblings (Makefile update-goldens, make/c.mk, make/cs.mk).
+const tableGoldenDir = goldenDir + "/tables"
+
+// tableUnit is one directory under testdata/golden/tables: the unit it pins
+// and the target that emitted it.
+type tableUnit struct {
+	name   string // the golden directory's name
+	dir    string // the unit's source directory
+	target string
+}
+
+// tableUnits derives the pinned tables units FROM THE DIRECTORY LISTING, so a
+// directory of goldens nobody compares cannot exist: a hand-kept list of the
+// units is how six maps headers went stale on main across two merges (#683 —
+// tables/maps, tables/arms, tables/lists and wide were pinned and compared by
+// nothing here). The names map by rule: `<unit>` is tables/<unit> emitted by
+// the C++ reference, `<unit>-c` and `<unit>-cs` are the same unit emitted by
+// the C and C# targets (make/c.mk, make/cs.mk), and `wide` is the one
+// directory whose unit lives outside tables/ — its home is examples-wide
+// (Makefile tables_generate). A directory that fits no rule is still a unit
+// under tables/, so a planted one is loaded and fails loudly rather than
+// being skipped.
+func tableUnits(goldenTables string) ([]tableUnit, error) {
+	entries, err := os.ReadDir(goldenTables)
+	if err != nil {
+		return nil, err
+	}
+	var units []tableUnit
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		unit := tableUnit{name: name, target: "cpp"}
+		switch {
+		case name == "wide":
+			unit.dir = corpusWideDir
+		case strings.HasSuffix(name, "-cs"):
+			unit.dir, unit.target = "../../tables/"+strings.TrimSuffix(name, "-cs"), "cs"
+		case strings.HasSuffix(name, "-c"):
+			unit.dir, unit.target = "../../tables/"+strings.TrimSuffix(name, "-c"), "c"
+		default:
+			unit.dir = "../../tables/" + name
+		}
+		units = append(units, unit)
+	}
+	return units, nil
+}
+
+// TestGoldenTableSource pins every tables unit's emitted Table sources
+// byte-for-byte (SPEC §7.2 gate 1), one directory of testdata/golden/tables
+// at a time, the set derived from the listing. What each directory pins is
+// the Makefile's choice (update-goldens copies *Table.h and *Table.cpp; the
+// C and C# legs their own sets); what this gate holds is that EVERY pinned
+// file in EVERY directory is what the compiler emits today — so a Table
+// emitter change that moves a pinned file is red on the PR that made it,
+// whichever unit it landed in.
+func TestGoldenTableSource(t *testing.T) {
+	units, err := tableUnits(tableGoldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unit := range units {
+		t.Run(unit.name, func(t *testing.T) {
+			u := loadCorpusDir(t, unit.dir)
+			files := generate(t, u, unit.target, nil)
+			dir := filepath.Join(tableGoldenDir, unit.name)
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pinned := map[string][]byte{}
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				got, ok := files[e.Name()]
+				if !ok {
+					t.Errorf("%s pins %s and the %s target no longer emits it for %s — a pinned file the emitter dropped is stop-the-line, not a stale pin", dir, e.Name(), unit.target, unit.dir)
+					continue
+				}
+				pinned[e.Name()] = got
+			}
+			pinDir(t, dir, pinned)
+		})
+	}
+}
+
+// TestGoldenTablesAreDerivedFromTheListing holds tableUnits to its rule: a
+// planted directory enters the compared set (there is no list to leave it off
+// of), and the four units #683 found uncompared are in the real set.
+func TestGoldenTablesAreDerivedFromTheListing(t *testing.T) {
+	planted := t.TempDir()
+	for _, name := range []string{"maps", "planted", "planted-c", "planted-cs", "wide"} {
+		if err := os.Mkdir(filepath.Join(planted, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(planted, "id.txt"), []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := tableUnits(planted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []tableUnit{
+		{"maps", "../../tables/maps", "cpp"},
+		{"planted", "../../tables/planted", "cpp"},
+		{"planted-c", "../../tables/planted", "c"},
+		{"planted-cs", "../../tables/planted", "cs"},
+		{"wide", corpusWideDir, "cpp"},
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("tableUnits over a planted listing = %v, want %v", got, want)
+	}
+	if _, err := os.Stat("../../tables/planted"); err == nil {
+		t.Fatal("tables/planted exists — the planted directory has a unit behind it and this test no longer plants anything")
+	}
+
+	real, err := tableUnits(tableGoldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"maps", "arms", "lists", "wide"} {
+		found := false
+		for _, unit := range real {
+			if unit.name == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("testdata/golden/tables/%s is not in the compared set — #683's uncompared unit is uncompared again", name)
+		}
+	}
+}
+
+// pinnedUnits is every compilation unit this package pins by the name its
+// golden files are stored under: the three corpora, then every tables unit
+// the goldens listing names (tableUnits), once each. The C and C# directories
+// are the SAME unit emitted by another target and `wide` IS examples-wide, so
+// those fold into the unit already named — excluded explicitly here, not by a
+// list that has to remember them.
+func pinnedUnits(t *testing.T) []struct{ name, dir string } {
+	t.Helper()
+	units := []struct{ name, dir string }{
+		{"examples", corpusDir},
+		{"examples128", corpus128Dir},
+		{"examples-wide", corpusWideDir},
+	}
+	tables, err := tableUnits(tableGoldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unit := range tables {
+		if unit.target != "cpp" || unit.dir == corpusWideDir {
+			continue
+		}
+		units = append(units, struct{ name, dir string }{"tables-" + unit.name, unit.dir})
+	}
+	return units
 }
 
 // TestWireLawBumpMovesEveryId holds the promise the codec law line is for
@@ -405,7 +550,7 @@ var pinnedUnits = []struct {
 func TestWireLawBumpMovesEveryId(t *testing.T) {
 	law := fmt.Sprintf("schema-wire-law %d\n", ir.WireLaw)
 	next := fmt.Sprintf("schema-wire-law %d\n", ir.WireLaw+1)
-	for _, unit := range pinnedUnits {
+	for _, unit := range pinnedUnits(t) {
 		t.Run(unit.name, func(t *testing.T) {
 			u := loadCorpusDir(t, unit.dir)
 			text := ir.WireProjection(u)
@@ -440,7 +585,7 @@ func digest(projection string) uint64 {
 // header lines alone, which is the case a reader has to be able to check by
 // eye.
 func TestGoldenBuildVersion(t *testing.T) {
-	for _, unit := range pinnedUnits {
+	for _, unit := range pinnedUnits(t) {
 		t.Run(unit.name, func(t *testing.T) {
 			u := loadCorpusDir(t, unit.dir)
 			got := fmt.Sprintf("0x%016x\n%s", ir.BuildVersion(u), ir.CookProjection(u))

--- a/testdata/golden/build-version/tables-arms.txt
+++ b/testdata/golden/build-version/tables-arms.txt
@@ -1,0 +1,56 @@
+0xdafcc33c5f3de681
+schema-build-version 3
+protocol 727cea182a6959a7
+byteorder little
+block prologue=magic:8,build_version:8,byte_order:8
+record Chain sizeof=24 alignof=8
+    field 5cc201a9f1b8274e kind=14 offset=0 size=16 union=Carry elem=24 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Gate sizeof=24 alignof=8
+    field 891da1f305deb858 kind=15 offset=0 size=16 union=Reach
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Hand sizeof=56 alignof=8
+    field c5b2a72c0845a253 kind=15 offset=0 size=52 union=Carry elem=24 array=bounded bound=2
+    field bf82010f6f71eae9 kind=4 offset=52 size=4
+record Holder sizeof=40 alignof=8
+    field afcd9a3b099f8ef0 kind=15 offset=0 size=24 union=Carry
+    field d94c56ef0798d723 kind=14 offset=24 size=16 elem=4 array=unbounded
+record Leaf sizeof=16 alignof=8
+    field 3e7884bf4f412c6f kind=14 offset=0 size=16 elem=4 array=unbounded
+record Nest sizeof=48 alignof=8
+    field 30e6ed678f5e1bd4 kind=15 offset=0 size=32 union=Outer
+    field d94c56ef0798d723 kind=14 offset=32 size=16 elem=4 array=unbounded
+record Node sizeof=4 alignof=4
+    field af63eb4c86020609 kind=4 offset=0 size=4
+record Only sizeof=4 alignof=4
+    field af63ea4c86020456 kind=4 offset=0 size=4
+record Rack sizeof=24 alignof=8
+    field 3e7884bf4f412c6f kind=14 offset=0 size=16 union=Slots elem=32 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Ring sizeof=24 alignof=8
+    field 3e7884bf4f412c6f kind=14 offset=0 size=16 union=Slot elem=16 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Tray sizeof=72 alignof=8
+    field c5b2a72c0845a253 kind=15 offset=0 size=68 union=Slots elem=32 array=bounded bound=2
+    field bf82010f6f71eae9 kind=4 offset=68 size=4
+record Twig sizeof=24 alignof=8
+    field 2d4c068f5f889287 kind=15 offset=0 size=24 union=Inner
+union Carry
+    arm 1 leaf payload=Leaf
+    arm 2 plain kind=4 offset=8 size=4
+union Inner
+    arm 1 leaf payload=Leaf
+    arm 2 plain kind=4 offset=8 size=4
+union Outer
+    arm 1 inner kind=15 offset=8 size=24 union=Inner
+    arm 2 plain kind=4 offset=8 size=4
+union Reach
+    arm 1 only kind=17 offset=8 size=8 type=Only
+    arm 2 text kind=17 offset=8 size=8 type=string
+    arm 3 plain kind=4 offset=8 size=4
+union Slot
+    arm 1 node kind=17 offset=8 size=8 type=Node
+    arm 2 plain kind=4 offset=8 size=4
+union Slots
+    arm 1 many kind=17 offset=8 size=24 type=Node elem=10 array=bounded bound=2
+    arm 2 plain kind=4 offset=8 size=4

--- a/testdata/golden/build-version/tables-lists.txt
+++ b/testdata/golden/build-version/tables-lists.txt
@@ -1,0 +1,82 @@
+0xab01029b01ed159e
+schema-build-version 3
+protocol 6f357df726f08bc5
+byteorder little
+block prologue=magic:8,build_version:8,byte_order:8
+record Album sizeof=24 alignof=8
+    field 40b1d94aff3ab130 kind=14 offset=0 size=16 type=Photo elem=8 array=unbounded
+    field aa19a78e404dea20 kind=17 offset=16 size=8 type=Photo
+record Army sizeof=24 alignof=8
+    field 7848019b0c02a926 kind=14 offset=0 size=16 type=Squad elem=24 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Bounded sizeof=40 alignof=4
+    field 3e7884bf4f412c6f kind=13 offset=0 size=36 type=Unit elem=4 array=bounded bound=8
+    field 56d7ab194448a4f3 kind=4 offset=36 size=4
+block Bounded sizeof=48 alignof=8
+    slot 3e7884bf4f412c6f offset=24 size=16 out_of_line stride=4
+    slot 56d7ab194448a4f3 offset=40 size=4
+record Bytes sizeof=24 alignof=8
+    field 855b556730a34a05 kind=14 offset=0 size=16 elem=1 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Deck sizeof=80 alignof=8
+    field 81b46a69304ee2c9 kind=13 offset=0 size=76 type=Row elem=24 array=bounded bound=3
+    field bf82010f6f71eae9 kind=4 offset=76 size=4
+record Floats sizeof=24 alignof=8
+    field 21277bcf1a4d67fb kind=14 offset=0 size=16 elem=4 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Ints sizeof=24 alignof=8
+    field 21277bcf1a4d67fb kind=14 offset=0 size=16 elem=4 array=unbounded
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Item sizeof=4 alignof=4
+    field b1e5e28e4479a274 kind=4 offset=0 size=4
+record LogEntry sizeof=4 alignof=4
+    field 1e7683ef2ebc7684 kind=8 offset=0 size=4
+record Mixed sizeof=64 alignof=8
+    field d90a4e7682f799c5 kind=14 offset=0 size=16 enum=Grade elem=1 array=unbounded
+    field 4af2ed8470862ea8 kind=14 offset=16 size=16 elem=8 array=unbounded
+    field 732dfbcc9b0cf0bb kind=14 offset=32 size=16 union=Hit elem=12 array=unbounded
+    field 52f60c4caef0b768 kind=14 offset=48 size=16 elem=4 array=unbounded min=0 max=100
+record Photo sizeof=8 alignof=4
+    field dbdacd932fd1e9bf kind=8 offset=0 size=4
+    field 17720bf67d347222 kind=8 offset=4 size=4
+record Placement sizeof=12 alignof=4
+    field af63f54c86021707 kind=10 offset=0 size=4
+    field af63f44c86021554 kind=10 offset=4 size=4
+    field 9de543933e6e703a kind=8 offset=8 size=4
+record Point sizeof=8 alignof=4
+    field af63f54c86021707 kind=4 offset=0 size=4
+    field af63f44c86021554 kind=4 offset=4 size=4
+record Row sizeof=24 alignof=8
+    field 3e7884bf4f412c6f kind=14 offset=0 size=16 type=Sample elem=4 array=unbounded
+    field 39f7fcec8fcb623d kind=4 offset=16 size=4
+record Sample sizeof=4 alignof=4
+    field af63eb4c86020609 kind=4 offset=0 size=4
+record Save sizeof=48 alignof=8
+    field d24733aa574d4b09 kind=14 offset=0 size=16 type=Placement elem=12 array=unbounded
+    field 125073191daf5431 kind=14 offset=16 size=16 type=LogEntry elem=8 array=unbounded
+    field 01986b0b27400fb2 kind=14 offset=32 size=16 elem=4 array=unbounded
+record Sheet sizeof=24 alignof=8
+    field a3a7061ff10a8138 kind=14 offset=0 size=16 type=Row elem=24 array=unbounded
+    field 5f82477707ad620f kind=17 offset=16 size=8 type=Row
+record Squad sizeof=24 alignof=8
+    field 1c84390d304f4f42 kind=14 offset=0 size=16 elem=8 array=map
+    field c4bcadba8e631b86 kind=4 offset=16 size=4
+record Unbounded sizeof=24 alignof=8
+    field 3e7884bf4f412c6f kind=14 offset=0 size=16 type=Unit elem=4 array=unbounded
+    field 56d7ab194448a4f3 kind=4 offset=16 size=4
+record Unit sizeof=4 alignof=4
+    field af63eb4c86020609 kind=4 offset=0 size=4
+record ec07a2f760550a91.1c84390d304f4f42 sizeof=8 alignof=4
+    field 3dc94a19365b10ec kind=6 offset=0 size=1
+    field 7ce4fd9430e80cea kind=13 offset=4 size=4 type=Item
+enum Grade
+    variant 1 A
+    variant 2 B
+    variant 3 C
+flags Perm
+    variant 0 Read
+    variant 1 Write
+    variant 2 Own
+union Hit
+    arm 1 point payload=Point
+    arm 2 damage kind=4 offset=4 size=4

--- a/testdata/golden/build-version/tables-maps.txt
+++ b/testdata/golden/build-version/tables-maps.txt
@@ -1,0 +1,138 @@
+0x194c2068d2c970dd
+schema-build-version 3
+protocol 1ac124decde5b2aa
+byteorder little
+block prologue=magic:8,build_version:8,byte_order:8
+record 033de3f1246bba76.755332609c470fbd sizeof=24 alignof=8
+    field 3dc94a19365b10ec kind=6 offset=0 size=1
+    field 7ce4fd9430e80cea kind=14 offset=8 size=16 type=Item elem=4 array=unbounded
+record 036ffe7360826852.ab01daa76a48769f sizeof=24 alignof=8
+    field 3dc94a19365b10ec kind=12 offset=0 size=16 bound=8
+    field 7ce4fd9430e80cea kind=17 offset=16 size=8 type=string
+record 0a53e00afba279af.294a5c4913e1ad44 sizeof=116 alignof=4
+    field 3dc94a19365b10ec kind=12 offset=0 size=40 bound=32
+    field 7ce4fd9430e80cea kind=13 offset=40 size=76 type=ShipConfig
+record 0a53e00afba279af.294fa1b3f0f5f070 sizeof=40 alignof=8
+    field 3dc94a19365b10ec kind=12 offset=0 size=24 bound=16
+    field 7ce4fd9430e80cea kind=14 offset=24 size=16 elem=8 array=map
+record 0a53e00afba279af.294fa1b3f0f5f070.7ce4fd9430e80cea sizeof=8 alignof=4
+    field 3dc94a19365b10ec kind=6 offset=0 size=1
+    field 7ce4fd9430e80cea kind=13 offset=4 size=4 type=Item
+record 0a53e00afba279af.6dd8dc6c5fdae3ce sizeof=8 alignof=4
+    field 3dc94a19365b10ec kind=3 offset=0 size=2
+    field 7ce4fd9430e80cea kind=13 offset=4 size=4 type=Item
+record 0a53e00afba279af.7b024c46e98d3404 sizeof=16 alignof=8
+    field 3dc94a19365b10ec kind=8 offset=0 size=4
+    field 7ce4fd9430e80cea kind=17 offset=8 size=8 type=ShipConfig
+record 1404200dab337086.e68c2e6bb1ee5646 sizeof=24 alignof=8
+    field 3dc94a19365b10ec kind=8 offset=0 size=4
+    field 7ce4fd9430e80cea kind=17 offset=8 size=16 type=Item elem=8 array=fixed bound=2
+record 1f781dc01a2b5152.a3a7061ff10a8138 sizeof=28 alignof=4
+    field 3dc94a19365b10ec kind=12 offset=0 size=16 bound=8
+    field 7ce4fd9430e80cea kind=4 offset=16 size=12 elem=4 array=fixed bound=3
+record 2492f5fb1b05b45e.14e2eaab9cde925b sizeof=20 alignof=4
+    field 3dc94a19365b10ec kind=4 offset=0 size=4
+    field 7ce4fd9430e80cea kind=14 offset=4 size=16 bound=10
+record 2492f5fb1b05b45e.a633f1f655715cca sizeof=20 alignof=4
+    field 3dc94a19365b10ec kind=7 offset=0 size=2
+    field 7ce4fd9430e80cea kind=33 offset=2 size=18
+record 2492f5fb1b05b45e.afb728fff268814f sizeof=40 alignof=4
+    field 3dc94a19365b10ec kind=12 offset=0 size=16 bound=8
+    field 7ce4fd9430e80cea kind=12 offset=16 size=24 bound=16
+record 816c207ba6213983.14e2eaab9cde925b sizeof=16 alignof=8
+    field 3dc94a19365b10ec kind=4 offset=0 size=4
+    field 7ce4fd9430e80cea kind=17 offset=8 size=8 type=bytes
+record Cells sizeof=24 alignof=8
+    field a3a7061ff10a8138 kind=14 offset=0 size=16 elem=28 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Chunks sizeof=24 alignof=8
+    field 14e2eaab9cde925b kind=14 offset=0 size=16 elem=16 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Crews sizeof=24 alignof=8
+    field 79d594675e391090 kind=14 offset=0 size=16 elem=32 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Depth sizeof=136 alignof=8
+    field 1a08aa1921ca5caf kind=13 offset=0 size=16 type=Squad
+    field 1f6459a2cea1fc02 kind=13 offset=16 size=52 type=Squad elem=16 array=bounded bound=3
+    field 70551ff29550f15d kind=13 offset=72 size=32 type=Squad elem=16 array=keyed bound=2 key=Slot
+    field e756c0190570ccb5 kind=15 offset=104 size=24 union=Force
+    field bf82010f6f71eae9 kind=4 offset=128 size=4
+record Docs sizeof=24 alignof=8
+    field ab01daa76a48769f kind=14 offset=0 size=16 elem=24 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record EdgeRow sizeof=40 alignof=8
+    field afb728fff268814f kind=14 offset=0 size=16 elem=312 array=map
+    field 2b7dea192bb7be29 kind=14 offset=16 size=16 elem=16 array=map
+    field bf82010f6f71eae9 kind=4 offset=32 size=4
+record Fleet sizeof=72 alignof=8
+    field 294a5c4913e1ad44 kind=14 offset=0 size=16 elem=116 array=map
+    field 7b024c46e98d3404 kind=14 offset=16 size=16 elem=16 array=map
+    field 63dfa0c4a4b3815d kind=17 offset=32 size=8 type=ShipConfig
+    field 294fa1b3f0f5f070 kind=14 offset=40 size=16 elem=40 array=map
+    field 6dd8dc6c5fdae3ce kind=14 offset=56 size=16 elem=8 array=map
+record Item sizeof=4 alignof=4
+    field b1e5e28e4479a274 kind=4 offset=0 size=4
+record Pairs sizeof=24 alignof=8
+    field e68c2e6bb1ee5646 kind=14 offset=0 size=16 elem=24 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Row sizeof=24 alignof=8
+    field c5b2a72c0845a253 kind=14 offset=0 size=16 elem=20 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Runs sizeof=24 alignof=8
+    field 437dfc8ab2566816 kind=14 offset=0 size=16 elem=24 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record ShipConfig sizeof=76 alignof=4
+    field c4bcadba8e631b86 kind=12 offset=0 size=72 bound=64
+    field 7f69d4b5288ba9cf kind=4 offset=72 size=4
+record Slots sizeof=24 alignof=8
+    field 7f6548303072b061 kind=14 offset=0 size=16 elem=12 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Spans sizeof=24 alignof=8
+    field 755332609c470fbd kind=14 offset=0 size=16 elem=24 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record Squad sizeof=16 alignof=8
+    field 1c84390d304f4f42 kind=14 offset=0 size=16 elem=8 array=map
+record Text sizeof=56 alignof=8
+    field afb728fff268814f kind=14 offset=0 size=16 elem=40 array=map
+    field a633f1f655715cca kind=14 offset=16 size=16 elem=20 array=map
+    field 14e2eaab9cde925b kind=14 offset=32 size=16 elem=20 array=map
+    field bf82010f6f71eae9 kind=4 offset=48 size=4
+record Trails sizeof=24 alignof=8
+    field 124250ad5a5b6d14 kind=14 offset=0 size=16 elem=24 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record WideRow sizeof=24 alignof=8
+    field c5b2a72c0845a253 kind=14 offset=0 size=16 elem=8 array=map
+    field bf82010f6f71eae9 kind=4 offset=16 size=4
+record a013e119fec906fb.c5b2a72c0845a253 sizeof=20 alignof=4
+    field 3dc94a19365b10ec kind=12 offset=0 size=16 bound=8
+    field 7ce4fd9430e80cea kind=13 offset=16 size=4 type=Item
+record b413964e3571a316.c5b2a72c0845a253 sizeof=8 alignof=4
+    field 3dc94a19365b10ec kind=8 offset=0 size=4
+    field 7ce4fd9430e80cea kind=13 offset=4 size=4 type=Item
+record b4578774a78fb150.124250ad5a5b6d14 sizeof=24 alignof=8
+    field 3dc94a19365b10ec kind=8 offset=0 size=4
+    field 7ce4fd9430e80cea kind=14 offset=8 size=16 type=Item elem=8 array=unbounded
+record c85b940060088651.79d594675e391090 sizeof=32 alignof=8
+    field 3dc94a19365b10ec kind=8 offset=0 size=4
+    field 7ce4fd9430e80cea kind=17 offset=8 size=20 type=Item elem=8 array=bounded bound=2
+record e8130af045a036f8.2b7dea192bb7be29 sizeof=16 alignof=8
+    field 3dc94a19365b10ec kind=9 offset=0 size=8
+    field 7ce4fd9430e80cea kind=13 offset=8 size=4 type=Item
+record e8130af045a036f8.afb728fff268814f sizeof=312 alignof=4
+    field 3dc94a19365b10ec kind=12 offset=0 size=308 bound=300
+    field 7ce4fd9430e80cea kind=13 offset=308 size=4 type=Item
+record ea7bdd2b70c8c2bb.437dfc8ab2566816 sizeof=24 alignof=4
+    field 3dc94a19365b10ec kind=7 offset=0 size=2
+    field 7ce4fd9430e80cea kind=13 offset=4 size=20 type=Item elem=4 array=bounded bound=4
+record ec07a2f760550a91.1c84390d304f4f42 sizeof=8 alignof=4
+    field 3dc94a19365b10ec kind=6 offset=0 size=1
+    field 7ce4fd9430e80cea kind=13 offset=4 size=4 type=Item
+record f96b15cd3921d4a6.7f6548303072b061 sizeof=12 alignof=4
+    field 3dc94a19365b10ec kind=4 offset=0 size=4
+    field 7ce4fd9430e80cea kind=4 offset=4 size=8 elem=4 array=keyed bound=2 key=Slot
+enum Slot
+    variant 1 Alpha
+    variant 2 Beta
+union Force
+    arm 1 squad payload=Squad
+    arm 2 plain kind=4 offset=8 size=4


### PR DESCRIPTION
Closes #683. Closes #693 (findings 1 and 2; the nit in finding 3 is untouched).

## What the reader gets

A stale pin under `testdata/golden/tables/` is red on the PR that made it stale, whichever unit it sits in, and a directory of goldens nobody compares can no longer exist, because the compared set is the directory listing. The bench's elixir leg runs on the repo-pinned BEAM toolchain or skips, never on a Homebrew or asdf elixir that happened to be on the caller's PATH. Aggregate's straggler refusal names the rows it withheld on every dimension, language included.

## The two mechanisms

For #683, in `internal/goldens`, `tableUnits` reads `testdata/golden/tables` and maps each directory by rule: `<unit>` is `tables/<unit>` through the C++ reference, `<unit>-c` and `<unit>-cs` are the same unit through the C and C# targets (make/c.mk, make/cs.mk), and `wide` is the one directory whose unit lives outside `tables/`; its home is `examples-wide`. `TestGoldenTableSource` holds every pinned file in every directory against what the compiler emits today (18 directories). `pinnedUnits` becomes a function over the same derived set, so the build-version and wire-law gates now cover `tables-maps`, `tables-lists` and `tables-arms`, and three new build-version goldens are pinned here. The C/C# directories and `wide` fold into the unit already named, and that exclusion is explicit in `pinnedUnits` rather than in a list that has to remember them. `TestGoldenTablesAreDerivedFromTheListing` plants directories in a temp listing, shows they enter the set with the right target and source, and checks that the four units #683 names are in the real set.

For #693, in `bench/run.sh`, `beam_pinned` walks `BEAM_PATH`'s own directories for an executable, and the elixir leg requires both `elixir` and `erl` there, skipping with a `skip_leg` reason otherwise. That is the shape of the java and dart legs' absolute `$JAVAC_BIN` and `$DART_BIN` tests. The run itself still prepends `BEAM_PATH`, since the elixir launcher is a shell script that needs the system's coreutils beside the pinned erl, and the preamble's `# elixir:` line records the pin or `not present`, never a system elixir the leg would refuse. In `bench/tools/aggregate.go`, the output loop remembers the printed keys as a set and the refusal names every accumulated key not in it, so a lang-only (or codec-only) straggler is named and the heading lists lang, bench, path and codec. `TestAggregateRefusesALanguageTheListDoesNotKnowByName` holds it.

## What was run

```
go test -count=1 ./internal/goldens/... ./bench/tools/...
ok  	github.com/mas-bandwidth/schema/v2/internal/goldens	0.918s
ok  	github.com/mas-bandwidth/schema/v2/bench/tools	11.048s
ok  	github.com/mas-bandwidth/schema/v2/bench/tools/realpacket-gen	0.367s
```

Each test fails without its fix. `TestGoldenTableSource`, with a byte appended to `testdata/golden/tables/maps/CellsTable.h`, is red naming the file with this PR's test file, while `go test ./internal/goldens` on main's test file with the same stale header is `ok`. `TestAggregateRefusesALanguageTheListDoesNotKnowByName` against main's `aggregate.go` is red: the refusal printed its heading over an empty list. The elixir gate, with `beam_pinned` extracted from run.sh and a shim `elixir` on PATH, answers no to a `BEAM_PATH` pointing at an absent `dist/` where the old prepend gate answered yes, and both answer yes to a populated one.

`bash -n bench/run.sh` passes. shellcheck is not installed on this machine, so it was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)