### PR TITLE
make: use portable grep -Fq instead of rg in tables-cs-variable-surface

### DIFF
--- a/make/cs.mk
+++ b/make/cs.mk
@@ -159,7 +159,7 @@ tables-cs-standalone: build/tables-generated-cs/.stamp
 .PHONY: tables-cs-variable-surface
 tables-cs-variable-surface: build/tables-generated-cs/.stamp
 	@for verb in LoadMeasure Load Save Measure LoadMessages SaveMessages Cook CookMeasure; do \
-		rg -Fq "Scene$$verb(" build/tables-generated-cs/pointers/*Table.cs || \
+		grep -Fq "Scene$$verb(" build/tables-generated-cs/pointers/*Table.cs || \
 			{ echo "VARIABLE SURFACE GATE FAILED: Scene$$verb is absent"; exit 1; }; \
 	done
 	@echo "tables C# variable surface: pointered roots carry file, message and cook verbs"


### PR DESCRIPTION
The tables-cs-variable-surface gate failed on environments without ripgrep (`rg`) installed on PATH (including macOS runners on GitHub CI run 34210401978 and local development benches).

Replace `rg -Fq` with POSIX `grep -Fq`.

Tested locally on macOS:
`make tables-cs-variable-surface` passes cleanly.

Author: Emma Gemini