### PR TITLE
Fixed-table profiling: require all selected legs and interleave verified rounds

### DIFF
--- a/bench/corpus/BenchTable.schema
+++ b/bench/corpus/BenchTable.schema
@@ -12,7 +12,10 @@
 // type wire and the tolerant table wire comparable at all: the ratio between
 // them is the price of tolerance, and nothing else.
 //
-// THE FOUR SUBSTITUTIONS, named rather than silently dropped. The table wire
+// HISTORICAL CORPUS SUBSTITUTIONS. Wide table kinds now exist in C/C++/C#/Go,
+// but this retained benchmark keeps its original shape and golden identity.
+// The historical explanation below is not a statement of current support.
+// THE SUBSTITUTIONS, named rather than silently dropped. The table wire
 // is a neutral byte wire with a closed set of kinds (§3), so four of
 // BenchMixed's declarations are REFUSED in a table body by name (§11 —
 // "`fixed`/`ufixed` or the 128-bit family (no wire kind), `const`/`reserved`/

--- a/bench/tables/README.md
+++ b/bench/tables/README.md
@@ -12,47 +12,39 @@ flatbuffers has a number for this, because it is the same job: a message of
 scalars, strings, an enum, a union, a nested record and bounded arrays of
 records, framed by ids, kinds and lengths.
 
-## What it measures, and what it does not
+## Scope and performance standard
 
-| | measured here | where it lives instead |
-|---|---|---|
-| tolerant wire, write + read | **yes — every language** | this leg |
-| block form fill and read | no | `make tables-block-gate2` (§12.1), and the game, on real render data |
-| cook open cost | no | `test/tables/cook_main.cpp`'s open-cost gate (§7.5) |
-| the JSON walk, `schema pack` | no, by design | tooling; not a hot path |
+The current profile is the fixed table's file form in **C, C++, C# and Go**.
+Glenn's September 8 direction is the **fastest correct implementation for each
+language**. The shared workload fixes the work being measured; each language may
+use its best correct representation, compiler and runtime techniques. Optimize
+from profiles and confirm gains with paired measurements and correctness checks.
 
-That split is the owner's scope ruling on the same issue: *"I think that's
-sufficient for now for the profiling, the rest can be C++/C# specific with
-render data tables as we work in space."* The per-language board is the
-tolerant wire. Block and cook numbers stay C++/C#, taken in the game on real
-render data, because that is where the render path actually is.
+The next representative corpus is a variable table. Message form, block form,
+and cooked save/load follow as separate measured operations. They do not acquire
+a performance result from this fixed-table pass.
 
 ## The corpus
 
-`bench/corpus/BenchTable.schema` declares `TableMixed`, and it **mirrors
-`BenchMixed`** — the type corpus's one measured shape — field for field: same
-field count, same kinds, same nesting, same bounds, same pinned structure. The
-owner's sizing rule, and his reason for it: *"Make the fixed table roughly
-equivalent to the profiled type in size"* … *"so we don't hyper-fixate on
-serializing a few fields and it's all memcpy."*
+[`bench/corpus/BenchTable.schema`](../corpus/BenchTable.schema) declares
+`TableMixed`, the existing fixed-table counterpart of the representative
+[`BenchMixed`](../corpus/Bench.schema) packet workload: eight nested entity
+updates, eighty statistic records, a tagged event, bounded text and payload,
+and mixed scalar fields. Every language generates its codec from this one file.
+The runners name the generated root once and do not duplicate its fields.
 
-Four of BenchMixed's declarations are refused in a table body by name
-(docs/SPEC-TABLES.md §11) and each is replaced by the nearest kind that does
-the same per-field work; the schema file lists all of them in its header, with
-the two that drop and why. The mirror is what makes the two boards
-comparable: the same shape on the bitpacked type wire and on the tolerant
-table wire, so the ratio between them is the price of tolerance and nothing
-else.
+This retained corpus predates wide table scalars. It substitutes compressed
+floats for the packet's fixed-point fields and 64-bit integers for its 128-bit
+fields, and replaces/drops packet framing declarations. Those are properties of
+this benchmark version, **not current language limitations**. Its range/default
+and enum-presence choices keep all variants the same length. It therefore
+measures a representative counterpart, not an identical scalar payload or the
+isolated cost of tolerance. A future corpus that restores these kinds needs its
+own version and golden identity; do not silently reinterpret older results.
 
-Pinned wire: **2391 bytes**, against BenchMixed's 438 — the ids, kinds and
-lengths, made visible. **1487 of those 2391, or 62%, are framing**: field id
-references, kind bytes, lengths, element counts and body terminators, not
-values. That count is the price of tolerance, stated as a number so the ratio
-is a measurement rather than an impression, and it is the figure
-docs/SPEC-TABLES.md's performance ladder cites from this page. What it does
-not license is a codec slower than those bytes require: the per-BYTE cost is
-this leg's own obligation, so a per-byte gap is a defect to explain or close
-and never the wire's price.
+The current pinned file is **2,147 bytes** per record. `bench-table-check`
+reconstructs all 64 records and compares them byte-for-byte before profiling.
+The packet corpus and its historical measurements are unchanged.
 
 ## The data, and why no runner builds an instance
 
@@ -127,34 +119,43 @@ cross-family division refuses on its own (§5.3) — a tolerant-wire number and 
 bitpacked-wire number are not the same measurement and the tools say so
 without anyone remembering to.
 
-## The legs, and what each one's number means
+## The four-language pass
 
-| leg | tier | what the number is |
-|---|---|---|
-| `cpp` | the reference | the bar every other row divides against |
-| `cs`, `go`, `rust` | native or JIT | same shape, same corpus, a codec compiled to machine code |
-| `elixir` | the READING TIER | what the BEAM costs: `save` allocates its own result because there is no caller-owned buffer, and `load` builds a term per field. About 37x C++ on write and 33x on round-trip, measured — a PAIRING CHECK, not a sitting (`results/2026-09-03-pairing-elixir-arm64-macbook.md`), with the lever named against #174 |
+C and C++ use their generated fixed codecs in release builds. Go uses its
+generated package in the ordinary optimized build. C# currently uses generated
+managed authoring values with reused output storage. The configuration is part
+of every result; a different representation or JIT setting must be measured
+and identified as a separate candidate before being called faster.
 
-**A reading-tier row is a number to be REPORTED, not a number to be matched.**
-The ladder in docs/SPEC-TABLES.md sets the bar for a language that can hold
-bytes; a language whose values are the runtime's holds a different one, and
-saying so is the point of the row.
+A passing shared corpus is required before any timing. The broader table
+conformance, unit, ownership and wire checks remain independent acceptance
+evidence. A passing fixed-table corpus does not clear an unrelated failing
+message or variable-table check.
 
 ## Running
 
     bench/tables/run.sh                    every registered leg -> bench/tables/results/
-    bench/tables/run.sh --only cs          one leg
+    bench/tables/run.sh --only c,cpp,cs,go --gate --bare
+                                          build and check all four, no timing
+    bench/tables/run.sh --only c,cpp,cs,go --rounds 7 --tag fixed
+                                          the four-language interleaved pass
+    bench/tables/run.sh --only cs          one required leg
     bench/tables/run.sh --rounds 5         interleaved rounds (§2.4)
     bench/tables/run.sh --tag pairing      name the sitting in the file name
     bench/tables/run.sh --bare             rows only, no preamble, stdout
 
-`make bench-tables` runs the default pass.
+`make bench-tables` runs the default pass. An explicitly selected language that
+cannot build is a failure, not a skipped row. All selected legs build before
+measurement. For multiple rounds, every language runs once before the next
+round begins; the packet benchmark's aggregation tool checks measurement
+identity and computes the combined statistics. A failed leg emits no completed
+pass: stdout and the result file are published only after every round succeeds.
 
-**A publishable number is a BOX sitting**, not a laptop run: core 15, the
-server stopped, not live, one bench at a time, blessed per run. A run on a
-shared interactive machine is a pairing check — it tells you the legs agree
-and roughly where they stand, and it certifies nothing. Say which one a board
-is, in the board.
+Record the machine, toolchains, optimization settings, revision, corpus and
+noise for every pass. Run one benchmark at a time and coordinate a quiet window
+on a shared machine. A Studio result is a local measurement; it is not a
+production-server certification. A server deployment or server benchmark keeps
+its own access and operational approval requirements.
 
 ## Registering a port
 
@@ -170,7 +171,7 @@ bench-tables` generates it (`docs/CONTRIBUTING.md`, "Adding a language").
        leg build            build the leg; exit 2 if its toolchain or
                             generated sources are not present (that prints
                             SKIP and is not a failure)
-       leg run [args...]    run the runner: --csv, --round K, --wire-dir,
+       leg run [args...]    run the runner: --gate (no timing), --csv, --round K, --wire-dir,
                             --variant-dir
 
 2. Write the runner itself in `bench/tables/<lang>/`. Port
@@ -187,10 +188,10 @@ bench-tables` generates it (`docs/CONTRIBUTING.md`, "Adding a language").
 3. Generate the unit in `make/<lang>.mk` and add its stamp to
    `BENCH_TABLES_LEGS` there.
 
-**The ratio to C++ is the port's speed bar** — *same speed, or not
-significantly slower* — the same bar the ladder sets for every rung
-(docs/SPEC-TABLES.md, the performance ladder). A port that lands wide of it
-has a defect to explain or close, not a trade to license.
+Compare absolute time per operation and throughput, with variation beside the
+headline. Cross-language results guide investigation; the implementation target
+is the fastest correct code for each language. A measured performance gap needs
+an explanation and an optimization candidate, not an assumed cause.
 
 ## The board
 

--- a/bench/tables/README.md
+++ b/bench/tables/README.md
@@ -210,12 +210,9 @@ Stated so a reader knows what is not here, and why:
   than borrowing C++'s spelling. `linkage` is `pkg`: the generated table codec
   is ordinary package code in the leg's binary and names no runtime at all.
 
-- **`relative rel` is C-referenced** (Glenn, 2026-08-17: *"make C the
-  reference"*), and this board's reference is C++ — the ratio a port is held
-  to — so `rel` and the tables board disagree about the denominator. C now
-  carries a tables leg, so a `--reference` flag serving both boards from one
-  renderer is the shape this wants; until then the tables board's own table
-  carries the C++ ratio in prose.
+- **`relative rel` is C-referenced.** A ratio is a comparison of this corpus
+  on this machine, not a language's implementation target. Publish absolute
+  times and throughput first, with the measurement spread.
 - **The tables emitters are not LOCKed** the way `bench/LOCK` locks the type
   emitters. The lock is a ruling about a profiling round, not a side effect of
   a board existing; it belongs to the round the owner opens after the first

--- a/bench/tables/c/table_main.c
+++ b/bench/tables/c/table_main.c
@@ -57,6 +57,7 @@ static int g_num_runs = MaxNumRuns; /* --round K drops this to 1 (§2.4) */
 #endif
 
 static int g_csv = 0;
+static int g_gate = 0;
 static const char * g_wire_dir = "testdata/wire";
 static const char * g_variant_dir = "bench/corpus/variants";
 
@@ -363,6 +364,8 @@ static void bench_table( const char * name, const char * golden, long base_iters
         }
     }
 
+    if ( g_gate ) return;
+
     /* WRITE: save the 64 pre-loaded instances round-robin. */
     for ( run = -1; run < g_num_runs; run++ )
     {
@@ -424,7 +427,8 @@ int main( int argc, char ** argv )
     int i;
     for ( i = 1; i < argc; i++ )
     {
-        if ( strcmp( argv[i], "--csv" ) == 0 ) { g_csv = 1; }
+        if ( strcmp( argv[i], "--gate" ) == 0 ) { g_gate = 1; }
+        else if ( strcmp( argv[i], "--csv" ) == 0 ) { g_csv = 1; }
         else if ( strcmp( argv[i], "--wire-dir" ) == 0 && i + 1 < argc ) { g_wire_dir = argv[++i]; }
         else if ( strcmp( argv[i], "--variant-dir" ) == 0 && i + 1 < argc ) { g_variant_dir = argv[++i]; }
         else if ( strcmp( argv[i], "--round" ) == 0 && i + 1 < argc )
@@ -440,7 +444,7 @@ int main( int argc, char ** argv )
         }
         else
         {
-            fprintf( stderr, "usage: %s [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/tables/cpp/table_main.cpp
+++ b/bench/tables/cpp/table_main.cpp
@@ -65,6 +65,7 @@ const long IterScale = 8;
 #endif
 
 static bool g_csv = false;
+static bool g_gate = false;
 static const char * g_wire_dir = "testdata/wire";
 static const char * g_variant_dir = "bench/corpus/variants";
 
@@ -301,6 +302,8 @@ static void bench_table( const char * name, const char * golden, long base_iters
         }
     }
 
+    if ( g_gate ) return;
+
     double write_rates[MaxNumRuns];
     double roundtrip_rates[MaxNumRuns];
 
@@ -377,7 +380,8 @@ int main( int argc, char ** argv )
 {
     for ( int i = 1; i < argc; i++ )
     {
-        if ( strcmp( argv[i], "--csv" ) == 0 )
+        if ( strcmp( argv[i], "--gate" ) == 0 ) { g_gate = true; }
+        else if ( strcmp( argv[i], "--csv" ) == 0 )
             g_csv = true;
         else if ( strcmp( argv[i], "--wire-dir" ) == 0 && i + 1 < argc )
             g_wire_dir = argv[++i];
@@ -396,7 +400,7 @@ int main( int argc, char ** argv )
         }
         else
         {
-            fprintf( stderr, "usage: %s [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/tables/cs/leg
+++ b/bench/tables/cs/leg
@@ -21,9 +21,9 @@ build)
     fi
     command -v dotnet >/dev/null 2>&1 || { echo "no dotnet" >&2; exit 2; }
     if [ -n "$SERIALIZE_CS" ]; then
-        dotnet build "$PROJ" -c Release -v q --nologo "-property:SerializeCsRoot=$SERIALIZE_CS" >&2
+        dotnet build "$PROJ" -c Release -v q --nologo -property:UseSharedCompilation=false "-property:SerializeCsRoot=$SERIALIZE_CS" >&2
     else
-        dotnet build "$PROJ" -c Release -v q --nologo >&2
+        dotnet build "$PROJ" -c Release -v q --nologo -property:UseSharedCompilation=false >&2
     fi
     ;;
 run)

--- a/bench/tables/cs/src/Program.cs
+++ b/bench/tables/cs/src/Program.cs
@@ -106,6 +106,7 @@ static class Program
 
     static ulong gSink; // defeats dead code elimination of computed values
     static bool gCsv;
+    static bool gGate;
     static string gWireDir = Path.Combine("testdata", "wire");
     static string gVariantDir = Path.Combine("bench", "corpus", "variants");
     static bool failed;
@@ -262,6 +263,8 @@ static class Program
             }
         }
 
+        if (gGate) return;
+
         double[] writeRates = new double[gNumRuns];
         double[] roundtripRates = new double[gNumRuns];
 
@@ -336,7 +339,11 @@ static class Program
     {
         for (int i = 0; i < args.Length; i++)
         {
-            if (args[i] == "--csv")
+            if (args[i] == "--gate")
+            {
+                gGate = true;
+            }
+            else if (args[i] == "--csv")
             {
                 gCsv = true;
             }
@@ -359,7 +366,7 @@ static class Program
             }
             else
             {
-                Console.Error.WriteLine("usage: schematablesbench [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]");
+                Console.Error.WriteLine("usage: schematablesbench [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]");
                 return 1;
             }
         }

--- a/bench/tables/run.sh
+++ b/bench/tables/run.sh
@@ -100,7 +100,7 @@ else
         echo "# cpp compiler: $(${CXX:-c++} --version 2>/dev/null | head -1)"
         echo "# dotnet: $(dotnet --version 2>/dev/null || echo 'not present')"
         echo "# rounds: $ROUNDS"
-        echo "# pinning: $( [ "$(uname -s)" = Linux ] && echo "taskset -c ${BENCH_CPU:-unset}" || echo "none (macOS has no taskset)" )"
+        echo "# pinning: not set by this driver; external affinity, if any, must be recorded in noise"
         echo "# noise: ${BENCH_NOISE:-unlabelled}"
         echo "# schema commit: $(commit_of .)"
         echo "# serialize.cs commit: $(commit_of "${SERIALIZE_CS:-../serialize.cs}")  (the closure's type codecs only — no line of the measured table path enters it)"

--- a/bench/tables/run.sh
+++ b/bench/tables/run.sh
@@ -3,7 +3,8 @@
 #
 #   bench/tables/run.sh                 every registered leg, one CSV under
 #                                       bench/tables/results/
-#   bench/tables/run.sh --only cs       one leg
+#   bench/tables/run.sh --only c,cpp,cs,go  four required legs
+#   bench/tables/run.sh --gate --only c,cpp,cs,go --bare  no timing
 #   bench/tables/run.sh --rounds 5      interleaved rounds (§2.4): every leg
 #                                       once per round, so every leg sees the
 #                                       same load window; the driver, not the
@@ -26,18 +27,24 @@
 set -e
 
 ONLY=""
+GATE=0
 ROUNDS=1
 BARE=0
 TAG=""
 while [ $# -gt 0 ]; do
     case "$1" in
-        --only)   ONLY="$2"; shift 2 ;;
-        --rounds) ROUNDS="$2"; shift 2 ;;
-        --tag)    TAG="$2"; shift 2 ;;
+        --only)   [ $# -ge 2 ] || exit 2; ONLY="$2"; shift 2 ;;
+        --gate)   GATE=1; shift ;;
+        --rounds) [ $# -ge 2 ] || exit 2; ROUNDS="$2"; shift 2 ;;
+        --tag)    [ $# -ge 2 ] || exit 2; TAG="$2"; shift 2 ;;
         --bare)   BARE=1; shift ;;
-        *) echo "usage: $0 [--only <lang>] [--rounds N] [--tag <name>] [--bare]" >&2; exit 1 ;;
+        *) echo "usage: $0 [--only <lang,...>] [--gate] [--rounds N] [--tag <name>] [--bare]" >&2; exit 1 ;;
     esac
 done
+
+case "$ROUNDS" in ''|*[!0-9]*|0|0*) echo "--rounds takes a positive integer" >&2; exit 2 ;; esac
+case "$TAG" in *[!a-zA-Z0-9._-]*) echo "--tag takes a filename label" >&2; exit 2 ;; esac
+case "$ONLY" in *[!a-z0-9,]*|,*|*,|*,,*) echo "--only takes comma-separated language names" >&2; exit 2 ;; esac
 
 if [ ! -d bench/tables ]; then
     echo "run this from the repository root" >&2
@@ -61,6 +68,13 @@ commit_of() {
     echo "$sha$dirty ($branch)"
 }
 
+mkdir -p build
+PASS_DIR=$(mktemp -d "build/table-pass.XXXXXX")
+trap 'rm -rf "$PASS_DIR"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+DRAFT="$PASS_DIR/result.csv"
+: > "$DRAFT"
 if [ "$BARE" = 1 ]; then
     OUT=/dev/stdout
 else
@@ -70,7 +84,7 @@ else
         echo "refusing to overwrite $OUT — pass --tag <name>, or remove it if the overwrite is deliberate" >&2
         exit 1
     fi
-    : > "$OUT"
+    : # Publish the file only after every selected leg and round succeeds.
     {
         echo "# schema TABLES bench results (bench/tables/README.md)"
         echo "# date: $(date -u +%FT%TZ)"
@@ -78,6 +92,11 @@ else
         echo "# cpu: $CPU"
         echo "# build: Release"
         echo "# corpus: bench/corpus/BenchTable.schema (one fixed table on the tolerant wire, docs/SPEC-TABLES.md §3)"
+        echo "# c compiler: $(${CC:-cc} --version 2>/dev/null | head -1)"
+        echo "# go: $(go version 2>/dev/null || echo absent)"
+        echo "# c flags: -std=c99 -Wall -Wextra -Werror -ffp-contract=off -${BENCH_OPT_LEVEL:-O3} -DNDEBUG"
+        echo "# cpp flags: -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -${BENCH_OPT_LEVEL:-O3} -DNDEBUG -fno-rtti"
+        echo "# dotnet tiered compilation: ${DOTNET_TieredCompilation:-runtime-default}"
         echo "# cpp compiler: $(${CXX:-c++} --version 2>/dev/null | head -1)"
         echo "# dotnet: $(dotnet --version 2>/dev/null || echo 'not present')"
         echo "# rounds: $ROUNDS"
@@ -85,59 +104,82 @@ else
         echo "# noise: ${BENCH_NOISE:-unlabelled}"
         echo "# schema commit: $(commit_of .)"
         echo "# serialize.cs commit: $(commit_of "${SERIALIZE_CS:-../serialize.cs}")  (the closure's type codecs only — no line of the measured table path enters it)"
-    } >> "$OUT"
+    } >> "$DRAFT"
 fi
 
-# The CSV v2 header (§5.1), written once here rather than by the first leg to
-# print one. emit() runs in a pipeline and therefore in a subshell, so it can
-# keep no state between legs; dropping every leg's header unconditionally is
-# the form that does not depend on any.
-echo "lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline" >> "$OUT"
-
-emit() {
-    while IFS= read -r line; do
-        case "$line" in
-            lang,bench,path,*) ;;
-            *) [ -n "$line" ] && echo "$line" >> "$OUT" ;;
-        esac
-    done
-}
-
-RAN=0
+# Build every selected leg before starting any clock. A requested missing leg
+# is a failed pass; only unrequested default discovery may skip unavailable ports.
+LEGS=""
 for cmd in bench/tables/*/leg; do
     [ -f "$cmd" ] || continue
     lang="$(basename "$(dirname "$cmd")")"
-    [ -n "$ONLY" ] && [ "$ONLY" != "$lang" ] && continue
-
+    if [ -n "$ONLY" ]; then
+        case ",$ONLY," in *,$lang,*) ;; *) continue ;; esac
+    fi
     echo "== $lang: build ==" >&2
-    set +e
-    "$cmd" build
-    status=$?
-    set -e
-    if [ "$status" = 2 ]; then
+    status=0
+    "$cmd" build || status=$?
+    if [ "$status" = 2 ] && [ -z "$ONLY" ]; then
         echo "SKIP $lang (toolchain or generated sources not present)" >&2
         continue
     fi
-    [ "$status" != 0 ] && { echo "FAIL $lang: build" >&2; exit 1; }
-
-    r=0
-    while [ "$r" -lt "$ROUNDS" ]; do
-        if [ "$ROUNDS" = 1 ]; then
-            echo "== $lang: run ==" >&2
-            "$cmd" run --csv | emit
-        else
-            echo "== $lang: round $r ==" >&2
-            "$cmd" run --csv --round "$r" | emit
-        fi
-        r=$(( r + 1 ))
-    done
-    RAN=$(( RAN + 1 ))
+    [ "$status" = 0 ] || { echo "FAIL $lang: build" >&2; exit 1; }
+    LEGS="$LEGS $lang"
+done
+[ -n "$LEGS" ] || { echo "no legs ran" >&2; exit 1; }
+for wanted in $(printf '%s' "$ONLY" | tr ',' ' '); do
+    case " $LEGS " in *" $wanted "*) ;; *) echo "requested leg $wanted is unavailable" >&2; exit 1 ;; esac
 done
 
-if [ "$RAN" = 0 ]; then
-    echo "no legs ran" >&2
-    exit 1
+if [ "$GATE" = 1 ]; then
+    for lang in $LEGS; do
+        echo "== $lang: correctness gate, no timing ==" >&2
+        bench/tables/"$lang"/leg run --gate || exit 1
+    done
+    echo "all selected corpus gates passed; no performance measured" >&2
+    exit 0
 fi
 
-[ "$BARE" = 0 ] && echo "wrote $OUT" >&2
-exit 0
+HEADER='lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline'
+r=0
+while [ "$r" -lt "$ROUNDS" ]; do
+    ROUND_FILE="$PASS_DIR/round-$r.csv"
+    printf '# round: %s\n%s\n' "$r" "$HEADER" > "$ROUND_FILE"
+    # The round is the outer loop: every language sees the same time window.
+    for lang in $LEGS; do
+        echo "== $lang: round $r ==" >&2
+        if [ "$ROUNDS" = 1 ]; then
+            bench/tables/"$lang"/leg run --csv > "$PASS_DIR/leg.csv" || exit 1
+        else
+            bench/tables/"$lang"/leg run --csv --round "$r" > "$PASS_DIR/leg.csv" || exit 1
+        fi
+        # Capture the producer's status before filtering its header. A pipeline
+        # ending in a successful filter must never turn a failed codec green.
+        awk -F, -v lang="$lang" '
+            /^lang,bench,path,/ || /^#/ || !NF {next}
+            NF != 17 || $1 != lang || $2 != "bench_table" || $13 != "table" {exit 1}
+            $3 == "write" {write++; print; next}
+            $3 == "round_trip" {trip++; print; next}
+            {exit 1}
+            END {if (write != 1 || trip != 1) exit 1}
+        ' "$PASS_DIR/leg.csv" >> "$ROUND_FILE" || {
+            echo "FAIL $lang: expected one write and one round_trip table row" >&2; exit 1;
+        }
+    done
+    r=$((r + 1))
+done
+
+if [ "$ROUNDS" = 1 ]; then
+    cat "$PASS_DIR/round-0.csv" >> "$DRAFT"
+else
+    # Reuse the packet pass's identity checks and statistical aggregation.
+    go run ./bench/tools aggregate "$PASS_DIR"/round-*.csv >> "$DRAFT"
+fi
+if [ "$BARE" = 1 ]; then
+    cat "$DRAFT"
+else
+    # Same-filesystem link is non-replacing, unlike a final mv after a stale
+    # existence check. A failed or interrupted pass leaves no results CSV.
+    ln "$DRAFT" "$OUT"
+    echo "wrote $OUT" >&2
+fi

--- a/bench/tools/table_pass_test.go
+++ b/bench/tools/table_pass_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These are synthetic runner-repair checks, with no codecs, clocked workload or
+// benchmark result. The existing aggregate tests cover the statistics separately.
+func tablePassFixture(t *testing.T, fail string) (string, []string) {
+	t.Helper()
+	root := t.TempDir()
+	script, err := os.ReadFile("../tables/run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("bench/tables/run.sh", string(script))
+	for _, lang := range []string{"c", "cpp"} {
+		write("bench/tables/"+lang+"/leg", "#!/bin/sh\necho '"+lang+" '"+"\"$*\" >> events\n"+
+			"[ \"$1\" = build ] && exit 0\n"+
+			"echo '"+lang+",bench_table,write,1,10,1,1,1,1,1,0,0123456789abcdef,table,hdr,contract,O3,unknown'\n"+
+			"echo '"+lang+",bench_table,round_trip,1,10,1,1,1,1,1,0,0123456789abcdef,table,hdr,contract,O3,unknown'\n"+
+			"[ '"+lang+"' = '"+fail+"' ] && exit 1\nexit 0\n")
+	}
+	// An aggregation stub keeps this test about orchestration, not Go startup.
+	write("bin/go", "#!/bin/sh\nshift 3\ncat \"$@\"\n")
+	env := append(os.Environ(), "PATH="+filepath.Join(root, "bin")+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return root, env
+}
+
+func TestTablePassInterleavesAfterEveryBuild(t *testing.T) {
+	root, env := tablePassFixture(t, "")
+	cmd := exec.Command("sh", "bench/tables/run.sh", "--only", "c,cpp", "--rounds", "2", "--bare")
+	cmd.Dir, cmd.Env = root, env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v: %s", err, out)
+	}
+	events, err := os.ReadFile(filepath.Join(root, "events"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "c build\ncpp build\nc run --csv --round 0\ncpp run --csv --round 0\nc run --csv --round 1\ncpp run --csv --round 1\n"
+	if string(events) != want {
+		t.Fatalf("order:\n%s\nwant:\n%s", events, want)
+	}
+}
+
+func TestTablePassRefusesFailedProducerWithoutPublishingRows(t *testing.T) {
+	root, env := tablePassFixture(t, "cpp")
+	cmd := exec.Command("sh", "bench/tables/run.sh", "--only", "c,cpp", "--bare")
+	cmd.Dir, cmd.Env = root, env
+	var stdout, stderr strings.Builder
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("failed producer was accepted")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("partial pass published rows: %s", stdout.String())
+	}
+}
+
+func TestTablePassRequiresEveryRequestedLanguage(t *testing.T) {
+	root, env := tablePassFixture(t, "")
+	cmd := exec.Command("sh", "bench/tables/run.sh", "--only", "c,cpp,cs", "--bare")
+	cmd.Dir, cmd.Env = root, env
+	if out, err := cmd.CombinedOutput(); err == nil || !strings.Contains(string(out), "requested leg cs is unavailable") {
+		t.Fatalf("missing language: err=%v output=%s", err, out)
+	}
+	events, _ := os.ReadFile(filepath.Join(root, "events"))
+	if strings.Contains(string(events), " run ") {
+		t.Fatalf("started timing before discovering a missing leg: %s", events)
+	}
+}

--- a/test/conformance/harness/registry_test.go
+++ b/test/conformance/harness/registry_test.go
@@ -51,7 +51,8 @@ func TestRegistryDiscoversAPlantedLanguage(t *testing.T) {
 	writeFile(t, filepath.Join(tree, "test", "conformance", "zz", "ci.json"),
 		`{"targets": "build/conformance-harness build/conformance-zz", "zztool": "1.0"}`+"\n")
 	writeExec(t, filepath.Join(tree, "bench", "tables", "zz", "leg"),
-		"#!/bin/sh\ncase \"$1\" in\nbuild) exit 0 ;;\nrun) echo 'zz,bench_table,write,1,1,1,1,1,1,1,0,0,table,pkg,contract,default,unknown' ;;\nesac\n")
+		"#!/bin/sh\ncase \"$1\" in\nbuild) exit 0 ;;\nrun) echo 'zz,bench_table,write,1,1,1,1,1,1,1,0,0,table,pkg,contract,default,unknown'\n"+
+			"echo 'zz,bench_table,round_trip,1,1,1,1,1,1,1,0,0,table,pkg,contract,default,unknown' ;;\nesac\n")
 	writeFile(t, filepath.Join(tree, "make", "zz.mk"), strings.Join([]string{
 		".PHONY: test-zz update-goldens-zz",
 		"test-zz: ;",


### PR DESCRIPTION
The fixed-table pass could report success when a codec runner failed, because the exit status came from its output filter. Its advertised interleaved rounds also ran every round for one language before advancing to the next.

This change captures and checks each producer, builds all selected languages before timing, requires every explicitly selected language, validates both measurement rows, interleaves by round and uses the existing packet statistics aggregator. No incomplete CSV is published. C/C++/C# gain the same no-timing corpus gate already available in Go. C# builds without a shared compiler server. The existing schema and golden data remain unchanged apart from explanatory comments.

The documented first pass is C, C++, C# and Go over the representative fixed TableMixed corpus. The performance target is the fastest correct implementation for each language. Documentation records the current 2,147-byte records and the retained corpus's older wide-scalar substitutions, with variable/message/block/cooked profiles as later work.

Validation: all four release builds and no-timing golden/64-variant round-trip checks passed on arm64 macOS, corpus b51387f36d9b59c4. The corpus producer verified 64 records of 2,147 bytes. Benchmark-tools tests passed, including synthetic checks for interleaving, a failed producer and a missing selected language; the three orchestration checks passed again after tightening row validation. Shape gate passed. C/C++ compile at O3 with strict warnings and floating-point contraction disabled; .NET SDK 10.0.400.

The timed four-language result and independent review are pending. No broad table or packet certification is implied by these focused benchmark checks.
