### PR TITLE
AnnounceRead accepts two declared shapes that derive one quantization

### DIFF
--- a/compiler/tablesmessage_test.go
+++ b/compiler/tablesmessage_test.go
@@ -1,0 +1,124 @@
+package compiler
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
+	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// announcementWith frames one vocabulary the way ir.TableAnnouncement frames
+// the unit's own (docs/SPEC-TABLES.md §3.3): a form-1 file whose body is the
+// build version under the reserved id at kind 9 and the vocabulary bytes
+// under the reserved id at kind 14 over element kind 6. The test needs it to
+// put an entry on the wire TWICE, which no compiler produces.
+func announcementWith(u *ir.Unit, vocabulary []byte) []byte {
+	leb := func(out []byte, v uint64) []byte {
+		for v >= 0x80 {
+			out = append(out, uint8(v)|0x80)
+			v >>= 7
+		}
+		return append(out, uint8(v))
+	}
+	body := append([]byte{uint8(ir.TableKindU8)}, leb(nil, uint64(len(vocabulary)))...)
+	body = append(body, vocabulary...)
+	out := []byte{ir.TableWireForm, 1, uint8(ir.TableKindU64)}
+	out = binary.LittleEndian.AppendUint64(out, ir.BuildVersion(u))
+	out = append(out, 2, uint8(ir.TableKindArray))
+	out = leb(out, uint64(len(body)))
+	out = append(out, body...)
+	out = append(out, 0)
+	out = binary.LittleEndian.AppendUint64(out, ir.TableBuildVersionWireId)
+	out = binary.LittleEndian.AppendUint64(out, ir.TableMessageVocabularyWireId)
+	return binary.LittleEndian.AppendUint64(out, 2)
+}
+
+// Two declared quantized shapes that DERIVE one quantization are two entries
+// (docs/SPEC-TABLES.md §3.3: the same name at a second shape takes a second
+// slot), and the C++ reference's AnnounceRead must take the compiler's own
+// announcement that carries them. Its duplicate scan compared the resolved
+// entries, which keep only §4.3's derivation and not the declared max and
+// res, so 0.1 and 0.1001 over [0, 1] collapsed into one entry and the unit's
+// own announcement read as malformed (#722). The scan now compares the
+// declared bytes, and a genuinely repeated entry is still malformed.
+func TestCppTableAnnouncementDistinctQuantizedShapes(t *testing.T) {
+	u := unitFromSource(t, `package probe
+table First { rate float32 | min = 0, max = 1, resolution = 0.1 }
+table Second { rate float32 | min = 0, max = 1, resolution = 0.1001 }
+`)
+	entries := ir.TableVocabulary(u)
+	rate := -1
+	for i, e := range entries {
+		if e.Kind != uint8(ir.TableKindF32) {
+			continue
+		}
+		if rate < 0 {
+			rate = i
+			continue
+		}
+		if entries[rate].Id != e.Id || entries[rate].Key() == e.Key() {
+			t.Fatalf("the two rates must share an id and differ in declared shape: %+v %+v", entries[rate], e)
+		}
+	}
+	if rate < 0 {
+		t.Fatal("the unit announces no quantized entry")
+	}
+	own := tablewire.Announce(u)
+	repeated := announcementWith(u, append(ir.TableVocabularyBytes(entries), entries[rate].Encode(nil)...))
+
+	// THE GO ENGINE IS THE CONTROL: it takes the compiler's own announcement
+	// and refuses the one carrying a byte-identical repeat.
+	var vocabulary tablewire.Vocabulary
+	var report tabletext.Report
+	if err := vocabulary.AnnounceRead(own, &report); err != nil || !vocabulary.Announced() || !report.Silent() {
+		t.Fatalf("go: the unit's own announcement was refused: %v %+v", err, report)
+	}
+	var again tablewire.Vocabulary
+	var refused tabletext.Report
+	// damage is an answer, not an error: the report says malformed and the
+	// vocabulary stays unset
+	if err := again.AnnounceRead(repeated, &refused); err != nil || again.Announced() || !refused.Malformed || refused.Refused {
+		t.Fatalf("go: a repeated entry must be malformed: %v %+v", err, refused)
+	}
+
+	files, err := New().Generate(u, "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe := fmt.Sprintf(`#include "ProbeTable.h"
+#include <cstdio>
+using namespace probe;
+#define REQUIRE(x) do { if (!(x)) { fprintf(stderr,"announcement failed at line %%d: %%s\n",__LINE__,#x); return 1; } } while(0)
+int main()
+{
+    static_assert( sizeof( TableMessageEntry ) == 96, "the resolved entry is pinned at 96 bytes" );
+    // the compiler's own announcement, read back through its own AnnounceRead
+    uint8_t own[ kTableAnnounceBytes ];
+    REQUIRE( Announce( own, (int64_t) sizeof( own ) ) == (int64_t) sizeof( own ) );
+    TableMessageEntry entries[ kTableMessageEntriesHere ];
+    TableVocabulary vocabulary( entries, kTableMessageEntriesHere );
+    TableReport report;
+    REQUIRE( AnnounceRead( vocabulary, own, (int64_t) sizeof( own ), &report ) );
+    REQUIRE( vocabulary.announced && !report.malformed && !report.refused );
+    REQUIRE( vocabulary.count == %d );
+    // the two rates: one id, kind 10, one derivation, TWO slots
+    const TableMessageEntry & first = TableVocabularyEntryAt( vocabulary, %d );
+    const TableMessageEntry & second = TableVocabularyEntryAt( vocabulary, %d );
+    REQUIRE( first.id == second.id && first.kind == 10 && second.kind == 10 );
+    REQUIRE( first.qmin == second.qmin && first.qdelta == second.qdelta && first.qcount == second.qcount );
+    REQUIRE( first.qcount == 10 && first.value_bits == second.value_bits );
+    // the control: an entry the wire spells twice, byte for byte, is malformed
+    const uint8_t repeated[] = { %s };
+    TableMessageEntry room[ kTableMessageEntriesHere + 1 ];
+    TableVocabulary twice( room, kTableMessageEntriesHere + 1 );
+    TableReport refused;
+    REQUIRE( !AnnounceRead( twice, repeated, (int64_t) sizeof( repeated ), &refused ) );
+    REQUIRE( !twice.announced && twice.refused && refused.malformed && !refused.refused );
+    return 0;
+}
+`, len(entries), rate+1, rate+2, cppWire(repeated))
+	referenceCompileRun(t, files, probe)
+}

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1601,6 +1587,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1611,16 +1598,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/internal/codegen/cpptable/message.go
+++ b/internal/codegen/cpptable/message.go
@@ -379,20 +379,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -821,6 +807,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -831,16 +818,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1620,6 +1606,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1630,16 +1617,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1620,6 +1606,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1630,16 +1617,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1621,6 +1607,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1631,16 +1618,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1620,6 +1606,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1630,16 +1617,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -1102,20 +1102,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1577,6 +1563,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1587,16 +1574,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -1082,20 +1082,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1618,6 +1604,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1628,16 +1615,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1617,6 +1603,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1627,16 +1614,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1547,6 +1533,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1557,16 +1544,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1547,6 +1533,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1557,16 +1544,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -1064,20 +1064,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1548,6 +1534,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1558,16 +1545,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -1082,20 +1082,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1686,6 +1672,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1696,16 +1683,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/RangesTable.h
+++ b/testdata/golden/tables/examples/RangesTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -1081,20 +1081,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1685,6 +1671,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1695,16 +1682,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1650,6 +1636,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1660,16 +1647,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1650,6 +1636,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1660,16 +1647,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1650,6 +1636,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1660,16 +1647,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1650,6 +1636,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1660,16 +1647,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1650,6 +1636,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1660,16 +1647,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1663,6 +1649,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1673,16 +1660,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1663,6 +1649,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1673,16 +1660,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1663,6 +1649,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1673,16 +1660,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1663,6 +1649,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1673,16 +1660,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -1127,20 +1127,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1663,6 +1649,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1673,16 +1660,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -1128,20 +1128,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1664,6 +1650,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1674,16 +1661,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1576,6 +1562,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1586,16 +1573,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -1123,20 +1123,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1628,6 +1614,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1638,16 +1625,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -1120,20 +1120,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1625,6 +1611,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1635,16 +1622,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -1120,20 +1120,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1625,6 +1611,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1635,16 +1622,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -1082,20 +1082,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1599,6 +1585,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1609,16 +1596,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -1102,20 +1102,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1582,6 +1568,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1592,16 +1579,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1540,6 +1526,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1550,16 +1537,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/tables/wide/WideTextTable.h
+++ b/testdata/golden/tables/wide/WideTextTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1540,6 +1526,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1550,16 +1537,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1540,6 +1526,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1550,16 +1537,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );

--- a/testdata/golden/wide/cpp/WideTextTable.h
+++ b/testdata/golden/wide/cpp/WideTextTable.h
@@ -1063,20 +1063,6 @@ struct TableMessageEntry
     uint8_t elem_packing = 0;
 };
 
-// TableMessageEntrySame reports whether two RESOLVED entries carry the same
-// shape, which is every fact of the entry but its id and its kind. It is what
-// the announcement's duplicate rule is asked in: two entries that agree on all
-// three parts are malformed (§3.3).
-inline bool TableMessageEntrySame( const TableMessageEntry & a, const TableMessageEntry & b )
-{
-    return a.min == b.min && a.max == b.max && a.base_lo == b.base_lo && a.base_hi == b.base_hi
-        && a.elem_max == b.elem_max && a.elem_base_lo == b.elem_base_lo && a.elem_base_hi == b.elem_base_hi
-        && a.qmin == b.qmin && a.qdelta == b.qdelta && a.qcount == b.qcount
-        && a.elem_qmin == b.elem_qmin && a.elem_qdelta == b.elem_qdelta && a.elem_qcount == b.elem_qcount
-        && a.value_bits == b.value_bits && a.elem_value_bits == b.elem_value_bits
-        && a.packing == b.packing && a.elem_kind == b.elem_kind && a.elem_packing == b.elem_packing;
-}
-
 // TableMessageKindBits is the widest RANGED value a kind can carry, its own
 // storage width: a width above it is a hostile width on the announcement.
 inline int64_t TableMessageKindBits( uint8_t kind )
@@ -1540,6 +1526,7 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
     {
         if ( count >= vocabulary.max_entries ) { to->refused = true; to->reason = vocabulary_too_large; return false; }
         TableMessageEntry & parsed = vocabulary.entries[ count ];
+        const int64_t began = at;
         if ( !TableMessageEntryRead( words, words_bytes, at, parsed ) ) { to->malformed = true; return false; }
         // THE RESERVED IDS WHERE THEY DO NOT BELONG (§3.3): the announcement's
         // own two never take a slot, and the node-table id takes exactly one,
@@ -1550,16 +1537,35 @@ inline bool AnnounceReadOnce( TableVocabulary & vocabulary, const uint8_t * buff
         // A TRIPLE ALREADY PLACED IS NEVER PLACED TWICE, so two entries that
         // agree on the id, the kind and every fact of the shape are malformed
         // (§3.3): no writer this wire has produces one, and a reader that took
-        // it would carry two slots naming one thing. The scan is quadratic in
-        // the entry count, and the entry count is bounded above at 4096, so it
-        // is at most eight million compares on a path that runs ONCE a
-        // connection and never again.
+        // it would carry two slots naming one thing. THE SHAPE IS THE DECLARED
+        // ONE, the bytes the announcement spells, and never the resolved
+        // entry: a resolved quantized entry keeps §4.3's derivation and not
+        // the max and res it consumed, so two declared resolutions that derive
+        // one delta and count would read as one entry there, and the unit's
+        // own announcement would be refused (#722). The entry's encoding is
+        // canonical, a minimal LEB128 and fixed four-byte floats, so byte
+        // equality is declared-fact equality, bit pattern for bit pattern.
+        // Each accepted entry parks its byte extent in min and max until the
+        // scan is over, and the second pass below resolves every entry in
+        // place, so no offset into the announcement outlives this call. The
+        // scan is quadratic in the entry count, and the entry count is bounded
+        // above at 4096, so it is at most eight million compares on a path
+        // that runs ONCE a connection and never again.
+        const int64_t length = at - began;
         for ( int64_t seen = 0; seen < count; seen++ )
         {
             const TableMessageEntry & other = vocabulary.entries[ seen ];
-            if ( other.id == parsed.id && other.kind == parsed.kind && TableMessageEntrySame( other, parsed ) ) { to->malformed = true; return false; }
+            if ( other.max - other.min == length && memcmp( words + other.min, words + began, (size_t) length ) == 0 ) { to->malformed = true; return false; }
         }
+        parsed.min = began;
+        parsed.max = at;
         count++;
+    }
+    // THE ENTRIES RESOLVED, over bytes the first pass already accepted
+    at = 0;
+    for ( int64_t slot = 0; slot < count; slot++ )
+    {
+        if ( !TableMessageEntryRead( words, words_bytes, at, vocabulary.entries[ slot ] ) ) { to->malformed = true; return false; }
     }
     vocabulary.count = count;
     vocabulary.ref_bits = TableBitsRequired( 0, count );


### PR DESCRIPTION
Fixes #722.

## What the reader gets

The C++ reference's `AnnounceRead` now takes the compiler's own announcement when two declared quantized shapes of one name derive the same quantization. `table First { rate float32 | min = 0, max = 1, resolution = 0.1 }` beside `table Second { rate float32 | min = 0, max = 1, resolution = 0.1001 }` announces two `rate` entries at one id and kind 10 whose declared `res` bytes differ (`cdcccc3d`, `3b01cd3d`) and whose derivations agree (qdelta 1, qcount 10). On main that announcement read back `malformed`; it now reads ok with both rates in two slots, matching the Go engine on the same bytes. An announcement that spells one entry twice, byte for byte, is still malformed, and the vocabulary stays unset with `refused` latched, as before.

## The mechanism

The duplicate scan in `AnnounceReadOnce` asked `TableMessageEntrySame`, which compares the RESOLVED entry. A resolved entry keeps only what a decode reads, §4.3's `qmin`, `qdelta` and `qcount`, and not the `max` and `res` the derivation consumed (docs/SPEC-TABLES.md pins it at 96 bytes), so two declared shapes the spec calls distinct ("the same name at a SECOND kind or shape takes a second slot") collapsed into one there.

The scan now keys on each entry's DECLARED bytes, the way `ir.TableVocabularyEntry.Key` does on the Go side:

- the first pass reads each entry, runs the reserved-id checks, compares its byte extent against every accepted entry's extent with `memcmp`, then parks the extent in the entry's `min` and `max`;
- a second linear pass re-reads every accepted entry in place, so the resolved entries are byte for byte what they were and no offset into the announcement outlives the call.

The entry encoding is canonical (the LEB reader rejects a non-minimal form, the floats are fixed four bytes), so byte equality is declared-fact equality, bit pattern for bit pattern. The scan stays quadratic in the entry count with the same 4096 bound. `TableMessageEntrySame` had no other caller and is removed. This is the same shape the C column's `announce_read` already takes.

## The test

`compiler/tablesmessage_test.go` adds `TestCppTableAnnouncementDistinctQuantizedShapes`: it generates the two-table unit, reads the unit's own announcement back through the generated header (plain and under ASan/UBSan), checks `count` is 8 and the two rates sit in adjacent slots at one id, kind 10, one derivation and `qcount == 10`, then hands it an announcement carrying one entry twice and checks `malformed` with the vocabulary unset. The Go engine is asserted on both announcements as the control. Without the fix it fails at the `AnnounceRead` call, as in the issue:

```
--- FAIL: TestCppTableAnnouncementDistinctQuantizedShapes/sanitizers=false
    announcement failed at line 14: AnnounceRead( vocabulary, own, (int64_t) sizeof( own ), &report )
```

## Goldens

The emitter text moved, so `go test ./internal/goldens -update -run TestGolden` and the `update-goldens` copy step (`build/tables-generated/<d>/*Table.{h,cpp}` into `testdata/golden/tables/<d>/`) re-pinned 45 files: 43 under `testdata/golden/tables/` and the two `testdata/golden/wide/cpp/` headers. Every hunk is the three code regions above.

## What was run

All with the local clang (`c++` = Apple clang) and serialize at the CI pin (v1.16.2).

- `go test ./compiler -run TestCppTableAnnouncementDistinctQuantizedShapes` — FAIL on main (above), PASS with the fix, both sanitizer legs.
- `go test ./compiler/... ./internal/...` — all ok.
- `go test ./test/conformance/harness -run Message` — ok.
- `make build/schema_test_tables build/schema_test_tables_asan` and ran both — `tables test passed`, exit 0.
- `make tables-block-zero-cost` — 123 Table sources byte-identical to their pins.
- `make tables-message-form-negative-control tables-retain-message-form-negative-control tables-message-form-retain-negative-control` — every control turned its gate red, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)