### PR TITLE
C LoadMeasure follows announced framing past a reserved id (#749)

### DIFF
--- a/compiler/tablescmessage_test.go
+++ b/compiler/tablescmessage_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -284,4 +285,39 @@ func TestCTableAnnouncementFailureClearsEntries(t *testing.T) {
  {TableMessageEntry full[kTableMessageEntriesHere];int64_t at;size_t j;int failures=0;for(at=0;at<n;at++){memset(full,0,sizeof(full));v=table_vocabulary(full,kTableMessageEntriesHere);report=(TableReport){0};wire[at]^=0x80;
  if(!announce_read(&v,wire,n,&report)){failures++;for(j=0;j<sizeof(full);j++)if(((uint8_t *)full)[j])return 5;}wire[at]^=0x80;}if(!failures)return 6;}return 0;
  }`)
+}
+
+// A sizing scan follows announced framing even when a reserved transport id
+// occurs in a root body. Typed decoding still rejects that body as damage.
+// This is schema#749: C LoadMeasure used to stop at the reserved id (192)
+// while C++ / the oracle sized the batch (960).
+func TestCTableMessageMeasureReservedFraming(t *testing.T) {
+	paths, err := filepath.Glob("../tables/pointers/*.schema")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := New().Load(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCTableWireProbe(t, u, `#include "GraphTable.h"
+#include <stdio.h>
+static const uint8_t wire[]={
+ 0x02,0x0c,0x01,0x00,0xa5,0x01,0x00,0x00,0x00,0xeb,0x04,0x00,0x00,0x00,0x28,0x01,
+ 0x61,0xcf,0x00,0xd6,0x11,0x00,0x00,0x00,0x10,0x66,0x70,0x00,0x74,0x6f,0x70,0x21,
+ 0x44,0x03,0x33,0x48,0x6c,0x65,0x66,0x74,0xc0,0x0c,0x16,0x72,0x69,0x67,0x68,0x74,
+ 0x00,0xcc,0xad,0x1b,0x6d,0x69,0x64,0x00,0x45,0x00,0x74,0x72,0x65,0x65,0x95,0xc0,
+ 0x90,0xc5,0xeb,0x00
+};
+int main(void){
+ TableMessageEntry entries[kTableMessageEntriesHere];TableVocabulary v=table_vocabulary(entries,kTableMessageEntriesHere);
+ TableReport report={0};const Scene * roots[256]={0};int64_t count=256,need;uint8_t * region;
+ if(!announce_read(&v,kTableAnnounce,kTableAnnounceBytes,&report))return 1;
+ need=scene_load_measure_messages(&v,wire,sizeof(wire));
+ if(need!=960){fprintf(stderr,"reserved framing extent %lld want 960\n",(long long)need);return 2;}
+ region=(uint8_t *)malloc((size_t)need);if(!region)return 3;
+ if(scene_load_messages(roots,&count,region,need,&v,wire,sizeof(wire),&report)||!report.malformed){free(region);return 4;}
+ free(region);return 0;
+}
+`)
 }

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -1147,6 +1147,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1155,7 +1158,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1566,7 +1570,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_event_wire_message_load_(TableM
  if(!table_message_ref(r,&entry,0))goto malformed;
  value->type=0;
  if(entry==NULL)return 1;
- if(entry->kind==0)goto malformed;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd)||entry->kind==0)goto malformed;
  switch(entry->id){
  case UINT64_C(0x33732819300680aa): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -3036,6 +3040,7 @@ static SCHEMA_UNUSED int table_entity_load_message_body(TableMessageReader * r,T
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x23fcfd6678e36712): {
  if(!(entry->kind==7 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,7)){r->report->widened++;
@@ -3589,6 +3594,7 @@ static SCHEMA_UNUSED int table_stat_load_message_body(TableMessageReader * r,Tab
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x80ab75f0866dbf65): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;
@@ -5961,6 +5967,7 @@ static SCHEMA_UNUSED int table_mixed_load_message_body(TableMessageReader * r,Ta
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x6a5a70d91aa115fd): {
  if(!(entry->kind==7 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,7)){r->report->widened++;
@@ -6944,6 +6951,7 @@ static SCHEMA_UNUSED int table_hit_event_load_message_body(TableMessageReader * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xb7bc9ac015a25050): {
  if(!(entry->kind==7 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,7)){r->report->widened++;
@@ -7327,6 +7335,7 @@ static SCHEMA_UNUSED int table_chat_event_load_message_body(TableMessageReader *
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xa5013e9ad5caeda4): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -7678,6 +7687,7 @@ static SCHEMA_UNUSED int table_pickup_event_load_message_body(TableMessageReader
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x9e7fd06d864fbd56): {
  if(!(entry->kind==7 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,7)){r->report->widened++;

--- a/internal/codegen/ctable/message_read.go
+++ b/internal/codegen/ctable/message_read.go
@@ -12,6 +12,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;@NODES@
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;*entry=NULL;
@@ -19,7 +22,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -330,7 +334,7 @@ func (g *tableGen) emitMessageReadDeclarations(members []*ir.Struct, unions []*i
 }
 
 func (g *tableGen) emitMessageUnionRead(un *ir.Union) {
-	g.pf("static SCHEMA_UNUSED int %s(TableMessageReader * r,%s * value)\n{\n const TableMessageEntry * entry;\n %sif(!table_message_ref(r,&entry,0))goto malformed;value->type=0;if(entry==NULL)return 1;if(entry->kind==0)goto malformed;\n switch(entry->id){\n", g.unionWireName(un, "message_load"), un.Name, g.retainUnionDiscard())
+	g.pf("static SCHEMA_UNUSED int %s(TableMessageReader * r,%s * value)\n{\n const TableMessageEntry * entry;\n %sif(!table_message_ref(r,&entry,0))goto malformed;value->type=0;if(entry==NULL)return 1;if(entry->id>=UINT64_C(0xfffffffffffffffd)||entry->kind==0)goto malformed;\n switch(entry->id){\n", g.unionWireName(un, "message_load"), un.Name, g.retainUnionDiscard())
 	for ordinal, v := range un.Variants {
 		g.pf(" case UINT64_C(0x%016x): {\n", ir.TableWireId(v.WireName()))
 		g.messageAccept(v.F, ir.TableArmEntry(v), " ")
@@ -356,7 +360,7 @@ func (g *tableGen) emitMessageRead(st *ir.Struct) {
 	if g.retain {
 		g.pf(" TableRetainWalk body_keep=retention;table_retain_discard(retention,0,0);\n")
 	}
-	g.pf(" %s(value);for(;;){const TableMessageEntry * entry;\n if(!table_message_ref(r,&entry,0))goto malformed;if(entry==NULL)return 1;switch(entry->id){\n", g.api(st.Name, "reset"))
+	g.pf(" %s(value);for(;;){const TableMessageEntry * entry;\n if(!table_message_ref(r,&entry,0))goto malformed;if(entry==NULL)return 1;if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;switch(entry->id){\n", g.api(st.Name, "reset"))
 	for ordinal, f := range st.Fields {
 		g.pf(" case UINT64_C(0x%016x): {\n", ir.TableFieldWireId(f))
 		g.messageAccept(f, ir.TableFieldEntry(f), " ")
@@ -390,7 +394,7 @@ func (g *tableGen) emitMessageMapKeyRead(f *ir.Field) {
 	n, key := f.MapEntry.Name, ir.MapKeyField(f)
 	readType := g.sym(n, "key_read")
 	kind := ir.TableWireScalarKind(key)
-	g.pf("static SCHEMA_UNUSED %s %s(TableMessageReader * r)\n{\n %s out;memset(&out,0,sizeof(out));for(;;){const TableMessageEntry * entry;\n if(!table_message_ref(r,&entry,0))goto malformed;if(entry==NULL)return out;\n if(entry->id==UINT64_C(0x%016x)){\n", readType, g.sym(n, "message_key"), readType, ir.MapKeyWireId)
+	g.pf("static SCHEMA_UNUSED %s %s(TableMessageReader * r)\n{\n %s out;memset(&out,0,sizeof(out));for(;;){const TableMessageEntry * entry;\n if(!table_message_ref(r,&entry,0))goto malformed;if(entry==NULL)return out;if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;\n if(entry->id==UINT64_C(0x%016x)){\n", readType, g.sym(n, "message_key"), readType, ir.MapKeyWireId)
 	g.pf(" out.kind_bad=entry->kind!=%d && !table_kind_widens(entry->kind,%d);if(entry->kind!=%d && !out.kind_bad)out.widened=1;\n if(!out.kind_bad){\n", kind, kind, kind)
 	if key.Type.Kind == ir.TString {
 		g.pf(" uint64_t count;if(!table_bit_get(&r->bits,&count,table_bits_required(0,entry->max))||!table_bit_align_read(&r->bits)||!table_bit_has(&r->bits,(int64_t)count*8))goto malformed;\n out.key.data=(const char *)(r->bits.buffer+(r->bits.offset>>3));out.key.length=(int32_t)count;out.over=count>%d;\n if(!table_wire_utf8((const uint8_t *)out.key.data,count))goto malformed;r->bits.offset+=(int64_t)count*8;\n", key.Type.Size)

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -1175,6 +1175,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1183,7 +1186,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -2142,6 +2146,7 @@ static SCHEMA_UNUSED int padded_row_load_message_body(TableMessageReader * r,Pad
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x56d7ab194448a4f3): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;
@@ -2795,6 +2800,7 @@ static SCHEMA_UNUSED int padded_frame_load_message_body(TableMessageReader * r,P
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xeddcb72b15486e77): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -2270,6 +2274,7 @@ static SCHEMA_UNUSED int render_camera_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -3146,6 +3151,7 @@ static SCHEMA_UNUSED int render_ship_load_message_body(TableMessageReader * r,Re
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -4093,6 +4099,7 @@ static SCHEMA_UNUSED int render_turret_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xb51afb05cd34709f): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -4825,6 +4832,7 @@ static SCHEMA_UNUSED int render_missile_load_message_body(TableMessageReader * r
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -5527,6 +5535,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_load_message_body(TableMessageReade
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -6257,6 +6266,7 @@ static SCHEMA_UNUSED int render_static_prop_load_message_body(TableMessageReader
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -7028,6 +7038,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_load_message_body(TableMessageRead
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -7672,6 +7683,7 @@ static SCHEMA_UNUSED int render_laser_load_message_body(TableMessageReader * r,R
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xee5d97ad45ad251f): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -8369,6 +8381,7 @@ static SCHEMA_UNUSED int render_explosion_load_message_body(TableMessageReader *
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x4cbf3a26fca1d74a): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -9623,6 +9636,7 @@ static SCHEMA_UNUSED int render_frame_load_message_body(TableMessageReader * r,R
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xbb62c62c9808ea37): {
  if(!(entry->kind==9 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,9)){r->report->widened++;
@@ -10173,6 +10187,7 @@ static SCHEMA_UNUSED int render_vector3_load_message_body(TableMessageReader * r
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xaf63f54c86021707): {
  if(!(entry->kind==11 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,11)){r->report->widened++;
@@ -10631,6 +10646,7 @@ static SCHEMA_UNUSED int render_quaternion_load_message_body(TableMessageReader 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xaf63f54c86021707): {
  if(!(entry->kind==11 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,11)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1819,6 +1823,7 @@ static SCHEMA_UNUSED int patrol_load_message_body(TableMessageReader * r,Patrol 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x6580790b036f0c6f): {
  if(!(entry->kind==1 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,1)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1753,6 +1757,7 @@ static SCHEMA_UNUSED int team_config_load_message_body(TableMessageReader * r,Te
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xceec99e2d65db674): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -2009,6 +2014,7 @@ static SCHEMA_UNUSED int gunner_config_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xb75aa3662201646a): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -2297,6 +2303,7 @@ static SCHEMA_UNUSED int turret_config_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7f6308be8ab37fc0): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -2719,6 +2726,7 @@ static SCHEMA_UNUSED int hull_config_load_message_body(TableMessageReader * r,Hu
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7f69d4b5288ba9cf): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -3303,6 +3311,7 @@ static SCHEMA_UNUSED int keyed_config_load_message_body(TableMessageReader * r,K
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xbaaeb048a5a8fa6d): {
  if(!(entry->kind==16 && entry->elem_kind==13)){if(0){r->report->widened++;
@@ -3678,6 +3687,7 @@ static SCHEMA_UNUSED int score_board_load_message_body(TableMessageReader * r,Sc
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xf10fad739a0e1660): {
  if(!(entry->kind==16 && entry->elem_kind==4)){if(0){r->report->widened++;

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -1175,6 +1175,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1183,7 +1186,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1617,6 +1621,7 @@ static SCHEMA_UNUSED int archive_config_load_message_body(TableMessageReader * r
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xa354fd1ff0c467c5): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1707,6 +1711,7 @@ static SCHEMA_UNUSED int gunner_settings_load_message_body(TableMessageReader * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xb75aa3662201646a): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -2194,6 +2199,7 @@ static SCHEMA_UNUSED int ship_entry_load_message_body(TableMessageReader * r,Shi
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x2d21d7cd66bd5a5d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -2744,6 +2750,7 @@ static SCHEMA_UNUSED int global_settings_load_message_body(TableMessageReader * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xa65f859b617deaf3): {
  if(!(entry->kind==8 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,8)){r->report->widened++;
@@ -3540,6 +3547,7 @@ static SCHEMA_UNUSED int pack_config_load_message_body(TableMessageReader * r,Pa
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xbb62c62c9808ea37): {
  if(!(entry->kind==8 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,8)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -2986,6 +2990,7 @@ static SCHEMA_UNUSED int ranged_signed_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x48121511bf702eb5): {
  if(!(entry->kind==2 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,2)){r->report->widened++;
@@ -4865,6 +4870,7 @@ static SCHEMA_UNUSED int ranged_unsigned_load_message_body(TableMessageReader * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x0f8897557f37c021): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;
@@ -5810,6 +5816,7 @@ static SCHEMA_UNUSED int ranged_widths_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x08a60c07b54d8dc7): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1585,7 +1589,7 @@ static SCHEMA_UNUSED int schema_tabledemo_effect_wire_message_load_(TableMessage
  if(!table_message_ref(r,&entry,0))goto malformed;
  value->type=0;
  if(entry==NULL)return 1;
- if(entry->kind==0)goto malformed;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd)||entry->kind==0)goto malformed;
  switch(entry->id){
  case UINT64_C(0xffb5be9be2e469cc): {
  if(!(entry->kind==13 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,13)){r->report->widened++;
@@ -2096,6 +2100,7 @@ static SCHEMA_UNUSED int weapon_config_load_message_body(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7f6308be8ab37fc0): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -2962,6 +2967,7 @@ static SCHEMA_UNUSED int loadout_config_load_message_body(TableMessageReader * r
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x32a89b2977c48ad4): {
  if(!(entry->kind==30 && entry->elem_kind==0)){if(0){r->report->widened++;
@@ -4168,6 +4174,7 @@ static SCHEMA_UNUSED int profile_config_load_message_body(TableMessageReader * r
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -4795,6 +4802,7 @@ static SCHEMA_UNUSED int root_config_load_message_body(TableMessageReader * r,Ro
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x8a67c9728746d394): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -5136,6 +5144,7 @@ static SCHEMA_UNUSED int attachment_load_message_body(TableMessageReader * r,Att
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x6a771618f6fe31d1): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -5351,6 +5360,7 @@ static SCHEMA_UNUSED int buff_load_message_body(TableMessageReader * r,Buff * va
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x9adc623a805c87c6): {
  if(!(entry->kind==10 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,10)){r->report->widened++;
@@ -5607,6 +5617,7 @@ static SCHEMA_UNUSED int debuff_load_message_body(TableMessageReader * r,Debuff 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x8113fe7ea2b16969): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -1174,6 +1174,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -1182,7 +1185,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -1725,6 +1729,7 @@ static SCHEMA_UNUSED int wide_blob_load_message_body(TableMessageReader * r,Wide
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x39f7fcec8fcb623d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -2032,6 +2032,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;TableNodeMap * nodes;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -2040,7 +2043,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -3630,6 +3634,7 @@ static SCHEMA_UNUSED int meta_load_message_body(TableMessageReader * r,Meta * va
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x802517e298c70b03): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -3974,6 +3979,7 @@ static SCHEMA_UNUSED int settings_load_message_body(TableMessageReader * r,Setti
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7a8060916400fe66): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -4280,6 +4286,7 @@ static SCHEMA_UNUSED int list_node_load_message_body(TableMessageReader * r,List
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7ce4fd9430e80cea): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -4525,6 +4532,7 @@ static SCHEMA_UNUSED int tree_node_load_message_body(TableMessageReader * r,Tree
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x39f7fcec8fcb623d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -4766,6 +4774,7 @@ static SCHEMA_UNUSED int layer_load_message_body(TableMessageReader * r,Layer * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x75d8e97600b296ea): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -5359,6 +5368,7 @@ static SCHEMA_UNUSED int scene_load_message_body(TableMessageReader * r,Scene * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -5848,6 +5858,7 @@ static SCHEMA_UNUSED int depot_load_message_body(TableMessageReader * r,Depot * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -6269,6 +6280,7 @@ static SCHEMA_UNUSED int album_load_message_body(TableMessageReader * r,Album * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -6656,6 +6668,7 @@ static SCHEMA_UNUSED int meta_load_message_body_retain(TableMessageReader * r,Me
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x802517e298c70b03): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -6979,6 +6992,7 @@ static SCHEMA_UNUSED int settings_load_message_body_retain(TableMessageReader * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7a8060916400fe66): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -7301,6 +7315,7 @@ static SCHEMA_UNUSED int list_node_load_message_body_retain(TableMessageReader *
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x7ce4fd9430e80cea): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -7573,6 +7588,7 @@ static SCHEMA_UNUSED int tree_node_load_message_body_retain(TableMessageReader *
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x39f7fcec8fcb623d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -7864,6 +7880,7 @@ static SCHEMA_UNUSED int layer_load_message_body_retain(TableMessageReader * r,L
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x75d8e97600b296ea): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -8552,6 +8569,7 @@ static SCHEMA_UNUSED int scene_load_message_body_retain(TableMessageReader * r,S
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -9092,6 +9110,7 @@ static SCHEMA_UNUSED int depot_load_message_body_retain(TableMessageReader * r,D
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -9556,6 +9575,7 @@ static SCHEMA_UNUSED int album_load_message_body_retain(TableMessageReader * r,A
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xc4bcadba8e631b86): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -2030,6 +2030,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;TableNodeMap * nodes;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -2038,7 +2041,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -3301,6 +3305,7 @@ static SCHEMA_UNUSED int tally_load_message_body(TableMessageReader * r,Tally * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x732dfbcc9b0cf0bb): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -3499,6 +3504,7 @@ static SCHEMA_UNUSED int marker_load_message_body(TableMessageReader * r,Marker 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x39f7fcec8fcb623d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -3757,6 +3763,7 @@ static SCHEMA_UNUSED int tally_load_message_body_retain(TableMessageReader * r,T
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x732dfbcc9b0cf0bb): {
  if(!(entry->kind==4 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,4)){r->report->widened++;
@@ -3958,6 +3965,7 @@ static SCHEMA_UNUSED int marker_load_message_body_retain(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x39f7fcec8fcb623d): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -2030,6 +2030,9 @@ typedef struct TableMessageReader {
  TableBitReader bits; const TableVocabulary * vocabulary; TableReport * report;
  int64_t index_bits; int extent_refused;TableNodeMap * nodes;
 } TableMessageReader;
+/* Framing scans skip by announced shape, including a reserved transport id
+   (kind 0, no extra bits). A NAME reference still refuses reserved ids.
+   Typed body reads diagnose reserved as malformed after resolving the entry. */
 static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMessageEntry ** entry,int name)
 {
  uint64_t ref=0;
@@ -2038,7 +2041,8 @@ static SCHEMA_UNUSED int table_message_ref(TableMessageReader * r,const TableMes
  if(ref==0)return 1;
  if(ref>(uint64_t)r->vocabulary->count)return 0;
  *entry=r->vocabulary->entries+ref-1;
- return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (!name || (*entry)->kind==0);
+ if(name) return (*entry)->id<UINT64_C(0xfffffffffffffffd) && (*entry)->kind==0;
+ return 1;
 }
 static SCHEMA_UNUSED TableMessageEntry table_message_element(const TableMessageEntry * e)
 {
@@ -3255,6 +3259,7 @@ static SCHEMA_UNUSED int stamp_load_message_body(TableMessageReader * r,Stamp * 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x56d7ab194448a4f3): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -3561,6 +3566,7 @@ static SCHEMA_UNUSED int colour_load_message_body(TableMessageReader * r,Colour 
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xaf63ef4c86020cd5): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;
@@ -3929,6 +3935,7 @@ static SCHEMA_UNUSED int stamp_load_message_body_retain(TableMessageReader * r,S
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0x56d7ab194448a4f3): {
  if(!(entry->kind==12 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,12)){r->report->widened++;
@@ -4169,6 +4176,7 @@ static SCHEMA_UNUSED int colour_load_message_body_retain(TableMessageReader * r,
  for(;;){const TableMessageEntry * entry;
  if(!table_message_ref(r,&entry,0))goto malformed;
  if(entry==NULL)return 1;
+ if(entry->id>=UINT64_C(0xfffffffffffffffd))goto malformed;
  switch(entry->id){
  case UINT64_C(0xaf63ef4c86020cd5): {
  if(!(entry->kind==6 && entry->elem_kind==0)){if(entry->elem_kind==0 && table_kind_widens(entry->kind,6)){r->report->widened++;


### PR DESCRIPTION
Fixes #749.

On main `9f283415`, `tables-c-wire-fuzz` failed after 188977 mutants:

```
LoadMeasure asks for 192 region bytes; the framing commands exactly 960
```

Corpus seed `graph_tree_message` (`graphdemo.Scene`), message form. The reader agreed with the oracle (same report `0,0,0,0,0,true,read`, both saved 3 bytes). C++ replay of the same mutant was green. The divergence was C `LoadMeasure`.

**Cause.** `table_message_ref` refused reserved transport ids on every path, including skip and extent. This mutant has no node table at the first field; the reserved node-table id appears later in the root body (vocab slot 37, kind 0). C treated that as framing failure, set `complete=0`, and sized only body 0: `sizeof(Scene)+dir` = 176+16 = 192. C++ `TableMessageSkipBody` and Go `tableMessageSkipBody` skip by announced shape (kind 0 carries no extra bits) and size the batch through later bodies: 5 × 192 = 960. Go already pins this split in `TestMessageMeasureReservedFraming`. Typed decode still reports malformed, which is the spec for a reserved id anywhere but its own transport.

**Fix.** Field references (`name=0`) skip by announced shape. Name references (`name=1`) still refuse reserved ids. Typed body reads (struct, union, map key) diagnose reserved as malformed after resolving the entry.

**Test.** `TestCTableMessageMeasureReservedFraming` compiles graphdemo C and pins the mutant: `scene_load_measure_messages` == 960, `scene_load_messages` malformed. Replay:

```
./build/conformance-harness wire-fuzz --driver ./build/wire-fuzz-c --replay <mutant> --unit graphdemo --root Scene --message
```

Green on `wire-fuzz-c` and `wire-fuzz-c-asan`. `go test ./compiler -run TestCTable` green. Goldens re-pinned.

Emma reviews. Rowan closer.

Author: Johnny Grok.