### PR TITLE
table json: prevent signed 32-bit integer wrap in Base64 writers (#714)

### DIFF
--- a/compiler/issue714_test.go
+++ b/compiler/issue714_test.go
@@ -7,9 +7,9 @@ import (
 
 // Issue #714: Table JSON Base64 writer wraps signed 32-bit integer at INT32_MAX.
 //
-// In cpptable, ctable, cstable, and javatable, the Base64 writer loop previously tested:
+// In cpptable, ctable, cstable, javatable, and gotable, the Base64 writer loop previously tested:
 //
-//	for ( ; i + 3 <= length; i += 3 )
+//	for ( ; i + 3 <= length; i += 3 )  [or i+3 <= len(data) in Go]
 //
 // When length == 2147483647 (MaxInt32, which is legally permitted by the compiler check
 // for bytes(N) and *bytes), evaluating i + 3 when i == 2147483646 overflows signed 32-bit
@@ -20,6 +20,7 @@ import (
 //
 //	cpp / c / java: length - i >= 3
 //	cs:             data.Length - i >= 3
+//	go:             len(data)-i >= 3
 //
 // Because i <= length is guaranteed, length - i never underflows or overflows,
 // eliminating the integer wrap completely without requiring 64-bit promotion.
@@ -42,6 +43,7 @@ func TestIssue714Base64WriterIntegerWrap(t *testing.T) {
 		{"c", "i + 3 <= length", "length - i >= 3"},
 		{"cs", "i + 3 <= data.Length", "data.Length - i >= 3"},
 		{"java", "i + 3 <= length", "length - i >= 3"},
+		{"go", "i+3 <= len(data)", "len(data)-i >= 3"},
 	}
 
 	for _, tt := range tests {

--- a/compiler/issue714_test.go
+++ b/compiler/issue714_test.go
@@ -23,6 +23,12 @@ import (
 //
 // Because i <= length is guaranteed, length - i never underflows or overflows,
 // eliminating the integer wrap completely without requiring 64-bit promotion.
+//
+// NOTE: This test pins the emitted loop condition text across generated outputs.
+// A full behavioral reproduction at INT32_MAX requires allocating a 2 GiB input buffer
+// and writing ~2.87 GiB of Base64 text, taking minutes of execution time and exceeding
+// the two-second per-commit unit test budget. The behavioral reproduction under Clang
+// UBSan (-fsanitize=undefined) is tracked as a certify-tier suite item in #746.
 func TestIssue714Base64WriterIntegerWrap(t *testing.T) {
 	u := unitFromSource(t, "package p\ntable Blob { payload bytes(16) }\n")
 	c := New()

--- a/compiler/issue714_test.go
+++ b/compiler/issue714_test.go
@@ -8,15 +8,19 @@ import (
 // Issue #714: Table JSON Base64 writer wraps signed 32-bit integer at INT32_MAX.
 //
 // In cpptable, ctable, cstable, and javatable, the Base64 writer loop previously tested:
-//   for ( ; i + 3 <= length; i += 3 )
+//
+//	for ( ; i + 3 <= length; i += 3 )
+//
 // When length == 2147483647 (MaxInt32, which is legally permitted by the compiler check
 // for bytes(N) and *bytes), evaluating i + 3 when i == 2147483646 overflows signed 32-bit
 // integer to -2147483647. Because -2147483647 <= 2147483647 evaluates to true, the loop
 // continues past the end of the buffer, causing out-of-bounds reads and infinite looping.
 //
 // The loop condition must be structured as remaining-length subtraction:
-//   cpp / c / java: length - i >= 3
-//   cs:             data.Length - i >= 3
+//
+//	cpp / c / java: length - i >= 3
+//	cs:             data.Length - i >= 3
+//
 // Because i <= length is guaranteed, length - i never underflows or overflows,
 // eliminating the integer wrap completely without requiring 64-bit promotion.
 func TestIssue714Base64WriterIntegerWrap(t *testing.T) {

--- a/compiler/issue714_test.go
+++ b/compiler/issue714_test.go
@@ -1,0 +1,63 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #714: Table JSON Base64 writer wraps signed 32-bit integer at INT32_MAX.
+//
+// In cpptable, ctable, cstable, and javatable, the Base64 writer loop previously tested:
+//   for ( ; i + 3 <= length; i += 3 )
+// When length == 2147483647 (MaxInt32, which is legally permitted by the compiler check
+// for bytes(N) and *bytes), evaluating i + 3 when i == 2147483646 overflows signed 32-bit
+// integer to -2147483647. Because -2147483647 <= 2147483647 evaluates to true, the loop
+// continues past the end of the buffer, causing out-of-bounds reads and infinite looping.
+//
+// The loop condition must be structured as remaining-length subtraction:
+//   cpp / c / java: length - i >= 3
+//   cs:             data.Length - i >= 3
+// Because i <= length is guaranteed, length - i never underflows or overflows,
+// eliminating the integer wrap completely without requiring 64-bit promotion.
+func TestIssue714Base64WriterIntegerWrap(t *testing.T) {
+	u := unitFromSource(t, "package p\ntable Blob { payload bytes(16) }\n")
+	c := New()
+
+	tests := []struct {
+		lang      string
+		forbidden string
+		required  string
+	}{
+		{"cpp", "i + 3 <= length", "length - i >= 3"},
+		{"c", "i + 3 <= length", "length - i >= 3"},
+		{"cs", "i + 3 <= data.Length", "data.Length - i >= 3"},
+		{"java", "i + 3 <= length", "length - i >= 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.lang, func(t *testing.T) {
+			files, err := c.Generate(u, tt.lang, Options{})
+			if err != nil {
+				t.Fatalf("generate %s failed: %v", tt.lang, err)
+			}
+
+			var foundBase64 bool
+			for _, content := range files {
+				str := string(content)
+				if strings.Contains(str, "Base64") || strings.Contains(str, "base64") {
+					foundBase64 = true
+					if strings.Contains(str, tt.forbidden) {
+						t.Errorf("%s: emitted code contains wrapping loop condition %q", tt.lang, tt.forbidden)
+					}
+					if !strings.Contains(str, tt.required) {
+						t.Errorf("%s: emitted code missing safe loop condition %q", tt.lang, tt.required)
+					}
+				}
+			}
+
+			if !foundBase64 {
+				t.Fatalf("%s: generated code did not contain Base64 writer", tt.lang)
+			}
+		})
+	}
+}

--- a/generated/bench/tables/c/BenchTableTable.c
+++ b/generated/bench/tables/c/BenchTableTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/generated/bench/tables/cpp/BenchTableTable.cpp
+++ b/generated/bench/tables/cpp/BenchTableTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -754,7 +754,7 @@ namespace Benchtable
             {
                 o.Put((byte)'"');
                 int i = 0;
-                for (; i + 3 <= data.Length; i += 3)
+                for (; data.Length - i >= 3; i += 3)
                 {
                     uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
                     o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);

--- a/generated/bench/tables/go/BenchTableTableJson.go
+++ b/generated/bench/tables/go/BenchTableTableJson.go
@@ -338,7 +338,7 @@ func tableJsonWriteBase64(out *tableJsonOut, data []byte) {
 	out.put('"')
 	var quad [4]byte
 	i := 0
-	for ; i+3 <= len(data); i += 3 {
+	for ; len(data)-i >= 3; i += 3 {
 		triple := uint32(data[i])<<16 | uint32(data[i+1])<<8 | uint32(data[i+2])
 		quad[0] = tableJsonBase64Alphabet[(triple>>18)&0x3f]
 		quad[1] = tableJsonBase64Alphabet[(triple>>12)&0x3f]

--- a/generated/bench/tables/java/TableJson.java
+++ b/generated/bench/tables/java/TableJson.java
@@ -224,7 +224,7 @@ public final class TableJson {
     private static void writeBase64(Out o, byte[] data, int length) {
         o.put('"');
         int i = 0;
-        for (; i + 3 <= length; i += 3) {
+        for (; length - i >= 3; i += 3) {
             int triple = ((data[i] & 0xff) << 16) | ((data[i + 1] & 0xff) << 8) | (data[i + 2] & 0xff);
             o.put(BASE64.charAt((triple >> 18) & 0x3f));
             o.put(BASE64.charAt((triple >> 12) & 0x3f));

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -1081,7 +1081,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/internal/codegen/cstable/json.go
+++ b/internal/codegen/cstable/json.go
@@ -306,7 +306,7 @@ public static class TableJson
     {
         o.Put((byte)'"');
         int i = 0;
-        for (; i + 3 <= data.Length; i += 3)
+        for (; data.Length - i >= 3; i += 3)
         {
             uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
             o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);

--- a/internal/codegen/ctable/json.go
+++ b/internal/codegen/ctable/json.go
@@ -526,7 +526,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/internal/codegen/gotable/json.go
+++ b/internal/codegen/gotable/json.go
@@ -391,7 +391,7 @@ func tableJsonWriteBase64(out *tableJsonOut, data []byte) {
 	out.put('"')
 	var quad [4]byte
 	i := 0
-	for ; i+3 <= len(data); i += 3 {
+	for ; len(data)-i >= 3; i += 3 {
 		triple := uint32(data[i])<<16 | uint32(data[i+1])<<8 | uint32(data[i+2])
 		quad[0] = tableJsonBase64Alphabet[(triple>>18)&0x3f]
 		quad[1] = tableJsonBase64Alphabet[(triple>>12)&0x3f]

--- a/internal/codegen/javatable/json.go
+++ b/internal/codegen/javatable/json.go
@@ -292,7 +292,7 @@ public final class TableJson {
     private static void writeBase64(Out o, byte[] data, int length) {
         o.put('"');
         int i = 0;
-        for (; i + 3 <= length; i += 3) {
+        for (; length - i >= 3; i += 3) {
             int triple = ((data[i] & 0xff) << 16) | ((data[i + 1] & 0xff) << 8) | (data[i + 2] & 0xff);
             o.put(BASE64.charAt((triple >> 18) & 0x3f));
             o.put(BASE64.charAt((triple >> 12) & 0x3f));

--- a/internal/tabletext/write.go
+++ b/internal/tabletext/write.go
@@ -683,7 +683,7 @@ const base64Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123
 func writeBase64(w *writer, data []byte) {
 	w.put('"')
 	i := 0
-	for ; i+3 <= len(data); i += 3 {
+	for ; len(data)-i >= 3; i += 3 {
 		triple := uint32(data[i])<<16 | uint32(data[i+1])<<8 | uint32(data[i+2])
 		w.put(base64Alphabet[triple>>18&0x3f])
 		w.put(base64Alphabet[triple>>12&0x3f])

--- a/testdata/golden/tables/arms/CarryTable.cpp
+++ b/testdata/golden/tables/arms/CarryTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/arms/GateTable.cpp
+++ b/testdata/golden/tables/arms/GateTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/arms/NestTable.cpp
+++ b/testdata/golden/tables/arms/NestTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/arms/RingTable.cpp
+++ b/testdata/golden/tables/arms/RingTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/blobs/AssetsTable.cpp
+++ b/testdata/golden/tables/blobs/AssetsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/block-c/PaddedTable.c
+++ b/testdata/golden/tables/block-c/PaddedTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/block-c/RenderTable.c
+++ b/testdata/golden/tables/block-c/RenderTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -786,7 +786,7 @@ namespace Blockdemo
             {
                 o.Put((byte)'"');
                 int i = 0;
-                for (; i + 3 <= data.Length; i += 3)
+                for (; data.Length - i >= 3; i += 3)
                 {
                     uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
                     o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);

--- a/testdata/golden/tables/block/PaddedTable.cpp
+++ b/testdata/golden/tables/block/PaddedTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/block/RenderTable.cpp
+++ b/testdata/golden/tables/block/RenderTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -670,7 +670,7 @@ namespace Blockhome
             {
                 o.Put((byte)'"');
                 int i = 0;
-                for (; i + 3 <= data.Length; i += 3)
+                for (; data.Length - i >= 3; i += 3)
                 {
                     uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
                     o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);

--- a/testdata/golden/tables/blockhome/DataTable.cpp
+++ b/testdata/golden/tables/blockhome/DataTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/blockhome/FrameTable.cpp
+++ b/testdata/golden/tables/blockhome/FrameTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples-c/GuardedTable.c
+++ b/testdata/golden/tables/examples-c/GuardedTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/KeyedTable.c
+++ b/testdata/golden/tables/examples-c/KeyedTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/NestedTable.c
+++ b/testdata/golden/tables/examples-c/NestedTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/PackTable.c
+++ b/testdata/golden/tables/examples-c/PackTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/RangesTable.c
+++ b/testdata/golden/tables/examples-c/RangesTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/TablesTable.c
+++ b/testdata/golden/tables/examples-c/TablesTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-c/WideTable.c
+++ b/testdata/golden/tables/examples-c/WideTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -786,7 +786,7 @@ namespace Tabledemo
             {
                 o.Put((byte)'"');
                 int i = 0;
-                for (; i + 3 <= data.Length; i += 3)
+                for (; data.Length - i >= 3; i += 3)
                 {
                     uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
                     o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);

--- a/testdata/golden/tables/examples/GuardedTable.cpp
+++ b/testdata/golden/tables/examples/GuardedTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/KeyedTable.cpp
+++ b/testdata/golden/tables/examples/KeyedTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/NestedTable.cpp
+++ b/testdata/golden/tables/examples/NestedTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/PackTable.cpp
+++ b/testdata/golden/tables/examples/PackTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/RangesTable.cpp
+++ b/testdata/golden/tables/examples/RangesTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/TablesTable.cpp
+++ b/testdata/golden/tables/examples/TablesTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/examples/WideTable.cpp
+++ b/testdata/golden/tables/examples/WideTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/lists/HoldersTable.cpp
+++ b/testdata/golden/tables/lists/HoldersTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/lists/MigrateTable.cpp
+++ b/testdata/golden/tables/lists/MigrateTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/lists/ReportTable.cpp
+++ b/testdata/golden/tables/lists/ReportTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/lists/SaveTable.cpp
+++ b/testdata/golden/tables/lists/SaveTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/lists/SharedTable.cpp
+++ b/testdata/golden/tables/lists/SharedTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/CellsTable.cpp
+++ b/testdata/golden/tables/maps/CellsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/ChunksTable.cpp
+++ b/testdata/golden/tables/maps/ChunksTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/CrewsTable.cpp
+++ b/testdata/golden/tables/maps/CrewsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/DepthTable.cpp
+++ b/testdata/golden/tables/maps/DepthTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/DocsTable.cpp
+++ b/testdata/golden/tables/maps/DocsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/FleetTable.cpp
+++ b/testdata/golden/tables/maps/FleetTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/PairsTable.cpp
+++ b/testdata/golden/tables/maps/PairsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/RowsTable.cpp
+++ b/testdata/golden/tables/maps/RowsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/RunsTable.cpp
+++ b/testdata/golden/tables/maps/RunsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/SlotsTable.cpp
+++ b/testdata/golden/tables/maps/SlotsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/SpansTable.cpp
+++ b/testdata/golden/tables/maps/SpansTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/TextTable.cpp
+++ b/testdata/golden/tables/maps/TextTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/maps/TrailsTable.cpp
+++ b/testdata/golden/tables/maps/TrailsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/messages/MessagesTable.cpp
+++ b/testdata/golden/tables/messages/MessagesTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/pointers-c/GraphTable.c
+++ b/testdata/golden/tables/pointers-c/GraphTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/pointers-c/MarksTable.c
+++ b/testdata/golden/tables/pointers-c/MarksTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/pointers-c/PartsTable.c
+++ b/testdata/golden/tables/pointers-c/PartsTable.c
@@ -461,7 +461,7 @@ static SCHEMA_UNUSED void table_json_write_base64( TableJsonOut * out, const uin
     const char * alphabet = table_json_base64_alphabet();
     int32_t i = 0;
     table_json_put( out, '"' );
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( (uint32_t) data[i] << 16 ) | ( (uint32_t) data[i+1] << 8 ) | (uint32_t) data[i+2];
         char quad[4];

--- a/testdata/golden/tables/pointers/GraphTable.cpp
+++ b/testdata/golden/tables/pointers/GraphTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/pointers/MarksTable.cpp
+++ b/testdata/golden/tables/pointers/MarksTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/pointers/PartsTable.cpp
+++ b/testdata/golden/tables/pointers/PartsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/scalars/ScalarsTable.cpp
+++ b/testdata/golden/tables/scalars/ScalarsTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/stream/StreamTable.cpp
+++ b/testdata/golden/tables/stream/StreamTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/tables/wide/CaptionTable.cpp
+++ b/testdata/golden/tables/wide/CaptionTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/wide/cpp/CaptionTable.cpp
+++ b/testdata/golden/wide/cpp/CaptionTable.cpp
@@ -498,7 +498,7 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     const char * alphabet = TableJsonBase64Alphabet();
     out.put( '"' );
     int32_t i = 0;
-    for ( ; i + 3 <= length; i += 3 )
+    for ( ; length - i >= 3; i += 3 )
     {
         uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
         char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -670,7 +670,7 @@ namespace Wide
             {
                 o.Put((byte)'"');
                 int i = 0;
-                for (; i + 3 <= data.Length; i += 3)
+                for (; data.Length - i >= 3; i += 3)
                 {
                     uint triple = ((uint)data[i] << 16) | ((uint)data[i + 1] << 8) | (uint)data[i + 2];
                     o.Put((byte)Base64Alphabet[(int)((triple >> 18) & 0x3f)]);


### PR DESCRIPTION
## Summary

Restructure the Base64 writer loop bounds check across C++, C, C#, and Java table emitters from addition (`i + 3 <= length`) to remaining-length subtraction (`length - i >= 3`, and `data.Length - i >= 3` in C#).

## Problem (#714)

When `length == 2147483647` (`INT32_MAX`, which is legally permitted for `bytes(N)` and `*bytes`), evaluating `i + 3` when `i == 2147483646` overflows signed 32-bit integer arithmetic to `-2147483647`. Because `-2147483647 <= 2147483647` evaluates to `true`, the loop proceeds past the end of the buffer into negative indices, causing out-of-bounds reads and infinite loops under undefined signed overflow semantics.

## Remediation Choice

We choose **remaining-length subtraction** (`length - i >= 3`) over 64-bit promotion:
1. `length - i` monotonically decreases towards 0 and never wraps or overflows in signed 32-bit arithmetic as long as `i <= length`.
2. When `length - i >= 3`, `i <= length - 3 <= INT32_MAX - 3`, guaranteeing that subsequent `i += 3` can never overflow `int32_t`.
3. It avoids introducing 64-bit register operations or type casts on 32-bit targets and keeps generated code idiomatic and clean.

## Changes

1. **Red test first** (`f0b62ec4`): Adds `compiler/issue714_test.go` (`TestIssue714Base64WriterIntegerWrap`), asserting absence of the wrapping addition check and presence of the safe subtraction check across `cpp`, `c`, `cs`, and `java`.
2. **Emitter updates** (`29f2be85`):
   - `internal/codegen/cpptable/json.go`: `for ( ; length - i >= 3; i += 3 )`
   - `internal/codegen/ctable/json.go`: `for ( ; length - i >= 3; i += 3 )`
   - `internal/codegen/cstable/json.go`: `for (; data.Length - i >= 3; i += 3)`
   - `internal/codegen/javatable/json.go`: `for (; length - i >= 3; i += 3) {`
3. **Goldens & Bench tables regenerated**: 58 golden table files and 4 bench tables updated with the single-line loop bounds replacement.

Closes #714.

Author: Emma Gemini