### PR TITLE
cstable: validate pointer arm framing before resolving node index (#751)

### DIFF
--- a/compiler/issue751_test.go
+++ b/compiler/issue751_test.go
@@ -1,0 +1,64 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #751: C# table wire-fuzz report differs on streamdemo.Feed
+// (KindMismatch 2 vs oracle 1) because pointer union arms resolved the node
+// index before validating that the arm's framed payload had no trailing bytes.
+//
+// Under SPEC-TABLES §3: "an L that is not the byte count of the reference it
+// frames ... is that arm's own framing damage — the union reads None,
+// malformed counts, and the parent reads on past L".
+//
+// Validating r.Offset == r.Buffer.Length before Graph.Resolve/NativePointer ensures
+// that framing damage prevents resolving the pointer, so no pointee kind
+// mismatch is erroneously counted.
+func TestIssue751PointerArmTrailingFraming(t *testing.T) {
+	src := `package p
+table Chunk {
+    data bytes(8)
+    next *Chunk
+}
+union Frame {
+    chunk Chunk
+    link *Chunk
+}
+table Feed {
+    id uint32
+    frame Frame
+    parts [..4]*Chunk
+}
+`
+	u := unitFromSource(t, src)
+	c := New()
+
+	files, err := c.Generate(u, "cs", Options{})
+	if err != nil {
+		t.Fatalf("generate cs: %v", err)
+	}
+
+	var foundWireCheck, foundRegionCheck bool
+	for name, content := range files {
+		str := string(content)
+		if strings.HasSuffix(name, "Table.cs") {
+			if strings.Contains(str, "!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length") {
+				foundWireCheck = true
+			}
+		}
+		if strings.HasSuffix(name, "Region.cs") {
+			if strings.Contains(str, "!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length") {
+				foundRegionCheck = true
+			}
+		}
+	}
+
+	if !foundWireCheck {
+		t.Errorf("C# generated Table.cs missing exact framing check for pointer arm")
+	}
+	if !foundRegionCheck {
+		t.Errorf("C# generated Region.cs missing exact framing check for pointer arm")
+	}
+}

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -4470,7 +4470,12 @@ namespace Benchtable
                     return r.Offset == r.Buffer.Length || Damage(report);
                 }
                 if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-                if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+                if (kind == 17)
+                {
+                    if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+                    f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+                    return true;
+                }
                 if (kind == 12 || kind == 33)
                 {
                     ResetArm(value, f);

--- a/internal/codegen/cstable/region.go
+++ b/internal/codegen/cstable/region.go
@@ -403,7 +403,12 @@ const tableRegionSource = `
             return r.Offset == r.Buffer.Length || Damage(report);
         }
         if (kind == 15) { return NativeReadElement(ref state, ref r, value, f, 0, kind, report, true); }
-        if (kind == 17) { if (!NativeReadElement(ref state, ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+        if (kind == 17)
+        {
+            if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+            NativePointer(ref state, value, f, 0, indexValue, report);
+            return true;
+        }
         if (kind == 12 || kind == 33)
         {
             NativeResetArm(value, f);

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -668,7 +668,12 @@ public static partial class TableWire
             return r.Offset == r.Buffer.Length || Damage(report);
         }
         if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-        if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+        if (kind == 17)
+        {
+            if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+            f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+            return true;
+        }
         if (kind == 12 || kind == 33)
         {
             ResetArm(value, f);

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -4502,7 +4502,12 @@ namespace Blockdemo
                     return r.Offset == r.Buffer.Length || Damage(report);
                 }
                 if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-                if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+                if (kind == 17)
+                {
+                    if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+                    f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+                    return true;
+                }
                 if (kind == 12 || kind == 33)
                 {
                     ResetArm(value, f);

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -4386,7 +4386,12 @@ namespace Blockhome
                     return r.Offset == r.Buffer.Length || Damage(report);
                 }
                 if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-                if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+                if (kind == 17)
+                {
+                    if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+                    f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+                    return true;
+                }
                 if (kind == 12 || kind == 33)
                 {
                     ResetArm(value, f);

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -4502,7 +4502,12 @@ namespace Tabledemo
                     return r.Offset == r.Buffer.Length || Damage(report);
                 }
                 if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-                if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+                if (kind == 17)
+                {
+                    if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+                    f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+                    return true;
+                }
                 if (kind == 12 || kind == 33)
                 {
                     ResetArm(value, f);

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -4386,7 +4386,12 @@ namespace Wide
                     return r.Offset == r.Buffer.Length || Damage(report);
                 }
                 if (kind == 15) { return ReadElement(ref r, value, f, 0, kind, report, true); }
-                if (kind == 17) { if (!ReadElement(ref r, value, f, 0, kind, report, true)) { return false; } return r.Offset == r.Buffer.Length || Damage(report); }
+                if (kind == 17)
+                {
+                    if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }
+                    f.SetChild(value, 0, r.Graph == null ? null : r.Graph.Resolve(indexValue, f, report));
+                    return true;
+                }
                 if (kind == 12 || kind == 33)
                 {
                     ResetArm(value, f);


### PR DESCRIPTION
Under SPEC-TABLES §3:
> "a reference-shaped arm whose L is not the byte count of the reference it frames ... are that arm's own framing damage — the union reads None, malformed counts, and the parent reads on past L".

### Problem
Previously, in C# `ReadArm` (`wire.go`) and `NativeReadArm` (`region.go`), `kind == 17` (pointer) called `ReadElement` / `NativeReadElement` first—which immediately read the varint index and resolved it via `Graph.Resolve` or `NativePointer`, incrementing `KindMismatch++` if the root's type differed from the pointee type—and only checked `r.Offset == r.Buffer.Length` afterwards.

When `pointer_arm_trailing` (mutant of `streamdemo.Feed`) supplied 11 trailing bytes after a 1-byte LEB128 reference, this was framing damage on the arm itself. The C++ reference (`emitNodeIndexLoad` with `exact: true`) and Go oracle (`decode.go:1280`) both enforce exact length before resolving the node index, marking `malformed = true` and returning without resolving the pointer or incrementing `kind_mismatch`.

### Fix
In `internal/codegen/cstable/wire.go` and `internal/codegen/cstable/region.go`, enforce `if (!r.Var(out ulong indexValue) || r.Offset != r.Buffer.Length) { return Damage(report); }` before resolving the pointer index.

### Verification
- Pinned vector `pointer_arm_trailing` replay: 1 mutant, 0 divergences.
- `tables-cs-wire-fuzz`: 252,842 mutants, 0 divergences.
- `tables-cs-region-fuzz`: 252,842 mutants, 0 divergences.
- `tables-cs-builder-fuzz`: 183,434 mutants, 0 divergences.
- `tables-cs-retain-fuzz`: 183,434 mutants, 0 divergences.
- Added `compiler/issue751_test.go` pinning the emitted code.
- Full Go `compiler` and `tablewire` suites pass cleanly.

Closes #751.

Author: Emma Gemini