### PR TITLE
Restore empty table defaults in C++ packet closure types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check out the C, C++ and Go serialize runtimes (pinned releases)
+      - name: Check out the C, C++, C# and Go serialize runtimes (pinned releases)
         run: |
           cd ..
           git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"   https://github.com/mas-bandwidth/serialize.git   serialize
           git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG" https://github.com/mas-bandwidth/serialize.c.git serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
           git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -223,9 +224,9 @@ jobs:
   # moment it joins one of them, with no edit to this file. Locally the same
   # check is those two targets and the same `git diff`.
   #
-  # ONE SIBLING, ../serialize, because the legs that write the wire pins are the
-  # C++ reference's and every other language's half of `update-goldens` is
-  # `bin/schema generate` and a copy. Its pin is the shared SERIALIZE_TAG above.
+  # The C++ reference writes the wire pins. The Go and C# sibling runtimes
+  # supply the generated-code fixtures in update-goldens' closing compiler
+  # tests. Each checkout uses its shared release pin above.
   #
   # MEASURED at 1m44s on the run that introduced it (34113070433), against
   # 4m27s for big-endian in the same run: this job is inside the two-minute
@@ -239,10 +240,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check out the C++ and Go serialize runtimes (pinned releases)
+      - name: Check out the C++, C# and Go serialize runtimes (pinned releases)
         run: |
           cd ..
           git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
           git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/compiler/tableclosuredefaults_test.go
+++ b/compiler/tableclosuredefaults_test.go
@@ -121,6 +121,7 @@ using namespace probe;
 #define RESET(v) RootReset(v)
 #define JSON(v,b,n,r) RootFromJson(v,b,n,r)
 #define LEAF_LOAD(v,b,n,r) LeafLoad(v,b,n,r)
+#define REPORT_RESET(v) ((v) = TableReport())
 #else
 #define LOAD(v,b,n,r) root_load(&(v),b,n,r)
 #define SAVE(v,b,n) root_save(&(v),b,n)
@@ -128,6 +129,7 @@ using namespace probe;
 #define RESET(v) root_reset(&(v))
 #define JSON(v,b,n,r) root_from_json(&(v),b,n,r)
 #define LEAF_LOAD(v,b,n,r) leaf_load(&(v),b,n,r)
+#define REPORT_RESET(v) memset(&(v),0,sizeof(v))
 #endif
 int main(void) {
  const uint8_t empty[] = {@EMPTY@}, full[] = {@FULL@};
@@ -139,14 +141,14 @@ int main(void) {
  Payload packet;
  CHECK(packet.leaf.values_count == 1 && packet.rows_count == 1 && packet.rows[1].values_count == 1);
 #endif
- memset(&report,0,sizeof(report));
+ REPORT_RESET(report);
  CHECK(LEAF_LOAD(leaf,empty,sizeof(empty),&report));
  CHECK(leaf.values_count == 0 && leaf.marker == 7);
  for(int i=0;i<8;i++) {
   const int populated = !(i&1);
   const uint8_t *wire = populated ? full : empty;
   const int64_t size = populated ? sizeof(full) : sizeof(empty);
-  memset(&report,0,sizeof(report));
+  REPORT_RESET(report);
   CHECK(LOAD(value,wire,size,&report));
   CHECK(!report.malformed && !report.refused && !report.unknown && !report.kind_mismatch && !report.clamped && !report.widened && !report.duplicate);
   CHECK(value.payload.leaf.values_count == (populated ? 1 : 0));
@@ -158,7 +160,7 @@ int main(void) {
  }
  RESET(value);
  CHECK(MEASURE(value)==sizeof(empty) && SAVE(value,saved,sizeof(saved))==sizeof(empty) && !memcmp(saved,empty,sizeof(empty)));
- memset(&report,0,sizeof(report));
+ REPORT_RESET(report);
  CHECK(JSON(value,"{}",2,&report) && !report.malformed);
  CHECK(value.payload.leaf.values_count==0 && value.payload.rows_count==0 && MEASURE(value)==sizeof(empty));
 #ifdef __cplusplus

--- a/compiler/tableclosuredefaults_test.go
+++ b/compiler/tableclosuredefaults_test.go
@@ -1,0 +1,228 @@
+package compiler
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
+	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
+)
+
+// Packet construction starts a positive-minimum count at that minimum (SPEC
+// 4.2). Table readers instead restore an absent array as empty: the file writer
+// elides count zero (SPEC-TABLES 3, 4). A closure type's packet constructor must
+// not change what an empty table means, including through nested backing slots.
+func TestTableClosureCountDefaults(t *testing.T) {
+	u := unitFromSource(t, `package probe
+enum Key { First, Second }
+type Leaf {
+ values [1..2]uint8
+ marker uint8 = 7
+ keyed [Key]uint8
+}
+type Payload {
+ leaf Leaf
+ rows [1..2]Leaf
+}
+table Root {
+ payload Payload
+ keyed [Key]uint8
+}
+`)
+	model := tabletext.NewModel(u)
+	value := model.New(u.Tables["Root"])
+	empty := []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0} // form, terminator, zero trailer entries
+	got, err := tablewire.Encode(model, value)
+	if err != nil || !bytes.Equal(got, empty) {
+		t.Fatalf("default table: %x, %v; want %x", got, err, empty)
+	}
+	var report tabletext.Report
+	if !model.Read(value, []byte(`{"payload":{"leaf":{"values":[9]},"rows":[{"values":[4,5]}]}}`), &report) {
+		t.Fatal(report)
+	}
+	full, err := tablewire.Encode(model, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, lang := range []string{"cpp", "c", "go", "cs"} {
+		t.Run(lang, func(t *testing.T) {
+			files, err := New().Generate(u, lang, Options{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := t.TempDir()
+			write := func(name, source string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(source), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for name, source := range files {
+				write(name, string(source))
+			}
+			replace := strings.NewReplacer("@EMPTY@", cppWire(empty), "@FULL@", cppWire(full))
+			switch lang {
+			case "cpp", "c":
+				cc, ext := "c++", ".cpp"
+				if lang == "c" {
+					cc, ext = "cc", ".c"
+				}
+				issue715CompileRun(t, dir, cc, ext, replace.Replace(tableClosureDefaultsC))
+			case "go":
+				runtime, err := filepath.Abs("../../serialize.go")
+				if err != nil {
+					t.Fatal(err)
+				}
+				write("go.mod", fmt.Sprintf("module probe\n\ngo 1.26\n\nrequire github.com/mas-bandwidth/serialize.go v0.0.0\nreplace github.com/mas-bandwidth/serialize.go => %q\n", runtime))
+				write("defaults_test.go", replace.Replace(tableClosureDefaultsGo))
+				cmd := exec.Command("go", "test", "-count=1", ".")
+				cmd.Dir = dir
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("generated Go: %v\n%s", err, out)
+				}
+			case "cs":
+				dotnet := findDotnet()
+				if dotnet == "" {
+					t.Skip("dotnet unavailable")
+				}
+				runtime, err := filepath.Abs("../../serialize.cs")
+				if err != nil {
+					t.Fatal(err)
+				}
+				write("defaults.csproj", `<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType><AllowUnsafeBlocks>true</AllowUnsafeBlocks></PropertyGroup>
+<ItemGroup><Compile Include="`+filepath.ToSlash(runtime)+`/src/Serialize.cs" /><Compile Include="`+filepath.ToSlash(runtime)+`/src/Int128Pair.cs" /></ItemGroup>
+</Project>`)
+				write("Program.cs", replace.Replace(tableClosureDefaultsCS))
+				cmd := exec.Command(dotnet, "run", "--configuration", "Release", "-property:UseSharedCompilation=false")
+				cmd.Dir = dir
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("generated C#: %v\n%s", err, out)
+				}
+			}
+		})
+	}
+}
+
+const tableClosureDefaultsC = `#include "ProbeTable.h"
+#include <stdio.h>
+#include <string.h>
+#define CHECK(x) do { if (!(x)) { fprintf(stderr,"line %d: %s\n",__LINE__,#x); return 1; } } while(0)
+#ifdef __cplusplus
+using namespace probe;
+#define LOAD(v,b,n,r) RootLoad(v,b,n,r)
+#define SAVE(v,b,n) RootSave(v,b,n)
+#define MEASURE(v) RootMeasure(v)
+#define RESET(v) RootReset(v)
+#define JSON(v,b,n,r) RootFromJson(v,b,n,r)
+#define LEAF_LOAD(v,b,n,r) LeafLoad(v,b,n,r)
+#else
+#define LOAD(v,b,n,r) root_load(&(v),b,n,r)
+#define SAVE(v,b,n) root_save(&(v),b,n)
+#define MEASURE(v) root_measure(&(v))
+#define RESET(v) root_reset(&(v))
+#define JSON(v,b,n,r) root_from_json(&(v),b,n,r)
+#define LEAF_LOAD(v,b,n,r) leaf_load(&(v),b,n,r)
+#endif
+int main(void) {
+ const uint8_t empty[] = {@EMPTY@}, full[] = {@FULL@};
+ uint8_t saved[sizeof(full)];
+ Root value;
+ Leaf leaf;
+ TableReport report;
+#ifdef __cplusplus
+ Payload packet;
+ CHECK(packet.leaf.values_count == 1 && packet.rows_count == 1 && packet.rows[1].values_count == 1);
+#endif
+ memset(&report,0,sizeof(report));
+ CHECK(LEAF_LOAD(leaf,empty,sizeof(empty),&report));
+ CHECK(leaf.values_count == 0 && leaf.marker == 7);
+ for(int i=0;i<8;i++) {
+  const int populated = !(i&1);
+  const uint8_t *wire = populated ? full : empty;
+  const int64_t size = populated ? sizeof(full) : sizeof(empty);
+  memset(&report,0,sizeof(report));
+  CHECK(LOAD(value,wire,size,&report));
+  CHECK(!report.malformed && !report.refused && !report.unknown && !report.kind_mismatch && !report.clamped && !report.widened && !report.duplicate);
+  CHECK(value.payload.leaf.values_count == (populated ? 1 : 0));
+  CHECK(value.payload.rows_count == (populated ? 1 : 0));
+  CHECK(value.payload.rows[0].values_count == (populated ? 2 : 0));
+  CHECK(value.payload.rows[1].values_count == 0 && value.payload.rows[1].marker == 7);
+  CHECK(value.payload.leaf.marker == 7 && value.payload.rows[0].marker == 7);
+  CHECK(MEASURE(value)==size && SAVE(value,saved,sizeof(saved))==size && !memcmp(saved,wire,(size_t)size));
+ }
+ RESET(value);
+ CHECK(MEASURE(value)==sizeof(empty) && SAVE(value,saved,sizeof(saved))==sizeof(empty) && !memcmp(saved,empty,sizeof(empty)));
+ memset(&report,0,sizeof(report));
+ CHECK(JSON(value,"{}",2,&report) && !report.malformed);
+ CHECK(value.payload.leaf.values_count==0 && value.payload.rows_count==0 && MEASURE(value)==sizeof(empty));
+#ifdef __cplusplus
+ // The same reset serves message loads and public file-open failure paths.
+ TableMessageEntry entries[kTableMessageEntriesHere];
+ TableVocabulary vocabulary(entries,kTableMessageEntriesHere);
+ CHECK(AnnounceRead(vocabulary,kTableAnnounce,kTableAnnounceBytes,NULL));
+ const uint8_t message[]={2,0,0}; // form 2, one body, zero reference and padding
+ int64_t count=1;
+ value.payload=Payload();
+ CHECK(RootLoadMessages(&value,&count,vocabulary,message,sizeof(message),&report) && count==1);
+ CHECK(value.payload.leaf.values_count==0 && value.payload.rows_count==0 && value.payload.rows[1].values_count==0);
+ CHECK(RootSaveMessages(&value,1,saved,sizeof(saved),&report)==sizeof(message) && !memcmp(saved,message,sizeof(message)));
+ value.payload=Payload();
+ CHECK(!RootLoad(value,empty,0,&report) && report.malformed);
+ CHECK(value.payload.leaf.values_count==0 && value.payload.rows_count==0);
+#endif
+ return 0;
+}
+`
+
+const tableClosureDefaultsGo = `package probe
+import("bytes";"testing")
+func TestDefaults(t *testing.T) {
+ empty, full := []byte{@EMPTY@}, []byte{@FULL@}
+ var value Root
+ var leaf Leaf
+ var report TableReport
+ if !LeafLoad(&leaf,empty,&report) || leaf.ValuesCount!=0 || leaf.Marker!=7 {t.Fatalf("leaf defaults: %+v",leaf)}
+ for i:=0;i<8;i++ {
+  wire:=empty; a,b:=int32(0),int32(0)
+  if i%2==0 {wire=full;a=1;b=2}
+  report=TableReport{}
+  if !RootLoad(&value,wire,&report)||report!=(TableReport{}) {t.Fatalf("load: %+v",report)}
+  p:=&value.Payload
+  if p.Leaf.ValuesCount!=a || p.RowsCount!=a || p.Rows[0].ValuesCount!=b || p.Rows[1].ValuesCount!=0 || p.Leaf.Marker!=7 || p.Rows[0].Marker!=7 || p.Rows[1].Marker!=7 {t.Fatalf("defaults: %+v",p)}
+  saved:=make([]byte,len(wire))
+  if RootMeasure(&value)!=int64(len(wire)) || RootSave(&value,saved)!=int64(len(wire)) || !bytes.Equal(saved,wire) {t.Fatal("wire mismatch")}
+ }
+ RootReset(&value)
+ if RootMeasure(&value)!=10 {t.Fatal("reset")}
+ if !RootFromJson(&value,[]byte("{}"),&report)||RootMeasure(&value)!=10 {t.Fatal("json defaults")}
+}
+`
+
+const tableClosureDefaultsCS = `using System;
+using Probe;
+class Program {
+ static void Check(bool ok) {if(!ok)throw new Exception("table closure defaults");}
+ static void Main() {
+  byte[] empty={@EMPTY@},full={@FULL@};
+  var value=new Root();var leaf=new Leaf();var report=new TableReport();
+  Check(Schema.LeafLoad(leaf,empty,report)&&leaf.ValuesCount==0&&leaf.Marker==7);
+  for(int i=0;i<8;i++) {
+   bool populated=i%2==0;var wire=populated?full:empty;report=new TableReport();
+   Check(Schema.RootLoad(value,wire,report)&&!report.Malformed&&!report.Refused&&report.Unknown==0&&report.KindMismatch==0&&report.Clamped==0&&report.Widened==0&&report.Duplicate==0);
+   var p=value.Payload;
+   Check(p.Leaf.ValuesCount==(populated?1:0)&&p.RowsCount==(populated?1:0)&&p.Rows[0].ValuesCount==(populated?2:0)&&p.Rows[1].ValuesCount==0);
+   Check(p.Leaf.Marker==7&&p.Rows[0].Marker==7&&p.Rows[1].Marker==7);
+   var saved=new byte[wire.Length];
+   Check(Schema.RootMeasure(value)==wire.Length&&Schema.RootSave(value,saved)==wire.Length&&saved.AsSpan().SequenceEqual(wire));
+  }
+  Schema.TableReset(value);Check(Schema.RootMeasure(value)==10);
+  Check(Schema.RootFromJson(value,new byte[]{123,125},report)&&Schema.RootMeasure(value)==10);
+ }
+}
+`

--- a/generated/bench/paired/cpp/BenchTable.h
+++ b/generated/bench/paired/cpp/BenchTable.h
@@ -2370,17 +2370,86 @@ inline void MixedChatEventReset( MixedChatEvent & value );
 inline void MixedPickupEventReset( MixedPickupEvent & value );
 inline void BenchMixedReset( BenchMixed & value );
 
-inline void MixedEntityReset( MixedEntity & value ) { value = MixedEntity(); }
+inline void MixedEntityReset( MixedEntity & value )
+{
+    value.entity_id = 0;
+    value.pos_x = 0;
+    value.pos_y = 0;
+    value.pos_z = 0;
+    value.yaw = 0;
+    value.pitch = 0;
+    value.vel_x = 0;
+    value.vel_y = 0;
+    value.vel_z = 0;
+    value.health = 0;
+    value.weapon = MixedWeapon::None;
+    value.damage = 0;
+    value.moving = false;
+    value.firing = false;
+}
 
-inline void MixedStatReset( MixedStat & value ) { value = MixedStat(); }
+inline void MixedStatReset( MixedStat & value )
+{
+    value.stat_id = 0;
+    value.delta = 0;
+}
 
-inline void MixedHitEventReset( MixedHitEvent & value ) { value = MixedHitEvent(); }
+inline void MixedHitEventReset( MixedHitEvent & value )
+{
+    value.target_id = 0;
+    value.damage = 0;
+    value.hit_kind = 0;
+    value.crit = false;
+}
 
-inline void MixedChatEventReset( MixedChatEvent & value ) { value = MixedChatEvent(); }
+inline void MixedChatEventReset( MixedChatEvent & value )
+{
+    value.channel = 0;
+    value.speaker = 0;
+}
 
-inline void MixedPickupEventReset( MixedPickupEvent & value ) { value = MixedPickupEvent(); }
+inline void MixedPickupEventReset( MixedPickupEvent & value )
+{
+    value.item_id = 0;
+    value.amount = 0;
+}
 
-inline void BenchMixedReset( BenchMixed & value ) { value = BenchMixed(); }
+inline void BenchMixedReset( BenchMixed & value )
+{
+    value.sequence = 0;
+    value.ack_sequence = 0;
+    value.ack_bits = 0;
+    value.session_id = 0;
+    value.client_id = 0;
+    value.nonce = 0;
+    value.world_time = 0;
+    value.frame_tick = 0;
+    value.server_time = 0;
+    MixedEntityReset( value.entities[0] );
+    for ( int32_t i = 1; i < 8; i++ ) { value.entities[i] = value.entities[0]; }
+    value.entities_count = 0;
+    MixedStatReset( value.stats[0] );
+    for ( int32_t i = 1; i < 80; i++ ) { value.stats[i] = value.stats[0]; }
+    value.stats_count = 0;
+    value.game_event = MixedEvent();
+    memset( value.loadout, 0, sizeof( value.loadout ) );
+    memset( value.player_name, 0, sizeof( value.player_name ) );
+    value.player_name_length = 0;
+    memset( value.payload, 0, sizeof( value.payload ) );
+    value.payload_length = 0;
+    value.aim_x = 0.0f;
+    value.aim_y = 0.0f;
+    value.aim_z = 0.0f;
+    value.recoil = 0.0f;
+    value.drift = 0.0;
+    value.wide_key = 0;
+    value.flux = 0;
+    value.ping = 0;
+    value.crc_hint = 0;
+    value.has_extra = true;
+    value.extra = 0;
+    value.idle_ticks = 0;
+}
 
 inline int64_t MixedEntityMeasureMessageBody( int64_t at, const MixedEntity & value );
 inline bool MixedEntitySaveMessageBody( TableBitWriter & w, const MixedEntity & value );

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -2500,11 +2500,25 @@ inline void TableMixedReset( TableMixed & value )
     value.idle_ticks = 0;
 }
 
-inline void TableHitEventReset( TableHitEvent & value ) { value = TableHitEvent(); }
+inline void TableHitEventReset( TableHitEvent & value )
+{
+    value.target_id = 0;
+    value.damage = 0;
+    value.hit_kind = 0;
+    value.crit = false;
+}
 
-inline void TableChatEventReset( TableChatEvent & value ) { value = TableChatEvent(); }
+inline void TableChatEventReset( TableChatEvent & value )
+{
+    value.channel = 0;
+    value.speaker = 0;
+}
 
-inline void TablePickupEventReset( TablePickupEvent & value ) { value = TablePickupEvent(); }
+inline void TablePickupEventReset( TablePickupEvent & value )
+{
+    value.item_id = 0;
+    value.amount = 0;
+}
 
 inline int64_t TableEntityMeasureMessageBody( int64_t at, const TableEntity & value );
 inline bool TableEntitySaveMessageBody( TableBitWriter & w, const TableEntity & value );

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -347,13 +347,13 @@ func (g *tableGen) emitTableResetDeclarations(members []*ir.Struct) {
 }
 
 func (g *tableGen) emitTableReset(st *ir.Struct) {
-	if !st.IsTable {
-		// a closure `type` is declared in <Base>.h and bounded by a packet: one
-		// value-init says exactly what its own initializers say, and costs the
-		// size of a packet field to compile
-		g.pf("inline void %sReset( %s & value ) { value = %s(); }\n\n", st.Name, st.Name, st.Name)
-		return
-	}
+	owner := g.owner
+	g.owner = st
+	defer func() { g.owner = owner }()
+	// A closure `type` shares packet storage, but table defaults are this
+	// wire's: an absent counted array is empty even when its packet constructor
+	// starts at a positive minimum. Reset members through the table rules so
+	// that distinction also reaches nested values and every backing array slot.
 	g.pf("inline void %sReset( %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value;\n")
@@ -410,7 +410,7 @@ func (g *tableGen) emitTableResetField(f *ir.Field) {
 		g.pf("    memset( value.%s, 0, sizeof( value.%s ) );\n", f.Name, f.Name)
 		g.pf("    value.%s_length = 0;\n", f.Name)
 	case f.KeyEnum != "":
-		g.emitTableResetArray("value."+f.Name+".slots", f.ArrayBound, typ, selfInit, f)
+		g.emitTableResetArray(g.keyedSlots("value.", f), f.ArrayBound, typ, selfInit, f)
 	case f.Array == ir.ArrayFixed:
 		g.emitTableResetArray("value."+f.Name, f.ArrayBound, typ, selfInit, f)
 	case f.Array == ir.ArrayCounted:

--- a/internal/codegen/cpptable/maps.go
+++ b/internal/codegen/cpptable/maps.go
@@ -1011,8 +1011,11 @@ func (g *tableGen) mapValueStorageType(f *ir.Field) string {
 func (g *tableGen) emitMapValueReset(f *ir.Field) {
 	value := ir.MapValueField(f)
 	saved := g.indent
+	owner := g.owner
 	g.indent = ""
+	g.owner = mapEntryOf(f)
 	g.emitTableResetField(value)
+	g.owner = owner
 	g.indent = saved
 }
 

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -3012,9 +3012,20 @@ inline void RenderFrameReset( RenderFrame & value )
     value.explosions_count = 0;
 }
 
-inline void RenderVector3Reset( RenderVector3 & value ) { value = RenderVector3(); }
+inline void RenderVector3Reset( RenderVector3 & value )
+{
+    value.x = 0.0;
+    value.y = 0.0;
+    value.z = 0.0;
+}
 
-inline void RenderQuaternionReset( RenderQuaternion & value ) { value = RenderQuaternion(); }
+inline void RenderQuaternionReset( RenderQuaternion & value )
+{
+    value.x = 0.0;
+    value.y = 0.0;
+    value.z = 0.0;
+    value.w = 1.0;
+}
 
 inline int64_t RenderCameraMeasureMessageBody( int64_t at, const RenderCamera & value );
 inline bool RenderCameraSaveMessageBody( TableBitWriter & w, const RenderCamera & value );

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -2190,13 +2190,38 @@ inline void ArmorConfigReset( ArmorConfig & value );
 inline void FiringGroupReset( FiringGroup & value );
 inline void GunnerSettingsReset( GunnerSettings & value );
 
-inline void ArmorPlateReset( ArmorPlate & value ) { value = ArmorPlate(); }
+inline void ArmorPlateReset( ArmorPlate & value )
+{
+    value.thickness = 0.0;
+    value.material = 0;
+    value.layer = 0;
+}
 
-inline void ArmorConfigReset( ArmorConfig & value ) { value = ArmorConfig(); }
+inline void ArmorConfigReset( ArmorConfig & value )
+{
+    ArmorPlateReset( value.front );
+    ArmorPlateReset( value.rear );
+    value.rating = 0.0f;
+    value.tier = 0;
+}
 
-inline void FiringGroupReset( FiringGroup & value ) { value = FiringGroup(); }
+inline void FiringGroupReset( FiringGroup & value )
+{
+    value.barrel = 0;
+    value.cooldown = 0.0f;
+}
 
-inline void GunnerSettingsReset( GunnerSettings & value ) { value = GunnerSettings(); }
+inline void GunnerSettingsReset( GunnerSettings & value )
+{
+    FiringGroupReset( value.firing_groups[0] );
+    for ( int32_t i = 1; i < 32; i++ ) { value.firing_groups[i] = value.firing_groups[0]; }
+    value.firing_groups_count = 0;
+    FiringGroupReset( value.missile_groups[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.missile_groups[i] = value.missile_groups[0]; }
+    value.missile_groups_count = 0;
+    value.reload_seconds = 0.0f;
+    value.gunner_id = 0;
+}
 
 inline int64_t ArmorPlateMeasureMessageBody( int64_t at, const ArmorPlate & value );
 inline bool ArmorPlateSaveMessageBody( TableBitWriter & w, const ArmorPlate & value );

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -2701,7 +2701,10 @@ inline void KeyedConfigReset( KeyedConfig & value )
     ScoreBoardReset( value.scores );
 }
 
-inline void ScoreBoardReset( ScoreBoard & value ) { value = ScoreBoard(); }
+inline void ScoreBoardReset( ScoreBoard & value )
+{
+    memset( value.per_team, 0, sizeof( value.per_team ) );
+}
 
 inline int64_t TeamConfigMeasureMessageBody( int64_t at, const TeamConfig & value );
 inline bool TeamConfigSaveMessageBody( TableBitWriter & w, const TeamConfig & value );

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -2618,11 +2618,21 @@ inline void RootConfigReset( RootConfig & value )
     value.profiles_count = 0;
 }
 
-inline void AttachmentReset( Attachment & value ) { value = Attachment(); }
+inline void AttachmentReset( Attachment & value )
+{
+    value.slot = 0;
+    value.power = 1.0f;
+}
 
-inline void BuffReset( Buff & value ) { value = Buff(); }
+inline void BuffReset( Buff & value )
+{
+    value.multiplier = 1.0f;
+}
 
-inline void DebuffReset( Debuff & value ) { value = Debuff(); }
+inline void DebuffReset( Debuff & value )
+{
+    value.amount = 0;
+}
 
 inline int64_t WeaponConfigMeasureMessageBody( int64_t at, const WeaponConfig & value );
 inline bool WeaponConfigSaveMessageBody( TableBitWriter & w, const WeaponConfig & value );

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -2633,9 +2633,16 @@ inline void ToolMessageReset( ToolMessage & value )
     value.marks_present = false;
 }
 
-inline void CursorReset( Cursor & value ) { value = Cursor(); }
+inline void CursorReset( Cursor & value )
+{
+    value.line = 0;
+    value.column = 0;
+}
 
-inline void PingReset( Ping & value ) { value = Ping(); }
+inline void PingReset( Ping & value )
+{
+    value.nonce = 0;
+}
 
 inline int64_t UserMeasureMessageBody( int64_t at, const User & value );
 inline bool UserSaveMessageBody( TableBitWriter & w, const User & value );

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -5106,7 +5106,12 @@ inline void StampReset( Stamp & value )
     value.seq = 0;
 }
 
-inline void ColourReset( Colour & value ) { value = Colour(); }
+inline void ColourReset( Colour & value )
+{
+    value.r = 0;
+    value.g = 0;
+    value.b = 0;
+}
 
 inline int64_t StampMeasureMessageBody( int64_t at, const Stamp & value );
 inline bool StampSaveMessageBody( TableBitWriter & w, const Stamp & value );

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -2462,7 +2462,12 @@ inline void SimStateReset( SimState & value )
     value.spawn_present = false;
 }
 
-inline void PoseReset( Pose & value ) { value = Pose(); }
+inline void PoseReset( Pose & value )
+{
+    value.x = 32768ll;
+    value.y = 0;
+    value.heading = 0;
+}
 
 inline int64_t SimStateMeasureMessageBody( int64_t at, const SimState & value );
 inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value );

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -2265,7 +2265,11 @@ inline void StampReset( Stamp & value )
     value.seq = 0;
 }
 
-inline void LineReset( Line & value ) { value = Line(); }
+inline void LineReset( Line & value )
+{
+    memset( value.text, 0, sizeof( value.text ) );
+    value.text_length = 0;
+}
 
 inline int64_t CaptionMeasureMessageBody( int64_t at, const Caption & value );
 inline bool CaptionSaveMessageBody( TableBitWriter & w, const Caption & value );

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -2265,7 +2265,11 @@ inline void StampReset( Stamp & value )
     value.seq = 0;
 }
 
-inline void LineReset( Line & value ) { value = Line(); }
+inline void LineReset( Line & value )
+{
+    memset( value.text, 0, sizeof( value.text ) );
+    value.text_length = 0;
+}
 
 inline int64_t CaptionMeasureMessageBody( int64_t at, const Caption & value );
 inline bool CaptionSaveMessageBody( TableBitWriter & w, const Caption & value );


### PR DESCRIPTION
An empty table loaded into a C++ packet type with a positive-minimum counted array restored the packet constructor's minimum count instead of the table default of zero. Saving that value could therefore add a field that was absent from the input. C, Go and C# already preserve the empty table correctly.

Generate the existing memberwise table reset for packet types reached by tables, including nested values and backing slots. Preserve owner context so enum-keyed packet arrays and table/map storage use their correct layout. Packet constructors keep their packet defaults.

Validation: the new generated C/C++/Go/C# regression fails before the fix only in C++ and passes afterward. It covers literal empty and independent populated wires, reused targets, nested defaults, exact Measure/Save bytes and JSON reset; C++ also checks message loads and failed opens. The short compiler/tablewire/tabletext suite, regular and ASan/UBSan C++ table suites, and all 64 paired corpus records pass. The actual generated BenchMixed smoke confirms packet construction count 1, empty table load count 0, and an exact ten-byte re-save.
