### PR TITLE
Message retention counts depth through nested framed values, so the 64 bound holds

### DIFF
--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpptable"
 	"github.com/mas-bandwidth/schema/v2/internal/parser"
 	"github.com/mas-bandwidth/schema/v2/internal/tablenames"
+	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
+	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
@@ -1015,6 +1017,88 @@ table ShipConfig
 		if !found {
 			t.Errorf("%s emits no BuildVersion constant at all (docs/SPEC-TABLES.md §20.7)", target)
 		}
+	}
+}
+
+// THE RESOLVING WALK'S CAP COUNTS NESTED FRAMED VALUES IN BOTH FORMS
+// (docs/SPEC-TABLES.md §6.6): a message body resolved against the connection's
+// vocabulary takes the same bound the file form's own walk takes, so the last
+// depth the cap admits rides and one past it is dropped, whichever form the
+// record arrived in. The C target pins the same pair in
+// TestCTableRetainFramedDepth. CONTROL: a message chain that passes its depth
+// through a framed value unchanged keeps the 65 row.
+func TestCppTableRetainFramedDepth(t *testing.T) {
+	old := unitFromSource(t, "package probe\ntable Root { next *Root }\n")
+	files, err := New().Generate(old, "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, depth := range []int{64, 65} {
+		t.Run(fmt.Sprint(depth), func(t *testing.T) {
+			var schema, fixture strings.Builder
+			schema.WriteString("package probe\ntable Root { next *Root\nextra T0 }\n")
+			fixture.WriteString(`{"extra":`)
+			for i := range depth {
+				if i+1 < depth {
+					fmt.Fprintf(&schema, "table T%d { nested T%d }\n", i, i+1)
+					fixture.WriteString(`{"nested":`)
+				} else {
+					fmt.Fprintf(&schema, "table T%d { x uint8 }\n", i)
+					fixture.WriteString(`{"x":7}`)
+				}
+			}
+			fixture.WriteString(strings.Repeat("}", depth))
+			future := unitFromSource(t, schema.String())
+			m := tabletext.NewModel(future)
+			value := m.New(m.Lookup("Root"))
+			var report tabletext.Report
+			if !m.Read(value, []byte(fixture.String()), &report) || !report.Silent() {
+				t.Fatalf("fixture: %+v", report)
+			}
+			wire, err := tablewire.Encode(m, value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			batch, err := tablewire.EncodeMessages(m, []*tabletext.Instance{value})
+			if err != nil {
+				t.Fatal(err)
+			}
+			announcement := tablewire.Announce(future)
+			kept := 0
+			if depth == 64 {
+				kept = 1
+			}
+			referenceCompileRun(t, files, fmt.Sprintf(`#include "ProbeTable.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+using namespace probe;
+#define CHECK(x) do { if (!(x)) { fprintf(stderr,"framed depth failed at line %%d: %%s\n",__LINE__,#x); return 1; } } while(0)
+static const uint8_t wire[]={%s};
+static const uint8_t batch[]={%s};
+static const uint8_t announcement[]={%s};
+int main(){
+ // THE FILE FORM, whose walk resolves against the wire's own trailer
+ {TableRetain retain;TableRetain::Id ids[256];TableReport report;uint8_t store[8192],out[8192];
+  retain.bytes=store;retain.capacity=sizeof(store);retain.ids=ids;retain.id_capacity=256;
+  const int64_t need=RootLoadMeasure(wire,sizeof(wire));CHECK(need>0);uint8_t * region=(uint8_t *)malloc((size_t)need);CHECK(region);
+  const Root * root=RootLoadRetain(region,need,wire,sizeof(wire),&retain,&report);
+  CHECK(root!=NULL&&!report.malformed&&!report.refused&&report.unknown==1&&report.retained==%d&&report.retain_lost==%d);
+  const int64_t bytes=RootMeasureRetain(root,&retain);CHECK(bytes>=0);CHECK(RootSaveRetain(root,&retain,out,sizeof(out),&report)==bytes);
+  free(region);}
+ // THE MESSAGE FORM, whose walk resolves against the announced vocabulary
+ {TableMessageEntry entries[256];TableVocabulary vocabulary(entries,256);TableReport report;TableRetain retain;TableRetain::Id ids[256];uint8_t store[8192],out[8192];const Root * roots[1];int64_t count=1;
+  CHECK(AnnounceRead(vocabulary,announcement,sizeof(announcement),&report));
+  const int64_t need=RootLoadMeasure(vocabulary,batch,sizeof(batch));CHECK(need>0);uint8_t * region=(uint8_t *)malloc((size_t)need);CHECK(region);
+  retain.bytes=store;retain.capacity=sizeof(store);retain.ids=ids;retain.id_capacity=256;
+  CHECK(RootLoadRetainMessages(roots,&count,region,need,vocabulary,batch,sizeof(batch),&retain,&report));
+  CHECK(count==1&&!report.malformed&&!report.refused&&report.unknown==1&&report.retained==%d&&report.retain_lost==%d);
+  const int64_t bytes=RootMeasureRetain(roots[0],&retain);CHECK(bytes>0);CHECK(RootSaveRetain(roots[0],&retain,out,sizeof(out),&report)==bytes);
+  if(report.retained){CHECK(bytes==(int64_t)sizeof(wire));CHECK(memcmp(wire,out,sizeof(wire))==0);}
+  free(region);}
+ return 0;}
+`, cppWire(wire), cppWire(batch), cppWire(announcement), kept, 1-kept, kept, 1-kept))
+		})
 	}
 }
 

--- a/internal/codegen/cpptable/retain.go
+++ b/internal/codegen/cpptable/retain.go
@@ -1539,7 +1539,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -1603,11 +1603,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -4538,7 +4538,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4602,11 +4602,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -4538,7 +4538,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4602,11 +4602,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -4539,7 +4539,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4603,11 +4603,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -4538,7 +4538,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4602,11 +4602,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -4444,7 +4444,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4508,11 +4508,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -4575,7 +4575,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4639,11 +4639,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -4575,7 +4575,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4639,11 +4639,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -4575,7 +4575,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4639,11 +4639,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -4575,7 +4575,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4639,11 +4639,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -4575,7 +4575,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4639,11 +4639,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -4696,7 +4696,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4760,11 +4760,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -4696,7 +4696,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4760,11 +4760,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -4696,7 +4696,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4760,11 +4760,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -4696,7 +4696,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4760,11 +4760,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -4696,7 +4696,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4760,11 +4760,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -4697,7 +4697,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4761,11 +4761,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -4607,7 +4607,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4671,11 +4671,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -4604,7 +4604,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4668,11 +4668,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -4604,7 +4604,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4668,11 +4668,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -4450,7 +4450,7 @@ inline int64_t TableMessageRetainElements( TableMessageRetainIn & s, const Table
             uint64_t key = 0;
             if ( !TableMessageRetainRef( s, key ) ) { return -1; }
             TableRetainInId( s.out, key );
-            if ( TableMessageRetainFramed( s, element, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, element, depth + 1 ) < 0 ) { return -1; }
             continue;
         }
         if ( TableMessageRetainPayload( s, element, depth ) < 0 ) { return -1; }
@@ -4514,11 +4514,11 @@ inline int64_t TableMessageRetainPayload( TableMessageRetainIn & s, const TableM
             if ( !TableMessageArmEntry( *s.vocabulary, ref, arm ) || TableRetainReservedId( arm.id ) ) { return -1; }
             TableRetainInId( s.out, arm.id );
             TableRetainInRaw( s.out, &arm.kind, 1 );
-            if ( TableMessageRetainFramed( s, arm, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, arm, depth + 1 ) < 0 ) { return -1; }
             break;
         }
         case 13: case 14: case 16:
-            if ( TableMessageRetainFramed( s, entry, depth ) < 0 ) { return -1; }
+            if ( TableMessageRetainFramed( s, entry, depth + 1 ) < 0 ) { return -1; }
             break;
         case 12: case 31: case 33:
             if ( !TableMessageRetainOpaque( s, entry, true ) ) { return -1; }


### PR DESCRIPTION
Fixes #719.

## What the reader gets

A retained record that arrived in the MESSAGE form is now held to the same nesting cap as one that arrived in the file form: a batch whose unknown field nests framed values 64 deep is retained, and one nesting 65 deep is dropped with `retain_lost`, exactly as `LoadRetain` on a file already does. Before this, `kTableRetainWalkDepthMax` was dead on the message path and a sender could nest without bound.

## Mechanism

`TableMessageRetainFramed`, `Body`, `Elements`, `Content` and `Payload` all forwarded `depth` unchanged, so the guard in `TableMessageRetainContent` compared a literal zero against 64 forever. The three sites that enter a nested framed value on the message chain (a keyed slot's element at `TableMessageRetainElements`, a union arm's payload and a body/array/keyed body under `TableMessageRetainPayload`) now pass `depth + 1`, which is the file chain's own spelling at `TableRetainInContent` (keyed slot) and `TableRetainInPayload` (arm, nested body), and the C target's in `internal/codegen/ctable/retain_message.go`.

## Test

`TestCppTableRetainFramedDepth` in `compiler/tables_test.go` mirrors `TestCTableRetainFramedDepth`: Go builds a 64- and a 65-deep sender unit, its file wire, its message batch and its announcement, then a generated C++ probe (plain and ASan/UBSan) loads both forms with retention and checks `retained`/`retain_lost` on each row, and that the message-form record saves back to the file-form bytes when kept.

With the emitter hunk stashed, the test fails on the 65 row's message form (both plain and sanitized), and the file form still passes:

```
--- FAIL: TestCppTableRetainFramedDepth/65/sanitizers=false
    framed depth failed at line 25: count==1&&!report.malformed&&!report.refused&&report.unknown==1&&report.retained==0&&report.retain_lost==1
```

With the fix: `--- PASS: TestCppTableRetainFramedDepth (5.01s)` on 64 and 65, plain and sanitized.

## What was run (Apple clang 21.0.0, go1.27.1, darwin/arm64)

`go test ./compiler/... ./internal/... -count=1`: every package `ok` (compiler 124.6 s, gotable 50.0 s, goldens 2.0 s).

`make tables-retain tables-retain-fixed-class-negative-control tables-retain-message-form-negative-control tables-message-form-retain-negative-control`:

```
retain: walk depth 8, 0.002 ms / 20, 0.003 ms / 40, 0.006 ms
retain: ok                                   (plain and ASan binaries)
the fixed-class root refuses retention BY NAME (docs/SPEC-TABLES.md §6.6)
retention writing form 2 refuses BY NAME (docs/SPEC-TABLES.md §3.3)
FAIL line 1042: report.retained == 10
negative control: removing the message path's call into the walk turns the pinned batch RED
```

`make tables-wire-fuzz-retain N=20000` (the count the Makefile's own test entry uses):

```
wire-fuzz retain: seed 24845619678, 24 seeds over 25 roots, 54522 enumerated + 20000 random = 74522 mutants, 0 divergences, 12.8 s   (wire-fuzz-cpp)
wire-fuzz retain: seed 24845619678, 24 seeds over 25 roots, 54522 enumerated + 20000 random = 74522 mutants, 0 divergences, 11.9 s   (wire-fuzz-cpp-asan)
```

`make tables-wire-fuzz-retain-negative-control N=0`: `negative control: removing the retain-class check from the emitter turns the retention leg RED`.

`make tables-c-retain tables-c-retain-negative-control N=20000` (make/c.mk): `go test ./compiler -run '^TestCTableRetain'` ok; 103434 mutants, 0 divergences on both the plain and ASan C drivers; `C retention negative control: dropped field fails the public round-trip report`.

`make tables-go-retain tables-go-retain-negative-controls tables-go-retain-wire-fuzz N=20000` (make/go.mk): gotable retain tests ok, the three ownership negative controls ok, 103434 mutants, 0 divergences.

Not run: `tables-cs-retain-fuzz` and `tables-cs-retain-negative-control` (make/cs.mk), no `dotnet` on this machine; the C# port is unaffected by this change.

## Goldens moved

The 27 committed C++ table headers that carry the message chain, re-pinned through `make build/tables-generated/.stamp` and the `update-goldens` copy step (`go test ./internal/goldens -update -run TestGolden` moved nothing, as those pin the packet files): `testdata/golden/tables/{arms,blobs,lists,maps,pointers,stream}/*Table.h`, 3 lines each, `depth` to `depth + 1` at the three sites. No wire golden under `testdata/wire/tables/` moves: none of the pinned vectors nests past 64.