### PR TITLE
Go's EnumName takes the enum's own type, and a check refusal that cites a spec section ends with the build's version line

### DIFF
--- a/compiler/tagenumsurface_test.go
+++ b/compiler/tagenumsurface_test.go
@@ -89,7 +89,7 @@ var tagEnumSurface = map[string]tagEnumClaim{
 	"go": {
 		count:    "WeaponFireTypeCount   WeaponFireType = 2 // the declared variant count (SPEC §4.2)",
 		max:      "WeaponFireTypeMax     WeaponFireType = 2 // the exported extent (SPEC §4.2)",
-		nameFunc: "func EnumNameWeaponFireType(value uint64) string {",
+		nameFunc: "func EnumNameWeaponFireType(value WeaponFireType) string {",
 	},
 	"java": {
 		count:    "        public static final byte count = 2;",

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -76,8 +76,9 @@ schema v2.4.0-148-gbafdb69 (go1.27.0)
 
 Write that number down. The language moves, and a diagnostic that cites a
 specification section cites it as it stands in the build that printed the
-diagnostic — so such a diagnostic ends with one more line, `schema <version>`,
-naming that build. When this page and your binary disagree, that line (or
+diagnostic. A refusal from the checker that cites a section ends with one
+more line, `schema <version>`, naming that build; a parse error does not
+carry it yet. When this page and your binary disagree, that line (or
 `schema version`) is the first thing to check.
 
 **Two more checkouts, before Part 3.** The generated C++ and C read and write

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -76,8 +76,9 @@ schema v2.4.0-148-gbafdb69 (go1.27.0)
 
 Write that number down. The language moves, and a diagnostic that cites a
 specification section cites it as it stands in the build that printed the
-diagnostic. When this page and your binary disagree, `schema version` is the
-first thing to check.
+diagnostic — so such a diagnostic ends with one more line, `schema <version>`,
+naming that build. When this page and your binary disagree, that line (or
+`schema version`) is the first thing to check.
 
 **Two more checkouts, before Part 3.** The generated C++ and C read and write
 bits through the serialize runtimes, which are header-only siblings of this

--- a/generated/bench/go/Bench.go
+++ b/generated/bench/go/Bench.go
@@ -366,39 +366,39 @@ const (
 
 // EnumNameMixedWeapon: debug/log/tooling name for any MixedWeapon wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameMixedWeapon(value uint64) string {
+func EnumNameMixedWeapon(value MixedWeapon) string {
 	switch value {
-	case uint64(MixedWeaponNone):
+	case MixedWeaponNone:
 		return "None"
-	case uint64(MixedWeaponFists):
+	case MixedWeaponFists:
 		return "Fists"
-	case uint64(MixedWeaponPistol):
+	case MixedWeaponPistol:
 		return "Pistol"
-	case uint64(MixedWeaponShotgun):
+	case MixedWeaponShotgun:
 		return "Shotgun"
-	case uint64(MixedWeaponRifle):
+	case MixedWeaponRifle:
 		return "Rifle"
-	case uint64(MixedWeaponSniper):
+	case MixedWeaponSniper:
 		return "Sniper"
-	case uint64(MixedWeaponSmg):
+	case MixedWeaponSmg:
 		return "Smg"
-	case uint64(MixedWeaponRocket):
+	case MixedWeaponRocket:
 		return "Rocket"
-	case uint64(MixedWeaponGrenade):
+	case MixedWeaponGrenade:
 		return "Grenade"
-	case uint64(MixedWeaponPlasma):
+	case MixedWeaponPlasma:
 		return "Plasma"
-	case uint64(MixedWeaponRailgun):
+	case MixedWeaponRailgun:
 		return "Railgun"
-	case uint64(MixedWeaponFlamer):
+	case MixedWeaponFlamer:
 		return "Flamer"
-	case uint64(MixedWeaponMine):
+	case MixedWeaponMine:
 		return "Mine"
-	case uint64(MixedWeaponTurret):
+	case MixedWeaponTurret:
 		return "Turret"
-	case uint64(MixedWeaponDrone):
+	case MixedWeaponDrone:
 		return "Drone"
-	case uint64(MixedWeaponRepair):
+	case MixedWeaponRepair:
 		return "Repair"
 	}
 	return "???"
@@ -831,15 +831,15 @@ const (
 
 // EnumNameMixedEventType: debug/log/tooling name for any MixedEventType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameMixedEventType(value uint64) string {
+func EnumNameMixedEventType(value MixedEventType) string {
 	switch value {
-	case uint64(MixedEventTypeNone):
+	case MixedEventTypeNone:
 		return "None"
-	case uint64(MixedEventTypeHit):
+	case MixedEventTypeHit:
 		return "Hit"
-	case uint64(MixedEventTypeChat):
+	case MixedEventTypeChat:
 		return "Chat"
-	case uint64(MixedEventTypePickup):
+	case MixedEventTypePickup:
 		return "Pickup"
 	}
 	return "???"

--- a/generated/bench/go/realworld/RealWorld.go
+++ b/generated/bench/go/realworld/RealWorld.go
@@ -38,19 +38,19 @@ const (
 
 // EnumNamePacketMode: debug/log/tooling name for any PacketMode wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNamePacketMode(value uint64) string {
+func EnumNamePacketMode(value PacketMode) string {
 	switch value {
-	case uint64(PacketModeNone):
+	case PacketModeNone:
 		return "None"
-	case uint64(PacketModeIdle):
+	case PacketModeIdle:
 		return "Idle"
-	case uint64(PacketModeActive):
+	case PacketModeActive:
 		return "Active"
-	case uint64(PacketModeCombat):
+	case PacketModeCombat:
 		return "Combat"
-	case uint64(PacketModeDocked):
+	case PacketModeDocked:
 		return "Docked"
-	case uint64(PacketModeWarping):
+	case PacketModeWarping:
 		return "Warping"
 	}
 	return "???"

--- a/generated/bench/tables/go/BenchTable.go
+++ b/generated/bench/tables/go/BenchTable.go
@@ -47,39 +47,39 @@ const (
 
 // EnumNameTableWeapon: debug/log/tooling name for any TableWeapon wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameTableWeapon(value uint64) string {
+func EnumNameTableWeapon(value TableWeapon) string {
 	switch value {
-	case uint64(TableWeaponNone):
+	case TableWeaponNone:
 		return "None"
-	case uint64(TableWeaponFists):
+	case TableWeaponFists:
 		return "Fists"
-	case uint64(TableWeaponPistol):
+	case TableWeaponPistol:
 		return "Pistol"
-	case uint64(TableWeaponShotgun):
+	case TableWeaponShotgun:
 		return "Shotgun"
-	case uint64(TableWeaponRifle):
+	case TableWeaponRifle:
 		return "Rifle"
-	case uint64(TableWeaponSniper):
+	case TableWeaponSniper:
 		return "Sniper"
-	case uint64(TableWeaponSmg):
+	case TableWeaponSmg:
 		return "Smg"
-	case uint64(TableWeaponRocket):
+	case TableWeaponRocket:
 		return "Rocket"
-	case uint64(TableWeaponGrenade):
+	case TableWeaponGrenade:
 		return "Grenade"
-	case uint64(TableWeaponPlasma):
+	case TableWeaponPlasma:
 		return "Plasma"
-	case uint64(TableWeaponRailgun):
+	case TableWeaponRailgun:
 		return "Railgun"
-	case uint64(TableWeaponFlamer):
+	case TableWeaponFlamer:
 		return "Flamer"
-	case uint64(TableWeaponMine):
+	case TableWeaponMine:
 		return "Mine"
-	case uint64(TableWeaponTurret):
+	case TableWeaponTurret:
 		return "Turret"
-	case uint64(TableWeaponDrone):
+	case TableWeaponDrone:
 		return "Drone"
-	case uint64(TableWeaponRepair):
+	case TableWeaponRepair:
 		return "Repair"
 	}
 	return "???"
@@ -312,15 +312,15 @@ const (
 
 // EnumNameTableEventType: debug/log/tooling name for any TableEventType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameTableEventType(value uint64) string {
+func EnumNameTableEventType(value TableEventType) string {
 	switch value {
-	case uint64(TableEventTypeNone):
+	case TableEventTypeNone:
 		return "None"
-	case uint64(TableEventTypeHit):
+	case TableEventTypeHit:
 		return "Hit"
-	case uint64(TableEventTypeChat):
+	case TableEventTypeChat:
 		return "Chat"
-	case uint64(TableEventTypePickup):
+	case TableEventTypePickup:
 		return "Pickup"
 	}
 	return "???"

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -7918,7 +7918,7 @@ var TableEntityTableFields = []TableFieldInfo{
 		CookOffset: 40, CookElemSize: 1, CookCountOffset: 4294967295, CookPresentOffset: 4294967295,
 		HasRange: false, RangeMin: 0.0, RangeMax: 0.0, EnumMax: 15,
 		FracBits: 0, Pointer: false, TargetId: 0x0000000000000000,
-		EnumName:    EnumNameTableWeapon,
+		EnumName:    func(v uint64) string { return EnumNameTableWeapon(TableWeapon(v)) },
 		VariantId:   func(v uint64) uint64 { id, _ := TableWeapon(v).TableEnumId(); return id },
 		KeyTypeName: "", KeyName: nil, KeyId: nil,
 		Arms:  nil,

--- a/generated/go-ludicrous/Ludicrous.go
+++ b/generated/go-ludicrous/Ludicrous.go
@@ -36,15 +36,15 @@ const (
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDriveMode(value uint64) string {
+func EnumNameDriveMode(value DriveMode) string {
 	switch value {
-	case uint64(DriveModeNone):
+	case DriveModeNone:
 		return "None"
-	case uint64(DriveModeCruise):
+	case DriveModeCruise:
 		return "Cruise"
-	case uint64(DriveModeWarp):
+	case DriveModeWarp:
 		return "Warp"
-	case uint64(DriveModeLudicrous):
+	case DriveModeLudicrous:
 		return "Ludicrous"
 	}
 	return "???"

--- a/generated/go/ArmDefaults.go
+++ b/generated/go/ArmDefaults.go
@@ -114,13 +114,13 @@ const (
 
 // EnumNameDefaultChoiceType: debug/log/tooling name for any DefaultChoiceType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDefaultChoiceType(value uint64) string {
+func EnumNameDefaultChoiceType(value DefaultChoiceType) string {
 	switch value {
-	case uint64(DefaultChoiceTypeNone):
+	case DefaultChoiceTypeNone:
 		return "None"
-	case uint64(DefaultChoiceTypeFirst):
+	case DefaultChoiceTypeFirst:
 		return "First"
-	case uint64(DefaultChoiceTypeSecond):
+	case DefaultChoiceTypeSecond:
 		return "Second"
 	}
 	return "???"
@@ -277,13 +277,13 @@ const (
 
 // EnumNameDefaultBulkChoiceType: debug/log/tooling name for any DefaultBulkChoiceType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDefaultBulkChoiceType(value uint64) string {
+func EnumNameDefaultBulkChoiceType(value DefaultBulkChoiceType) string {
 	switch value {
-	case uint64(DefaultBulkChoiceTypeNone):
+	case DefaultBulkChoiceTypeNone:
 		return "None"
-	case uint64(DefaultBulkChoiceTypeFirst):
+	case DefaultBulkChoiceTypeFirst:
 		return "First"
-	case uint64(DefaultBulkChoiceTypeSecond):
+	case DefaultBulkChoiceTypeSecond:
 		return "Second"
 	}
 	return "???"

--- a/generated/go/Clauses.go
+++ b/generated/go/Clauses.go
@@ -793,13 +793,13 @@ const (
 
 // EnumNameEmptyUnionType: debug/log/tooling name for any EmptyUnionType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameEmptyUnionType(value uint64) string {
+func EnumNameEmptyUnionType(value EmptyUnionType) string {
 	switch value {
-	case uint64(EmptyUnionTypeNone):
+	case EmptyUnionTypeNone:
 		return "None"
-	case uint64(EmptyUnionTypeA):
+	case EmptyUnionTypeA:
 		return "A"
-	case uint64(EmptyUnionTypeB):
+	case EmptyUnionTypeB:
 		return "B"
 	}
 	return "???"

--- a/generated/go/Enums.go
+++ b/generated/go/Enums.go
@@ -23,13 +23,13 @@ const (
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameTeam(value uint64) string {
+func EnumNameTeam(value Team) string {
 	switch value {
-	case uint64(TeamNone):
+	case TeamNone:
 		return "None"
-	case uint64(TeamRed):
+	case TeamRed:
 		return "Red"
-	case uint64(TeamBlue):
+	case TeamBlue:
 		return "Blue"
 	}
 	return "???"
@@ -51,19 +51,19 @@ const (
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameShipType(value uint64) string {
+func EnumNameShipType(value ShipType) string {
 	switch value {
-	case uint64(ShipTypeNone):
+	case ShipTypeNone:
 		return "None"
-	case uint64(ShipTypeFighter):
+	case ShipTypeFighter:
 		return "Fighter"
-	case uint64(ShipTypeCorvette):
+	case ShipTypeCorvette:
 		return "Corvette"
-	case uint64(ShipTypeBomber):
+	case ShipTypeBomber:
 		return "Bomber"
-	case uint64(ShipTypeDestroyer):
+	case ShipTypeDestroyer:
 		return "Destroyer"
-	case uint64(ShipTypeCarrier):
+	case ShipTypeCarrier:
 		return "Carrier"
 	}
 	return "???"
@@ -83,15 +83,15 @@ const (
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameMissileType(value uint64) string {
+func EnumNameMissileType(value MissileType) string {
 	switch value {
-	case uint64(MissileTypeNone):
+	case MissileTypeNone:
 		return "None"
-	case uint64(MissileTypeHeatseeker):
+	case MissileTypeHeatseeker:
 		return "Heatseeker"
-	case uint64(MissileTypeTorpedo):
+	case MissileTypeTorpedo:
 		return "Torpedo"
-	case uint64(MissileTypeNuke):
+	case MissileTypeNuke:
 		return "Nuke"
 	}
 	return "???"
@@ -114,21 +114,21 @@ const (
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNamePropType(value uint64) string {
+func EnumNamePropType(value PropType) string {
 	switch value {
-	case uint64(PropTypeNone):
+	case PropTypeNone:
 		return "None"
-	case uint64(PropTypeAsteroid):
+	case PropTypeAsteroid:
 		return "Asteroid"
-	case uint64(PropTypeChunk):
+	case PropTypeChunk:
 		return "Chunk"
-	case uint64(PropTypeFragment):
+	case PropTypeFragment:
 		return "Fragment"
-	case uint64(PropTypeSphere):
+	case PropTypeSphere:
 		return "Sphere"
-	case uint64(PropTypeBlackHole):
+	case PropTypeBlackHole:
 		return "BlackHole"
-	case uint64(PropTypeDysonPanel):
+	case PropTypeDysonPanel:
 		return "DysonPanel"
 	}
 	return "???"
@@ -145,9 +145,9 @@ const (
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNamePending(value uint64) string {
+func EnumNamePending(value Pending) string {
 	switch value {
-	case uint64(PendingNone):
+	case PendingNone:
 		return "None"
 	}
 	return "???"

--- a/generated/go/Joins.go
+++ b/generated/go/Joins.go
@@ -537,13 +537,13 @@ const (
 
 // EnumNameUnevenType: debug/log/tooling name for any UnevenType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameUnevenType(value uint64) string {
+func EnumNameUnevenType(value UnevenType) string {
 	switch value {
-	case uint64(UnevenTypeNone):
+	case UnevenTypeNone:
 		return "None"
-	case uint64(UnevenTypeNarrow):
+	case UnevenTypeNarrow:
 		return "Narrow"
-	case uint64(UnevenTypeWide):
+	case UnevenTypeWide:
 		return "Wide"
 	}
 	return "???"

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -36,15 +36,15 @@ const (
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameWeapon(value uint64) string {
+func EnumNameWeapon(value Weapon) string {
 	switch value {
-	case uint64(WeaponNone):
+	case WeaponNone:
 		return "None"
-	case uint64(WeaponLaser):
+	case WeaponLaser:
 		return "Laser"
-	case uint64(WeaponMissile):
+	case WeaponMissile:
 		return "Missile"
-	case uint64(WeaponRailgun):
+	case WeaponRailgun:
 		return "Railgun"
 	}
 	return "???"
@@ -472,13 +472,13 @@ const (
 
 // EnumNameProbeShapeType: debug/log/tooling name for any ProbeShapeType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameProbeShapeType(value uint64) string {
+func EnumNameProbeShapeType(value ProbeShapeType) string {
 	switch value {
-	case uint64(ProbeShapeTypeNone):
+	case ProbeShapeTypeNone:
 		return "None"
-	case uint64(ProbeShapeTypeRing):
+	case ProbeShapeTypeRing:
 		return "Ring"
-	case uint64(ProbeShapeTypeSlab):
+	case ProbeShapeTypeSlab:
 		return "Slab"
 	}
 	return "???"

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mas-bandwidth/schema/v2/internal/ast"
 	"github.com/mas-bandwidth/schema/v2/internal/tablenames"
+	"github.com/mas-bandwidth/schema/v2/internal/version"
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
@@ -93,7 +94,19 @@ type constEntry struct {
 }
 
 func (c *checker) errf(pos ast.Pos, format string, args ...any) {
-	c.errs = append(c.errs, fmt.Errorf("%s: %s", pos, fmt.Sprintf(format, args...)))
+	c.errs = append(c.errs, fmt.Errorf("%s: %s", pos, versioned(fmt.Sprintf(format, args...))))
+}
+
+// versioned appends the build's version line to a refusal that cites a spec
+// section (#458): a section is cited as it stands in the build that printed
+// the refusal, so a message pasted into an issue from a stale binary dates
+// itself instead of contradicting the page as it reads today. A refusal
+// that cites nothing is returned as it is.
+func versioned(msg string) string {
+	if !strings.Contains(msg, "§") {
+		return msg
+	}
+	return msg + "\nschema " + version.Version()
 }
 
 // Unit checks the files and lowers them to IR. Files may arrive in any order;
@@ -2162,8 +2175,8 @@ func (c *checker) checkCycles() {
 	visit = func(name string) bool {
 		switch color[name] {
 		case grey:
-			c.errs = append(c.errs, fmt.Errorf("type composition cycle: %s -> %s (SPEC §4.6)",
-				strings.Join(path, " -> "), name))
+			c.errs = append(c.errs, fmt.Errorf("%s", versioned(fmt.Sprintf("type composition cycle: %s -> %s (SPEC §4.6)",
+				strings.Join(path, " -> "), name))))
 			return false
 		case black:
 			return true

--- a/internal/check/issue458_test.go
+++ b/internal/check/issue458_test.go
@@ -1,0 +1,39 @@
+package check
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/version"
+)
+
+// A refusal that cites a spec section carries the build's version as its
+// last line (#458): the section is cited as it stands in the build that
+// printed the refusal, so a message pasted from a stale binary dates itself
+// instead of contradicting the page as it reads today. The cite stays where
+// it was, at the end of the message's own line, so a test matching the
+// refusal's text still matches. A refusal that cites nothing carries no
+// trailer.
+func TestIssue458RefusalCarriesTheBuildVersion(t *testing.T) {
+	trailer := "\nschema " + version.Version()
+	for _, tc := range []struct{ src, cite string }{
+		{"package p\ntype A { again A }\n", "(SPEC §4.6)"},
+		{"package p\ntype T { a []uint8 }\n", "(docs/SPEC-TABLES.md §2.9, §11)"},
+	} {
+		errs := runUnit(t, map[string]string{"T.schema": tc.src})
+		if len(errs) != 1 {
+			t.Fatalf("%q: got %v, want one refusal", tc.src, errs)
+		}
+		got := errs[0].Error()
+		if !strings.HasSuffix(got, tc.cite+trailer) {
+			t.Fatalf("%q: got %q, want the cite %q then the trailer %q", tc.src, got, tc.cite, trailer)
+		}
+		if strings.Count(got, "\n") != 1 {
+			t.Fatalf("%q: got %q, want the trailer as the one added line", tc.src, got)
+		}
+	}
+	errs := runUnit(t, map[string]string{"T.schema": "package p\ntype T { a uint8 = 300 }\n"})
+	if len(errs) != 1 || strings.Contains(errs[0].Error(), "\n") {
+		t.Fatalf("got %v, want one refusal on one line, citing no section and carrying no trailer", errs)
+	}
+}

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -166,14 +166,15 @@ func (g *gen) emitTagEnum(name string, members []string, docs []string, comment 
 	// the tag enum's name surface is a declared enum's, member for member: a
 	// reader logging which message arrived writes EnumName<Tag>( value )
 	// whichever enum it is. Nothing on the read or write path calls it. The
-	// uint64 parameter (not the tag type) keeps out-of-set values exact.
+	// parameter is the tag type itself, so the typed field is passed as it
+	// is; every wire-legal value fits the storage, so nothing truncates.
 	g.pf("// EnumName%s: debug/log/tooling name for any %s wire value —\n", name, name)
 	g.pf("// out-of-set values (wire-legal up to the declared max) name as \"???\"\n")
-	g.pf("func EnumName%s(value uint64) string {\n", name)
+	g.pf("func EnumName%s(value %s) string {\n", name, name)
 	g.pf("\tswitch value {\n")
-	g.pf("\tcase uint64(%sNone):\n\t\treturn \"None\"\n", name)
+	g.pf("\tcase %sNone:\n\t\treturn \"None\"\n", name)
 	for _, m := range members {
-		g.pf("\tcase uint64(%s%s):\n\t\treturn \"%s\"\n", name, m, m)
+		g.pf("\tcase %s%s:\n\t\treturn \"%s\"\n", name, m, m)
 	}
 	g.pf("\t}\n\treturn \"???\"\n}\n\n")
 }
@@ -249,15 +250,16 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("\t%sCount %s = %d // the declared variant count (SPEC §4.2)\n", d.Name, d.Name, len(d.Variants))
 	g.pf("\t%sMax %s = %d // the exported extent (SPEC §4.2)\n", d.Name, d.Name, d.Max)
 	g.pf(")\n\n")
-	// the uint64 parameter (not the enum type) keeps out-of-set values exact:
-	// a narrower named type would truncate 256 -> 0 -> "None" for an 8-bit enum
+	// the parameter is the enum type itself, so a log site passes the typed
+	// field as it is (#457); the storage is sized to the declared max, so
+	// every wire-legal value fits and nothing truncates
 	g.pf("// EnumName%s: debug/log/tooling name for any %s wire value —\n", d.Name, d.Name)
 	g.pf("// out-of-set values (wire-legal up to the declared max) name as \"???\"\n")
-	g.pf("func EnumName%s(value uint64) string {\n", d.Name)
+	g.pf("func EnumName%s(value %s) string {\n", d.Name, d.Name)
 	g.pf("\tswitch value {\n")
-	g.pf("\tcase uint64(%sNone):\n\t\treturn \"None\"\n", d.Name)
+	g.pf("\tcase %sNone:\n\t\treturn \"None\"\n", d.Name)
 	for _, v := range d.Variants {
-		g.pf("\tcase uint64(%s%s):\n\t\treturn \"%s\"\n", d.Name, v, v)
+		g.pf("\tcase %s%s:\n\t\treturn \"%s\"\n", d.Name, v, v)
 	}
 	g.pf("\t}\n\treturn \"???\"\n}\n\n")
 }

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -2,6 +2,9 @@ package golang
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -536,5 +539,39 @@ func TestFlatFallbackReEmitsItemsNotPieces(t *testing.T) {
 	if got := countAcross(files, "math."); got != 0 {
 		t.Errorf("a bare two-float unit referenced math %d times — its runs fall back "+
 			"to serialize's own float calls", got)
+	}
+}
+
+// EnumName<E> takes E itself (#457): a log site passes the typed field as it
+// is, the way C++'s overload takes the enum. The gate compiles a probe that
+// does so for a declared enum's field and a union's tag, against the
+// serialize runtime beside this repository; a uint64 parameter refuses both
+// calls.
+func TestEnumNameTakesTheEnumType(t *testing.T) {
+	files := generateGo(t, "Typed", "package typed\n\n"+
+		"enum ShipType { Fighter, Bomber, Scout }\n\n"+
+		"type Ship\n{\n    ship_type ShipType\n}\n\n"+
+		"type LaserFire\n{\n    target_id uint16\n}\n\n"+
+		"union WeaponFire\n{\n    laser LaserFire\n}\n\n"+
+		"type FireCommand\n{\n    fire WeaponFire\n}\n")
+	runtime, err := filepath.Abs("../../../../serialize.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files["go.mod"] = []byte(fmt.Sprintf("module probe\n\ngo 1.26\n\nrequire github.com/mas-bandwidth/serialize.go v0.0.0\nreplace github.com/mas-bandwidth/serialize.go => %q\n", runtime))
+	files["probe.go"] = []byte("package typed\n\n" +
+		"func probe(ship *Ship, command *FireCommand) (string, string) {\n" +
+		"\treturn EnumNameShipType(ship.ShipType), EnumNameWeaponFireType(command.Fire.Type)\n" +
+		"}\n")
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("go", "build", ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("a typed EnumName call does not compile: %v\n%s", err, out)
 	}
 }

--- a/internal/codegen/gotable/codecs.go
+++ b/internal/codegen/gotable/codecs.go
@@ -653,7 +653,7 @@ func (g *tableGen) emitTableFieldDescriptor(st *ir.Struct, f *ir.Field, guard st
 	case *ir.Enum:
 		if f.Type.Kind == ir.TNamed {
 			enumMax = fmt.Sprintf("%d", ref.Max)
-			enumName = fmt.Sprintf("EnumName%s", f.Type.Name)
+			enumName = fmt.Sprintf("func(v uint64) string { return EnumName%s(%s(v)) }", f.Type.Name, f.Type.Name)
 			variantId = fmt.Sprintf("func(v uint64) uint64 { id, _ := %s(v).TableEnumId(); return id }", f.Type.Name)
 		}
 	case *ir.Flags:
@@ -680,7 +680,7 @@ func (g *tableGen) emitTableFieldDescriptor(st *ir.Struct, f *ir.Field, guard st
 	keyTypeName, keyName, keyId := `""`, "nil", "nil"
 	if f.KeyEnum != "" {
 		keyTypeName = fmt.Sprintf("%q", f.KeyEnum)
-		keyName = fmt.Sprintf("EnumName%s", f.KeyEnum)
+		keyName = fmt.Sprintf("func(v uint64) string { return EnumName%s(%s(v)) }", f.KeyEnum, f.KeyEnum)
 		keyId = fmt.Sprintf("func(v uint64) uint64 { id, _ := %s(v).TableEnumId(); return id }", f.KeyEnum)
 	}
 

--- a/internal/codegen/gotable/unions.go
+++ b/internal/codegen/gotable/unions.go
@@ -30,7 +30,7 @@ func (g *tableGen) emitTableUnion(un *ir.Union) {
 		}
 		g.tf("}\n")
 	}
-	g.pf("func EnumName%sType(value uint64) string { switch value { case 0:return \"None\"\n", un.Name)
+	g.pf("func EnumName%sType(value %sType) string { switch value { case 0:return \"None\"\n", un.Name, un.Name)
 	for i, v := range un.Variants {
 		g.pf("case %d:return %q\n", i+1, ir.GoExportName(v.Name))
 	}

--- a/testdata/golden/go/ArmDefaults.go
+++ b/testdata/golden/go/ArmDefaults.go
@@ -114,13 +114,13 @@ const (
 
 // EnumNameDefaultChoiceType: debug/log/tooling name for any DefaultChoiceType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDefaultChoiceType(value uint64) string {
+func EnumNameDefaultChoiceType(value DefaultChoiceType) string {
 	switch value {
-	case uint64(DefaultChoiceTypeNone):
+	case DefaultChoiceTypeNone:
 		return "None"
-	case uint64(DefaultChoiceTypeFirst):
+	case DefaultChoiceTypeFirst:
 		return "First"
-	case uint64(DefaultChoiceTypeSecond):
+	case DefaultChoiceTypeSecond:
 		return "Second"
 	}
 	return "???"
@@ -277,13 +277,13 @@ const (
 
 // EnumNameDefaultBulkChoiceType: debug/log/tooling name for any DefaultBulkChoiceType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDefaultBulkChoiceType(value uint64) string {
+func EnumNameDefaultBulkChoiceType(value DefaultBulkChoiceType) string {
 	switch value {
-	case uint64(DefaultBulkChoiceTypeNone):
+	case DefaultBulkChoiceTypeNone:
 		return "None"
-	case uint64(DefaultBulkChoiceTypeFirst):
+	case DefaultBulkChoiceTypeFirst:
 		return "First"
-	case uint64(DefaultBulkChoiceTypeSecond):
+	case DefaultBulkChoiceTypeSecond:
 		return "Second"
 	}
 	return "???"

--- a/testdata/golden/go/Clauses.go
+++ b/testdata/golden/go/Clauses.go
@@ -793,13 +793,13 @@ const (
 
 // EnumNameEmptyUnionType: debug/log/tooling name for any EmptyUnionType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameEmptyUnionType(value uint64) string {
+func EnumNameEmptyUnionType(value EmptyUnionType) string {
 	switch value {
-	case uint64(EmptyUnionTypeNone):
+	case EmptyUnionTypeNone:
 		return "None"
-	case uint64(EmptyUnionTypeA):
+	case EmptyUnionTypeA:
 		return "A"
-	case uint64(EmptyUnionTypeB):
+	case EmptyUnionTypeB:
 		return "B"
 	}
 	return "???"

--- a/testdata/golden/go/Enums.go
+++ b/testdata/golden/go/Enums.go
@@ -23,13 +23,13 @@ const (
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameTeam(value uint64) string {
+func EnumNameTeam(value Team) string {
 	switch value {
-	case uint64(TeamNone):
+	case TeamNone:
 		return "None"
-	case uint64(TeamRed):
+	case TeamRed:
 		return "Red"
-	case uint64(TeamBlue):
+	case TeamBlue:
 		return "Blue"
 	}
 	return "???"
@@ -51,19 +51,19 @@ const (
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameShipType(value uint64) string {
+func EnumNameShipType(value ShipType) string {
 	switch value {
-	case uint64(ShipTypeNone):
+	case ShipTypeNone:
 		return "None"
-	case uint64(ShipTypeFighter):
+	case ShipTypeFighter:
 		return "Fighter"
-	case uint64(ShipTypeCorvette):
+	case ShipTypeCorvette:
 		return "Corvette"
-	case uint64(ShipTypeBomber):
+	case ShipTypeBomber:
 		return "Bomber"
-	case uint64(ShipTypeDestroyer):
+	case ShipTypeDestroyer:
 		return "Destroyer"
-	case uint64(ShipTypeCarrier):
+	case ShipTypeCarrier:
 		return "Carrier"
 	}
 	return "???"
@@ -83,15 +83,15 @@ const (
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameMissileType(value uint64) string {
+func EnumNameMissileType(value MissileType) string {
 	switch value {
-	case uint64(MissileTypeNone):
+	case MissileTypeNone:
 		return "None"
-	case uint64(MissileTypeHeatseeker):
+	case MissileTypeHeatseeker:
 		return "Heatseeker"
-	case uint64(MissileTypeTorpedo):
+	case MissileTypeTorpedo:
 		return "Torpedo"
-	case uint64(MissileTypeNuke):
+	case MissileTypeNuke:
 		return "Nuke"
 	}
 	return "???"
@@ -114,21 +114,21 @@ const (
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNamePropType(value uint64) string {
+func EnumNamePropType(value PropType) string {
 	switch value {
-	case uint64(PropTypeNone):
+	case PropTypeNone:
 		return "None"
-	case uint64(PropTypeAsteroid):
+	case PropTypeAsteroid:
 		return "Asteroid"
-	case uint64(PropTypeChunk):
+	case PropTypeChunk:
 		return "Chunk"
-	case uint64(PropTypeFragment):
+	case PropTypeFragment:
 		return "Fragment"
-	case uint64(PropTypeSphere):
+	case PropTypeSphere:
 		return "Sphere"
-	case uint64(PropTypeBlackHole):
+	case PropTypeBlackHole:
 		return "BlackHole"
-	case uint64(PropTypeDysonPanel):
+	case PropTypeDysonPanel:
 		return "DysonPanel"
 	}
 	return "???"
@@ -145,9 +145,9 @@ const (
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNamePending(value uint64) string {
+func EnumNamePending(value Pending) string {
 	switch value {
-	case uint64(PendingNone):
+	case PendingNone:
 		return "None"
 	}
 	return "???"

--- a/testdata/golden/go/Joins.go
+++ b/testdata/golden/go/Joins.go
@@ -537,13 +537,13 @@ const (
 
 // EnumNameUnevenType: debug/log/tooling name for any UnevenType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameUnevenType(value uint64) string {
+func EnumNameUnevenType(value UnevenType) string {
 	switch value {
-	case uint64(UnevenTypeNone):
+	case UnevenTypeNone:
 		return "None"
-	case uint64(UnevenTypeNarrow):
+	case UnevenTypeNarrow:
 		return "Narrow"
-	case uint64(UnevenTypeWide):
+	case UnevenTypeWide:
 		return "Wide"
 	}
 	return "???"

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -36,15 +36,15 @@ const (
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameWeapon(value uint64) string {
+func EnumNameWeapon(value Weapon) string {
 	switch value {
-	case uint64(WeaponNone):
+	case WeaponNone:
 		return "None"
-	case uint64(WeaponLaser):
+	case WeaponLaser:
 		return "Laser"
-	case uint64(WeaponMissile):
+	case WeaponMissile:
 		return "Missile"
-	case uint64(WeaponRailgun):
+	case WeaponRailgun:
 		return "Railgun"
 	}
 	return "???"
@@ -472,13 +472,13 @@ const (
 
 // EnumNameProbeShapeType: debug/log/tooling name for any ProbeShapeType wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameProbeShapeType(value uint64) string {
+func EnumNameProbeShapeType(value ProbeShapeType) string {
 	switch value {
-	case uint64(ProbeShapeTypeNone):
+	case ProbeShapeTypeNone:
 		return "None"
-	case uint64(ProbeShapeTypeRing):
+	case ProbeShapeTypeRing:
 		return "Ring"
-	case uint64(ProbeShapeTypeSlab):
+	case ProbeShapeTypeSlab:
 		return "Slab"
 	}
 	return "???"

--- a/testdata/golden/ludicrous/go/Ludicrous.go
+++ b/testdata/golden/ludicrous/go/Ludicrous.go
@@ -36,15 +36,15 @@ const (
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —
 // out-of-set values (wire-legal up to the declared max) name as "???"
-func EnumNameDriveMode(value uint64) string {
+func EnumNameDriveMode(value DriveMode) string {
 	switch value {
-	case uint64(DriveModeNone):
+	case DriveModeNone:
 		return "None"
-	case uint64(DriveModeCruise):
+	case DriveModeCruise:
 		return "Cruise"
-	case uint64(DriveModeWarp):
+	case DriveModeWarp:
 		return "Warp"
-	case uint64(DriveModeLudicrous):
+	case DriveModeLudicrous:
 		return "Ludicrous"
 	}
 	return "???"


### PR DESCRIPTION
Closes #457. Closes #458.

## What the reader gets

- A Go log site writes `EnumNameShipType(ship.ShipType)` and it compiles: the generated `EnumName<E>` takes `E` itself (and `<Union>Type` for a union's tag), the way C++'s overload takes the enum, instead of `uint64` with a cast at every call.
- A check refusal that cites a spec section ends with one more line, `schema <version>`, so a message pasted into an issue from a stale binary dates itself instead of contradicting the page as it reads today.

## The two mechanisms

**#457, the typed parameter.** `internal/codegen/golang/golang.go` emits `func EnumName<E>(value E) string` for declared enums (`emitEnum`) and for union tag enums (`emitTagEnum`), with the `case` arms no longer cast; the storage is sized to the declared max, so every wire-legal value fits and nothing truncates. The tables backend's tag enum (`internal/codegen/gotable/unions.go`) takes the same shape. `TableFieldInfo.EnumName`/`KeyName` keep their `func(uint64) string` column, so `internal/codegen/gotable/codecs.go` now wraps the typed call, `func(v uint64) string { return EnumName<E>(E(v)) }`, mirroring the C++ tables descriptor's lambda. No in-tree caller passed a `uint64`; the only assertion on the old signature was `compiler/tagenumsurface_test.go`, updated. The Go goldens under `testdata/golden/{go,ludicrous/go}` and the checked-in `generated/{go,go-ludicrous,bench/go,bench/tables/go}` are regenerated with `go test ./internal/goldens -update` and the `make/go.mk` stamp targets, not by hand. New gate: `TestEnumNameTakesTheEnumType` in `internal/codegen/golang/golang_test.go` generates a unit with an enum field and a union and compiles a probe that calls both name functions with the typed field; it fails on main with `cannot use ship.ShipType (variable of uint8 type ShipType) as uint64 value`.

**#458, the version trailer.** The version already reaches the binary as `internal/version.Version()`: the Makefile's `-X .../internal/version.version=$(git describe --tags --dirty)` stamp, falling back to the module version, the VCS revision, or `devel` (what a `go test` build reports). `internal/check/check.go` gains `versioned(msg)`, which appends `"\nschema " + version.Version()` when the message contains `§` and returns it untouched otherwise; both refusal sites go through it, `errf` and the type-composition-cycle append. The cite stays at the end of the message's own line, so every existing `strings.Contains` match on refusal text is unchanged (no test in the tree matched a whole message). New gate: `TestIssue458RefusalCarriesTheBuildVersion` in `internal/check/issue458_test.go` asserts the cite-then-trailer suffix on one refusal from each site, that the trailer is the one added line, and that a refusal citing nothing carries none; it fails on main. `docs/TUTORIAL.md`'s "write that number down" paragraph mentions the line.

Refusals raised outside `internal/check` (parser, backends, pack/cook) are out of this PR's scope and carry no trailer.

## What was run

- `go test ./internal/check -run TestIssue458 -count=1` and `go test ./internal/codegen/golang -run TestEnumNameTakesTheEnumType -count=1`: both FAIL with the source files stashed, both `ok` with them restored.
- `go test ./compiler/... ./internal/... -count=1`: 27 packages `ok`, exit 0.
- `make test-go` (local go1.27.1; the `GOTOOLCHAIN=go1.26.0` legs in `make/go.mk` as pinned): exit 0, including the conformance negative controls, the tables JSON walk and fuzz legs, `test/go-tables`, the bench legs, `test/go` and `test/go-ludicrous`. The `FAILED:` lines in its log are the negative controls going red as designed.
- `gofmt -l` and `go vet` on the touched packages: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## API change, stated plainly

Go code that called the name function the old signature forced, for example `EnumNameShipType(uint64(ship.ShipType))`, no longer compiles: a non-constant `uint64` cannot be passed where the enum type is expected. Pass the typed value, `EnumNameShipType(ship.ShipType)`. Untyped constants still compile. Only the checker's refusals carry the version line; parser diagnostics do not yet.
