### PR TITLE
C++ tables: the reader resolves the trailer into compile-time slots at open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3072,6 +3072,17 @@ test: toolchain build/schema_test build/schema_test_guard build/schema_test_tabl
 	$(MAKE) projection-union-arm-order-negative-control
 	./build/schema_test_tables
 	./build/schema_test_tables_asan
+	# THE ID TABLE'S DISTINCTNESS AND RESOLVE GATE (docs/SPEC-TABLES.md §3):
+	# TableOpen answers "one id in two entries" three ways and resolves every
+	# entry into a compile-time slot, and the corpus above takes only one of
+	# those ways, so the gate below builds the other tables by hand and holds
+	# every verdict against a pairwise reference and every slot against the
+	# hash. Its controls remove each structure's own test and require the gate
+	# to go red on that structure's cases.
+	$(MAKE) tables-distinctness
+	$(MAKE) tables-distinctness-negative-control
+	$(MAKE) tables-slot-bitmap-negative-control
+	$(MAKE) tables-slot-resolve-negative-control
 	# THE WIRE FUZZER (docs/SPEC-TABLES.md §4.2): the tolerant read on hostile
 	# bytes against the engine, plain and sanitized, at a short random pass —
 	# the enumerated passes run whole whatever N is — and its two controls at
@@ -4466,6 +4477,128 @@ build/wire-fuzz-cpp-asan: build/tables-generated/.stamp test/tables/wire_fuzz_ma
 	$(CXX) $(TABLES_CXXFLAGS) -O1 -fsanitize=address,undefined -fno-sanitize-recover=all \
 		-fno-omit-frame-pointer -g $(CONFORMANCE_INCLUDES) test/tables/wire_fuzz_main.cpp \
 		$(CONFORMANCE_SOURCES) -o $@
+
+# THE ID TABLE'S DISTINCTNESS AND RESOLVE GATE (docs/SPEC-TABLES.md §3): a
+# table that carries one id twice is malformed, and TableOpen answers that
+# question with THREE structures — a bitmap over the compile-time SLOTS for
+# every id this build can name, a hashed PROBE over a stack array for the
+# foreign subset, and the pairwise walk above kTableIdRefBound. The property is
+# that a READER CANNOT TELL WHICH ONE RAN, and a corpus cannot say so on its
+# own, because every table this schema writes is small and every id in it is
+# one this build names. So this gate builds tables BY HAND, drives TableOpen
+# directly and compares every verdict against an independent pairwise
+# reference: both sides of the bound, a repeat planted at every position, the
+# known set and the foreign set separately and interleaved, the three reserved
+# ids, and the ALL-COLLIDING tables a hostile writer builds by inverting each
+# multiply. It also holds the RESOLVE itself: every entry's slot out of the
+# array TableOpen filled must equal the slot the hash gives, on both sides of
+# the bound, and a slot that is not kTableIdSlotUnknown must name that id.
+#
+# It is built THREE ways because the check is READ SIDE and a read-side check
+# never compiles out: the debug build, an NDEBUG release build that has to
+# reach the same verdict on the same bytes, and a sanitized one, for the reason
+# the wire fuzzer carries its own — the probe indexes a stack array.
+# The generated header is the whole dependency, which is also what "the codec
+# is header-only and names no runtime" means when a leg says it.
+.PHONY: tables-distinctness
+tables-distinctness: build/tables-generated/.stamp test/tables/distinct_main.cpp
+	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/tables-generated/examples \
+		test/tables/distinct_main.cpp -o build/schema_test_distinct
+	./build/schema_test_distinct
+	$(CXX) $(TABLES_CXXFLAGS) -DNDEBUG -O2 -Ibuild/tables-generated/examples \
+		test/tables/distinct_main.cpp -o build/schema_test_distinct_ndebug
+	./build/schema_test_distinct_ndebug
+	$(CXX) $(TABLES_CXXFLAGS) -fsanitize=address,undefined -fno-sanitize-recover=all \
+		-fno-omit-frame-pointer -g -Ibuild/tables-generated/examples \
+		test/tables/distinct_main.cpp -o build/schema_test_distinct_asan
+	./build/schema_test_distinct_asan
+	@echo "distinctness gate: one verdict across both walks, debug, release and sanitized"
+
+# ITS NEGATIVE CONTROL. A gate over a check that is correct THREE times cannot
+# be read for which walk earned the green: the pairwise walk alone would answer
+# every case in this test correctly if the bound never sent anything down the
+# fast path. So this removes the PROBE's comparison from a copy of the emitter,
+# leaves the pairwise walk untouched, and requires the gate to go red ON THE
+# PROBE'S OWN CASES — which is also the standing proof that the bound is live.
+# Its sibling below does the same to the SLOT bitmap, which is the structure
+# this change added and the one that carries every id a real wire names.
+.PHONY: tables-distinctness-negative-control
+tables-distinctness-negative-control: bin/schema test/tables/distinct_main.cpp
+	@rm -rf build/distinct-nc && mkdir -p build/distinct-nc
+	@sed -e 's|if ( seen\[p\] == id ) { return TableOpenDamaged; }|if ( false \&\& seen[p] == id ) { return TableOpenDamaged; } // SABOTAGED|' \
+		internal/codegen/cpptable/cpptable.go > build/distinct-nc/cpptable.go.txt
+	@cmp -s build/distinct-nc/cpptable.go.txt internal/codegen/cpptable/cpptable.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/distinct-nc/cpptable.go.txt"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/distinct-nc/overlay.json
+	go build -overlay=build/distinct-nc/overlay.json -o build/distinct-nc/schema ./cmd/schema
+	./build/distinct-nc/schema generate --lang cpp --out build/distinct-nc/examples tables/examples
+	@grep -q SABOTAGED build/distinct-nc/examples/TablesTable.h || \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotaged emitter did not reach the header"; exit 1; }
+	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/distinct-nc/examples \
+		test/tables/distinct_main.cpp -o build/distinct-nc/schema_test_distinct
+	@if ./build/distinct-nc/schema_test_distinct > build/distinct-nc/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the gate stayed green with the probe's comparison removed"; exit 1; \
+	fi
+	@grep -q "^FAIL probe:" build/distinct-nc/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on a probe case"; cat build/distinct-nc/log; exit 1; }
+	@echo "negative control: removing the probe's comparison turns the distinctness gate RED on the probe's own cases"
+
+
+# THE SLOT BITMAP'S OWN NEGATIVE CONTROL. The probe control above proves the
+# FOREIGN walk is live; this one proves the KNOWN walk is, which is the walk
+# every real wire takes, because every id a wire this build wrote carries is
+# one this build names. It removes the bitmap's "already set" test from a copy
+# of the emitter, leaves the probe and the pairwise walk untouched, and
+# requires the gate to go red on a case built out of the known set.
+.PHONY: tables-slot-bitmap-negative-control
+tables-slot-bitmap-negative-control: bin/schema test/tables/distinct_main.cpp
+	@rm -rf build/slotmap-nc && mkdir -p build/slotmap-nc
+	@sed -e 's|if ( ( known\[ s >> 6 \] & bit ) != 0 ) { return TableOpenDamaged; }|if ( false \&\& ( known[ s >> 6 ] \& bit ) != 0 ) { return TableOpenDamaged; } // SABOTAGED|' \
+		internal/codegen/cpptable/cpptable.go > build/slotmap-nc/cpptable.go.txt
+	@cmp -s build/slotmap-nc/cpptable.go.txt internal/codegen/cpptable/cpptable.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/slotmap-nc/cpptable.go.txt"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/slotmap-nc/overlay.json
+	go build -overlay=build/slotmap-nc/overlay.json -o build/slotmap-nc/schema ./cmd/schema
+	./build/slotmap-nc/schema generate --lang cpp --out build/slotmap-nc/examples tables/examples
+	@grep -q SABOTAGED build/slotmap-nc/examples/TablesTable.h || \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotaged emitter did not reach the header"; exit 1; }
+	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/slotmap-nc/examples \
+		test/tables/distinct_main.cpp -o build/slotmap-nc/schema_test_distinct
+	@if ./build/slotmap-nc/schema_test_distinct > build/slotmap-nc/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the gate stayed green with the slot bitmap's test removed"; exit 1; \
+	fi
+	@grep -q "^FAIL known" build/slotmap-nc/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on a known-id case"; cat build/slotmap-nc/log; exit 1; }
+	@echo "negative control: removing the slot bitmap's test turns the distinctness gate RED on the known set's own cases"
+
+# THE RESOLVE'S NEGATIVE CONTROL. The two above prove the distinctness verdict
+# is earned; this one proves the RESOLVE is, which is what every body's
+# dispatch reads. It makes TableOpen leave one entry's slot behind — the
+# resolved array disagreeing with the hash by one position — and requires the
+# gate to go red, which is what says the slot_of check in the gate is live.
+.PHONY: tables-slot-resolve-negative-control
+tables-slot-resolve-negative-control: bin/schema test/tables/distinct_main.cpp
+	@rm -rf build/slotres-nc && mkdir -p build/slotres-nc
+	@sed -e 's|table.slots\[ i + 1 \] = s;|table.slots[ i + 1 ] = i == 0 ? kTableIdSlotUnknown : s; // SABOTAGED|' \
+		internal/codegen/cpptable/cpptable.go > build/slotres-nc/cpptable.go.txt
+	@cmp -s build/slotres-nc/cpptable.go.txt internal/codegen/cpptable/cpptable.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/slotres-nc/cpptable.go.txt"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/slotres-nc/overlay.json
+	go build -overlay=build/slotres-nc/overlay.json -o build/slotres-nc/schema ./cmd/schema
+	./build/slotres-nc/schema generate --lang cpp --out build/slotres-nc/examples tables/examples
+	@grep -q SABOTAGED build/slotres-nc/examples/TablesTable.h || \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotaged emitter did not reach the header"; exit 1; }
+	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/slotres-nc/examples \
+		test/tables/distinct_main.cpp -o build/slotres-nc/schema_test_distinct
+	@if ./build/slotres-nc/schema_test_distinct > build/slotres-nc/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the gate stayed green with one entry's slot dropped"; exit 1; \
+	fi
+	@grep -q "resolved to slot" build/slotres-nc/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on the resolve"; cat build/slotres-nc/log; exit 1; }
+	@echo "negative control: dropping one entry's resolved slot turns the distinctness gate RED on the resolve"
 
 .PHONY: tables-wire-fuzz
 tables-wire-fuzz: build/conformance-harness build/wire-fuzz-cpp build/wire-fuzz-cpp-asan

--- a/generated/bench/paired/cpp/BenchTable.h
+++ b/generated/bench/paired/cpp/BenchTable.h
@@ -378,6 +378,145 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 82;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x0c9cc190eed84e3bull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xaa38aca481f528a8ull, 0x0dbe005c56697c3eull, 0x9bae0da8b829ee03ull, 0xb7d7b5650a590b05ull,
+    0x6d7b98e2d095967eull, 0x73a94c71d60dc0d8ull, 0x3eee6b51be54fc85ull, 0x7bbc035f7b6d0112ull,
+    0x3c460475f9be69c6ull, 0x935d0fb07bb3822aull, 0xee639cad45b1994cull, 0x2e35dc5321aa5790ull,
+    0x5759ce7586bbb5a3ull, 0x13a62f542cf8e86eull, 0xcfb8a9d063b5e9e5ull, 0xdbaf7be5e24296c9ull,
+    0xdbaf7ae5e2429516ull, 0xdbaf79e5e2429363ull, 0x9cef31fff7e2e457ull, 0x5ab3f9c9341f6c04ull,
+    0xa3348580461faf16ull, 0xd61bdd7908af2642ull, 0xbf30e00dc53307a9ull, 0x560d6527ccd8515full,
+    0xc08292176cfd8672ull, 0xfd29ee12a979cb69ull, 0x78101ac0aa8cbcfeull, 0x7ce4fd9430e80ceaull,
+    0xa5013e9ad5caeda4ull, 0xfbf1ac4d96ebd022ull, 0x23fcfd6678e36712ull, 0xcb4b37357667310eull,
+    0xcb4b3835766732c1ull, 0xcb4b353576672da8ull, 0xb54d8e19798e16e8ull, 0x53a9f665a90cc1b1ull,
+    0x6cede6b6eb60ee67ull, 0x6cede5b6eb60ecb4ull, 0x6cede8b6eb60f1cdull, 0x7f69d4b5288ba9cfull,
+    0xa0b610205f2c6e01ull, 0x7f6308be8ab37fc0ull, 0x11a44fc1d1243da7ull, 0x7674cfd19b9031caull,
+    0xb7bc9ac015a25050ull, 0x01fbc365b059b925ull, 0x126167908c9aa52dull, 0x9e7fd06d864fbd56ull,
+    0x8113fe7ea2b16969ull, 0x80ab75f0866dbf65ull, 0x52076675ec13a0c1ull, 0xa790eee12766cf0cull,
+    0x9fbfefa835da8476ull, 0x188bbb1783928a95ull, 0x2c3667b9c2f272f1ull, 0x0ca8b41b00d755f6ull,
+    0x985fc819fab21a4eull, 0x229d0447c3086a55ull, 0x011c7b49a7228f9dull, 0x89f7566e1123e15full,
+    0x8d7f25318b3b4469ull, 0xd9cd0dcc285b7816ull, 0x04dc16aea8ff5276ull, 0x35e53bc341129217ull,
+    0x2cc8282fb0de8831ull, 0x20bada21bc8cb334ull, 0x33732819300680aaull, 0xf2a38d910b5b348bull,
+    0x9fa3a41c86ecb765ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x85df369cdca746b3ull, 0x3d827cb76b809d8cull, 0x9367b84cab99cdc3ull,
+    0x9f2c9da926a7408aull, 0xac9fe3b25a77f1d7ull, 0xc42975bfe5e07baaull, 0xeb80cfd516eb3d5cull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF,    31, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    71,
+    0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    13,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       55, 0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF,    43, 0xFFFF, 0xFFFF, 0xFFFF,    15, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       44, 0xFFFF, 0xFFFF,    76, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    40,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF,
+       58, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       78,     4, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21,    20, 0xFFFF,    19, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+       17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF,    14, 0xFFFF,
+    0xFFFF, 0xFFFF,    65, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF,    74, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF,
+       67, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    81, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF,    70, 0xFFFF,
+    0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF,    36, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    18,    63, 0xFFFF,    28, 0xFFFF, 0xFFFF,    79, 0xFFFF, 0xFFFF,
+    0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    69, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF,    42,    57, 0xFFFF,     3, 0xFFFF,
+        5,    61, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 69;
+static const uint16_t kTableIdSlotBuildVersion = 80;
+static const uint16_t kTableIdSlotVocabulary = 81;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -386,16 +525,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BENCH_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -715,6 +872,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -746,16 +915,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2359,6 +2611,28 @@ inline bool TableEnumValue( uint64_t id, MixedWeapon & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, MixedWeapon & out )
+{
+    switch ( slot )
+    {
+        case 51: out = MixedWeapon::Fists; return true; // id 0xa790eee12766cf0cull
+        case 52: out = MixedWeapon::Pistol; return true; // id 0x9fbfefa835da8476ull
+        case 53: out = MixedWeapon::Shotgun; return true; // id 0x188bbb1783928a95ull
+        case 54: out = MixedWeapon::Rifle; return true; // id 0x2c3667b9c2f272f1ull
+        case 55: out = MixedWeapon::Sniper; return true; // id 0x0ca8b41b00d755f6ull
+        case 56: out = MixedWeapon::Smg; return true; // id 0x985fc819fab21a4eull
+        case 57: out = MixedWeapon::Rocket; return true; // id 0x229d0447c3086a55ull
+        case 58: out = MixedWeapon::Grenade; return true; // id 0x011c7b49a7228f9dull
+        case 59: out = MixedWeapon::Plasma; return true; // id 0x89f7566e1123e15full
+        case 60: out = MixedWeapon::Railgun; return true; // id 0x8d7f25318b3b4469ull
+        case 61: out = MixedWeapon::Flamer; return true; // id 0xd9cd0dcc285b7816ull
+        case 62: out = MixedWeapon::Mine; return true; // id 0x04dc16aea8ff5276ull
+        case 63: out = MixedWeapon::Turret; return true; // id 0x35e53bc341129217ull
+        case 64: out = MixedWeapon::Drone; return true; // id 0x2cc8282fb0de8831ull
+        case 65: out = MixedWeapon::Repair; return true; // id 0x20bada21bc8cb334ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BENCH_SCHEMA_TABLE_ENUM_MIXEDWEAPON
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2556,10 +2830,10 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2570,9 +2844,9 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x23fcfd6678e36712ull: // entity_id
+            case 30: // entity_id, id 0x23fcfd6678e36712ull
             {
                 if ( kind != 7 )
                 {
@@ -2600,7 +2874,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.entity_id = decoded_v;
                 break;
             }
-            case 0xcb4b37357667310eull: // pos_x
+            case 31: // pos_x, id 0xcb4b37357667310eull
             {
                 if ( kind != 4 )
                 {
@@ -2630,7 +2904,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.pos_x = decoded_v;
                 break;
             }
-            case 0xcb4b3835766732c1ull: // pos_y
+            case 32: // pos_y, id 0xcb4b3835766732c1ull
             {
                 if ( kind != 4 )
                 {
@@ -2660,7 +2934,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.pos_y = decoded_v;
                 break;
             }
-            case 0xcb4b353576672da8ull: // pos_z
+            case 33: // pos_z, id 0xcb4b353576672da8ull
             {
                 if ( kind != 4 )
                 {
@@ -2690,7 +2964,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.pos_z = decoded_v;
                 break;
             }
-            case 0xb54d8e19798e16e8ull: // yaw
+            case 34: // yaw, id 0xb54d8e19798e16e8ull
             {
                 if ( kind != 7 )
                 {
@@ -2718,7 +2992,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.yaw = decoded_v;
                 break;
             }
-            case 0x53a9f665a90cc1b1ull: // pitch
+            case 35: // pitch, id 0x53a9f665a90cc1b1ull
             {
                 if ( kind != 7 )
                 {
@@ -2746,7 +3020,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.pitch = decoded_v;
                 break;
             }
-            case 0x6cede6b6eb60ee67ull: // vel_x
+            case 36: // vel_x, id 0x6cede6b6eb60ee67ull
             {
                 if ( kind != 4 )
                 {
@@ -2776,7 +3050,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.vel_x = decoded_v;
                 break;
             }
-            case 0x6cede5b6eb60ecb4ull: // vel_y
+            case 37: // vel_y, id 0x6cede5b6eb60ecb4ull
             {
                 if ( kind != 4 )
                 {
@@ -2806,7 +3080,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.vel_y = decoded_v;
                 break;
             }
-            case 0x6cede8b6eb60f1cdull: // vel_z
+            case 38: // vel_z, id 0x6cede8b6eb60f1cdull
             {
                 if ( kind != 4 )
                 {
@@ -2836,7 +3110,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.vel_z = decoded_v;
                 break;
             }
-            case 0x7f69d4b5288ba9cfull: // health
+            case 39: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 4 )
                 {
@@ -2866,7 +3140,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.health = decoded_v;
                 break;
             }
-            case 0xa0b610205f2c6e01ull: // weapon
+            case 40: // weapon, id 0xa0b610205f2c6e01ull
             {
                 if ( kind != 30 )
                 {
@@ -2880,14 +3154,14 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.weapon = MixedWeapon::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.weapon ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.weapon ) )
                 {
                     value.weapon = MixedWeapon::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 41: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 9 )
                 {
@@ -2913,7 +3187,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.damage = decoded_v;
                 break;
             }
-            case 0x11a44fc1d1243da7ull: // moving
+            case 42: // moving, id 0x11a44fc1d1243da7ull
             {
                 if ( kind != 1 )
                 {
@@ -2927,7 +3201,7 @@ BENCH_TABLE_INLINE bool MixedEntityLoadBody( TableReader & r, MixedEntity & valu
                 value.moving = r.get8() != 0;
                 break;
             }
-            case 0x7674cfd19b9031caull: // firing
+            case 43: // firing, id 0x7674cfd19b9031caull
             {
                 if ( kind != 1 )
                 {
@@ -3877,10 +4151,10 @@ BENCH_TABLE_INLINE bool MixedStatLoadBody( TableReader & r, MixedStat & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3891,9 +4165,9 @@ BENCH_TABLE_INLINE bool MixedStatLoadBody( TableReader & r, MixedStat & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x80ab75f0866dbf65ull: // stat_id
+            case 49: // stat_id, id 0x80ab75f0866dbf65ull
             {
                 if ( kind != 6 )
                 {
@@ -3908,7 +4182,7 @@ BENCH_TABLE_INLINE bool MixedStatLoadBody( TableReader & r, MixedStat & value )
                 value.stat_id = decoded_v;
                 break;
             }
-            case 0x52076675ec13a0c1ull: // delta
+            case 50: // delta, id 0x52076675ec13a0c1ull
             {
                 if ( kind != 4 )
                 {
@@ -4278,10 +4552,10 @@ BENCH_TABLE_INLINE bool MixedHitEventLoadBody( TableReader & r, MixedHitEvent & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4292,9 +4566,9 @@ BENCH_TABLE_INLINE bool MixedHitEventLoadBody( TableReader & r, MixedHitEvent & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb7bc9ac015a25050ull: // target_id
+            case 44: // target_id, id 0xb7bc9ac015a25050ull
             {
                 if ( kind != 7 )
                 {
@@ -4322,7 +4596,7 @@ BENCH_TABLE_INLINE bool MixedHitEventLoadBody( TableReader & r, MixedHitEvent & 
                 value.target_id = decoded_v;
                 break;
             }
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 41: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 4 )
                 {
@@ -4352,7 +4626,7 @@ BENCH_TABLE_INLINE bool MixedHitEventLoadBody( TableReader & r, MixedHitEvent & 
                 value.damage = decoded_v;
                 break;
             }
-            case 0x01fbc365b059b925ull: // hit_kind
+            case 45: // hit_kind, id 0x01fbc365b059b925ull
             {
                 if ( kind != 4 )
                 {
@@ -4382,7 +4656,7 @@ BENCH_TABLE_INLINE bool MixedHitEventLoadBody( TableReader & r, MixedHitEvent & 
                 value.hit_kind = decoded_v;
                 break;
             }
-            case 0x126167908c9aa52dull: // crit
+            case 46: // crit, id 0x126167908c9aa52dull
             {
                 if ( kind != 1 )
                 {
@@ -4825,10 +5099,10 @@ BENCH_TABLE_INLINE bool MixedChatEventLoadBody( TableReader & r, MixedChatEvent 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4839,9 +5113,9 @@ BENCH_TABLE_INLINE bool MixedChatEventLoadBody( TableReader & r, MixedChatEvent 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa5013e9ad5caeda4ull: // channel
+            case 28: // channel, id 0xa5013e9ad5caeda4ull
             {
                 if ( kind != 4 )
                 {
@@ -4871,7 +5145,7 @@ BENCH_TABLE_INLINE bool MixedChatEventLoadBody( TableReader & r, MixedChatEvent 
                 value.channel = decoded_v;
                 break;
             }
-            case 0xfbf1ac4d96ebd022ull: // speaker
+            case 29: // speaker, id 0xfbf1ac4d96ebd022ull
             {
                 if ( kind != 7 )
                 {
@@ -5244,10 +5518,10 @@ BENCH_TABLE_INLINE bool MixedPickupEventLoadBody( TableReader & r, MixedPickupEv
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5258,9 +5532,9 @@ BENCH_TABLE_INLINE bool MixedPickupEventLoadBody( TableReader & r, MixedPickupEv
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x9e7fd06d864fbd56ull: // item_id
+            case 47: // item_id, id 0x9e7fd06d864fbd56ull
             {
                 if ( kind != 7 )
                 {
@@ -5288,7 +5562,7 @@ BENCH_TABLE_INLINE bool MixedPickupEventLoadBody( TableReader & r, MixedPickupEv
                 value.item_id = decoded_v;
                 break;
             }
-            case 0x8113fe7ea2b16969ull: // amount
+            case 48: // amount, id 0x8113fe7ea2b16969ull
             {
                 if ( kind != 4 )
                 {
@@ -6010,10 +6284,10 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6024,9 +6298,9 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaa38aca481f528a8ull: // sequence
+            case 0: // sequence, id 0xaa38aca481f528a8ull
             {
                 if ( kind != 7 )
                 {
@@ -6052,7 +6326,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.sequence = decoded_v;
                 break;
             }
-            case 0x0dbe005c56697c3eull: // ack_sequence
+            case 1: // ack_sequence, id 0x0dbe005c56697c3eull
             {
                 if ( kind != 4 )
                 {
@@ -6082,7 +6356,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.ack_sequence = decoded_v;
                 break;
             }
-            case 0x9bae0da8b829ee03ull: // ack_bits
+            case 2: // ack_bits, id 0x9bae0da8b829ee03ull
             {
                 if ( kind != 8 )
                 {
@@ -6108,7 +6382,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.ack_bits = decoded_v;
                 break;
             }
-            case 0xb7d7b5650a590b05ull: // session_id
+            case 3: // session_id, id 0xb7d7b5650a590b05ull
             {
                 if ( kind != 9 )
                 {
@@ -6134,7 +6408,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.session_id = decoded_v;
                 break;
             }
-            case 0x6d7b98e2d095967eull: // client_id
+            case 4: // client_id, id 0x6d7b98e2d095967eull
             {
                 if ( kind != 8 )
                 {
@@ -6160,7 +6434,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.client_id = decoded_v;
                 break;
             }
-            case 0x73a94c71d60dc0d8ull: // nonce
+            case 5: // nonce, id 0x73a94c71d60dc0d8ull
             {
                 if ( kind != 9 )
                 {
@@ -6186,7 +6460,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.nonce = decoded_v;
                 break;
             }
-            case 0x3eee6b51be54fc85ull: // world_time
+            case 6: // world_time, id 0x3eee6b51be54fc85ull
             {
                 if ( kind != 5 )
                 {
@@ -6216,7 +6490,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.world_time = decoded_v;
                 break;
             }
-            case 0x7bbc035f7b6d0112ull: // frame_tick
+            case 7: // frame_tick, id 0x7bbc035f7b6d0112ull
             {
                 if ( kind != 9 )
                 {
@@ -6244,7 +6518,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.frame_tick = decoded_v;
                 break;
             }
-            case 0x3c460475f9be69c6ull: // server_time
+            case 8: // server_time, id 0x3c460475f9be69c6ull
             {
                 if ( kind != 22 )
                 {
@@ -6261,7 +6535,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.server_time = decoded_v;
                 break;
             }
-            case 0x935d0fb07bb3822aull: // entities
+            case 9: // entities, id 0x935d0fb07bb3822aull
             {
                 if ( kind != 14 )
                 {
@@ -6319,7 +6593,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xee639cad45b1994cull: // stats
+            case 10: // stats, id 0xee639cad45b1994cull
             {
                 if ( kind != 14 )
                 {
@@ -6377,7 +6651,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x2e35dc5321aa5790ull: // game_event
+            case 11: // game_event, id 0x2e35dc5321aa5790ull
             {
                 if ( kind != 15 )
                 {
@@ -6391,16 +6665,16 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.game_event.type = MixedEventType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x33732819300680aaull: // hit
+                        case 66: // hit, id 0x33732819300680aaull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6415,7 +6689,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                             if ( sub.offset != sub.size ) { value.game_event.type = MixedEventType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xf2a38d910b5b348bull: // chat
+                        case 67: // chat, id 0xf2a38d910b5b348bull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6430,7 +6704,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                             if ( sub.offset != sub.size ) { value.game_event.type = MixedEventType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x9fa3a41c86ecb765ull: // pickup
+                        case 68: // pickup, id 0x9fa3a41c86ecb765ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6459,7 +6733,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x5759ce7586bbb5a3ull: // loadout
+            case 12: // loadout, id 0x5759ce7586bbb5a3ull
             {
                 if ( kind != 14 )
                 {
@@ -6505,7 +6779,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x13a62f542cf8e86eull: // player_name
+            case 13: // player_name, id 0x13a62f542cf8e86eull
             {
                 if ( kind != 12 )
                 {
@@ -6534,7 +6808,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xcfb8a9d063b5e9e5ull: // payload
+            case 14: // payload, id 0xcfb8a9d063b5e9e5ull
             {
                 if ( kind != 14 )
                 {
@@ -6583,7 +6857,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xdbaf7be5e24296c9ull: // aim_x
+            case 15: // aim_x, id 0xdbaf7be5e24296c9ull
             {
                 if ( kind != 10 )
                 {
@@ -6600,7 +6874,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.aim_x = decoded_f;
                 break;
             }
-            case 0xdbaf7ae5e2429516ull: // aim_y
+            case 16: // aim_y, id 0xdbaf7ae5e2429516ull
             {
                 if ( kind != 10 )
                 {
@@ -6617,7 +6891,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.aim_y = decoded_f;
                 break;
             }
-            case 0xdbaf79e5e2429363ull: // aim_z
+            case 17: // aim_z, id 0xdbaf79e5e2429363ull
             {
                 if ( kind != 10 )
                 {
@@ -6634,7 +6908,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.aim_z = decoded_f;
                 break;
             }
-            case 0x9cef31fff7e2e457ull: // recoil
+            case 18: // recoil, id 0x9cef31fff7e2e457ull
             {
                 if ( kind != 10 )
                 {
@@ -6648,7 +6922,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.recoil = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x5ab3f9c9341f6c04ull: // drift
+            case 19: // drift, id 0x5ab3f9c9341f6c04ull
             {
                 if ( kind != 11 )
                 {
@@ -6671,7 +6945,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.drift = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xa3348580461faf16ull: // wide_key
+            case 20: // wide_key, id 0xa3348580461faf16ull
             {
                 if ( kind != 19 )
                 {
@@ -6698,7 +6972,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.wide_key = decoded_v;
                 break;
             }
-            case 0xd61bdd7908af2642ull: // flux
+            case 21: // flux, id 0xd61bdd7908af2642ull
             {
                 if ( kind != 18 )
                 {
@@ -6729,7 +7003,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.flux = decoded_v;
                 break;
             }
-            case 0xbf30e00dc53307a9ull: // ping
+            case 22: // ping, id 0xbf30e00dc53307a9ull
             {
                 if ( kind != 26 )
                 {
@@ -6745,7 +7019,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.ping = decoded_v;
                 break;
             }
-            case 0x560d6527ccd8515full: // crc_hint
+            case 23: // crc_hint, id 0x560d6527ccd8515full
             {
                 if ( kind != 8 )
                 {
@@ -6773,7 +7047,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.crc_hint = decoded_v;
                 break;
             }
-            case 0xc08292176cfd8672ull: // has_extra
+            case 24: // has_extra, id 0xc08292176cfd8672ull
             {
                 if ( kind != 1 )
                 {
@@ -6787,7 +7061,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.has_extra = r.get8() != 0;
                 break;
             }
-            case 0xfd29ee12a979cb69ull: // extra
+            case 25: // extra, id 0xfd29ee12a979cb69ull
             {
                 if ( kind != 4 )
                 {
@@ -6817,7 +7091,7 @@ BENCH_TABLE_INLINE bool BenchMixedLoadBody( TableReader & r, BenchMixed & value 
                 value.extra = decoded_v;
                 break;
             }
-            case 0x78101ac0aa8cbcfeull: // idle_ticks
+            case 26: // idle_ticks, id 0x78101ac0aa8cbcfeull
             {
                 if ( kind != 4 )
                 {

--- a/generated/bench/paired/cpp/FixedTableTable.h
+++ b/generated/bench/paired/cpp/FixedTableTable.h
@@ -379,6 +379,145 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 82;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x0c9cc190eed84e3bull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xaa38aca481f528a8ull, 0x0dbe005c56697c3eull, 0x9bae0da8b829ee03ull, 0xb7d7b5650a590b05ull,
+    0x6d7b98e2d095967eull, 0x73a94c71d60dc0d8ull, 0x3eee6b51be54fc85ull, 0x7bbc035f7b6d0112ull,
+    0x3c460475f9be69c6ull, 0x935d0fb07bb3822aull, 0xee639cad45b1994cull, 0x2e35dc5321aa5790ull,
+    0x5759ce7586bbb5a3ull, 0x13a62f542cf8e86eull, 0xcfb8a9d063b5e9e5ull, 0xdbaf7be5e24296c9ull,
+    0xdbaf7ae5e2429516ull, 0xdbaf79e5e2429363ull, 0x9cef31fff7e2e457ull, 0x5ab3f9c9341f6c04ull,
+    0xa3348580461faf16ull, 0xd61bdd7908af2642ull, 0xbf30e00dc53307a9ull, 0x560d6527ccd8515full,
+    0xc08292176cfd8672ull, 0xfd29ee12a979cb69ull, 0x78101ac0aa8cbcfeull, 0x7ce4fd9430e80ceaull,
+    0xa5013e9ad5caeda4ull, 0xfbf1ac4d96ebd022ull, 0x23fcfd6678e36712ull, 0xcb4b37357667310eull,
+    0xcb4b3835766732c1ull, 0xcb4b353576672da8ull, 0xb54d8e19798e16e8ull, 0x53a9f665a90cc1b1ull,
+    0x6cede6b6eb60ee67ull, 0x6cede5b6eb60ecb4ull, 0x6cede8b6eb60f1cdull, 0x7f69d4b5288ba9cfull,
+    0xa0b610205f2c6e01ull, 0x7f6308be8ab37fc0ull, 0x11a44fc1d1243da7ull, 0x7674cfd19b9031caull,
+    0xb7bc9ac015a25050ull, 0x01fbc365b059b925ull, 0x126167908c9aa52dull, 0x9e7fd06d864fbd56ull,
+    0x8113fe7ea2b16969ull, 0x80ab75f0866dbf65ull, 0x52076675ec13a0c1ull, 0xa790eee12766cf0cull,
+    0x9fbfefa835da8476ull, 0x188bbb1783928a95ull, 0x2c3667b9c2f272f1ull, 0x0ca8b41b00d755f6ull,
+    0x985fc819fab21a4eull, 0x229d0447c3086a55ull, 0x011c7b49a7228f9dull, 0x89f7566e1123e15full,
+    0x8d7f25318b3b4469ull, 0xd9cd0dcc285b7816ull, 0x04dc16aea8ff5276ull, 0x35e53bc341129217ull,
+    0x2cc8282fb0de8831ull, 0x20bada21bc8cb334ull, 0x33732819300680aaull, 0xf2a38d910b5b348bull,
+    0x9fa3a41c86ecb765ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x85df369cdca746b3ull, 0x3d827cb76b809d8cull, 0x9367b84cab99cdc3ull,
+    0x9f2c9da926a7408aull, 0xac9fe3b25a77f1d7ull, 0xc42975bfe5e07baaull, 0xeb80cfd516eb3d5cull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF,    31, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    71,
+    0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    13,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       55, 0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF,    43, 0xFFFF, 0xFFFF, 0xFFFF,    15, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       44, 0xFFFF, 0xFFFF,    76, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    40,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF,
+       58, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       78,     4, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21,    20, 0xFFFF,    19, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+       17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF,    14, 0xFFFF,
+    0xFFFF, 0xFFFF,    65, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF,    74, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF,
+       67, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    81, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF,    70, 0xFFFF,
+    0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF,    36, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    18,    63, 0xFFFF,    28, 0xFFFF, 0xFFFF,    79, 0xFFFF, 0xFFFF,
+    0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    69, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF,    42,    57, 0xFFFF,     3, 0xFFFF,
+        5,    61, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 69;
+static const uint16_t kTableIdSlotBuildVersion = 80;
+static const uint16_t kTableIdSlotVocabulary = 81;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -387,16 +526,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BENCH_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -716,6 +873,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -747,16 +916,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2324,10 +2576,10 @@ BENCH_TABLE_INLINE bool FixedTableLoadBody( TableReader & r, FixedTable & value 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2338,9 +2590,9 @@ BENCH_TABLE_INLINE bool FixedTableLoadBody( TableReader & r, FixedTable & value 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7ce4fd9430e80ceaull: // value
+            case 27: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -377,6 +377,145 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 81;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xb3c4904a6d278933ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa5013e9ad5caeda4ull, 0xfbf1ac4d96ebd022ull, 0x23fcfd6678e36712ull, 0xcb4b37357667310eull,
+    0xcb4b3835766732c1ull, 0xcb4b353576672da8ull, 0xb54d8e19798e16e8ull, 0x53a9f665a90cc1b1ull,
+    0x6cede6b6eb60ee67ull, 0x6cede5b6eb60ecb4ull, 0x6cede8b6eb60f1cdull, 0x7f69d4b5288ba9cfull,
+    0xa0b610205f2c6e01ull, 0x7f6308be8ab37fc0ull, 0x11a44fc1d1243da7ull, 0x7674cfd19b9031caull,
+    0xb7bc9ac015a25050ull, 0x01fbc365b059b925ull, 0x126167908c9aa52dull, 0x6a5a70d91aa115fdull,
+    0xaa38aca481f528a8ull, 0x0dbe005c56697c3eull, 0x9bae0da8b829ee03ull, 0xb7d7b5650a590b05ull,
+    0x6d7b98e2d095967eull, 0x73a94c71d60dc0d8ull, 0x3eee6b51be54fc85ull, 0x7bbc035f7b6d0112ull,
+    0x3c460475f9be69c6ull, 0x935d0fb07bb3822aull, 0xee639cad45b1994cull, 0x2e35dc5321aa5790ull,
+    0x5759ce7586bbb5a3ull, 0x13a62f542cf8e86eull, 0xcfb8a9d063b5e9e5ull, 0xdbaf7be5e24296c9ull,
+    0xdbaf7ae5e2429516ull, 0xdbaf79e5e2429363ull, 0x9cef31fff7e2e457ull, 0x5ab3f9c9341f6c04ull,
+    0xa3348580461faf16ull, 0xd61bdd7908af2642ull, 0xbf30e00dc53307a9ull, 0x560d6527ccd8515full,
+    0xc08292176cfd8672ull, 0xfd29ee12a979cb69ull, 0x78101ac0aa8cbcfeull, 0x9e7fd06d864fbd56ull,
+    0x8113fe7ea2b16969ull, 0x80ab75f0866dbf65ull, 0x52076675ec13a0c1ull, 0xa790eee12766cf0cull,
+    0x9fbfefa835da8476ull, 0x188bbb1783928a95ull, 0x2c3667b9c2f272f1ull, 0x0ca8b41b00d755f6ull,
+    0x985fc819fab21a4eull, 0x229d0447c3086a55ull, 0x011c7b49a7228f9dull, 0x89f7566e1123e15full,
+    0x8d7f25318b3b4469ull, 0xd9cd0dcc285b7816ull, 0x04dc16aea8ff5276ull, 0x35e53bc341129217ull,
+    0x2cc8282fb0de8831ull, 0x20bada21bc8cb334ull, 0x33732819300680aaull, 0xf2a38d910b5b348bull,
+    0x9fa3a41c86ecb765ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x3161723596c6cba8ull, 0x439ae459d6f88a8eull, 0x296aa8e669b99c95ull,
+    0x746c6429cbf8aba8ull, 0x78a8188d74947dedull, 0x969901d577faad3bull, 0xfffffffffffffffeull,
+    0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    37, 0xFFFF, 0xFFFF,    25,
+    0xFFFF,    48, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF,    57,    72, 0xFFFF,    58, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    28,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,     2, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF,     4,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,    75, 0xFFFF,     1, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    17,    19, 0xFFFF,    31, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35,
+    0xFFFF, 0xFFFF,    43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    64,    69, 0xFFFF, 0xFFFF,
+        5, 0xFFFF, 0xFFFF,    41, 0xFFFF, 0xFFFF,    77,    65, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    60, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    29, 0xFFFF, 0xFFFF,    70,    15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    56, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF,
+    0xFFFF, 0xFFFF,     3,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21,    24, 0xFFFF, 0xFFFF, 0xFFFF,
+       11, 0xFFFF, 0xFFFF, 0xFFFF,    61,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    66,    78, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    36, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    68,    74, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    71, 0xFFFF, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    53,    55, 0xFFFF,    14,     6,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF,
+       76, 0xFFFF, 0xFFFF, 0xFFFF,    59, 0xFFFF, 0xFFFF,    30,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 69;
+static const uint16_t kTableIdSlotBuildVersion = 79;
+static const uint16_t kTableIdSlotVocabulary = 80;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +524,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BENCHTABLE_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +871,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +914,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2427,6 +2679,28 @@ inline bool TableEnumValue( uint64_t id, TableWeapon & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, TableWeapon & out )
+{
+    switch ( slot )
+    {
+        case 51: out = TableWeapon::Fists; return true; // id 0xa790eee12766cf0cull
+        case 52: out = TableWeapon::Pistol; return true; // id 0x9fbfefa835da8476ull
+        case 53: out = TableWeapon::Shotgun; return true; // id 0x188bbb1783928a95ull
+        case 54: out = TableWeapon::Rifle; return true; // id 0x2c3667b9c2f272f1ull
+        case 55: out = TableWeapon::Sniper; return true; // id 0x0ca8b41b00d755f6ull
+        case 56: out = TableWeapon::Smg; return true; // id 0x985fc819fab21a4eull
+        case 57: out = TableWeapon::Rocket; return true; // id 0x229d0447c3086a55ull
+        case 58: out = TableWeapon::Grenade; return true; // id 0x011c7b49a7228f9dull
+        case 59: out = TableWeapon::Plasma; return true; // id 0x89f7566e1123e15full
+        case 60: out = TableWeapon::Railgun; return true; // id 0x8d7f25318b3b4469ull
+        case 61: out = TableWeapon::Flamer; return true; // id 0xd9cd0dcc285b7816ull
+        case 62: out = TableWeapon::Mine; return true; // id 0x04dc16aea8ff5276ull
+        case 63: out = TableWeapon::Turret; return true; // id 0x35e53bc341129217ull
+        case 64: out = TableWeapon::Drone; return true; // id 0x2cc8282fb0de8831ull
+        case 65: out = TableWeapon::Repair; return true; // id 0x20bada21bc8cb334ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BENCHTABLE_SCHEMA_TABLE_ENUM_TABLEWEAPON
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2680,10 +2954,10 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2694,9 +2968,9 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x23fcfd6678e36712ull: // entity_id
+            case 2: // entity_id, id 0x23fcfd6678e36712ull
             {
                 if ( kind != 7 )
                 {
@@ -2724,7 +2998,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.entity_id = decoded_v;
                 break;
             }
-            case 0xcb4b37357667310eull: // pos_x
+            case 3: // pos_x, id 0xcb4b37357667310eull
             {
                 if ( kind != 4 )
                 {
@@ -2754,7 +3028,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.pos_x = decoded_v;
                 break;
             }
-            case 0xcb4b3835766732c1ull: // pos_y
+            case 4: // pos_y, id 0xcb4b3835766732c1ull
             {
                 if ( kind != 4 )
                 {
@@ -2784,7 +3058,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.pos_y = decoded_v;
                 break;
             }
-            case 0xcb4b353576672da8ull: // pos_z
+            case 5: // pos_z, id 0xcb4b353576672da8ull
             {
                 if ( kind != 4 )
                 {
@@ -2814,7 +3088,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.pos_z = decoded_v;
                 break;
             }
-            case 0xb54d8e19798e16e8ull: // yaw
+            case 6: // yaw, id 0xb54d8e19798e16e8ull
             {
                 if ( kind != 7 )
                 {
@@ -2842,7 +3116,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.yaw = decoded_v;
                 break;
             }
-            case 0x53a9f665a90cc1b1ull: // pitch
+            case 7: // pitch, id 0x53a9f665a90cc1b1ull
             {
                 if ( kind != 7 )
                 {
@@ -2870,7 +3144,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.pitch = decoded_v;
                 break;
             }
-            case 0x6cede6b6eb60ee67ull: // vel_x
+            case 8: // vel_x, id 0x6cede6b6eb60ee67ull
             {
                 if ( kind != 4 )
                 {
@@ -2900,7 +3174,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.vel_x = decoded_v;
                 break;
             }
-            case 0x6cede5b6eb60ecb4ull: // vel_y
+            case 9: // vel_y, id 0x6cede5b6eb60ecb4ull
             {
                 if ( kind != 4 )
                 {
@@ -2930,7 +3204,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.vel_y = decoded_v;
                 break;
             }
-            case 0x6cede8b6eb60f1cdull: // vel_z
+            case 10: // vel_z, id 0x6cede8b6eb60f1cdull
             {
                 if ( kind != 4 )
                 {
@@ -2960,7 +3234,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.vel_z = decoded_v;
                 break;
             }
-            case 0x7f69d4b5288ba9cfull: // health
+            case 11: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 4 )
                 {
@@ -2990,7 +3264,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.health = decoded_v;
                 break;
             }
-            case 0xa0b610205f2c6e01ull: // weapon
+            case 12: // weapon, id 0xa0b610205f2c6e01ull
             {
                 if ( kind != 30 )
                 {
@@ -3004,14 +3278,14 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.weapon = TableWeapon::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.weapon ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.weapon ) )
                 {
                     value.weapon = TableWeapon::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 13: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 9 )
                 {
@@ -3037,7 +3311,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.damage = decoded_v;
                 break;
             }
-            case 0x11a44fc1d1243da7ull: // moving
+            case 14: // moving, id 0x11a44fc1d1243da7ull
             {
                 if ( kind != 1 )
                 {
@@ -3051,7 +3325,7 @@ BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity &
                 value.moving = r.get8() != 0;
                 break;
             }
-            case 0x7674cfd19b9031caull: // firing
+            case 15: // firing, id 0x7674cfd19b9031caull
             {
                 if ( kind != 1 )
                 {
@@ -4001,10 +4275,10 @@ BENCHTABLE_TABLE_INLINE bool TableStatLoadBody( TableReader & r, TableStat & val
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4015,9 +4289,9 @@ BENCHTABLE_TABLE_INLINE bool TableStatLoadBody( TableReader & r, TableStat & val
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x80ab75f0866dbf65ull: // stat_id
+            case 49: // stat_id, id 0x80ab75f0866dbf65ull
             {
                 if ( kind != 6 )
                 {
@@ -4032,7 +4306,7 @@ BENCHTABLE_TABLE_INLINE bool TableStatLoadBody( TableReader & r, TableStat & val
                 value.stat_id = decoded_v;
                 break;
             }
-            case 0x52076675ec13a0c1ull: // delta
+            case 50: // delta, id 0x52076675ec13a0c1ull
             {
                 if ( kind != 4 )
                 {
@@ -4743,10 +5017,10 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4757,9 +5031,9 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x6a5a70d91aa115fdull: // protocol_magic
+            case 19: // protocol_magic, id 0x6a5a70d91aa115fdull
             {
                 if ( kind != 7 )
                 {
@@ -4785,7 +5059,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.protocol_magic = decoded_v;
                 break;
             }
-            case 0xaa38aca481f528a8ull: // sequence
+            case 20: // sequence, id 0xaa38aca481f528a8ull
             {
                 if ( kind != 7 )
                 {
@@ -4811,7 +5085,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.sequence = decoded_v;
                 break;
             }
-            case 0x0dbe005c56697c3eull: // ack_sequence
+            case 21: // ack_sequence, id 0x0dbe005c56697c3eull
             {
                 if ( kind != 4 )
                 {
@@ -4841,7 +5115,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.ack_sequence = decoded_v;
                 break;
             }
-            case 0x9bae0da8b829ee03ull: // ack_bits
+            case 22: // ack_bits, id 0x9bae0da8b829ee03ull
             {
                 if ( kind != 8 )
                 {
@@ -4867,7 +5141,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.ack_bits = decoded_v;
                 break;
             }
-            case 0xb7d7b5650a590b05ull: // session_id
+            case 23: // session_id, id 0xb7d7b5650a590b05ull
             {
                 if ( kind != 9 )
                 {
@@ -4893,7 +5167,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.session_id = decoded_v;
                 break;
             }
-            case 0x6d7b98e2d095967eull: // client_id
+            case 24: // client_id, id 0x6d7b98e2d095967eull
             {
                 if ( kind != 8 )
                 {
@@ -4919,7 +5193,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.client_id = decoded_v;
                 break;
             }
-            case 0x73a94c71d60dc0d8ull: // nonce
+            case 25: // nonce, id 0x73a94c71d60dc0d8ull
             {
                 if ( kind != 9 )
                 {
@@ -4949,7 +5223,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.nonce = decoded_v;
                 break;
             }
-            case 0x3eee6b51be54fc85ull: // world_time
+            case 26: // world_time, id 0x3eee6b51be54fc85ull
             {
                 if ( kind != 5 )
                 {
@@ -4979,7 +5253,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.world_time = decoded_v;
                 break;
             }
-            case 0x7bbc035f7b6d0112ull: // frame_tick
+            case 27: // frame_tick, id 0x7bbc035f7b6d0112ull
             {
                 if ( kind != 9 )
                 {
@@ -5007,7 +5281,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.frame_tick = decoded_v;
                 break;
             }
-            case 0x3c460475f9be69c6ull: // server_time
+            case 28: // server_time, id 0x3c460475f9be69c6ull
             {
                 if ( kind != 10 )
                 {
@@ -5024,7 +5298,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.server_time = decoded_f;
                 break;
             }
-            case 0x935d0fb07bb3822aull: // entities
+            case 29: // entities, id 0x935d0fb07bb3822aull
             {
                 if ( kind != 14 )
                 {
@@ -5082,7 +5356,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xee639cad45b1994cull: // stats
+            case 30: // stats, id 0xee639cad45b1994cull
             {
                 if ( kind != 14 )
                 {
@@ -5140,7 +5414,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x2e35dc5321aa5790ull: // game_event
+            case 31: // game_event, id 0x2e35dc5321aa5790ull
             {
                 if ( kind != 15 )
                 {
@@ -5154,16 +5428,16 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.game_event.type = TableEventType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x33732819300680aaull: // hit
+                        case 66: // hit, id 0x33732819300680aaull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5178,7 +5452,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                             if ( sub.offset != sub.size ) { value.game_event.type = TableEventType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xf2a38d910b5b348bull: // chat
+                        case 67: // chat, id 0xf2a38d910b5b348bull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5193,7 +5467,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                             if ( sub.offset != sub.size ) { value.game_event.type = TableEventType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x9fa3a41c86ecb765ull: // pickup
+                        case 68: // pickup, id 0x9fa3a41c86ecb765ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5222,7 +5496,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x5759ce7586bbb5a3ull: // loadout
+            case 32: // loadout, id 0x5759ce7586bbb5a3ull
             {
                 if ( kind != 14 )
                 {
@@ -5268,7 +5542,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x13a62f542cf8e86eull: // player_name
+            case 33: // player_name, id 0x13a62f542cf8e86eull
             {
                 if ( kind != 12 )
                 {
@@ -5297,7 +5571,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xcfb8a9d063b5e9e5ull: // payload
+            case 34: // payload, id 0xcfb8a9d063b5e9e5ull
             {
                 if ( kind != 14 )
                 {
@@ -5346,7 +5620,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xdbaf7be5e24296c9ull: // aim_x
+            case 35: // aim_x, id 0xdbaf7be5e24296c9ull
             {
                 if ( kind != 10 )
                 {
@@ -5363,7 +5637,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.aim_x = decoded_f;
                 break;
             }
-            case 0xdbaf7ae5e2429516ull: // aim_y
+            case 36: // aim_y, id 0xdbaf7ae5e2429516ull
             {
                 if ( kind != 10 )
                 {
@@ -5380,7 +5654,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.aim_y = decoded_f;
                 break;
             }
-            case 0xdbaf79e5e2429363ull: // aim_z
+            case 37: // aim_z, id 0xdbaf79e5e2429363ull
             {
                 if ( kind != 10 )
                 {
@@ -5397,7 +5671,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.aim_z = decoded_f;
                 break;
             }
-            case 0x9cef31fff7e2e457ull: // recoil
+            case 38: // recoil, id 0x9cef31fff7e2e457ull
             {
                 if ( kind != 10 )
                 {
@@ -5411,7 +5685,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.recoil = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x5ab3f9c9341f6c04ull: // drift
+            case 39: // drift, id 0x5ab3f9c9341f6c04ull
             {
                 if ( kind != 11 )
                 {
@@ -5434,7 +5708,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.drift = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xa3348580461faf16ull: // wide_key
+            case 40: // wide_key, id 0xa3348580461faf16ull
             {
                 if ( kind != 9 )
                 {
@@ -5460,7 +5734,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.wide_key = decoded_v;
                 break;
             }
-            case 0xd61bdd7908af2642ull: // flux
+            case 41: // flux, id 0xd61bdd7908af2642ull
             {
                 if ( kind != 5 )
                 {
@@ -5490,7 +5764,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.flux = decoded_v;
                 break;
             }
-            case 0xbf30e00dc53307a9ull: // ping
+            case 42: // ping, id 0xbf30e00dc53307a9ull
             {
                 if ( kind != 10 )
                 {
@@ -5507,7 +5781,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.ping = decoded_f;
                 break;
             }
-            case 0x560d6527ccd8515full: // crc_hint
+            case 43: // crc_hint, id 0x560d6527ccd8515full
             {
                 if ( kind != 8 )
                 {
@@ -5535,7 +5809,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.crc_hint = decoded_v;
                 break;
             }
-            case 0xc08292176cfd8672ull: // has_extra
+            case 44: // has_extra, id 0xc08292176cfd8672ull
             {
                 if ( kind != 1 )
                 {
@@ -5549,7 +5823,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.has_extra = r.get8() != 0;
                 break;
             }
-            case 0xfd29ee12a979cb69ull: // extra
+            case 45: // extra, id 0xfd29ee12a979cb69ull
             {
                 if ( kind != 4 )
                 {
@@ -5579,7 +5853,7 @@ BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & v
                 value.extra = decoded_v;
                 break;
             }
-            case 0x78101ac0aa8cbcfeull: // idle_ticks
+            case 46: // idle_ticks, id 0x78101ac0aa8cbcfeull
             {
                 if ( kind != 4 )
                 {
@@ -7314,10 +7588,10 @@ BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEve
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7328,9 +7602,9 @@ BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEve
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb7bc9ac015a25050ull: // target_id
+            case 16: // target_id, id 0xb7bc9ac015a25050ull
             {
                 if ( kind != 7 )
                 {
@@ -7358,7 +7632,7 @@ BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEve
                 value.target_id = decoded_v;
                 break;
             }
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 13: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 4 )
                 {
@@ -7388,7 +7662,7 @@ BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEve
                 value.damage = decoded_v;
                 break;
             }
-            case 0x01fbc365b059b925ull: // hit_kind
+            case 17: // hit_kind, id 0x01fbc365b059b925ull
             {
                 if ( kind != 4 )
                 {
@@ -7418,7 +7692,7 @@ BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEve
                 value.hit_kind = decoded_v;
                 break;
             }
-            case 0x126167908c9aa52dull: // crit
+            case 18: // crit, id 0x126167908c9aa52dull
             {
                 if ( kind != 1 )
                 {
@@ -7861,10 +8135,10 @@ BENCHTABLE_TABLE_INLINE bool TableChatEventLoadBody( TableReader & r, TableChatE
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7875,9 +8149,9 @@ BENCHTABLE_TABLE_INLINE bool TableChatEventLoadBody( TableReader & r, TableChatE
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa5013e9ad5caeda4ull: // channel
+            case 0: // channel, id 0xa5013e9ad5caeda4ull
             {
                 if ( kind != 4 )
                 {
@@ -7907,7 +8181,7 @@ BENCHTABLE_TABLE_INLINE bool TableChatEventLoadBody( TableReader & r, TableChatE
                 value.channel = decoded_v;
                 break;
             }
-            case 0xfbf1ac4d96ebd022ull: // speaker
+            case 1: // speaker, id 0xfbf1ac4d96ebd022ull
             {
                 if ( kind != 7 )
                 {
@@ -8280,10 +8554,10 @@ BENCHTABLE_TABLE_INLINE bool TablePickupEventLoadBody( TableReader & r, TablePic
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8294,9 +8568,9 @@ BENCHTABLE_TABLE_INLINE bool TablePickupEventLoadBody( TableReader & r, TablePic
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x9e7fd06d864fbd56ull: // item_id
+            case 47: // item_id, id 0x9e7fd06d864fbd56ull
             {
                 if ( kind != 7 )
                 {
@@ -8324,7 +8598,7 @@ BENCHTABLE_TABLE_INLINE bool TablePickupEventLoadBody( TableReader & r, TablePic
                 value.item_id = decoded_v;
                 break;
             }
-            case 0x8113fe7ea2b16969ull: // amount
+            case 48: // amount, id 0x8113fe7ea2b16969ull
             {
                 if ( kind != 4 )
                 {

--- a/internal/codegen/cpptable/arms.go
+++ b/internal/codegen/cpptable/arms.go
@@ -386,7 +386,7 @@ func (g *tableGen) emitArmLoad(v ir.UnionVariant, base, ind, rdr, tag, none, sfx
 		g.pf("%s}\n", ind)
 	case kind == tkUnion:
 		un := f.Type.Ref.(*ir.Union)
-		ref, id, length := "arm_inner_ref"+sfx, "arm_inner_id"+sfx, "arm_inner_len"+sfx
+		ref, id, length := "arm_inner_ref"+sfx, "arm_inner_slot"+sfx, "arm_inner_len"+sfx
 		inner, innerKind := "arm_inner"+sfx, "arm_inner_kind"+sfx
 		g.pf("%s{\n%s    uint64_t %s = 0;\n", ind, ind, ref)
 		g.pf("%s    if ( !%s.getleb( %s ) ) { %s = %s; r.report->malformed = true; break; }\n", ind, rdr, ref, tag, none)
@@ -397,15 +397,15 @@ func (g *tableGen) emitArmLoad(v ir.UnionVariant, base, ind, rdr, tag, none, sfx
 		// not decoded — THIS union reads None, malformed counts, and the
 		// enclosing body continues past the arm by `L`
 		g.pf("%s        if ( %s > (uint64_t) r.ids->count ) { %s = %s; r.report->malformed = true; break; }\n", ind, ref, tag, none)
-		g.pf("%s        const uint64_t %s = r.ids->at( %s );\n", ind, id, ref)
+		g.pf("%s        const uint16_t %s = r.ids->slot_of( %s );\n", ind, id, ref)
 		g.pf("%s        if ( !%s.has( 1 ) ) { %s = %s; r.report->malformed = true; break; }\n", ind, rdr, tag, none)
 		g.pf("%s        const uint8_t %s = %s.get8();\n", ind, innerKind, rdr)
 		g.pf("%s        uint64_t %s = 0;\n", ind, length)
 		g.pf("%s        if ( !%s.getleb( %s ) || !%s.room( %s ) ) { %s = %s; r.report->malformed = true; break; }\n", ind, rdr, length, rdr, length, tag, none)
 		g.pf("%s        TableReader %s( %s.buffer + %s.offset, (int64_t) %s, r.report, r.ids );\n", ind, inner, rdr, rdr, length)
-		g.pf("%s        switch ( %s ) // the arm's NAME hash (§5)\n%s        {\n", ind, id, ind)
+		g.pf("%s        switch ( %s ) // the arm's name, at its compile-time SLOT (§3, §5)\n%s        {\n", ind, id, ind)
 		for _, in := range un.Variants {
-			g.pf("%s            case 0x%016xull: // %s\n%s            {\n", ind, ir.TableWireId(in.WireName()), in.Name, ind)
+			g.pf("%s            case %d: // %s, id 0x%016xull\n%s            {\n", ind, g.idSlotOf(ir.TableWireId(in.WireName())), in.Name, ir.TableWireId(in.WireName()), ind)
 			g.pf("%s                if ( %s != %d )\n%s                {\n", ind, innerKind, armWireKind(in), ind)
 			g.emitArmWiden(in, value, innerKind, inner, value+".type",
 				un.Name+"Type::"+ir.GoExportName(in.Name), un.Name+"Type::None", ind+"                    ")

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -623,6 +623,23 @@ func (g *tableGen) emitEnumIdentity(e *ir.Enum) {
 	}
 	g.pf("        default: return false; // an id this build cannot name\n")
 	g.pf("    }\n}\n")
+	// THE FILE FORM'S HALF, over the trailer's RESOLVED SLOT rather than over
+	// the id (docs/SPEC-TABLES.md §3, and the id slot map). The answer is the
+	// same on every input, because the map is injective over the unit's set
+	// and an id outside it has no slot; what changes is the dispatch, which is
+	// a dense switch over consecutive slots — a variant's slots are
+	// consecutive, the vocabulary places an enum's variants in a run — where
+	// it was a chain of 64-bit compares. TableEnumValue above is untouched:
+	// the MESSAGE form has no id table and no trailer to resolve, and a report
+	// or a dump still holds a raw id.
+	g.pf("inline bool TableEnumValueAt( uint16_t slot, %s & out )\n{\n", e.Name)
+	g.pf("    switch ( slot )\n    {\n")
+	for i, v := range e.Variants {
+		id := ir.TableWireId(e.VariantWireName(i))
+		g.pf("        case %d: out = %s::%s; return true; // id 0x%016xull\n", g.idSlotOf(id), e.Name, v, id)
+	}
+	g.pf("        default: return false; // a slot this build cannot name\n")
+	g.pf("    }\n}\n")
 	g.pf("#endif // %s\n\n", guard)
 }
 
@@ -1549,10 +1566,19 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	g.pf("        if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }\n")
 	g.pf("        if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE\n")
 	g.pf("        if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count\n")
-	g.pf("        const uint64_t field_id = r.ids->at( field_ref );\n")
+	// THE REFERENCE RESOLVES TO A SLOT, NOT TO AN ID (docs/SPEC-TABLES.md §3,
+	// and the id slot map in the header). TableOpen resolved the whole trailer
+	// once, so this is one array load where it was an eight-byte decode, and
+	// the switch below dispatches on a DENSE index where it dispatched on a
+	// 64-bit hash. The id itself is decoded only where something still wants
+	// it: a RETAINED record carries the id it could not name.
+	g.pf("        const uint16_t field_slot = r.ids->slot_of( field_ref );\n")
+	if g.retain {
+		g.pf("        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)\n")
+	}
 	g.pf("        if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }\n")
 	g.pf("        uint8_t kind = r.get8();\n")
-	g.pf("        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )\n        {\n")
+	g.pf("        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )\n        {\n")
 	g.pf("            // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,\n")
 	g.pf("            // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node\n")
 	g.pf("            // table's is the ROOT body's alone, on the numbering's own\n")
@@ -1562,7 +1588,7 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	g.pf("            r.report->malformed = true;\n")
 	g.pf("            return false;\n        }\n")
 	if len(st.Fields) > 0 {
-		g.pf("        switch ( field_id )\n        {\n")
+		g.pf("        switch ( field_slot )\n        {\n")
 		for _, f := range st.Fields {
 			id := tableFieldWireId(f)
 			kind := tableScalarKind(f)
@@ -1593,7 +1619,7 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 			if f.Type.Kind == ir.TBytes && !f.Type.Blob() {
 				kind = tkU8 // bytes travel as an array of u8 elements; a *bytes is a node index (§2.5)
 			}
-			g.pf("            case 0x%016xull: // %s\n            {\n", id, f.Name)
+			g.pf("            case %d: // %s, id 0x%016xull\n            {\n", g.idSlotOf(id), f.Name, id)
 			g.pf("                if ( kind != %d )\n                {\n", wireKind)
 			if plainScalar(f) {
 				// THE WIDENING BRANCH (docs/SPEC-TABLES.md §4) lives inside
@@ -1632,7 +1658,7 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 			// the table, it is where the numbering travelled. An `unknown` here
 			// would mean "a build without kind 17", which is the difference §4
 			// exists to report and not one this reader has.
-			g.pf("            case 0x%016xull:\n            {\n", ir.TableNodeWireId)
+			g.pf("            case kTableIdSlotNodeTable: // id 0x%016xull\n            {\n", ir.TableNodeWireId)
 			g.pf("                if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }\n")
 			g.pf("                break;\n            }\n")
 		}
@@ -1748,7 +1774,7 @@ func (g *tableGen) emitEnumRefLoad(f *ir.Field, dst, ind, rdr, onBad string) {
 	g.pf("%sif ( !%s.getleb( variant_ref ) ) { %s }\n", ind, rdr, onBad)
 	g.pf("%sif ( variant_ref == 0 ) { %s = %s::None; } // the zero reference is the enum's None\n", ind, dst, e)
 	g.pf("%selse if ( variant_ref > (uint64_t) r.ids->count ) { %s }\n", ind, onBad)
-	g.pf("%selse if ( !TableEnumValue( r.ids->at( variant_ref ), %s ) )\n%s{\n", ind, dst, ind)
+	g.pf("%selse if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), %s ) )\n%s{\n", ind, dst, ind)
 	g.pf("%s    %s = %s::None;\n%s    r.report->unknown++;%s\n%s}\n", ind, dst, e, ind, g.retainLostInline(), ind)
 }
 
@@ -1930,18 +1956,18 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%sif ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%sif ( arm_ref == 0 ) { value.%s.type = %sType::None; break; } // empty: the reference is the whole payload\n", ind, f.Name, un.Name)
 		g.pf("%sif ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }\n", ind)
-		g.pf("%sconst uint64_t arm_id = r.ids->at( arm_ref );\n", ind)
+		g.pf("%sconst uint16_t arm_slot = r.ids->slot_of( arm_ref );\n", ind)
 		g.pf("%sif ( !r.has( 1 ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%sconst uint8_t arm_kind = r.get8();\n", ind)
 		g.pf("%suint64_t body_len = 0;\n", ind)
 		g.pf("%sif ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );\n", ind, ind)
-		g.pf("%s    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)\n%s    {\n", ind, ind)
+		g.pf("%s    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)\n%s    {\n", ind, ind)
 		wasField := g.unionField
 		g.unionField = f
 		defer func() { g.unionField = wasField }()
 		for ai, v := range un.Variants {
-			g.pf("%s        case 0x%016xull: // %s\n%s        {\n", ind, ir.TableWireId(v.WireName()), v.Name, ind)
+			g.pf("%s        case %d: // %s, id 0x%016xull\n%s        {\n", ind, g.idSlotOf(ir.TableWireId(v.WireName())), v.Name, ir.TableWireId(v.WireName()), ind)
 			g.pf("%s            if ( arm_kind != %d )\n%s            {\n", ind, armWireKind(v), ind)
 			g.emitArmWiden(v, "value."+f.Name, "arm_kind", "sub", fmt.Sprintf("value.%s.type", f.Name),
 				un.Name+"Type::"+ir.GoExportName(v.Name), un.Name+"Type::None", ind+"                ")
@@ -2007,7 +2033,7 @@ func (g *tableGen) emitTableReadElementInto(f *ir.Field, kind int, dst, ind, rdr
 		// re-established as None before the arm is read, so a repeated field id
 		// leaves no earlier arm standing (§4).
 		un := f.Type.Ref.(*ir.Union)
-		ref, id, length := "elem_arm_ref"+sfx, "elem_arm_id"+sfx, "elem_arm_len"+sfx
+		ref, id, length := "elem_arm_ref"+sfx, "elem_arm_slot"+sfx, "elem_arm_len"+sfx
 		armKind := "elem_arm_kind" + sfx
 		wasPath, wasIndex := g.pathExpr, g.elemIndex
 		g.pathExpr, g.elemIndex = g.step(f), "0"
@@ -2017,18 +2043,18 @@ func (g *tableGen) emitTableReadElementInto(f *ir.Field, kind int, dst, ind, rdr
 		g.pf("%s    %s.type = %sType::None;\n", ind, dst, un.Name)
 		g.pf("%s    if ( %s != 0 ) // the zero reference is a None element in its place\n%s    {\n", ind, ref, ind)
 		g.pf("%s        if ( %s > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }\n", ind, ref)
-		g.pf("%s        const uint64_t %s = r.ids->at( %s );\n", ind, id, ref)
+		g.pf("%s        const uint16_t %s = r.ids->slot_of( %s );\n", ind, id, ref)
 		g.pf("%s        if ( !%s.has( 1 ) ) { r.report->malformed = true; break; }\n", ind, rdr)
 		g.pf("%s        const uint8_t %s = %s.get8();\n", ind, armKind, rdr)
 		g.pf("%s        uint64_t %s = 0;\n", ind, length)
 		g.pf("%s        if ( !%s.getleb( %s ) || !%s.room( %s ) ) { r.report->malformed = true; break; }\n", ind, rdr, length, rdr, length)
 		g.pf("%s        TableReader elem_arm%s( %s.buffer + %s.offset, (int64_t) %s, r.report, r.ids );\n", ind, sfx, rdr, rdr, length)
-		g.pf("%s        switch ( %s ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)\n%s        {\n", ind, id, ind)
+		g.pf("%s        switch ( %s ) // the arm's name, at its compile-time SLOT (§3, §5)\n%s        {\n", ind, id, ind)
 		wasField := g.unionField
 		g.unionField = f
 		defer func() { g.unionField = wasField }()
 		for ai, v := range un.Variants {
-			g.pf("%s            case 0x%016xull: // %s\n%s            {\n", ind, ir.TableWireId(v.WireName()), v.Name, ind)
+			g.pf("%s            case %d: // %s, id 0x%016xull\n%s            {\n", ind, g.idSlotOf(ir.TableWireId(v.WireName())), v.Name, ir.TableWireId(v.WireName()), ind)
 			g.pf("%s                if ( %s != %d )\n%s                {\n", ind, armKind, armWireKind(v), ind)
 			g.emitArmWiden(v, dst, armKind, "elem_arm"+sfx, dst+".type",
 				un.Name+"Type::"+ir.GoExportName(v.Name), un.Name+"Type::None", ind+"                    ")

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -118,6 +118,13 @@ type tableGen struct {
 	// entry takes, keyed by the triple (§3.3), so a generated field header
 	// carries its reference as a literal and a save does no lookup at all.
 	slots map[string]uint64
+	// idSlot is the FILE FORM's own numbering, id -> slot: the compile-time
+	// slot every id this unit can spell takes in the header's id slot map
+	// (docs/SPEC-TABLES.md §3, and slots.go). It is NOT the message form's
+	// vocabulary slot above: that one is keyed by the TRIPLE, because one name
+	// may ride at two shapes there, and this one is keyed by the id alone,
+	// because a trailer entry is an id and nothing else.
+	idSlot map[uint64]int
 	// msgDepth is the message codec's nesting depth while it emits: every
 	// loop variable and local a nested payload declares carries the depth as
 	// a suffix, so an element's decode inside an element's decode shadows
@@ -484,6 +491,21 @@ func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool, anyExtent bool
 	idCapacity := strconv.Itoa(idCap)
 	idBuckets := strconv.Itoa(buckets)
 	idShift := strconv.Itoa(64 - bits)
+	// THE ID SLOT MAP, the read side's half of the same compile-time fact
+	// (docs/SPEC-TABLES.md §3, and slots.go): the set of ids this unit can
+	// spell, each at a settled slot, with the probe table that finds one.
+	slotMap := buildIdSlotMap(tableIdSlotOrder(u))
+	refBound := tableRefBound(idCap)
+	// The UNKNOWN-ID PROBE's size. Only an id the unit cannot spell reaches it:
+	// a KNOWN id's repeat shows as a repeated SLOT, which is one bit of a
+	// bitmap over the compile-time set. It is TWICE the resolved-trailer bound,
+	// so the foreign subset of any trailer the reader resolves fits with the
+	// table never fuller than half, and the probe can neither overflow nor need
+	// a bound of its own.
+	probeSlots := 16
+	for probeSlots < 2*refBound {
+		probeSlots *= 2
+	}
 	keyedStorage := ""
 	if anyKeyed {
 		keyedStorage = tableKeyedStorage
@@ -869,6 +891,7 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+` + tableSlotRuntime(&slotMap, refBound) + `
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -877,16 +900,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    ` + forceInline + ` uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -1022,6 +1063,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = ` + strconv.Itoa(probeSlots) + `;
+static const int32_t kTableIdProbeShift = ` + strconv.Itoa(64-probeBits(probeSlots)) + `;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -1053,16 +1106,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -1127,9 +1263,14 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// compiler settled for it. A generated field header carries the slot as a
 	// literal beside the id.
 	slots := ir.TableVocabularySlots(u)
+	// THE FILE FORM'S ID SLOT MAP (docs/SPEC-TABLES.md §3), derived once for
+	// the unit and emitted into the header: the compile-time slot every id the
+	// closure can spell takes, which is what every read-side switch dispatches
+	// on once TableOpen has resolved the trailer.
+	idSlot := buildIdSlotMap(tableIdSlotOrder(u)).slot
 	for _, f := range u.Files {
 		g := &tableGen{unit: u, file: f, anyVariable: anyVariable, anyKeyed: anyKeyed, anyMap: anyMap, anyList: anyList, anyExtent: anyExtent, blocks: blocks, variable: variable, targets: targets,
-			includes: map[string]bool{}, nativeIncludes: map[string]bool{}, slots: slots}
+			includes: map[string]bool{}, nativeIncludes: map[string]bool{}, slots: slots, idSlot: idSlot}
 		var members []*ir.Struct
 		members = append(members, orderTables(f.Tables)...)
 		for _, d := range f.Decls {

--- a/internal/codegen/cpptable/extent.go
+++ b/internal/codegen/cpptable/extent.go
@@ -453,28 +453,28 @@ func (g *tableGen) emitUnionWireExtent(un *ir.Union) {
 	g.pf("    if ( !r.getleb( arm_ref ) ) { r.offset = r.size; return true; }\n")
 	g.pf("    if ( arm_ref == 0 ) { return true; } // None: the reference is the whole payload\n")
 	g.pf("    if ( r.ids == NULL || arm_ref > (uint64_t) r.ids->count ) { r.offset = r.size; return true; }\n")
-	g.pf("    const uint64_t arm_id = r.ids->at( arm_ref );\n")
+	g.pf("    const uint16_t arm_slot = r.ids->slot_of( arm_ref );\n")
 	g.pf("    if ( !r.has( 1 ) ) { r.offset = r.size; return true; }\n")
 	g.pf("    r.offset += 1; // the arm's kind byte\n")
 	g.pf("    uint64_t arm_len = 0;\n")
 	g.pf("    if ( !r.getleb( arm_len ) || !r.room( arm_len ) ) { r.offset = r.size; return true; }\n")
 	g.pf("    const uint8_t * arm_body = r.buffer + r.offset;\n")
 	g.pf("    r.offset += (int64_t) arm_len;\n")
-	g.pf("    switch ( arm_id )\n    {\n")
+	g.pf("    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)\n    {\n")
 	for _, v := range un.Variants {
 		if v.F == nil {
 			continue
 		}
 		switch {
 		case v.Body() && g.hasExtent(v.Ref):
-			g.pf("        case 0x%016xull: if ( !%sWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // %s\n",
-				ir.TableWireId(v.WireName()), v.Type, v.Name)
+			g.pf("        case %d: if ( !%sWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // %s, id 0x%016xull\n",
+				g.idSlotOf(ir.TableWireId(v.WireName())), v.Type, v.Name, ir.TableWireId(v.WireName()))
 		default:
 			inner, isUnion := v.F.Type.Ref.(*ir.Union)
 			if !isUnion || !g.unionHasExtent(inner, map[*ir.Union]bool{}) {
 				continue
 			}
-			g.pf("        case 0x%016xull: // %s: an arm that is another union\n        {\n", ir.TableWireId(v.WireName()), v.Name)
+			g.pf("        case %d: // %s: an arm that is another union, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableWireId(v.WireName())), v.Name, ir.TableWireId(v.WireName()))
 			g.pf("            TableReader arm( arm_body, (int64_t) arm_len, r.report, r.ids );\n")
 			g.pf("            if ( !%sWireArmExtent( arm, at, reason ) ) { return false; }\n", inner.Name)
 			g.pf("            break;\n        }\n")
@@ -538,7 +538,7 @@ func (g *tableGen) emitWireExtent(st *ir.Struct) {
 	g.pf("        if ( !r.getleb( field_ref ) ) { return true; }\n")
 	g.pf("        if ( field_ref == 0 ) { return true; }\n")
 	g.pf("        if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }\n")
-	g.pf("        const uint64_t field_id = ids->at( field_ref );\n")
+	g.pf("        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)\n")
 	g.pf("        if ( !r.has( 1 ) ) { return true; }\n")
 	g.pf("        uint8_t field_kind = r.get8();\n")
 	g.emitWireExtentCases(st)
@@ -558,7 +558,7 @@ func (g *tableGen) emitWireExtentCases(st *ir.Struct) {
 			if g.hasExtent(entry) {
 				inner = "&" + entry.Name + "WireExtent"
 			}
-			g.pf("        if ( field_id == 0x%016xull && field_kind == %d ) // %s\n        {\n", ir.TableFieldWireId(f), tkArray, f.Name)
+			g.pf("        if ( field_slot == %d && field_kind == %d ) // %s, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableFieldWireId(f)), tkArray, f.Name, ir.TableFieldWireId(f))
 			g.pf("            uint64_t map_len = 0;\n")
 			g.pf("            if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }\n")
 			g.pf("            const uint8_t * map_body = r.buffer + r.offset;\n")
@@ -574,7 +574,7 @@ func (g *tableGen) emitWireExtentCases(st *ir.Struct) {
 			if ref := listElementStruct(f); ref != nil && g.hasExtent(ref) {
 				inner = "&" + ref.Name + "WireExtent"
 			}
-			g.pf("        if ( field_id == 0x%016xull && field_kind == %d ) // %s: an unbounded array\n        {\n", ir.TableFieldWireId(f), tkArray, f.Name)
+			g.pf("        if ( field_slot == %d && field_kind == %d ) // %s: an unbounded array, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableFieldWireId(f)), tkArray, f.Name, ir.TableFieldWireId(f))
 			g.pf("            uint64_t list_len = 0;\n")
 			g.pf("            if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }\n")
 			g.pf("            const uint8_t * list_body = r.buffer + r.offset;\n")
@@ -604,7 +604,7 @@ func (g *tableGen) emitWireExtentCases(st *ir.Struct) {
 			case f.Array != ir.ArrayNone:
 				kind, walk = tkArray, "TableWireExtentElements"
 			}
-			g.pf("        if ( field_id == 0x%016xull && field_kind == %d ) // %s: a nesting that holds a list or a map\n        {\n", ir.TableFieldWireId(f), kind, f.Name)
+			g.pf("        if ( field_slot == %d && field_kind == %d ) // %s: a nesting that holds a list or a map, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableFieldWireId(f)), kind, f.Name, ir.TableFieldWireId(f))
 			g.pf("            uint64_t nested_len = 0;\n")
 			g.pf("            if ( !r.getleb( nested_len ) || !r.room( nested_len ) ) { return true; }\n")
 			g.pf("            const uint8_t * nested_body = r.buffer + r.offset;\n")
@@ -623,12 +623,12 @@ func (g *tableGen) emitWireExtentCases(st *ir.Struct) {
 			// THE FIELD'S ACTUAL SHAPE decides the framing: a union field is one
 			// arm header, and an array of unions is a kind 14 body of them
 			if f.Array == ir.ArrayNone {
-				g.pf("        if ( field_id == 0x%016xull && field_kind == %d ) // %s: a union arm that holds a list or a map\n        {\n", ir.TableFieldWireId(f), tkUnion, f.Name)
+				g.pf("        if ( field_slot == %d && field_kind == %d ) // %s: a union arm that holds a list or a map, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableFieldWireId(f)), tkUnion, f.Name, ir.TableFieldWireId(f))
 				g.pf("            if ( !%sWireArmExtent( r, at, reason ) ) { return false; }\n", un.Name)
 				g.pf("            continue;\n        }\n")
 				continue
 			}
-			g.pf("        if ( field_id == 0x%016xull && field_kind == %d ) // %s: an array of unions whose arms hold a list or a map\n        {\n", ir.TableFieldWireId(f), tkArray, f.Name)
+			g.pf("        if ( field_slot == %d && field_kind == %d ) // %s: an array of unions whose arms hold a list or a map, id 0x%016xull\n        {\n", g.idSlotOf(ir.TableFieldWireId(f)), tkArray, f.Name, ir.TableFieldWireId(f))
 			g.pf("            uint64_t arms_len = 0;\n")
 			g.pf("            if ( !r.getleb( arms_len ) || !r.room( arms_len ) ) { return true; }\n")
 			g.pf("            const uint8_t * arms_body = r.buffer + r.offset;\n")

--- a/internal/codegen/cpptable/maps.go
+++ b/internal/codegen/cpptable/maps.go
@@ -1140,10 +1140,10 @@ func (g *tableGen) emitMapKeyReader(f *ir.Field) {
 	g.pf("        if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }\n")
 	g.pf("        if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L\n")
 	g.pf("        if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }\n")
-	g.pf("        const uint64_t field_id = ids->at( field_ref );\n")
+	g.pf("        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)\n")
 	g.pf("        if ( !r.has( 1 ) ) { out.malformed = true; return out; }\n")
 	g.pf("        uint8_t field_kind = r.get8();\n")
-	g.pf("        if ( field_id == 0x%016xull ) // `key`, the ordinary hash of an ordinary name\n        {\n", ir.MapKeyWireId)
+	g.pf("        if ( field_slot == %d ) // `key`, at its slot; the id is the ordinary hash of an ordinary name\n        {\n", g.idSlotOf(ir.MapKeyWireId))
 	if !mapKeyIsString(f) && widenable(kind) {
 		// A KEY KIND THE DECLARATION WIDENS IS NOT A DISAGREEMENT (§2.8,
 		// §4): the key decodes exactly at its own width and the entry lands.

--- a/internal/codegen/cpptable/slots.go
+++ b/internal/codegen/cpptable/slots.go
@@ -1,0 +1,316 @@
+package cpptable
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// THE ID SLOT MAP (docs/SPEC-TABLES.md §3). "HOW a reader turns a reference
+// into a decision is its own choice — an array of the ids it read, a per-type
+// array of resolved slots, a perfect hash — because nothing on the wire
+// depends on it and no conformance case can see the difference."
+//
+// This backend's choice is the third with the second on top of it: the emitter
+// knows the whole set of ids the unit's closure can SPELL, which is the same
+// compile-time fact TableIds::kCapacity already is, so it settles a SLOT for
+// each of them at compile time and puts a hash over that set in the header.
+// TableOpen then resolves the trailer ONCE, at open — the spec's own words —
+// into one small slot a trailer entry, and every body dispatches on the slot
+// rather than on a 64-bit hash: a dense switch the compiler turns into a jump
+// table, where the id switch was a chain of 64-bit compares.
+//
+// NOTHING ABOUT THE VERDICT MOVES. An id the unit cannot spell resolves to
+// kTableIdSlotUnknown, which is the default arm the unknown counter already sat
+// in, and the kind check that follows a matched slot is the kind check that
+// followed a matched id.
+
+// idSlotMap is the compile-time map: the ids in slot order, and an
+// open-addressed probe table over them.
+//
+// The probe table holds SLOT NUMBERS, not ids, and the id a slot names lives
+// in the parallel ids array — so the table costs two bytes a slot rather than
+// eight, and the ids array is one entry an id rather than one an empty slot.
+// A miss walks to the first empty slot and stops; the emitter measures the
+// longest run of occupied slots the chosen multiplier leaves, so the WORST
+// CASE of a lookup is a compile-time constant of the header and not a
+// property of the input. THE SET IS THE UNIT'S, so a hostile wire cannot
+// lengthen a run: it can only ask for ids that miss.
+type idSlotMap struct {
+	ids      []uint64 // slot -> id, in slot order
+	slot     map[uint64]int
+	probe    []int  // probe slot -> id slot, -1 for empty
+	size     int    // len(probe), a power of two
+	shift    uint   // 64 - log2(size)
+	mul      uint64 // the multiplier the search settled on
+	maxProbe int    // the longest lookup, in slots examined
+}
+
+// tableIdSlotOrder is the order the slots are numbered in: the vocabulary's
+// own order first (docs/SPEC-TABLES.md §3.3, §20.2), which walks the closure
+// record by record and each record's fields in layout order, so A RECORD'S OWN
+// FIELDS LAND IN A RUN OF CONSECUTIVE SLOTS and its switch is dense. Then
+// every remaining id the closure can spell, ascending, and last the two
+// reserved ids the announcement's own transport rides under, which the
+// vocabulary holds back because they take no slot THERE (§3.3).
+//
+// The order is a pure function of the unit, so two runs of the emitter number
+// the slots the same way and the goldens hold.
+func tableIdSlotOrder(u *ir.Unit) []uint64 {
+	var out []uint64
+	seen := map[uint64]bool{}
+	add := func(id uint64) {
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	for _, e := range ir.TableVocabulary(u) {
+		add(e.Id)
+	}
+	for _, id := range ir.TableWireIds(u) {
+		add(id)
+	}
+	// THE ANNOUNCEMENT'S TWO RESERVED IDS take a slot HERE even though they
+	// take none in the vocabulary: a file-form body meets them, and meeting
+	// one is MALFORMED (§3.1, §3.3). The reader tests that by slot like every
+	// other id, so both have to be nameable.
+	add(ir.TableBuildVersionWireId)
+	add(ir.TableMessageVocabularyWireId)
+	return out
+}
+
+// idSlotMul walks a deterministic sequence of odd multipliers. The first is
+// the Fibonacci constant TableIds::bucket_of already interns with, and the
+// rest are one LCG apart from it, so the search is reproducible byte for byte
+// on every machine that runs the emitter.
+func idSlotMul(i int) uint64 {
+	m := uint64(0x9E3779B97F4A7C15)
+	for range i {
+		m = m*6364136223846793005 + 1442695040888963407
+	}
+	return m | 1
+}
+
+// buildIdSlotMap places the unit's ids and searches for the multiplier that
+// leaves the SHORTEST longest run. The table is at least twice the set, so it
+// is never fuller than half and an empty slot always ends a run.
+func buildIdSlotMap(ids []uint64) idSlotMap {
+	// FOUR SLOTS AN ID. The table is two bytes a slot, so a quarter load costs
+	// a few hundred bytes of rodata and buys a shorter longest run — and the
+	// run is the worst case the header states.
+	size := 16
+	for size < 4*len(ids) {
+		size *= 2
+	}
+	shift := uint(64)
+	for s := size; s > 1; s >>= 1 {
+		shift--
+	}
+	best := idSlotMap{}
+	bestRun := 1 << 30
+	probe := make([]int, size)
+	for attempt := range 4096 {
+		mul := idSlotMul(attempt)
+		for i := range probe {
+			probe[i] = -1
+		}
+		for s, id := range ids {
+			i := uint32((id * mul) >> shift)
+			for probe[i] >= 0 {
+				i = (i + 1) & uint32(size-1)
+			}
+			probe[i] = s
+		}
+		run := longestRun(probe)
+		if run < bestRun {
+			bestRun = run
+			best = idSlotMap{ids: ids, probe: append([]int(nil), probe...), size: size, shift: shift, mul: mul, maxProbe: run + 1}
+			if run <= 1 {
+				break
+			}
+		}
+	}
+	best.slot = make(map[uint64]int, len(ids))
+	for s, id := range ids {
+		best.slot[id] = s
+	}
+	return best
+}
+
+// longestRun is the longest CYCLIC run of occupied slots. A lookup examines at
+// most one slot past the run it starts in — the empty slot that ends it — so
+// maxProbe is this plus one, and every id in the table is inside its own run.
+func longestRun(probe []int) int {
+	n := len(probe)
+	empty := -1
+	for i := range n {
+		if probe[i] < 0 {
+			empty = i
+			break
+		}
+	}
+	if empty < 0 {
+		return n // cannot happen: the table is never fuller than half
+	}
+	best, run := 0, 0
+	for k := 1; k <= n; k++ {
+		if probe[(empty+k)%n] >= 0 {
+			run++
+			if run > best {
+				best = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	return best
+}
+
+// tableSlotRuntime is the header text: the slot count, the ids in slot order,
+// the probe table, and the one lookup every read path goes through.
+func tableSlotRuntime(m *idSlotMap, refBound int) string {
+	var b strings.Builder
+	p := func(format string, args ...any) { fmt.Fprintf(&b, format, args...) }
+	p(`
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = %d;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = %d;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than %d, so no lookup examines more than %d. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = %d;
+static const uint64_t kTableIdSlotMultiplier = 0x%016xull;
+static const uint32_t kTableIdSlotShift = %d;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+`, len(m.ids), m.size, m.maxProbe-1, m.maxProbe, m.maxProbe, m.mul, m.shift)
+	p("// the id each slot names, in slot order — what TableIdTable::at hands back,\n")
+	p("// settled at compile time instead of decoded from the wire\n")
+	p("static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {\n")
+	for i, id := range m.ids {
+		if i%4 == 0 {
+			p("   ")
+		}
+		p(" 0x%016xull,", id)
+		if i%4 == 3 || i == len(m.ids)-1 {
+			p("\n")
+		}
+	}
+	p("};\n")
+	p("// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits\n")
+	p("static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {\n")
+	for i, s := range m.probe {
+		if i%12 == 0 {
+			p("   ")
+		}
+		if s < 0 {
+			p(" 0xFFFF,")
+		} else {
+			p(" %5d,", s)
+		}
+		if i%12 == 11 || i == len(m.probe)-1 {
+			p("\n")
+		}
+	}
+	p("};\n")
+	p(`
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of %d covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = %d;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = %d;
+static const uint16_t kTableIdSlotBuildVersion = %d;
+static const uint16_t kTableIdSlotVocabulary = %d;
+`, tableRefFloor, refBound,
+		m.slot[ir.TableNodeWireId], m.slot[ir.TableBuildVersionWireId], m.slot[ir.TableMessageVocabularyWireId])
+	return b.String()
+}
+
+// tableRefFloor is the smallest trailer the slot array is sized for, whatever
+// the unit's own capacity: a unit of four ids still resolves a foreign wire's
+// hundred-entry trailer through the array rather than through the hash.
+const tableRefFloor = 128
+
+// idSlotOf is the compile-time slot an id takes, and it is what a read-side
+// case label carries. EVERY ID A CASE LABEL CAN SPELL IS IN THE MAP by
+// construction — the map is the union of the announced vocabulary, every id
+// the closure can name, and the three the language holds back — so a miss is
+// an emitter invariant broken and never a schema the map cannot hold. The
+// whole golden corpus goes through here on every run.
+func (g *tableGen) idSlotOf(id uint64) int {
+	s, ok := g.idSlot[id]
+	if !ok {
+		panic(fmt.Sprintf("cpptable: id 0x%016x has no slot in the unit's id slot map", id))
+	}
+	return s
+}
+
+// probeBits is log2 of a power of two, which is what turns the mixed hash into
+// a slot index.
+func probeBits(n int) int {
+	b := 0
+	for ; n > 1; n >>= 1 {
+		b++
+	}
+	return b
+}
+
+// tableRefBound is the resolved-trailer bound: the floor, or the unit's own id
+// capacity when that is larger, because a wire THIS BUILD WROTE can name every
+// id the closure spells and must never fall back.
+func tableRefBound(idCap int) int {
+	if idCap > tableRefFloor {
+		return idCap
+	}
+	return tableRefFloor
+}

--- a/internal/codegen/cpptable/view.go
+++ b/internal/codegen/cpptable/view.go
@@ -69,7 +69,8 @@ func generateViewFiles(u *ir.Unit, closure map[string]bool, anyVariable, anyKeye
 	g := &tableGen{unit: u, file: &ir.File{Base: viewBase(u.Package)},
 		anyVariable: anyVariable, anyKeyed: anyKeyed, anyMap: anyMap, anyList: anyList, anyExtent: anyExtent,
 		blocks: blocks, variable: variable, targets: targets,
-		includes: map[string]bool{}, nativeIncludes: map[string]bool{}, slots: ir.TableVocabularySlots(u)}
+		includes: map[string]bool{}, nativeIncludes: map[string]bool{}, slots: ir.TableVocabularySlots(u),
+		idSlot: buildIdSlotMap(tableIdSlotOrder(u)).slot}
 
 	base := viewBase(u.Package)
 	return map[string][]byte{

--- a/internal/codegen/cpptable/widen.go
+++ b/internal/codegen/cpptable/widen.go
@@ -261,7 +261,7 @@ func (g *tableGen) emitKeyedTriples(f *ir.Field, kind int, ind string, widened b
 	g.pf("%s        uint64_t elem_len = 0;\n", ind)
 	g.pf("%s        if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }\n", ind)
 	g.pf("%s        %s slot = %s::None;\n", ind, f.KeyEnum, f.KeyEnum)
-	g.pf("%s        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )\n%s        {\n", ind, ind)
+	g.pf("%s        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )\n%s        {\n", ind, ind)
 	g.pf("%s            r.report->unknown++;%s // a slot this reader cannot name\n", ind, g.retainLostInline())
 	g.pf("%s            sub.offset += (int64_t) elem_len;\n%s            continue;\n%s        }\n", ind, ind, ind)
 	g.pf("%s        {\n%s            TableReader elem( sub.buffer + sub.offset, (int64_t) elem_len, r.report, r.ids );\n", ind, ind)

--- a/internal/tablenames/cpp.go
+++ b/internal/tablenames/cpp.go
@@ -81,6 +81,13 @@ func init() {
 		// spells neither name.
 		Name{Name: "TableEnumId", What: "an enum value -> its table-wire variant id"},
 		Name{Name: "TableEnumValue", What: "a table-wire variant id -> its enum value"},
+		// the FILE FORM's half of the same answer (docs/SPEC-TABLES.md §3): a
+		// reader resolves the trailer ONCE, at open, and dispatches on the
+		// compile-time SLOT it resolved to rather than on the id, so the pair
+		// above gains a third spelling keyed by slot. Claimed on the pair's
+		// own terms, and for the same reason: a name free today must not
+		// become a collision the day a build reads a table.
+		Name{Name: "TableEnumValueAt", What: "a table-wire variant's RESOLVED SLOT -> its enum value (§3)"},
 		// the ENUM-KEYED array's storage type (docs/SPEC-TABLES.md §2.4). C++ spells it
 		// a class template and C# a generic class; both put it at unit level, and
 		// both emit it ONLY into a unit that declares a keyed array — but the

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -268,6 +268,16 @@
       ]
     },
     {
+      "name": "table-distinctness",
+      "when": "pull-request",
+      "why": "the id table's three distinctness and resolve controls, together, because each is an overlay rebuild: they patch the C++ table emitter's foreign probe, its known-slot bitmap and its resolve in turn, rebuild the compiler under each overlay, regenerate one unit and require the distinctness gate to go red on that structure's own cases. They cost what the other overlay rebuilds cost, without the fuzzer's pass on top. Measured about 90 s over 3 controls on the author's machine.",
+      "targets": [
+        "tables-distinctness-negative-control",
+        "tables-slot-bitmap-negative-control",
+        "tables-slot-resolve-negative-control"
+      ]
+    },
+    {
       "name": "wire-fuzz",
       "when": "pull-request",
       "why": "the tolerant-wire oracle and node-type controls, which read a pinned vector rather than rebuilding the compiler. The five oracles ran as one job at 82 s of control time on run 34115675206, most of it the fuzz driver they all build, so they run as two. Measured 11 s over 2 controls.",

--- a/test/tables/distinct_main.cpp
+++ b/test/tables/distinct_main.cpp
@@ -1,0 +1,662 @@
+// THE ID TABLE'S DISTINCTNESS AND RESOLVE, held to ONE ANSWER across every
+// structure TableOpen carries (docs/SPEC-TABLES.md §3: "a table that carries
+// one id twice is malformed", and "a reader RESOLVES THE TABLE ONCE, at open").
+//
+// TableOpen answers distinctness THREE ways — a BITMAP over the compile-time
+// slots for every id this build can name, a hashed PROBE over a stack array
+// for the foreign subset, the pairwise walk above kTableIdRefBound — and the
+// whole property is that a reader cannot tell which one ran. In the same pass
+// it RESOLVES every entry into its compile-time slot, which is what every
+// body's dispatch then reads. This test is the gate on both: it builds tables
+// BY HAND, drives TableOpen directly, holds the verdict against an independent
+// O(n^2) reference over the same bytes, and holds every resolved slot against
+// the hash that TableIdSlotOf computes from the id.
+//
+// The check is READ SIDE, so it is unconditional and this file is compiled
+// BOTH ways, with and without NDEBUG, by its Makefile leg. Nothing here
+// asserts: a failure prints the case and returns non-zero, so a release build
+// gates exactly as a debug build does.
+//
+// The cases that matter, and why each one is here:
+//
+//   - a table at EXACTLY the bound, all distinct              (probe, accept)
+//   - a table one PAST the bound, all distinct             (fallback, accept)
+//   - a repeat of entry 0 in the LAST slot, on both paths       (both, damaged)
+//   - a repeat in the middle and an adjacent repeat, on both paths
+//   - an ALL-COLLIDING table: n distinct ids the Fibonacci multiply lands in
+//     ONE slot, which is the cluster a hostile writer builds. Accepted when
+//     distinct, damaged when one of them repeats.
+//   - id 0 and id 0xFFFFFFFFFFFFFFFF as ORDINARY entries, because an entry is
+//     fnv1a64( name ) and nothing else (§3): no 64-bit value is a sentinel,
+//     which is why the probe carries an occupancy bitmap.
+//   - a sweep over every count from 0 to the bound + 4, each with no repeat
+//     and then with a repeat planted at every position, compared against the
+//     reference — the sweep is what proves the walks agree rather than that
+//     each one is separately plausible.
+//   - THE KNOWN SET: the ids this build can name, which take the slot bitmap
+//     and no probe slot at all — the whole set, a repeat planted at every
+//     position of it, the THREE RESERVED IDS the language holds back, and the
+//     known and foreign sets interleaved with the repeat on either side.
+//   - THE SLOT MAP'S OWN HOSTILE SHAPE: foreign ids aimed by inverting
+//     kTableIdSlotMultiplier at one home of the slot map's probe, on both
+//     sides of the bound. Each must still answer kTableIdSlotUnknown.
+//   - A TRAILER AT THE READER'S MAXIMUM, and one entry past it.
+//   - AND WHAT THE RESOLVE IS FOR: a body naming an id this build cannot name,
+//     at every kind the four skip rules cover, which must be skipped by its
+//     kind and counted `unknown` and nothing else — and the kinds that are not
+//     skippable at all, which must be framing damage.
+//
+// It names ONE generated unit, and one root of it only to press Load: the
+// checks are properties of the wire's trailer and of §4's unknown rule, not of
+// any field of any schema.
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "TablesTable.h"
+
+using tabledemo::TableIdTable;
+using tabledemo::TableOpen;
+using tabledemo::TableOpenVerdict;
+using tabledemo::TableOpenOk;
+using tabledemo::TableOpenDamaged;
+using tabledemo::kTableIdRefBound;
+using tabledemo::kTableIdProbeShift;
+using tabledemo::kTableIdSlotUnknown;
+using tabledemo::kTableIdSlotCount;
+using tabledemo::kTableIdSlotId;
+using tabledemo::TableIdSlotOf;
+using tabledemo::kTableIdSlotMultiplier;
+using tabledemo::kTableIdSlotShift;
+using tabledemo::kTableIdSlotProbeSize;
+using tabledemo::TableReport;
+using tabledemo::Debuff;
+using tabledemo::DebuffLoad;
+using tabledemo::kTableIdProbeSlots;
+
+static int g_failures = 0;
+
+// A WIRE THAT IS NOTHING BUT A TRAILER: the form byte, an empty root body, the
+// entries, the count. TableOpen reads the form byte and the trailer and hands
+// back the body's length, and it never walks the body, so an empty one is the
+// smallest wire that puts a given id table in front of the check.
+static std::vector<uint8_t> wire_of( const std::vector<uint64_t> & ids )
+{
+    std::vector<uint8_t> w;
+    w.push_back( 1 );                                   // the FORM BYTE (§3)
+    for ( size_t i = 0; i < ids.size(); i++ )
+    {
+        for ( int b = 0; b < 8; b++ ) { w.push_back( (uint8_t) ( ids[i] >> ( 8 * b ) ) ); }
+    }
+    const uint64_t count = (uint64_t) ids.size();
+    for ( int b = 0; b < 8; b++ ) { w.push_back( (uint8_t) ( count >> ( 8 * b ) ) ); }
+    return w;
+}
+
+// THE REFERENCE VERDICT, written the slowest way there is on purpose: every
+// pair, no hash, no bound. It is what the two walks in TableOpen are held to.
+static bool has_repeat( const std::vector<uint64_t> & ids )
+{
+    for ( size_t i = 1; i < ids.size(); i++ )
+    {
+        for ( size_t j = 0; j < i; j++ )
+        {
+            if ( ids[j] == ids[i] ) { return true; }
+        }
+    }
+    return false;
+}
+
+static void expect( const char * name, const std::vector<uint64_t> & ids )
+{
+    const std::vector<uint8_t> w = wire_of( ids );
+    TableIdTable table;
+    int64_t body_bytes = -1;
+    const TableOpenVerdict got = TableOpen( w.data(), (int64_t) w.size(), table, body_bytes );
+    const TableOpenVerdict want = has_repeat( ids ) ? TableOpenDamaged : TableOpenOk;
+    if ( got != want )
+    {
+        printf( "FAIL %s: count %d, verdict %d, expected %d\n",
+                name, (int) ids.size(), (int) got, (int) want );
+        g_failures++;
+        return;
+    }
+    if ( want == TableOpenOk )
+    {
+        // a clean table also has to hand back the body it framed, and every
+        // entry has to read back where the trailer put it.
+        if ( body_bytes != 0 )
+        {
+            printf( "FAIL %s: body_bytes %lld, expected 0\n", name, (long long) body_bytes );
+            g_failures++;
+            return;
+        }
+        if ( table.count != (int64_t) ids.size() )
+        {
+            printf( "FAIL %s: table.count %lld, expected %d\n",
+                    name, (long long) table.count, (int) ids.size() );
+            g_failures++;
+            return;
+        }
+        for ( size_t i = 0; i < ids.size(); i++ )
+        {
+            if ( table.at( (uint64_t) i + 1 ) != ids[i] )
+            {
+                printf( "FAIL %s: entry %d read back wrong\n", name, (int) i );
+                g_failures++;
+                return;
+            }
+            // THE RESOLVE IS THE SAME ANSWER THE HASH GIVES, on both sides of
+            // kTableIdRefBound: under it the slot came out of the array
+            // TableOpen filled, over it slot_of hashes the id on the spot, and
+            // the two must never differ. Every table this file builds goes
+            // through here, the whole sweep included.
+            const uint16_t got_slot = table.slot_of( (uint64_t) i + 1 );
+            const uint16_t want_slot = TableIdSlotOf( ids[i] );
+            if ( got_slot != want_slot )
+            {
+                printf( "FAIL %s: entry %d resolved to slot %u, the hash says %u\n",
+                        name, (int) i, (unsigned) got_slot, (unsigned) want_slot );
+                g_failures++;
+                return;
+            }
+            // and a slot that is not kTableIdSlotUnknown names THIS id
+            if ( got_slot != kTableIdSlotUnknown )
+            {
+                if ( (int) got_slot >= (int) kTableIdSlotCount || kTableIdSlotId[ got_slot ] != ids[i] )
+                {
+                    printf( "FAIL %s: entry %d resolved to a slot that names another id\n", name, (int) i );
+                    g_failures++;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+// A DISTINCT ID PER POSITION, spread so the probe does ordinary work.
+static std::vector<uint64_t> spread( int n )
+{
+    std::vector<uint64_t> ids;
+    for ( int i = 0; i < n; i++ ) { ids.push_back( 0x9E3779B97F4A7C15ull * (uint64_t) ( i + 1 ) ^ 0x0123456789ABCDEFull ); }
+    return ids;
+}
+
+// THE HOSTILE SHAPE. The probe's hash is the multiply TableIds::bucket_of
+// interns with, and a multiply by an ODD constant is INVERTIBLE mod 2^64 — so
+// a writer who wants every entry in one slot solves for it, and these are the
+// ids that come out. n of them make one cluster of length n, which is the
+// worst case the emitter's comment costs out.
+static uint64_t multiply_inverse()
+{
+    const uint64_t k = 0x9E3779B97F4A7C15ull;
+    uint64_t x = k;                                          // exact mod 2^3 for every odd k
+    for ( int i = 0; i < 6; i++ ) { x = x * ( 2 - k * x ); }  // Newton on the 2-adics
+    return x;
+}
+
+static std::vector<uint64_t> all_colliding( int n, uint32_t slot )
+{
+    const uint64_t inv = multiply_inverse();
+    std::vector<uint64_t> ids;
+    for ( int i = 0; i < n; i++ )
+    {
+        // id * k == ( slot << kTableIdProbeShift ) | i, so the top eight bits are slot for all of them
+        const uint64_t target = ( (uint64_t) slot << kTableIdProbeShift ) | (uint64_t) i;
+        ids.push_back( inv * target );
+    }
+    return ids;
+}
+
+static void check_collision_setup( const std::vector<uint64_t> & ids, uint32_t slot )
+{
+    for ( size_t i = 0; i < ids.size(); i++ )
+    {
+        const uint32_t s = uint32_t( ( ids[i] * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+        if ( s != slot )
+        {
+            printf( "FAIL collision setup: entry %d lands in slot %u, not %u\n", (int) i, s, slot );
+            g_failures++;
+            return;
+        }
+    }
+}
+
+// ---- THE KNOWN SET: the ids this build CAN name (docs/SPEC-TABLES.md §3) ----
+//
+// A known id takes no probe slot at all: its repeat is a repeated SLOT, which
+// is one bit of a bitmap over a set whose size is a compile-time fact. That is
+// a SECOND walk inside the fast path, so it needs its own cases — the ones the
+// probe's cases cannot reach.
+
+// every id the unit can spell, in slot order
+static std::vector<uint64_t> known_ids( int n )
+{
+    std::vector<uint64_t> ids;
+    for ( int i = 0; i < n && i < (int) kTableIdSlotCount; i++ ) { ids.push_back( kTableIdSlotId[i] ); }
+    return ids;
+}
+
+// THE SLOT MAP'S OWN HOSTILE SHAPE. TableIdSlotOf lands an id at
+// ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift and walks forward to the
+// first empty slot, so a writer who wants a MISS to do the most work it can be
+// made to do aims every foreign id at the same home. The multiply is odd and
+// therefore invertible, so these are the ids that come out. Each of them MUST
+// still answer kTableIdSlotUnknown: the map is closed over the unit's set and
+// a collision is not a match.
+static uint64_t odd_inverse( uint64_t k )
+{
+    uint64_t x = k;                                          // exact mod 2^3 for every odd k
+    for ( int i = 0; i < 6; i++ ) { x = x * ( 2 - k * x ); }  // Newton on the 2-adics
+    return x;
+}
+
+static std::vector<uint64_t> slot_map_colliding( int n, uint32_t home )
+{
+    const uint64_t inv = odd_inverse( kTableIdSlotMultiplier );
+    std::vector<uint64_t> ids;
+    for ( int i = 0; i < n; i++ )
+    {
+        const uint64_t target = ( (uint64_t) home << kTableIdSlotShift ) | (uint64_t) i;
+        const uint64_t id = inv * target;
+        // an id the unit CAN name would make this case something else: skip it
+        if ( TableIdSlotOf( id ) == kTableIdSlotUnknown ) { ids.push_back( id ); }
+    }
+    return ids;
+}
+
+static void run_slot_cases( int bound )
+{
+    // ---- the known set, and a repeat inside it. It is taken UNDER the
+    // resolved-trailer bound on purpose: over it the pairwise walk runs and
+    // the slot bitmap is not the structure under test. The whole set, when it
+    // is larger than the bound, rides in the "maximum" cases below.
+    {
+        std::vector<uint64_t> ids = known_ids( bound < (int) kTableIdSlotCount ? bound : (int) kTableIdSlotCount );
+        expect( "known: every id the build can name", ids );
+        if ( ids.size() > 1 )
+        {
+            std::vector<uint64_t> dup = ids;
+            dup[ dup.size() - 1 ] = dup[0];
+            expect( "known: first id repeated last", dup );
+            dup = ids;
+            dup[1] = dup[0];
+            expect( "known: adjacent repeat at the front", dup );
+            dup = ids;
+            dup[ dup.size() / 2 ] = dup[ dup.size() / 2 - 1 ];
+            expect( "known: repeat in the middle", dup );
+        }
+        // a repeat planted at EVERY position of the known set
+        for ( size_t at = 1; at < ids.size(); at++ )
+        {
+            std::vector<uint64_t> dup = ids;
+            dup[at] = ids[ at / 2 ];
+            expect( "known sweep planted", dup );
+        }
+    }
+
+    // ---- THE THREE RESERVED IDS, which are known ids like any other ----
+    {
+        std::vector<uint64_t> ids;
+        ids.push_back( 0xFFFFFFFFFFFFFFFFull ); // the node table's (§3.1)
+        ids.push_back( 0xFFFFFFFFFFFFFFFEull ); // the announcement's build version (§3.3)
+        ids.push_back( 0xFFFFFFFFFFFFFFFDull ); // the announcement's vocabulary (§3.3)
+        expect( "reserved: all three, distinct", ids );
+        for ( int a = 0; a < 3; a++ )
+        {
+            for ( int b = 0; b < 3; b++ )
+            {
+                std::vector<uint64_t> dup = ids;
+                dup[a] = ids[b];
+                expect( a == b ? "reserved: unchanged" : "reserved: one replaced by another", dup );
+            }
+        }
+        // and beside foreign entries, on both sides of the bound
+        std::vector<uint64_t> mixed = spread( bound - 3 );
+        for ( size_t i = 0; i < ids.size(); i++ ) { mixed.push_back( ids[i] ); }
+        expect( "reserved: at the bound beside foreign ids", mixed );
+        mixed[ mixed.size() - 1 ] = mixed[ mixed.size() - 2 ];
+        expect( "reserved: repeated at the bound", mixed );
+        mixed = spread( bound + 1 );
+        for ( size_t i = 0; i < ids.size(); i++ ) { mixed.push_back( ids[i] ); }
+        expect( "fallback: reserved beside foreign ids", mixed );
+        mixed[ mixed.size() - 1 ] = mixed[0];
+        expect( "fallback: a foreign id repeated after the reserved ones", mixed );
+    }
+
+    // ---- KNOWN AND FOREIGN INTERLEAVED, the repeat on either side ----
+    {
+        std::vector<uint64_t> ids;
+        const std::vector<uint64_t> k = known_ids( bound / 2 );
+        const std::vector<uint64_t> f = spread( bound / 2 );
+        for ( size_t i = 0; i < k.size() && i < f.size(); i++ ) { ids.push_back( k[i] ); ids.push_back( f[i] ); }
+        expect( "mixed: known and foreign interleaved", ids );
+        for ( size_t at = 1; at < ids.size(); at++ )
+        {
+            std::vector<uint64_t> dup = ids;
+            dup[at] = ids[ at - 1 ];
+            expect( "mixed: adjacent repeat, planted at every position", dup );
+        }
+        // a KNOWN id repeated across a long run of foreign ones, and back
+        std::vector<uint64_t> far = ids;
+        far[ far.size() - 1 ] = far[0];
+        expect( "mixed: the first known id repeated last", far );
+        far = ids;
+        far[ far.size() - 2 ] = far[1];
+        expect( "mixed: the first foreign id repeated last", far );
+    }
+
+    // ---- THE SLOT MAP'S HOSTILE CLUSTER: foreign ids aimed at one home ----
+    for ( uint32_t home = 0; home < 3; home++ )
+    {
+        const uint32_t h = home == 2 ? (uint32_t) ( kTableIdSlotProbeSize - 1 ) : home;
+        std::vector<uint64_t> ids = slot_map_colliding( bound, h );
+        if ( ids.size() < 2 ) { continue; }
+        expect( "slot map: foreign ids all aimed at one home, distinct", ids );
+        std::vector<uint64_t> dup = ids;
+        dup[ dup.size() - 1 ] = dup[0];
+        expect( "slot map: foreign ids all aimed at one home, first repeated last", dup );
+        dup = ids;
+        dup[1] = dup[0];
+        expect( "slot map: foreign ids all aimed at one home, repeat at the front", dup );
+        // the same shape ONE PAST the bound, where slot_of hashes per reference
+        std::vector<uint64_t> over = slot_map_colliding( bound + 8, h );
+        if ( (int) over.size() > bound )
+        {
+            expect( "slot map: one past the bound, aimed at one home", over );
+            over[ over.size() - 1 ] = over[0];
+            expect( "slot map: one past the bound, repeated", over );
+        }
+    }
+
+    // ---- A KNOWN ID AIMED AT A FOREIGN ID'S HOME, and the reverse. The two
+    // walks are separate structures, so an id in one must never be found by
+    // the other: a foreign id that lands on a known id's probe home is still
+    // unknown, and a known id never enters the foreign probe at all.
+    {
+        std::vector<uint64_t> ids = known_ids( 8 );
+        const std::vector<uint64_t> collide = slot_map_colliding( 8, uint32_t( ( kTableIdSlotId[0] * kTableIdSlotMultiplier ) >> kTableIdSlotShift ) );
+        for ( size_t i = 0; i < collide.size(); i++ ) { ids.push_back( collide[i] ); }
+        expect( "crossed: foreign ids at a known id's home", ids );
+        if ( ids.size() > 1 )
+        {
+            std::vector<uint64_t> dup = ids;
+            dup[ dup.size() - 1 ] = dup[0];
+            expect( "crossed: the known id repeated last", dup );
+        }
+    }
+
+    // ---- A TRAILER AT EXACTLY THE READER'S MAXIMUM, and one past it, built
+    // out of the known set repeated as far as it goes plus foreign filler ----
+    {
+        std::vector<uint64_t> ids = known_ids( bound < (int) kTableIdSlotCount ? bound : (int) kTableIdSlotCount );
+        const std::vector<uint64_t> f = spread( bound + 4 );
+        for ( size_t i = 0; (int) ids.size() < bound && i < f.size(); i++ ) { ids.push_back( f[i] ); }
+        expect( "maximum: a full trailer, known set then foreign", ids );
+        std::vector<uint64_t> dup = ids;
+        dup[ bound - 1 ] = dup[0];
+        expect( "maximum: a full trailer with the first id repeated last", dup );
+        ids.push_back( f[ f.size() - 1 ] );
+        expect( "maximum: one past the maximum", ids );
+        dup = ids;
+        dup[ dup.size() - 1 ] = dup[0];
+        expect( "maximum: one past the maximum, repeated", dup );
+    }
+}
+
+// ---- AND THE OTHER HALF: WHAT A RESOLVED SLOT DECIDES ----
+//
+// Everything above holds the RESOLVE. This holds what the resolve is FOR: a
+// body that names an id, and the read that follows. The tables here carry no
+// field of the reader's schema — one FOREIGN id at a time, at every kind — so
+// the file stays a property of the wire rather than of a declaration, and the
+// answer it checks is §4's ordinary one: AN ID THIS BUILD CANNOT NAME IS
+// SKIPPED BY ITS KIND AND COUNTED `unknown`, and never anything else.
+
+// a form-1 FILE whose root body is one field under one id, then the terminator
+static std::vector<uint8_t> file_of_one_field( uint64_t id, uint8_t kind,
+                                               const std::vector<uint8_t> & payload )
+{
+    std::vector<uint8_t> w;
+    w.push_back( 1 );          // the FORM BYTE (§3)
+    w.push_back( 1 );          // reference 1: the trailer's only entry
+    w.push_back( kind );
+    for ( size_t i = 0; i < payload.size(); i++ ) { w.push_back( payload[i] ); }
+    w.push_back( 0 );          // the body ENDS AT ITS OWN ZERO REFERENCE
+    for ( int b = 0; b < 8; b++ ) { w.push_back( (uint8_t) ( id >> ( 8 * b ) ) ); }
+    const uint64_t count = 1;
+    for ( int b = 0; b < 8; b++ ) { w.push_back( (uint8_t) ( count >> ( 8 * b ) ) ); }
+    return w;
+}
+
+static void expect_unknown( const char * name, uint8_t kind, const std::vector<uint8_t> & payload )
+{
+    // an id NO NAME HASHES TO in this unit: the gate asserts it before using it
+    const uint64_t foreign = 0x0123456789ABCDEFull;
+    if ( TableIdSlotOf( foreign ) != kTableIdSlotUnknown )
+    {
+        printf( "FAIL %s: the chosen foreign id is one this build names\n", name );
+        g_failures++;
+        return;
+    }
+    const std::vector<uint8_t> w = file_of_one_field( foreign, kind, payload );
+    Debuff value;
+    TableReport report;
+    const bool ok = DebuffLoad( value, w.data(), (int64_t) w.size(), &report );
+    if ( !ok || report.malformed || report.unknown != 1 || report.kind_mismatch != 0 ||
+         report.widened != 0 || report.clamped != 0 || report.duplicate != 0 || report.refused )
+    {
+        printf( "FAIL %s: kind %u read ok=%d unknown=%d kind_mismatch=%d malformed=%d\n",
+                name, (unsigned) kind, (int) ok, report.unknown, report.kind_mismatch,
+                (int) report.malformed );
+        g_failures++;
+    }
+}
+
+static void expect_unskippable( const char * name, uint8_t kind )
+{
+    const uint64_t foreign = 0x0123456789ABCDEFull;
+    std::vector<uint8_t> payload;
+    const std::vector<uint8_t> w = file_of_one_field( foreign, kind, payload );
+    Debuff value;
+    TableReport report;
+    DebuffLoad( value, w.data(), (int64_t) w.size(), &report );
+    if ( !report.malformed )
+    {
+        printf( "FAIL %s: kind %u is not skippable and was not framing damage\n",
+                name, (unsigned) kind );
+        g_failures++;
+    }
+}
+
+static void run_unknown_cases()
+{
+    // THE FOUR SKIP RULES (docs/SPEC-TABLES.md §3), each over an id this build
+    // cannot name, each answering one unknown and nothing else.
+    const uint8_t fixed1[] = { 1, 2, 6, 20, 25 };
+    const uint8_t fixed2[] = { 3, 7, 21, 26 };
+    const uint8_t fixed4[] = { 4, 8, 10, 22, 27 };
+    const uint8_t fixed8[] = { 5, 9, 11, 23, 28 };
+    const uint8_t fixed16[] = { 18, 19, 24, 29 };
+    const uint8_t lengthed[] = { 12, 13, 14, 16, 31, 32, 33 };
+    for ( size_t i = 0; i < sizeof( fixed1 ); i++ )
+    { expect_unknown( "unknown: a one-byte kind", fixed1[i], std::vector<uint8_t>( 1, 0 ) ); }
+    for ( size_t i = 0; i < sizeof( fixed2 ); i++ )
+    { expect_unknown( "unknown: a two-byte kind", fixed2[i], std::vector<uint8_t>( 2, 0 ) ); }
+    for ( size_t i = 0; i < sizeof( fixed4 ); i++ )
+    { expect_unknown( "unknown: a four-byte kind", fixed4[i], std::vector<uint8_t>( 4, 0 ) ); }
+    for ( size_t i = 0; i < sizeof( fixed8 ); i++ )
+    { expect_unknown( "unknown: an eight-byte kind", fixed8[i], std::vector<uint8_t>( 8, 0 ) ); }
+    for ( size_t i = 0; i < sizeof( fixed16 ); i++ )
+    { expect_unknown( "unknown: a sixteen-byte kind", fixed16[i], std::vector<uint8_t>( 16, 0 ) ); }
+    for ( size_t i = 0; i < sizeof( lengthed ); i++ )
+    { expect_unknown( "unknown: a length-shaped kind", lengthed[i], std::vector<uint8_t>( 1, 0 ) ); }
+    // kinds 17 and 30 read ONE LEB128 and stop
+    expect_unknown( "unknown: a node index", 17, std::vector<uint8_t>( 1, 7 ) );
+    expect_unknown( "unknown: an enum reference", 30, std::vector<uint8_t>( 1, 3 ) );
+    // kind 15 is the union: the arm id reference, and 0 is the whole payload
+    expect_unknown( "unknown: an empty union", 15, std::vector<uint8_t>( 1, 0 ) );
+    {
+        std::vector<uint8_t> arm;
+        arm.push_back( 1 );  // the arm's id reference
+        arm.push_back( 9 );  // its kind
+        arm.push_back( 8 );  // its L
+        for ( int i = 0; i < 8; i++ ) { arm.push_back( 0 ); }
+        expect_unknown( "unknown: a set union arm", 15, arm );
+    }
+    // A KIND THIS READER DOES NOT KNOW AT ALL IS NOT SKIPPABLE (§3), and 34 is
+    // RESERVED BY NAME for float16 and is met only as damage.
+    expect_unskippable( "unknown: kind 34, reserved and not this major's", 34 );
+    expect_unskippable( "unknown: kind 35", 35 );
+    expect_unskippable( "unknown: kind 200", 200 );
+    expect_unskippable( "unknown: kind 0", 0 );
+}
+
+int main()
+{
+    const int bound = (int) kTableIdRefBound;
+
+    // ---- the two paths, clean ----
+    expect( "at the bound", spread( bound ) );
+    expect( "one past the bound", spread( bound + 1 ) );
+    expect( "well under the bound", spread( 53 ) );
+    expect( "well over the bound", spread( bound * 3 ) );
+
+    // ---- entry 0 repeated in the LAST slot, on both paths ----
+    {
+        std::vector<uint64_t> ids = spread( bound );
+        ids[ bound - 1 ] = ids[0];
+        expect( "probe: first id repeated last", ids );
+    }
+    {
+        std::vector<uint64_t> ids = spread( bound + 1 );
+        ids[ bound ] = ids[0];
+        expect( "fallback: first id repeated last", ids );
+    }
+
+    // ---- a repeat in the middle, and an adjacent repeat, on both paths ----
+    {
+        std::vector<uint64_t> ids = spread( bound );
+        ids[ bound / 2 ] = ids[ 3 ];
+        expect( "probe: middle repeat", ids );
+        ids = spread( bound );
+        ids[ 41 ] = ids[ 40 ];
+        expect( "probe: adjacent repeat", ids );
+    }
+    {
+        std::vector<uint64_t> ids = spread( bound + 1 );
+        ids[ bound / 2 ] = ids[ 3 ];
+        expect( "fallback: middle repeat", ids );
+        ids = spread( bound + 1 );
+        ids[ 41 ] = ids[ 40 ];
+        expect( "fallback: adjacent repeat", ids );
+    }
+
+    // ---- the smallest tables there are ----
+    expect( "empty table", std::vector<uint64_t>() );
+    expect( "one entry", std::vector<uint64_t>( 1, 0x1111ull ) );
+    {
+        std::vector<uint64_t> ids;
+        ids.push_back( 7 ); ids.push_back( 7 );
+        expect( "two entries, both the same", ids );
+        ids[1] = 8;
+        expect( "two entries, distinct", ids );
+    }
+
+    // ---- NO 64-BIT VALUE IS A SENTINEL (§3) ----
+    {
+        std::vector<uint64_t> ids = spread( 20 );
+        ids[0] = 0;                             // a hash of 0 is an ordinary id
+        ids[1] = 0xFFFFFFFFFFFFFFFFull;         // the node table's reserved id
+        ids[2] = 0xFFFFFFFFFFFFFFFEull;         // the announcement's build version
+        expect( "probe: 0 and the reserved ids as ordinary entries", ids );
+        ids[19] = 0;
+        expect( "probe: 0 repeated", ids );
+        ids[19] = 0xFFFFFFFFFFFFFFFFull;
+        expect( "probe: the reserved id repeated", ids );
+    }
+    {
+        std::vector<uint64_t> ids = spread( bound + 2 );
+        ids[0] = 0;
+        ids[1] = 0xFFFFFFFFFFFFFFFFull;
+        expect( "fallback: 0 and the reserved id as ordinary entries", ids );
+        ids[ bound + 1 ] = 0;
+        expect( "fallback: 0 repeated", ids );
+    }
+
+    // ---- THE HOSTILE CLUSTER: every entry in one slot ----
+    for ( uint32_t slot = 0; slot < 3; slot++ )
+    {
+        const uint32_t s = slot == 2 ? (uint32_t) ( kTableIdProbeSlots - 1 ) : slot;
+        std::vector<uint64_t> ids = all_colliding( bound, s );
+        check_collision_setup( ids, s );
+        expect( "probe: every id in one slot, distinct", ids );
+        ids[ bound - 1 ] = ids[0];
+        expect( "probe: every id in one slot, first repeated last", ids );
+        ids = all_colliding( bound, s );
+        ids[1] = ids[0];
+        expect( "probe: every id in one slot, repeat at the front", ids );
+        // the same shape one past the bound, where the pairwise walk runs and
+        // the hash is not consulted at all
+        ids = all_colliding( bound + 1, s );
+        expect( "fallback: every id in one slot, distinct", ids );
+        ids[ bound ] = ids[0];
+        expect( "fallback: every id in one slot, first repeated last", ids );
+    }
+
+    // A CLUSTER THAT WRAPS the slot array: the probe's linear step is masked,
+    // so a cluster starting at the last slot has to walk over the end and find
+    // the repeat on the other side.
+    {
+        std::vector<uint64_t> ids = all_colliding( bound, (uint32_t) ( kTableIdProbeSlots - 1 ) );
+        ids[ bound / 2 ] = ids[ bound / 2 - 1 ];
+        expect( "probe: wrapping cluster, repeat inside it", ids );
+    }
+
+    // ---- THE SWEEP: every count either side of the bound, clean and with a
+    // repeat planted at every position, against the reference verdict ----
+    for ( int n = 0; n <= bound + 4; n++ )
+    {
+        expect( "sweep clean", spread( n ) );
+        for ( int at = 1; at < n; at++ )
+        {
+            std::vector<uint64_t> ids = spread( n );
+            ids[at] = ids[ at / 2 ];
+            expect( "sweep planted", ids );
+            if ( g_failures > 8 ) { printf( "too many failures, stopping\n" ); return 1; }
+        }
+    }
+
+    // the same sweep over the hostile cluster, which is the shape where the
+    // probe does the most work it can be made to do
+    for ( int n = 0; n <= bound + 2; n++ )
+    {
+        expect( "hostile sweep clean", all_colliding( n, 5 ) );
+        if ( n > 1 )
+        {
+            std::vector<uint64_t> ids = all_colliding( n, 5 );
+            ids[ n - 1 ] = ids[0];
+            expect( "hostile sweep planted", ids );
+        }
+    }
+
+    // ---- everything the SLOT MAP brought: the known set, the reserved ids,
+    // the two walks crossed, and the hostile shapes aimed at each ----
+    run_slot_cases( bound );
+
+    // ---- and what the resolved slot DECIDES: an id this build cannot name,
+    // counted unknown and skipped by its kind ----
+    run_unknown_cases();
+
+    if ( g_failures != 0 )
+    {
+        printf( "DISTINCTNESS GATE FAILED: %d case(s)\n", g_failures );
+        return 1;
+    }
+    printf( "distinctness gate: both walks agree with the pairwise reference on every table, "
+            "and every resolved slot agrees with the hash (bound %d, probe slots %d, id slots %d over %d)\n",
+            bound, (int) kTableIdProbeSlots, (int) kTableIdSlotCount, (int) kTableIdSlotProbeSize );
+    return 0;
+}

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -435,6 +435,112 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 35;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xbc69cf4276846d19ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x5cc201a9f1b8274eull, 0xbf82010f6f71eae9ull, 0x891da1f305deb858ull, 0xc5b2a72c0845a253ull,
+    0xafcd9a3b099f8ef0ull, 0xd94c56ef0798d723ull, 0x3e7884bf4f412c6full, 0x30e6ed678f5e1bd4ull,
+    0xaf63eb4c86020609ull, 0xaf63ea4c86020456ull, 0x2d4c068f5f889287ull, 0x24ad84ada20208d5ull,
+    0xfd4d194e1652b207ull, 0x072ddab46af04ab7ull, 0xfa04f4ef1995407eull, 0x3c2f1bbad18642adull,
+    0x1f6459a2cea1fc02ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x670377dcbe2f82b6ull, 0xb5877a7e05bbfed2ull, 0x58ba95d8757c67c0ull,
+    0xa1f526c44ead452full, 0xa5c085b4bb73d1b5ull, 0x0fe46fc6a1b583abull, 0x66bd1cc6d2f6b68dull,
+    0x31badbc06c5f0b97ull, 0x986d012bd380b0b2ull, 0xdcea4d2bfa11ceebull, 0x85a6b5fb5284964dull,
+    0x9f8e22fb612a2f78ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    26, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       19, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15,    25, 0xFFFF,
+    0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,     2, 0xFFFF,
+    0xFFFF, 0xFFFF,    12,    31, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF,
+    0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF,    29,    22, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 17;
+static const uint16_t kTableIdSlotBuildVersion = 33;
+static const uint16_t kTableIdSlotVocabulary = 34;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +549,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    ARMDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +896,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +939,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5909,10 +6128,10 @@ inline bool LeafLoadBody( TableReader & r, const TableNodeMap & nodes, Leaf & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5923,9 +6142,9 @@ inline bool LeafLoadBody( TableReader & r, const TableNodeMap & nodes, Leaf & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -6011,7 +6230,7 @@ inline bool LeafLoadBody( TableReader & r, const TableNodeMap & nodes, Leaf & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6295,10 +6514,10 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6309,9 +6528,9 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafcd9a3b099f8ef0ull: // carry
+            case 4: // carry, id 0xafcd9a3b099f8ef0ull
             {
                 if ( kind != 15 )
                 {
@@ -6325,16 +6544,16 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.carry.type = CarryType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x24ad84ada20208d5ull: // leaf
+                        case 11: // leaf, id 0x24ad84ada20208d5ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6350,7 +6569,7 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
                             if ( sub.offset != sub.size ) { value.carry.type = CarryType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -6395,7 +6614,7 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xd94c56ef0798d723ull: // tail
+            case 5: // tail, id 0xd94c56ef0798d723ull
             {
                 if ( kind != 14 )
                 {
@@ -6481,7 +6700,7 @@ inline bool HolderLoadBody( TableReader & r, const TableNodeMap & nodes, Holder 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6949,10 +7168,10 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6963,9 +7182,9 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 3: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -7011,15 +7230,15 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x24ad84ada20208d5ull: // leaf
+                                    case 11: // leaf, id 0x24ad84ada20208d5ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -7031,7 +7250,7 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
                                         if ( elem_arm.offset != elem_arm.size ) { value.entries[(int32_t) i].type = CarryType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xfd4d194e1652b207ull: // plain
+                                    case 12: // plain, id 0xfd4d194e1652b207ull
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -7074,7 +7293,7 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7100,7 +7319,7 @@ inline bool HandLoadBody( TableReader & r, const TableNodeMap & nodes, Hand & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7600,10 +7819,10 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7614,9 +7833,9 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x5cc201a9f1b8274eull: // links
+            case 0: // links, id 0x5cc201a9f1b8274eull
             {
                 if ( kind != 14 )
                 {
@@ -7666,15 +7885,15 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
                                     if ( elem_arm_ref_links != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_links > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_links = r.ids->at( elem_arm_ref_links );
+                                        const uint16_t elem_arm_slot_links = r.ids->slot_of( elem_arm_ref_links );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_links = sub.get8();
                                         uint64_t elem_arm_len_links = 0;
                                         if ( !sub.getleb( elem_arm_len_links ) || !sub.room( elem_arm_len_links ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_links( sub.buffer + sub.offset, (int64_t) elem_arm_len_links, r.report, r.ids );
-                                        switch ( elem_arm_id_links ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_links ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x24ad84ada20208d5ull: // leaf
+                                            case 11: // leaf, id 0x24ad84ada20208d5ull
                                             {
                                                 if ( elem_arm_kind_links != 13 )
                                                 {
@@ -7686,7 +7905,7 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
                                                 if ( elem_arm_links.offset != elem_arm_links.size ) { ( *slot ).type = CarryType::None; r.report->malformed = true; break; }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_links != 4 )
                                                 {
@@ -7728,7 +7947,7 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7754,7 +7973,7 @@ inline bool ChainLoadBody( TableReader & r, const TableNodeMap & nodes, Chain & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8108,10 +8327,10 @@ inline bool LeafWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3e7884bf4f412c6full && field_kind == 14 ) // items: an unbounded array
+        if ( field_slot == 6 && field_kind == 14 ) // items: an unbounded array, id 0x3e7884bf4f412c6full
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8186,15 +8405,15 @@ inline bool HolderWireExtent( const uint8_t * body, int64_t length, int64_t & at
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xafcd9a3b099f8ef0ull && field_kind == 15 ) // carry: a union arm that holds a list or a map
+        if ( field_slot == 4 && field_kind == 15 ) // carry: a union arm that holds a list or a map, id 0xafcd9a3b099f8ef0ull
         {
             if ( !CarryWireArmExtent( r, at, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0xd94c56ef0798d723ull && field_kind == 14 ) // tail: an unbounded array
+        if ( field_slot == 5 && field_kind == 14 ) // tail: an unbounded array, id 0xd94c56ef0798d723ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8287,10 +8506,10 @@ inline bool HandWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xc5b2a72c0845a253ull && field_kind == 14 ) // entries: an array of unions whose arms hold a list or a map
+        if ( field_slot == 3 && field_kind == 14 ) // entries: an array of unions whose arms hold a list or a map, id 0xc5b2a72c0845a253ull
         {
             uint64_t arms_len = 0;
             if ( !r.getleb( arms_len ) || !r.room( arms_len ) ) { return true; }
@@ -8393,10 +8612,10 @@ inline bool ChainWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x5cc201a9f1b8274eull && field_kind == 14 ) // links: an unbounded array
+        if ( field_slot == 0 && field_kind == 14 ) // links: an unbounded array, id 0x5cc201a9f1b8274eull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8490,16 +8709,16 @@ inline bool CarryWireArmExtent( TableReader & r, int64_t & at, TableRefuseReason
     if ( !r.getleb( arm_ref ) ) { r.offset = r.size; return true; }
     if ( arm_ref == 0 ) { return true; } // None: the reference is the whole payload
     if ( r.ids == NULL || arm_ref > (uint64_t) r.ids->count ) { r.offset = r.size; return true; }
-    const uint64_t arm_id = r.ids->at( arm_ref );
+    const uint16_t arm_slot = r.ids->slot_of( arm_ref );
     if ( !r.has( 1 ) ) { r.offset = r.size; return true; }
     r.offset += 1; // the arm's kind byte
     uint64_t arm_len = 0;
     if ( !r.getleb( arm_len ) || !r.room( arm_len ) ) { r.offset = r.size; return true; }
     const uint8_t * arm_body = r.buffer + r.offset;
     r.offset += (int64_t) arm_len;
-    switch ( arm_id )
+    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
     {
-        case 0x24ad84ada20208d5ull: if ( !LeafWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // leaf
+        case 11: if ( !LeafWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // leaf, id 0x24ad84ada20208d5ull
         default: break; // an arm this reader cannot name reads None
     }
     return true;
@@ -12593,10 +12812,11 @@ inline bool LeafLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Lea
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12607,9 +12827,9 @@ inline bool LeafLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Lea
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -12695,7 +12915,7 @@ inline bool LeafLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Lea
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -12923,10 +13143,11 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12937,9 +13158,9 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafcd9a3b099f8ef0ull: // carry
+            case 4: // carry, id 0xafcd9a3b099f8ef0ull
             {
                 if ( kind != 15 )
                 {
@@ -12954,16 +13175,16 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.carry.type = CarryType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x24ad84ada20208d5ull: // leaf
+                        case 11: // leaf, id 0x24ad84ada20208d5ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -12979,7 +13200,7 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
                             if ( sub.offset != sub.size ) { value.carry.type = CarryType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -13024,7 +13245,7 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xd94c56ef0798d723ull: // tail
+            case 5: // tail, id 0xd94c56ef0798d723ull
             {
                 if ( kind != 14 )
                 {
@@ -13110,7 +13331,7 @@ inline bool HolderLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, H
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -13462,10 +13683,11 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13476,9 +13698,9 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 3: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -13527,15 +13749,15 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x24ad84ada20208d5ull: // leaf
+                                    case 11: // leaf, id 0x24ad84ada20208d5ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -13547,7 +13769,7 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
                                         if ( elem_arm.offset != elem_arm.size ) { value.entries[(int32_t) i].type = CarryType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xfd4d194e1652b207ull: // plain
+                                    case 12: // plain, id 0xfd4d194e1652b207ull
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -13590,7 +13812,7 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -13616,7 +13838,7 @@ inline bool HandLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Han
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -14001,10 +14223,11 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14015,9 +14238,9 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x5cc201a9f1b8274eull: // links
+            case 0: // links, id 0x5cc201a9f1b8274eull
             {
                 if ( kind != 14 )
                 {
@@ -14070,15 +14293,15 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                                     if ( elem_arm_ref_links != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_links > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_links = r.ids->at( elem_arm_ref_links );
+                                        const uint16_t elem_arm_slot_links = r.ids->slot_of( elem_arm_ref_links );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_links = sub.get8();
                                         uint64_t elem_arm_len_links = 0;
                                         if ( !sub.getleb( elem_arm_len_links ) || !sub.room( elem_arm_len_links ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_links( sub.buffer + sub.offset, (int64_t) elem_arm_len_links, r.report, r.ids );
-                                        switch ( elem_arm_id_links ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_links ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x24ad84ada20208d5ull: // leaf
+                                            case 11: // leaf, id 0x24ad84ada20208d5ull
                                             {
                                                 if ( elem_arm_kind_links != 13 )
                                                 {
@@ -14090,7 +14313,7 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                                                 if ( elem_arm_links.offset != elem_arm_links.size ) { ( *slot ).type = CarryType::None; r.report->malformed = true; break; }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_links != 4 )
                                                 {
@@ -14132,7 +14355,7 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -14158,7 +14381,7 @@ inline bool ChainLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -435,6 +435,112 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 35;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xbc69cf4276846d19ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x5cc201a9f1b8274eull, 0xbf82010f6f71eae9ull, 0x891da1f305deb858ull, 0xc5b2a72c0845a253ull,
+    0xafcd9a3b099f8ef0ull, 0xd94c56ef0798d723ull, 0x3e7884bf4f412c6full, 0x30e6ed678f5e1bd4ull,
+    0xaf63eb4c86020609ull, 0xaf63ea4c86020456ull, 0x2d4c068f5f889287ull, 0x24ad84ada20208d5ull,
+    0xfd4d194e1652b207ull, 0x072ddab46af04ab7ull, 0xfa04f4ef1995407eull, 0x3c2f1bbad18642adull,
+    0x1f6459a2cea1fc02ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x670377dcbe2f82b6ull, 0xb5877a7e05bbfed2ull, 0x58ba95d8757c67c0ull,
+    0xa1f526c44ead452full, 0xa5c085b4bb73d1b5ull, 0x0fe46fc6a1b583abull, 0x66bd1cc6d2f6b68dull,
+    0x31badbc06c5f0b97ull, 0x986d012bd380b0b2ull, 0xdcea4d2bfa11ceebull, 0x85a6b5fb5284964dull,
+    0x9f8e22fb612a2f78ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    26, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       19, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15,    25, 0xFFFF,
+    0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,     2, 0xFFFF,
+    0xFFFF, 0xFFFF,    12,    31, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF,
+    0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF,    29,    22, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 17;
+static const uint16_t kTableIdSlotBuildVersion = 33;
+static const uint16_t kTableIdSlotVocabulary = 34;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +549,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    ARMDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +896,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +939,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5842,10 +6061,10 @@ ARMDEMO_TABLE_INLINE bool OnlyLoadBody( TableReader & r, Only & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5856,9 +6075,9 @@ ARMDEMO_TABLE_INLINE bool OnlyLoadBody( TableReader & r, Only & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63ea4c86020456ull: // w
+            case 9: // w, id 0xaf63ea4c86020456ull
             {
                 if ( kind != 4 )
                 {
@@ -6262,10 +6481,10 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6276,9 +6495,9 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x891da1f305deb858ull: // reach
+            case 2: // reach, id 0x891da1f305deb858ull
             {
                 if ( kind != 15 )
                 {
@@ -6292,16 +6511,16 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.reach.type = ReachType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x072ddab46af04ab7ull: // only
+                        case 13: // only, id 0x072ddab46af04ab7ull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -6320,7 +6539,7 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
                             }
                             break;
                         }
-                        case 0xfa04f4ef1995407eull: // text
+                        case 14: // text, id 0xfa04f4ef1995407eull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -6339,7 +6558,7 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
                             }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -6384,7 +6603,7 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -6410,7 +6629,7 @@ inline bool GateLoadBody( TableReader & r, const TableNodeMap & nodes, Gate & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8022,10 +8241,11 @@ ARMDEMO_TABLE_INLINE bool OnlyLoadBodyRetain( TableReader & r, Only & value, Tab
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8036,9 +8256,9 @@ ARMDEMO_TABLE_INLINE bool OnlyLoadBodyRetain( TableReader & r, Only & value, Tab
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63ea4c86020456ull: // w
+            case 9: // w, id 0xaf63ea4c86020456ull
             {
                 if ( kind != 4 )
                 {
@@ -8308,10 +8528,11 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8322,9 +8543,9 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x891da1f305deb858ull: // reach
+            case 2: // reach, id 0x891da1f305deb858ull
             {
                 if ( kind != 15 )
                 {
@@ -8339,16 +8560,16 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.reach.type = ReachType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x072ddab46af04ab7ull: // only
+                        case 13: // only, id 0x072ddab46af04ab7ull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -8367,7 +8588,7 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
                             }
                             break;
                         }
-                        case 0xfa04f4ef1995407eull: // text
+                        case 14: // text, id 0xfa04f4ef1995407eull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -8386,7 +8607,7 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
                             }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -8431,7 +8652,7 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -8457,7 +8678,7 @@ inline bool GateLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Gat
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -436,6 +436,112 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 35;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xbc69cf4276846d19ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x5cc201a9f1b8274eull, 0xbf82010f6f71eae9ull, 0x891da1f305deb858ull, 0xc5b2a72c0845a253ull,
+    0xafcd9a3b099f8ef0ull, 0xd94c56ef0798d723ull, 0x3e7884bf4f412c6full, 0x30e6ed678f5e1bd4ull,
+    0xaf63eb4c86020609ull, 0xaf63ea4c86020456ull, 0x2d4c068f5f889287ull, 0x24ad84ada20208d5ull,
+    0xfd4d194e1652b207ull, 0x072ddab46af04ab7ull, 0xfa04f4ef1995407eull, 0x3c2f1bbad18642adull,
+    0x1f6459a2cea1fc02ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x670377dcbe2f82b6ull, 0xb5877a7e05bbfed2ull, 0x58ba95d8757c67c0ull,
+    0xa1f526c44ead452full, 0xa5c085b4bb73d1b5ull, 0x0fe46fc6a1b583abull, 0x66bd1cc6d2f6b68dull,
+    0x31badbc06c5f0b97ull, 0x986d012bd380b0b2ull, 0xdcea4d2bfa11ceebull, 0x85a6b5fb5284964dull,
+    0x9f8e22fb612a2f78ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    26, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       19, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15,    25, 0xFFFF,
+    0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,     2, 0xFFFF,
+    0xFFFF, 0xFFFF,    12,    31, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF,
+    0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF,    29,    22, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 17;
+static const uint16_t kTableIdSlotBuildVersion = 33;
+static const uint16_t kTableIdSlotVocabulary = 34;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +550,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    ARMDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +897,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +940,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5902,10 +6121,10 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5916,9 +6135,9 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x2d4c068f5f889287ull: // inner
+            case 10: // inner, id 0x2d4c068f5f889287ull
             {
                 if ( kind != 15 )
                 {
@@ -5932,16 +6151,16 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.inner.type = InnerType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x24ad84ada20208d5ull: // leaf
+                        case 11: // leaf, id 0x24ad84ada20208d5ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5957,7 +6176,7 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
                             if ( sub.offset != sub.size ) { value.inner.type = InnerType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -6002,7 +6221,7 @@ inline bool TwigLoadBody( TableReader & r, const TableNodeMap & nodes, Twig & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6437,10 +6656,10 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6451,9 +6670,9 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x30e6ed678f5e1bd4ull: // outer
+            case 7: // outer, id 0x30e6ed678f5e1bd4ull
             {
                 if ( kind != 15 )
                 {
@@ -6467,16 +6686,16 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.outer.type = OuterType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x2d4c068f5f889287ull: // inner
+                        case 10: // inner, id 0x2d4c068f5f889287ull
                         {
                             if ( arm_kind != 15 )
                             {
@@ -6494,15 +6713,15 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                                 if ( arm_inner_ref != 0 ) // the zero reference is the inner union's None
                                 {
                                     if ( arm_inner_ref > (uint64_t) r.ids->count ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
-                                    const uint64_t arm_inner_id = r.ids->at( arm_inner_ref );
+                                    const uint16_t arm_inner_slot = r.ids->slot_of( arm_inner_ref );
                                     if ( !sub.has( 1 ) ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
                                     const uint8_t arm_inner_kind = sub.get8();
                                     uint64_t arm_inner_len = 0;
                                     if ( !sub.getleb( arm_inner_len ) || !sub.room( arm_inner_len ) ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
                                     TableReader arm_inner( sub.buffer + sub.offset, (int64_t) arm_inner_len, r.report, r.ids );
-                                    switch ( arm_inner_id ) // the arm's NAME hash (§5)
+                                    switch ( arm_inner_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                     {
-                                        case 0x24ad84ada20208d5ull: // leaf
+                                        case 11: // leaf, id 0x24ad84ada20208d5ull
                                         {
                                             if ( arm_inner_kind != 13 )
                                             {
@@ -6514,7 +6733,7 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                                             if ( arm_inner.offset != arm_inner.size ) { value.outer.inner.type = InnerType::None; r.report->malformed = true; break; }
                                             break;
                                         }
-                                        case 0xfd4d194e1652b207ull: // plain
+                                        case 12: // plain, id 0xfd4d194e1652b207ull
                                         {
                                             if ( arm_inner_kind != 4 )
                                             {
@@ -6548,7 +6767,7 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                             }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -6593,7 +6812,7 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xd94c56ef0798d723ull: // tail
+            case 5: // tail, id 0xd94c56ef0798d723ull
             {
                 if ( kind != 14 )
                 {
@@ -6679,7 +6898,7 @@ inline bool NestLoadBody( TableReader & r, const TableNodeMap & nodes, Nest & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7119,10 +7338,10 @@ inline bool TwigWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x2d4c068f5f889287ull && field_kind == 15 ) // inner: a union arm that holds a list or a map
+        if ( field_slot == 10 && field_kind == 15 ) // inner: a union arm that holds a list or a map, id 0x2d4c068f5f889287ull
         {
             if ( !InnerWireArmExtent( r, at, reason ) ) { return false; }
             continue;
@@ -7189,15 +7408,15 @@ inline bool NestWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x30e6ed678f5e1bd4ull && field_kind == 15 ) // outer: a union arm that holds a list or a map
+        if ( field_slot == 7 && field_kind == 15 ) // outer: a union arm that holds a list or a map, id 0x30e6ed678f5e1bd4ull
         {
             if ( !OuterWireArmExtent( r, at, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0xd94c56ef0798d723ull && field_kind == 14 ) // tail: an unbounded array
+        if ( field_slot == 5 && field_kind == 14 ) // tail: an unbounded array, id 0xd94c56ef0798d723ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -7300,16 +7519,16 @@ inline bool InnerWireArmExtent( TableReader & r, int64_t & at, TableRefuseReason
     if ( !r.getleb( arm_ref ) ) { r.offset = r.size; return true; }
     if ( arm_ref == 0 ) { return true; } // None: the reference is the whole payload
     if ( r.ids == NULL || arm_ref > (uint64_t) r.ids->count ) { r.offset = r.size; return true; }
-    const uint64_t arm_id = r.ids->at( arm_ref );
+    const uint16_t arm_slot = r.ids->slot_of( arm_ref );
     if ( !r.has( 1 ) ) { r.offset = r.size; return true; }
     r.offset += 1; // the arm's kind byte
     uint64_t arm_len = 0;
     if ( !r.getleb( arm_len ) || !r.room( arm_len ) ) { r.offset = r.size; return true; }
     const uint8_t * arm_body = r.buffer + r.offset;
     r.offset += (int64_t) arm_len;
-    switch ( arm_id )
+    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
     {
-        case 0x24ad84ada20208d5ull: if ( !LeafWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // leaf
+        case 11: if ( !LeafWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // leaf, id 0x24ad84ada20208d5ull
         default: break; // an arm this reader cannot name reads None
     }
     return true;
@@ -7338,16 +7557,16 @@ inline bool OuterWireArmExtent( TableReader & r, int64_t & at, TableRefuseReason
     if ( !r.getleb( arm_ref ) ) { r.offset = r.size; return true; }
     if ( arm_ref == 0 ) { return true; } // None: the reference is the whole payload
     if ( r.ids == NULL || arm_ref > (uint64_t) r.ids->count ) { r.offset = r.size; return true; }
-    const uint64_t arm_id = r.ids->at( arm_ref );
+    const uint16_t arm_slot = r.ids->slot_of( arm_ref );
     if ( !r.has( 1 ) ) { r.offset = r.size; return true; }
     r.offset += 1; // the arm's kind byte
     uint64_t arm_len = 0;
     if ( !r.getleb( arm_len ) || !r.room( arm_len ) ) { r.offset = r.size; return true; }
     const uint8_t * arm_body = r.buffer + r.offset;
     r.offset += (int64_t) arm_len;
-    switch ( arm_id )
+    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
     {
-        case 0x2d4c068f5f889287ull: // inner: an arm that is another union
+        case 10: // inner: an arm that is another union, id 0x2d4c068f5f889287ull
         {
             TableReader arm( arm_body, (int64_t) arm_len, r.report, r.ids );
             if ( !InnerWireArmExtent( arm, at, reason ) ) { return false; }
@@ -9479,10 +9698,11 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9493,9 +9713,9 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x2d4c068f5f889287ull: // inner
+            case 10: // inner, id 0x2d4c068f5f889287ull
             {
                 if ( kind != 15 )
                 {
@@ -9510,16 +9730,16 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.inner.type = InnerType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x24ad84ada20208d5ull: // leaf
+                        case 11: // leaf, id 0x24ad84ada20208d5ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -9535,7 +9755,7 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
                             if ( sub.offset != sub.size ) { value.inner.type = InnerType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -9580,7 +9800,7 @@ inline bool TwigLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Twi
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9935,10 +10155,11 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9949,9 +10170,9 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x30e6ed678f5e1bd4ull: // outer
+            case 7: // outer, id 0x30e6ed678f5e1bd4ull
             {
                 if ( kind != 15 )
                 {
@@ -9966,16 +10187,16 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.outer.type = OuterType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x2d4c068f5f889287ull: // inner
+                        case 10: // inner, id 0x2d4c068f5f889287ull
                         {
                             if ( arm_kind != 15 )
                             {
@@ -9993,15 +10214,15 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                                 if ( arm_inner_ref != 0 ) // the zero reference is the inner union's None
                                 {
                                     if ( arm_inner_ref > (uint64_t) r.ids->count ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
-                                    const uint64_t arm_inner_id = r.ids->at( arm_inner_ref );
+                                    const uint16_t arm_inner_slot = r.ids->slot_of( arm_inner_ref );
                                     if ( !sub.has( 1 ) ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
                                     const uint8_t arm_inner_kind = sub.get8();
                                     uint64_t arm_inner_len = 0;
                                     if ( !sub.getleb( arm_inner_len ) || !sub.room( arm_inner_len ) ) { value.outer.type = OuterType::None; r.report->malformed = true; break; }
                                     TableReader arm_inner( sub.buffer + sub.offset, (int64_t) arm_inner_len, r.report, r.ids );
-                                    switch ( arm_inner_id ) // the arm's NAME hash (§5)
+                                    switch ( arm_inner_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                     {
-                                        case 0x24ad84ada20208d5ull: // leaf
+                                        case 11: // leaf, id 0x24ad84ada20208d5ull
                                         {
                                             if ( arm_inner_kind != 13 )
                                             {
@@ -10013,7 +10234,7 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                                             if ( arm_inner.offset != arm_inner.size ) { value.outer.inner.type = InnerType::None; r.report->malformed = true; break; }
                                             break;
                                         }
-                                        case 0xfd4d194e1652b207ull: // plain
+                                        case 12: // plain, id 0xfd4d194e1652b207ull
                                         {
                                             if ( arm_inner_kind != 4 )
                                             {
@@ -10047,7 +10268,7 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                             }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 12: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -10092,7 +10313,7 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xd94c56ef0798d723ull: // tail
+            case 5: // tail, id 0xd94c56ef0798d723ull
             {
                 if ( kind != 14 )
                 {
@@ -10178,7 +10399,7 @@ inline bool NestLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Nes
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -435,6 +435,112 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 35;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xbc69cf4276846d19ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x5cc201a9f1b8274eull, 0xbf82010f6f71eae9ull, 0x891da1f305deb858ull, 0xc5b2a72c0845a253ull,
+    0xafcd9a3b099f8ef0ull, 0xd94c56ef0798d723ull, 0x3e7884bf4f412c6full, 0x30e6ed678f5e1bd4ull,
+    0xaf63eb4c86020609ull, 0xaf63ea4c86020456ull, 0x2d4c068f5f889287ull, 0x24ad84ada20208d5ull,
+    0xfd4d194e1652b207ull, 0x072ddab46af04ab7ull, 0xfa04f4ef1995407eull, 0x3c2f1bbad18642adull,
+    0x1f6459a2cea1fc02ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x670377dcbe2f82b6ull, 0xb5877a7e05bbfed2ull, 0x58ba95d8757c67c0ull,
+    0xa1f526c44ead452full, 0xa5c085b4bb73d1b5ull, 0x0fe46fc6a1b583abull, 0x66bd1cc6d2f6b68dull,
+    0x31badbc06c5f0b97ull, 0x986d012bd380b0b2ull, 0xdcea4d2bfa11ceebull, 0x85a6b5fb5284964dull,
+    0x9f8e22fb612a2f78ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    26, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       19, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15,    25, 0xFFFF,
+    0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,     2, 0xFFFF,
+    0xFFFF, 0xFFFF,    12,    31, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    30, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF,
+    0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF,    29,    22, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 17;
+static const uint16_t kTableIdSlotBuildVersion = 33;
+static const uint16_t kTableIdSlotVocabulary = 34;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +549,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    ARMDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +896,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +939,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5959,10 +6178,10 @@ ARMDEMO_TABLE_INLINE bool NodeLoadBody( TableReader & r, Node & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5973,9 +6192,9 @@ ARMDEMO_TABLE_INLINE bool NodeLoadBody( TableReader & r, Node & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 8: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -6410,10 +6629,10 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6424,9 +6643,9 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -6476,15 +6695,15 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
                                     if ( elem_arm_ref_items != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_items > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_items = r.ids->at( elem_arm_ref_items );
+                                        const uint16_t elem_arm_slot_items = r.ids->slot_of( elem_arm_ref_items );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_items = sub.get8();
                                         uint64_t elem_arm_len_items = 0;
                                         if ( !sub.getleb( elem_arm_len_items ) || !sub.room( elem_arm_len_items ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_items( sub.buffer + sub.offset, (int64_t) elem_arm_len_items, r.report, r.ids );
-                                        switch ( elem_arm_id_items ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_items ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x3c2f1bbad18642adull: // node
+                                            case 15: // node, id 0x3c2f1bbad18642adull
                                             {
                                                 if ( elem_arm_kind_items != 17 )
                                                 {
@@ -6499,7 +6718,7 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
                                                 }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_items != 4 )
                                                 {
@@ -6541,7 +6760,7 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -6567,7 +6786,7 @@ inline bool RingLoadBody( TableReader & r, const TableNodeMap & nodes, Ring & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7101,10 +7320,10 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7115,9 +7334,9 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -7167,15 +7386,15 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
                                     if ( elem_arm_ref_items != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_items > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_items = r.ids->at( elem_arm_ref_items );
+                                        const uint16_t elem_arm_slot_items = r.ids->slot_of( elem_arm_ref_items );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_items = sub.get8();
                                         uint64_t elem_arm_len_items = 0;
                                         if ( !sub.getleb( elem_arm_len_items ) || !sub.room( elem_arm_len_items ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_items( sub.buffer + sub.offset, (int64_t) elem_arm_len_items, r.report, r.ids );
-                                        switch ( elem_arm_id_items ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_items ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x1f6459a2cea1fc02ull: // many
+                                            case 16: // many, id 0x1f6459a2cea1fc02ull
                                             {
                                                 if ( elem_arm_kind_items != 14 )
                                                 {
@@ -7208,7 +7427,7 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
                                                 }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_items != 4 )
                                                 {
@@ -7250,7 +7469,7 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7276,7 +7495,7 @@ inline bool RackLoadBody( TableReader & r, const TableNodeMap & nodes, Rack & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7823,10 +8042,10 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7837,9 +8056,9 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 3: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -7885,15 +8104,15 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x1f6459a2cea1fc02ull: // many
+                                    case 16: // many, id 0x1f6459a2cea1fc02ull
                                     {
                                         if ( elem_arm_kind != 14 )
                                         {
@@ -7926,7 +8145,7 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
                                         }
                                         break;
                                     }
-                                    case 0xfd4d194e1652b207ull: // plain
+                                    case 12: // plain, id 0xfd4d194e1652b207ull
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -7969,7 +8188,7 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7995,7 +8214,7 @@ inline bool TrayLoadBody( TableReader & r, const TableNodeMap & nodes, Tray & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8382,10 +8601,10 @@ inline bool RingWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3e7884bf4f412c6full && field_kind == 14 ) // items: an unbounded array
+        if ( field_slot == 6 && field_kind == 14 ) // items: an unbounded array, id 0x3e7884bf4f412c6full
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8460,10 +8679,10 @@ inline bool RackWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3e7884bf4f412c6full && field_kind == 14 ) // items: an unbounded array
+        if ( field_slot == 6 && field_kind == 14 ) // items: an unbounded array, id 0x3e7884bf4f412c6full
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -11929,10 +12148,11 @@ ARMDEMO_TABLE_INLINE bool NodeLoadBodyRetain( TableReader & r, Node & value, Tab
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11943,9 +12163,9 @@ ARMDEMO_TABLE_INLINE bool NodeLoadBodyRetain( TableReader & r, Node & value, Tab
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 8: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -12246,10 +12466,11 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12260,9 +12481,9 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -12315,15 +12536,15 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
                                     if ( elem_arm_ref_items != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_items > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_items = r.ids->at( elem_arm_ref_items );
+                                        const uint16_t elem_arm_slot_items = r.ids->slot_of( elem_arm_ref_items );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_items = sub.get8();
                                         uint64_t elem_arm_len_items = 0;
                                         if ( !sub.getleb( elem_arm_len_items ) || !sub.room( elem_arm_len_items ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_items( sub.buffer + sub.offset, (int64_t) elem_arm_len_items, r.report, r.ids );
-                                        switch ( elem_arm_id_items ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_items ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x3c2f1bbad18642adull: // node
+                                            case 15: // node, id 0x3c2f1bbad18642adull
                                             {
                                                 if ( elem_arm_kind_items != 17 )
                                                 {
@@ -12338,7 +12559,7 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
                                                 }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_items != 4 )
                                                 {
@@ -12380,7 +12601,7 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -12406,7 +12627,7 @@ inline bool RingLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rin
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -12820,10 +13041,11 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12834,9 +13056,9 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 6: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -12889,15 +13111,15 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
                                     if ( elem_arm_ref_items != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_items > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_items = r.ids->at( elem_arm_ref_items );
+                                        const uint16_t elem_arm_slot_items = r.ids->slot_of( elem_arm_ref_items );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_items = sub.get8();
                                         uint64_t elem_arm_len_items = 0;
                                         if ( !sub.getleb( elem_arm_len_items ) || !sub.room( elem_arm_len_items ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_items( sub.buffer + sub.offset, (int64_t) elem_arm_len_items, r.report, r.ids );
-                                        switch ( elem_arm_id_items ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_items ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x1f6459a2cea1fc02ull: // many
+                                            case 16: // many, id 0x1f6459a2cea1fc02ull
                                             {
                                                 if ( elem_arm_kind_items != 14 )
                                                 {
@@ -12930,7 +13152,7 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
                                                 }
                                                 break;
                                             }
-                                            case 0xfd4d194e1652b207ull: // plain
+                                            case 12: // plain, id 0xfd4d194e1652b207ull
                                             {
                                                 if ( elem_arm_kind_items != 4 )
                                                 {
@@ -12972,7 +13194,7 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -12998,7 +13220,7 @@ inline bool RackLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Rac
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -13425,10 +13647,11 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13439,9 +13662,9 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 3: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -13490,15 +13713,15 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x1f6459a2cea1fc02ull: // many
+                                    case 16: // many, id 0x1f6459a2cea1fc02ull
                                     {
                                         if ( elem_arm_kind != 14 )
                                         {
@@ -13531,7 +13754,7 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
                                         }
                                         break;
                                     }
-                                    case 0xfd4d194e1652b207ull: // plain
+                                    case 12: // plain, id 0xfd4d194e1652b207ull
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -13574,7 +13797,7 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 1: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -13600,7 +13823,7 @@ inline bool TrayLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tra
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -410,6 +410,97 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 17;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0xbc69cf4276846d19ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xc4bcadba8e631b86ull, 0xef9c96d721673243ull, 0x855b556730a34a05ull, 0x5daa28eb864c02a5ull,
+    0xe5316cbaa025f028ull, 0x0a8f12cc5f9a0c03ull, 0x613b19720ff4b203ull, 0x3bf8fbbad1587cddull,
+    0x509220bb65a646b7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x8e4e6dccfe5f64fbull, 0x1f1750c1bc916638ull, 0xfffffffffffffffeull,
+    0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF,
+       11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15, 0xFFFF,     6, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 9;
+static const uint16_t kTableIdSlotBuildVersion = 15;
+static const uint16_t kTableIdSlotVocabulary = 16;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -418,16 +509,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOBDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -747,6 +856,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -778,16 +899,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5190,10 +5394,10 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5204,9 +5408,9 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -5235,7 +5439,7 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xef9c96d721673243ull: // kind
+            case 1: // kind, id 0xef9c96d721673243ull
             {
                 if ( kind != 8 )
                 {
@@ -5261,7 +5465,7 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 value.kind = decoded_v;
                 break;
             }
-            case 0x855b556730a34a05ull: // data
+            case 2: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 17 )
                 {
@@ -5281,7 +5485,7 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 }
                 break;
             }
-            case 0x5daa28eb864c02a5ull: // caption
+            case 3: // caption, id 0x5daa28eb864c02a5ull
             {
                 if ( kind != 17 )
                 {
@@ -5301,7 +5505,7 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 }
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 4: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -5321,7 +5525,7 @@ inline bool AssetLoadBody( TableReader & r, const TableNodeMap & nodes, Asset & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -5725,10 +5929,10 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5739,9 +5943,9 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -5770,7 +5974,7 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -5790,7 +5994,7 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 }
                 break;
             }
-            case 0x613b19720ff4b203ull: // thumb
+            case 6: // thumb, id 0x613b19720ff4b203ull
             {
                 if ( kind != 17 )
                 {
@@ -5810,7 +6014,7 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 }
                 break;
             }
-            case 0x3bf8fbbad1587cddull: // note
+            case 7: // note, id 0x3bf8fbbad1587cddull
             {
                 if ( kind != 17 )
                 {
@@ -5830,7 +6034,7 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 }
                 break;
             }
-            case 0x509220bb65a646b7ull: // alias
+            case 8: // alias, id 0x509220bb65a646b7ull
             {
                 if ( kind != 17 )
                 {
@@ -5850,7 +6054,7 @@ inline bool CatalogLoadBody( TableReader & r, const TableNodeMap & nodes, Catalo
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8482,10 +8686,11 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8496,9 +8701,9 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -8527,7 +8732,7 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xef9c96d721673243ull: // kind
+            case 1: // kind, id 0xef9c96d721673243ull
             {
                 if ( kind != 8 )
                 {
@@ -8553,7 +8758,7 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 value.kind = decoded_v;
                 break;
             }
-            case 0x855b556730a34a05ull: // data
+            case 2: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 17 )
                 {
@@ -8573,7 +8778,7 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 }
                 break;
             }
-            case 0x5daa28eb864c02a5ull: // caption
+            case 3: // caption, id 0x5daa28eb864c02a5ull
             {
                 if ( kind != 17 )
                 {
@@ -8593,7 +8798,7 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 }
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 4: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -8613,7 +8818,7 @@ inline bool AssetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, As
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8927,10 +9132,11 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8941,9 +9147,9 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -8972,7 +9178,7 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -8992,7 +9198,7 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 }
                 break;
             }
-            case 0x613b19720ff4b203ull: // thumb
+            case 6: // thumb, id 0x613b19720ff4b203ull
             {
                 if ( kind != 17 )
                 {
@@ -9012,7 +9218,7 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 }
                 break;
             }
-            case 0x3bf8fbbad1587cddull: // note
+            case 7: // note, id 0x3bf8fbbad1587cddull
             {
                 if ( kind != 17 )
                 {
@@ -9032,7 +9238,7 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 }
                 break;
             }
-            case 0x509220bb65a646b7ull: // alias
+            case 8: // alias, id 0x509220bb65a646b7ull
             {
                 if ( kind != 17 )
                 {
@@ -9052,7 +9258,7 @@ inline bool CatalogLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -396,6 +396,147 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 91;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x5dacbc0222cbc053ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xeddcb72b15486e77ull, 0xee7ba9ad45c64144ull, 0xa3a7061ff10a8138ull, 0xc573b39bc29148caull,
+    0x56d7ab194448a4f3ull, 0x7ce4fd9430e80ceaull, 0xd5f2d079088c0b17ull, 0x08b72e07b55c3ac0ull,
+    0x39f7fcec8fcb623dull, 0xe68c2e6bb1ee5646ull, 0xbaaeb048a5a8fa6dull, 0x77976c7416517c63ull,
+    0x4cbf3a26fca1d74aull, 0xb51afb05cd34709full, 0x9f61700f084ab92eull, 0x336d3dc7fffd0c9bull,
+    0x6a0c6a156952b9c2ull, 0xdcb27c18fed9e15cull, 0x6aacb9fbb71a1d91ull, 0x17a3a1a985f75aecull,
+    0xb66e4449e56b2e26ull, 0x4d7bf73bcbddc228ull, 0xe5626f155e4c5dadull, 0xfa23d9ef19afc32cull,
+    0x0bdab42c07f19812ull, 0x5de0015285763c46ull, 0xaf63e94c860202a3ull, 0xfd7f3fa0b16ed778ull,
+    0x0bee7b3cb4046c93ull, 0xdc89eb9cd3393be5ull, 0xbb62c62c9808ea37ull, 0x0f9222d2ba7aa2a7ull,
+    0x294a5c4913e1ad44ull, 0x84f8260bc283608cull, 0x1c3027194b1ba4d0ull, 0x43125398a9903d27ull,
+    0xc1f8d7edff7fcfd2ull, 0x33408e39f5f480ffull, 0xd982b77b3e92d16dull, 0x876a8c1a85806a69ull,
+    0xee5d97ad45ad251full, 0x6917a5bab91540f2ull, 0xcd29c05f390294ecull, 0x96b593c242133841ull,
+    0x151b2a0e2c07b4bcull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0xaf63f74c86021a6dull,
+    0xaf63ea4c86020456ull, 0xcfd587cb3100cd73ull, 0x1f7d2e86a2e77268ull, 0x1554fa45a1220171ull,
+    0x4d5be97ba1b9cb81ull, 0xd23da7ab574b95c3ull, 0x88a11a6aed541f54ull, 0x3d2cc8d952adebecull,
+    0xc8736ef79380e634ull, 0x94e8a172d8f4805eull, 0xa0745aa7967eeffaull, 0xf5d0a4d25a76afcaull,
+    0x478d7972f6d9075dull, 0xcaa6172bef74e234ull, 0x4f98acac2852d653ull, 0x7f3a7e4744ea3019ull,
+    0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull, 0x6c2321a3d00e23dbull, 0x9ff1de19feac1b7cull,
+    0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull, 0xc416c97e0d3218b3ull, 0xffffffffffffffffull,
+    0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0xbf050ec6de1ec3e0ull,
+    0x1d3a1648d6207581ull, 0x11c6b29d15f30306ull, 0x5ff5bdbae776636full, 0xcca6d00e1bb40147ull,
+    0x0cc738b585c9e5f8ull, 0x9b2749fb3fc30f4eull, 0xb0947dbe6c23d994ull, 0x93dab31114da135bull,
+    0x5b00edd93fad6007ull, 0xc19ad62b865276feull, 0x4034181fa408c29full, 0x5bdf5fe3e05f510bull,
+    0xdd519511c4d9d295ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,
+       47, 0xFFFF, 0xFFFF,    43, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,    77,    36, 0xFFFF, 0xFFFF,    46, 0xFFFF,
+       73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF,    55,    81, 0xFFFF, 0xFFFF,    59, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF,     2,
+    0xFFFF,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    72,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11,    65, 0xFFFF, 0xFFFF,    13,     1, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    62, 0xFFFF,     3, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    86, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       26,    54, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21,    16,
+    0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    27,    78, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF, 0xFFFF,    51, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF,    69,    41, 0xFFFF,
+       71, 0xFFFF,    63, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57,    14, 0xFFFF,
+       33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70, 0xFFFF,
+    0xFFFF,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    31,    29, 0xFFFF,    22,    67,
+    0xFFFF, 0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF,    15,    53, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9,    56, 0xFFFF,    87, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    60, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    30,    49,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    74, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 71;
+static const uint16_t kTableIdSlotBuildVersion = 89;
+static const uint16_t kTableIdSlotVocabulary = 90;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -404,16 +545,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOCKDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -733,6 +892,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -764,16 +935,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2450,6 +2704,17 @@ inline bool TableEnumValue( uint64_t id, Team & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Team & out )
+{
+    switch ( slot )
+    {
+        case 67: out = Team::Red; return true; // id 0x9ff1de19feac1b7cull
+        case 68: out = Team::Blue; return true; // id 0xecf3d3a7c1693e2dull
+        case 69: out = Team::Green; return true; // id 0xcf00d78fd5953f1cull
+        case 70: out = Team::Gold; return true; // id 0xc416c97e0d3218b3ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_TEAM
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2661,10 +2926,10 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2675,9 +2940,9 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x56d7ab194448a4f3ull: // tag
+            case 4: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 6 )
                 {
@@ -2692,7 +2957,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 value.tag = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 5: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 11 )
                 {
@@ -2715,7 +2980,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 value.value = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xd5f2d079088c0b17ull: // flag
+            case 6: // flag, id 0xd5f2d079088c0b17ull
             {
                 if ( kind != 1 )
                 {
@@ -2729,7 +2994,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 value.flag = r.get8() != 0;
                 break;
             }
-            case 0x08b72e07b55c3ac0ull: // id
+            case 7: // id, id 0x08b72e07b55c3ac0ull
             {
                 if ( kind != 8 )
                 {
@@ -2755,7 +3020,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 value.id = decoded_v;
                 break;
             }
-            case 0x39f7fcec8fcb623dull: // label
+            case 8: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -2784,7 +3049,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xe68c2e6bb1ee5646ull: // slots
+            case 9: // slots, id 0xe68c2e6bb1ee5646ull
             {
                 if ( kind != 14 )
                 {
@@ -2847,7 +3112,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbaaeb048a5a8fa6dull: // teams
+            case 10: // teams, id 0xbaaeb048a5a8fa6dull
             {
                 if ( kind != 16 )
                 {
@@ -2884,7 +3149,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Team slot = Team::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -2902,7 +3167,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & valu
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x77976c7416517c63ull: // counter
+            case 11: // counter, id 0x77976c7416517c63ull
             {
                 if ( kind != 4 )
                 {
@@ -3666,10 +3931,10 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3680,9 +3945,9 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xeddcb72b15486e77ull: // marker
+            case 0: // marker, id 0xeddcb72b15486e77ull
             {
                 if ( kind != 6 )
                 {
@@ -3697,7 +3962,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
                 value.marker = decoded_v;
                 break;
             }
-            case 0xee7ba9ad45c64144ull: // stamp
+            case 1: // stamp, id 0xee7ba9ad45c64144ull
             {
                 if ( kind != 9 )
                 {
@@ -3723,7 +3988,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
                 value.stamp = decoded_v;
                 break;
             }
-            case 0xa3a7061ff10a8138ull: // rows
+            case 2: // rows, id 0xa3a7061ff10a8138ull
             {
                 if ( kind != 14 )
                 {
@@ -3781,7 +4046,7 @@ BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xc573b39bc29148caull: // blob
+            case 3: // blob, id 0xc573b39bc29148caull
             {
                 if ( kind != 14 )
                 {

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -395,6 +395,147 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 91;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x5dacbc0222cbc053ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xeddcb72b15486e77ull, 0xee7ba9ad45c64144ull, 0xa3a7061ff10a8138ull, 0xc573b39bc29148caull,
+    0x56d7ab194448a4f3ull, 0x7ce4fd9430e80ceaull, 0xd5f2d079088c0b17ull, 0x08b72e07b55c3ac0ull,
+    0x39f7fcec8fcb623dull, 0xe68c2e6bb1ee5646ull, 0xbaaeb048a5a8fa6dull, 0x77976c7416517c63ull,
+    0x4cbf3a26fca1d74aull, 0xb51afb05cd34709full, 0x9f61700f084ab92eull, 0x336d3dc7fffd0c9bull,
+    0x6a0c6a156952b9c2ull, 0xdcb27c18fed9e15cull, 0x6aacb9fbb71a1d91ull, 0x17a3a1a985f75aecull,
+    0xb66e4449e56b2e26ull, 0x4d7bf73bcbddc228ull, 0xe5626f155e4c5dadull, 0xfa23d9ef19afc32cull,
+    0x0bdab42c07f19812ull, 0x5de0015285763c46ull, 0xaf63e94c860202a3ull, 0xfd7f3fa0b16ed778ull,
+    0x0bee7b3cb4046c93ull, 0xdc89eb9cd3393be5ull, 0xbb62c62c9808ea37ull, 0x0f9222d2ba7aa2a7ull,
+    0x294a5c4913e1ad44ull, 0x84f8260bc283608cull, 0x1c3027194b1ba4d0ull, 0x43125398a9903d27ull,
+    0xc1f8d7edff7fcfd2ull, 0x33408e39f5f480ffull, 0xd982b77b3e92d16dull, 0x876a8c1a85806a69ull,
+    0xee5d97ad45ad251full, 0x6917a5bab91540f2ull, 0xcd29c05f390294ecull, 0x96b593c242133841ull,
+    0x151b2a0e2c07b4bcull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0xaf63f74c86021a6dull,
+    0xaf63ea4c86020456ull, 0xcfd587cb3100cd73ull, 0x1f7d2e86a2e77268ull, 0x1554fa45a1220171ull,
+    0x4d5be97ba1b9cb81ull, 0xd23da7ab574b95c3ull, 0x88a11a6aed541f54ull, 0x3d2cc8d952adebecull,
+    0xc8736ef79380e634ull, 0x94e8a172d8f4805eull, 0xa0745aa7967eeffaull, 0xf5d0a4d25a76afcaull,
+    0x478d7972f6d9075dull, 0xcaa6172bef74e234ull, 0x4f98acac2852d653ull, 0x7f3a7e4744ea3019ull,
+    0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull, 0x6c2321a3d00e23dbull, 0x9ff1de19feac1b7cull,
+    0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull, 0xc416c97e0d3218b3ull, 0xffffffffffffffffull,
+    0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0xbf050ec6de1ec3e0ull,
+    0x1d3a1648d6207581ull, 0x11c6b29d15f30306ull, 0x5ff5bdbae776636full, 0xcca6d00e1bb40147ull,
+    0x0cc738b585c9e5f8ull, 0x9b2749fb3fc30f4eull, 0xb0947dbe6c23d994ull, 0x93dab31114da135bull,
+    0x5b00edd93fad6007ull, 0xc19ad62b865276feull, 0x4034181fa408c29full, 0x5bdf5fe3e05f510bull,
+    0xdd519511c4d9d295ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,
+       47, 0xFFFF, 0xFFFF,    43, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF,    77,    36, 0xFFFF, 0xFFFF,    46, 0xFFFF,
+       73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF,    55,    81, 0xFFFF, 0xFFFF,    59, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF,     2,
+    0xFFFF,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    72,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11,    65, 0xFFFF, 0xFFFF,    13,     1, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    62, 0xFFFF,     3, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    86, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       26,    54, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21,    16,
+    0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    27,    78, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF, 0xFFFF,    51, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF,    69,    41, 0xFFFF,
+       71, 0xFFFF,    63, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57,    14, 0xFFFF,
+       33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70, 0xFFFF,
+    0xFFFF,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    31,    29, 0xFFFF,    22,    67,
+    0xFFFF, 0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF,    15,    53, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9,    56, 0xFFFF,    87, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    60, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    30,    49,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    74, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 71;
+static const uint16_t kTableIdSlotBuildVersion = 89;
+static const uint16_t kTableIdSlotVocabulary = 90;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +544,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOCKDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +891,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +934,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2555,6 +2809,16 @@ inline bool TableEnumValue( uint64_t id, ShipType & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, ShipType & out )
+{
+    switch ( slot )
+    {
+        case 64: out = ShipType::Fighter; return true; // id 0xd011f7c3c15285c2ull
+        case 65: out = ShipType::Bomber; return true; // id 0xa8216aa1c554cb8aull
+        case 66: out = ShipType::Freighter; return true; // id 0x6c2321a3d00e23dbull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_SHIPTYPE
 
 // Team on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2623,6 +2887,17 @@ inline bool TableEnumValue( uint64_t id, Team & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Team & out )
+{
+    switch ( slot )
+    {
+        case 67: out = Team::Red; return true; // id 0x9ff1de19feac1b7cull
+        case 68: out = Team::Blue; return true; // id 0xecf3d3a7c1693e2dull
+        case 69: out = Team::Green; return true; // id 0xcf00d78fd5953f1cull
+        case 70: out = Team::Gold; return true; // id 0xc416c97e0d3218b3ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_TEAM
 
 // MissileType on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2679,6 +2954,15 @@ inline bool TableEnumValue( uint64_t id, MissileType & out )
         case 0xf5d0a4d25a76afcaull: out = MissileType::Seeker; return true;
         case 0x478d7972f6d9075dull: out = MissileType::Dumb; return true;
         default: return false; // an id this build cannot name
+    }
+}
+inline bool TableEnumValueAt( uint16_t slot, MissileType & out )
+{
+    switch ( slot )
+    {
+        case 59: out = MissileType::Seeker; return true; // id 0xf5d0a4d25a76afcaull
+        case 60: out = MissileType::Dumb; return true; // id 0x478d7972f6d9075dull
+        default: return false; // a slot this build cannot name
     }
 }
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_MISSILETYPE
@@ -2744,6 +3028,16 @@ inline bool TableEnumValue( uint64_t id, PropType & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, PropType & out )
+{
+    switch ( slot )
+    {
+        case 61: out = PropType::Rock; return true; // id 0xcaa6172bef74e234ull
+        case 62: out = PropType::Station; return true; // id 0x4f98acac2852d653ull
+        case 63: out = PropType::Beacon; return true; // id 0x7f3a7e4744ea3019ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_PROPTYPE
 
 // LaserType on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2802,6 +3096,15 @@ inline bool TableEnumValue( uint64_t id, LaserType & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, LaserType & out )
+{
+    switch ( slot )
+    {
+        case 57: out = LaserType::Pulse; return true; // id 0x94e8a172d8f4805eull
+        case 58: out = LaserType::Beam; return true; // id 0xa0745aa7967eeffaull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_LASERTYPE
 
 // ExplosionType on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2858,6 +3161,15 @@ inline bool TableEnumValue( uint64_t id, ExplosionType & out )
         case 0x3d2cc8d952adebecull: out = ExplosionType::Small; return true;
         case 0xc8736ef79380e634ull: out = ExplosionType::Large; return true;
         default: return false; // an id this build cannot name
+    }
+}
+inline bool TableEnumValueAt( uint16_t slot, ExplosionType & out )
+{
+    switch ( slot )
+    {
+        case 55: out = ExplosionType::Small; return true; // id 0x3d2cc8d952adebecull
+        case 56: out = ExplosionType::Large; return true; // id 0xc8736ef79380e634ull
+        default: return false; // a slot this build cannot name
     }
 }
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_EXPLOSIONTYPE
@@ -3196,10 +3508,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3210,9 +3522,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -3236,7 +3548,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -3260,7 +3572,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x9f61700f084ab92eull: // camera_id
+            case 14: // camera_id, id 0x9f61700f084ab92eull
             {
                 if ( kind != 8 )
                 {
@@ -3286,7 +3598,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
                 value.camera_id = decoded_v;
                 break;
             }
-            case 0x336d3dc7fffd0c9bull: // camera_type
+            case 15: // camera_type, id 0x336d3dc7fffd0c9bull
             {
                 if ( kind != 8 )
                 {
@@ -3312,7 +3624,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
                 value.camera_type = decoded_v;
                 break;
             }
-            case 0x6a0c6a156952b9c2ull: // target_object_id
+            case 16: // target_object_id, id 0x6a0c6a156952b9c2ull
             {
                 if ( kind != 8 )
                 {
@@ -3338,7 +3650,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera 
                 value.target_object_id = decoded_v;
                 break;
             }
-            case 0xdcb27c18fed9e15cull: // fov
+            case 17: // fov, id 0xdcb27c18fed9e15cull
             {
                 if ( kind != 10 )
                 {
@@ -3937,10 +4249,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3951,9 +4263,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -3977,7 +4289,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -4001,7 +4313,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -4027,7 +4339,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.flags = decoded_v;
                 break;
             }
-            case 0x0bdab42c07f19812ull: // object_id
+            case 24: // object_id, id 0x0bdab42c07f19812ull
             {
                 if ( kind != 8 )
                 {
@@ -4053,7 +4365,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.object_id = decoded_v;
                 break;
             }
-            case 0x6a0c6a156952b9c2ull: // target_object_id
+            case 16: // target_object_id, id 0x6a0c6a156952b9c2ull
             {
                 if ( kind != 8 )
                 {
@@ -4079,7 +4391,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.target_object_id = decoded_v;
                 break;
             }
-            case 0xcfd587cb3100cd73ull: // thrust
+            case 49: // thrust, id 0xcfd587cb3100cd73ull
             {
                 if ( kind != 10 )
                 {
@@ -4093,7 +4405,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.thrust = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x5de0015285763c46ull: // object_sequence
+            case 25: // object_sequence, id 0x5de0015285763c46ull
             {
                 if ( kind != 6 )
                 {
@@ -4108,7 +4420,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.object_sequence = decoded_v;
                 break;
             }
-            case 0x1f7d2e86a2e77268ull: // ship_type
+            case 50: // ship_type, id 0x1f7d2e86a2e77268ull
             {
                 if ( kind != 30 )
                 {
@@ -4122,14 +4434,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.ship_type = ShipType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.ship_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.ship_type ) )
                 {
                     value.ship_type = ShipType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -4143,14 +4455,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0x1554fa45a1220171ull: // has_target_lock
+            case 51: // has_target_lock, id 0x1554fa45a1220171ull
             {
                 if ( kind != 1 )
                 {
@@ -4164,7 +4476,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & va
                 value.has_target_lock = r.get8() != 0;
                 break;
             }
-            case 0x4d5be97ba1b9cb81ull: // predicted_explode
+            case 52: // predicted_explode, id 0x4d5be97ba1b9cb81ull
             {
                 if ( kind != 1 )
                 {
@@ -4880,10 +5192,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4894,9 +5206,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -4920,7 +5232,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -4946,7 +5258,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.flags = decoded_v;
                 break;
             }
-            case 0x0bdab42c07f19812ull: // object_id
+            case 24: // object_id, id 0x0bdab42c07f19812ull
             {
                 if ( kind != 8 )
                 {
@@ -4972,7 +5284,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.object_id = decoded_v;
                 break;
             }
-            case 0x0bee7b3cb4046c93ull: // parent_object_id
+            case 28: // parent_object_id, id 0x0bee7b3cb4046c93ull
             {
                 if ( kind != 8 )
                 {
@@ -4998,7 +5310,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.parent_object_id = decoded_v;
                 break;
             }
-            case 0x88a11a6aed541f54ull: // turret_index
+            case 54: // turret_index, id 0x88a11a6aed541f54ull
             {
                 if ( kind != 8 )
                 {
@@ -5024,7 +5336,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.turret_index = decoded_v;
                 break;
             }
-            case 0x6a0c6a156952b9c2ull: // target_object_id
+            case 16: // target_object_id, id 0x6a0c6a156952b9c2ull
             {
                 if ( kind != 8 )
                 {
@@ -5050,7 +5362,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.target_object_id = decoded_v;
                 break;
             }
-            case 0x5de0015285763c46ull: // object_sequence
+            case 25: // object_sequence, id 0x5de0015285763c46ull
             {
                 if ( kind != 6 )
                 {
@@ -5065,7 +5377,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 value.object_sequence = decoded_v;
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -5079,14 +5391,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret 
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0x1554fa45a1220171ull: // has_target_lock
+            case 51: // has_target_lock, id 0x1554fa45a1220171ull
             {
                 if ( kind != 1 )
                 {
@@ -5777,10 +6089,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5791,9 +6103,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -5817,7 +6129,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -5841,7 +6153,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -5867,7 +6179,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 value.flags = decoded_v;
                 break;
             }
-            case 0x0bdab42c07f19812ull: // object_id
+            case 24: // object_id, id 0x0bdab42c07f19812ull
             {
                 if ( kind != 8 )
                 {
@@ -5893,7 +6205,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 value.object_id = decoded_v;
                 break;
             }
-            case 0x5de0015285763c46ull: // object_sequence
+            case 25: // object_sequence, id 0x5de0015285763c46ull
             {
                 if ( kind != 6 )
                 {
@@ -5908,7 +6220,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 value.object_sequence = decoded_v;
                 break;
             }
-            case 0x151b2a0e2c07b4bcull: // missile_type
+            case 44: // missile_type, id 0x151b2a0e2c07b4bcull
             {
                 if ( kind != 30 )
                 {
@@ -5922,14 +6234,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.missile_type = MissileType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.missile_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.missile_type ) )
                 {
                     value.missile_type = MissileType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -5943,7 +6255,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissil
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -6528,10 +6840,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6542,9 +6854,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -6568,7 +6880,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -6592,7 +6904,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -6618,7 +6930,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 value.flags = decoded_v;
                 break;
             }
-            case 0x0bdab42c07f19812ull: // object_id
+            case 24: // object_id, id 0x0bdab42c07f19812ull
             {
                 if ( kind != 8 )
                 {
@@ -6644,7 +6956,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 value.object_id = decoded_v;
                 break;
             }
-            case 0x5de0015285763c46ull: // object_sequence
+            case 25: // object_sequence, id 0x5de0015285763c46ull
             {
                 if ( kind != 6 )
                 {
@@ -6659,7 +6971,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 value.object_sequence = decoded_v;
                 break;
             }
-            case 0xe5626f155e4c5dadull: // prop_type
+            case 22: // prop_type, id 0xe5626f155e4c5dadull
             {
                 if ( kind != 30 )
                 {
@@ -6673,14 +6985,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.prop_type = PropType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.prop_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.prop_type ) )
                 {
                     value.prop_type = PropType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -6694,7 +7006,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDy
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -7279,10 +7591,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7293,9 +7605,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -7319,7 +7631,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -7343,7 +7655,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x6aacb9fbb71a1d91ull: // scale
+            case 18: // scale, id 0x6aacb9fbb71a1d91ull
             {
                 if ( kind != 11 )
                 {
@@ -7366,7 +7678,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 value.scale = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -7392,7 +7704,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 value.flags = decoded_v;
                 break;
             }
-            case 0xd23da7ab574b95c3ull: // static_prop_id
+            case 53: // static_prop_id, id 0xd23da7ab574b95c3ull
             {
                 if ( kind != 8 )
                 {
@@ -7418,7 +7730,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 value.static_prop_id = decoded_v;
                 break;
             }
-            case 0xe5626f155e4c5dadull: // prop_type
+            case 22: // prop_type, id 0xe5626f155e4c5dadull
             {
                 if ( kind != 30 )
                 {
@@ -7432,14 +7744,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.prop_type = PropType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.prop_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.prop_type ) )
                 {
                     value.prop_type = PropType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -7453,7 +7765,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderSta
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -8055,10 +8367,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8069,9 +8381,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -8095,7 +8407,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -8119,7 +8431,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x6aacb9fbb71a1d91ull: // scale
+            case 18: // scale, id 0x6aacb9fbb71a1d91ull
             {
                 if ( kind != 11 )
                 {
@@ -8142,7 +8454,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 value.scale = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0x17a3a1a985f75aecull: // flags
+            case 19: // flags, id 0x17a3a1a985f75aecull
             {
                 if ( kind != 9 )
                 {
@@ -8168,7 +8480,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 value.flags = decoded_v;
                 break;
             }
-            case 0xb66e4449e56b2e26ull: // cosmetic_prop_id
+            case 20: // cosmetic_prop_id, id 0xb66e4449e56b2e26ull
             {
                 if ( kind != 8 )
                 {
@@ -8194,7 +8506,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 value.cosmetic_prop_id = decoded_v;
                 break;
             }
-            case 0x4d7bf73bcbddc228ull: // prop_sequence
+            case 21: // prop_sequence, id 0x4d7bf73bcbddc228ull
             {
                 if ( kind != 6 )
                 {
@@ -8209,7 +8521,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 value.prop_sequence = decoded_v;
                 break;
             }
-            case 0xe5626f155e4c5dadull: // prop_type
+            case 22: // prop_type, id 0xe5626f155e4c5dadull
             {
                 if ( kind != 30 )
                 {
@@ -8223,14 +8535,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.prop_type = PropType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.prop_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.prop_type ) )
                 {
                     value.prop_type = PropType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -8244,7 +8556,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderC
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -8867,10 +9179,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8881,9 +9193,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xee5d97ad45ad251full: // start
+            case 40: // start, id 0xee5d97ad45ad251full
             {
                 if ( kind != 13 )
                 {
@@ -8907,7 +9219,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x6917a5bab91540f2ull: // finish
+            case 41: // finish, id 0x6917a5bab91540f2ull
             {
                 if ( kind != 13 )
                 {
@@ -8931,7 +9243,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xaf63e94c860202a3ull: // t
+            case 26: // t, id 0xaf63e94c860202a3ull
             {
                 if ( kind != 11 )
                 {
@@ -8954,7 +9266,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 value.t = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xcd29c05f390294ecull: // laser_id
+            case 42: // laser_id, id 0xcd29c05f390294ecull
             {
                 if ( kind != 8 )
                 {
@@ -8980,7 +9292,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 value.laser_id = decoded_v;
                 break;
             }
-            case 0x96b593c242133841ull: // laser_type
+            case 43: // laser_type, id 0x96b593c242133841ull
             {
                 if ( kind != 30 )
                 {
@@ -8994,14 +9306,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.laser_type = LaserType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.laser_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.laser_type ) )
                 {
                     value.laser_type = LaserType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -9015,7 +9327,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & 
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -9565,10 +9877,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9579,9 +9891,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x4cbf3a26fca1d74aull: // position
+            case 12: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 13 )
                 {
@@ -9605,7 +9917,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb51afb05cd34709full: // rotation
+            case 13: // rotation, id 0xb51afb05cd34709full
             {
                 if ( kind != 13 )
                 {
@@ -9629,7 +9941,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xaf63e94c860202a3ull: // t
+            case 26: // t, id 0xaf63e94c860202a3ull
             {
                 if ( kind != 11 )
                 {
@@ -9652,7 +9964,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 value.t = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xfd7f3fa0b16ed778ull: // explosion_id
+            case 27: // explosion_id, id 0xfd7f3fa0b16ed778ull
             {
                 if ( kind != 8 )
                 {
@@ -9678,7 +9990,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 value.explosion_id = decoded_v;
                 break;
             }
-            case 0x0bee7b3cb4046c93ull: // parent_object_id
+            case 28: // parent_object_id, id 0x0bee7b3cb4046c93ull
             {
                 if ( kind != 8 )
                 {
@@ -9704,7 +10016,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 value.parent_object_id = decoded_v;
                 break;
             }
-            case 0xdc89eb9cd3393be5ull: // explosion_type
+            case 29: // explosion_type, id 0xdc89eb9cd3393be5ull
             {
                 if ( kind != 30 )
                 {
@@ -9718,14 +10030,14 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.explosion_type = ExplosionType::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.explosion_type ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.explosion_type ) )
                 {
                     value.explosion_type = ExplosionType::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xfa23d9ef19afc32cull: // team
+            case 23: // team, id 0xfa23d9ef19afc32cull
             {
                 if ( kind != 30 )
                 {
@@ -9739,7 +10051,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExpl
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.team = Team::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.team ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.team ) )
                 {
                     value.team = Team::None;
                     r.report->unknown++;
@@ -10595,10 +10907,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10609,9 +10921,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xbb62c62c9808ea37ull: // version
+            case 30: // version, id 0xbb62c62c9808ea37ull
             {
                 if ( kind != 9 )
                 {
@@ -10637,7 +10949,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 value.version = decoded_v;
                 break;
             }
-            case 0x0f9222d2ba7aa2a7ull: // cameras
+            case 31: // cameras, id 0x0f9222d2ba7aa2a7ull
             {
                 if ( kind != 14 )
                 {
@@ -10695,7 +11007,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x294a5c4913e1ad44ull: // ships
+            case 32: // ships, id 0x294a5c4913e1ad44ull
             {
                 if ( kind != 14 )
                 {
@@ -10753,7 +11065,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x84f8260bc283608cull: // turrets
+            case 33: // turrets, id 0x84f8260bc283608cull
             {
                 if ( kind != 14 )
                 {
@@ -10811,7 +11123,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x1c3027194b1ba4d0ull: // missiles
+            case 34: // missiles, id 0x1c3027194b1ba4d0ull
             {
                 if ( kind != 14 )
                 {
@@ -10869,7 +11181,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x43125398a9903d27ull: // dynamic_props
+            case 35: // dynamic_props, id 0x43125398a9903d27ull
             {
                 if ( kind != 14 )
                 {
@@ -10927,7 +11239,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xc1f8d7edff7fcfd2ull: // static_props
+            case 36: // static_props, id 0xc1f8d7edff7fcfd2ull
             {
                 if ( kind != 14 )
                 {
@@ -10985,7 +11297,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x33408e39f5f480ffull: // cosmetic_props
+            case 37: // cosmetic_props, id 0x33408e39f5f480ffull
             {
                 if ( kind != 14 )
                 {
@@ -11043,7 +11355,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xd982b77b3e92d16dull: // lasers
+            case 38: // lasers, id 0xd982b77b3e92d16dull
             {
                 if ( kind != 14 )
                 {
@@ -11101,7 +11413,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x876a8c1a85806a69ull: // explosions
+            case 39: // explosions, id 0x876a8c1a85806a69ull
             {
                 if ( kind != 14 )
                 {
@@ -11959,10 +12271,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11973,9 +12285,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 45: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 11 )
                 {
@@ -11998,7 +12310,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector
                 value.x = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 46: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 11 )
                 {
@@ -12021,7 +12333,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector
                 value.y = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xaf63f74c86021a6dull: // z
+            case 47: // z, id 0xaf63f74c86021a6dull
             {
                 if ( kind != 11 )
                 {
@@ -12423,10 +12735,10 @@ BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQua
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12437,9 +12749,9 @@ BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQua
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 45: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 11 )
                 {
@@ -12462,7 +12774,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQua
                 value.x = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 46: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 11 )
                 {
@@ -12485,7 +12797,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQua
                 value.y = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xaf63f74c86021a6dull: // z
+            case 47: // z, id 0xaf63f74c86021a6dull
             {
                 if ( kind != 11 )
                 {
@@ -12508,7 +12820,7 @@ BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQua
                 value.z = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xaf63ea4c86020456ull: // w
+            case 48: // w, id 0xaf63ea4c86020456ull
             {
                 if ( kind != 11 )
                 {

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -377,6 +377,100 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 31;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x1069e6a57e06665dull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x538b8c566e9e4b38ull, 0x4ce65d1fbfdde703ull, 0x4e79ecbefe5ff4d0ull, 0x1e6f84ef2eb65989ull,
+    0xdbae65ca25b4f315ull, 0x026f7568983161e0ull, 0x84e39fec29768c56ull, 0x8ece059ad360b651ull,
+    0xdc2cbe6953343d48ull, 0x260b8ca6b0c3db7full, 0x3c99105aa087f6bcull, 0xad9b64728ea52486ull,
+    0xbd9be53180256e02ull, 0xbb62c62c9808ea37ull, 0x0c519da7a1f958c5ull, 0xd19988b67e699194ull,
+    0x40dbb648c0cd44aaull, 0x04d6206b33415104ull, 0x6a771618f6fe31d1ull, 0xffffffffffffffffull,
+    0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x7ca1b7fd9e3a2fb1ull,
+    0x27c461282640b1f0ull, 0x6993400379bdc520ull, 0x98a368eb20d65c7dull, 0xb76842b2253337afull,
+    0xe8a7e2d995bb4cd2ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     6,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    27,
+    0xFFFF,    12, 0xFFFF,     2, 0xFFFF, 0xFFFF,    28,    26, 0xFFFF, 0xFFFF,     7, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8,    22, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    24,     1, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF,     3,    10,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9,    15, 0xFFFF,     0, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,    17, 0xFFFF,    30,    20, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 19;
+static const uint16_t kTableIdSlotBuildVersion = 29;
+static const uint16_t kTableIdSlotVocabulary = 30;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +479,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOCKHOME_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +826,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +869,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -377,6 +377,100 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 31;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x1069e6a57e06665dull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x538b8c566e9e4b38ull, 0x4ce65d1fbfdde703ull, 0x4e79ecbefe5ff4d0ull, 0x1e6f84ef2eb65989ull,
+    0xdbae65ca25b4f315ull, 0x026f7568983161e0ull, 0x84e39fec29768c56ull, 0x8ece059ad360b651ull,
+    0xdc2cbe6953343d48ull, 0x260b8ca6b0c3db7full, 0x3c99105aa087f6bcull, 0xad9b64728ea52486ull,
+    0xbd9be53180256e02ull, 0xbb62c62c9808ea37ull, 0x0c519da7a1f958c5ull, 0xd19988b67e699194ull,
+    0x40dbb648c0cd44aaull, 0x04d6206b33415104ull, 0x6a771618f6fe31d1ull, 0xffffffffffffffffull,
+    0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x7ca1b7fd9e3a2fb1ull,
+    0x27c461282640b1f0ull, 0x6993400379bdc520ull, 0x98a368eb20d65c7dull, 0xb76842b2253337afull,
+    0xe8a7e2d995bb4cd2ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     6,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    27,
+    0xFFFF,    12, 0xFFFF,     2, 0xFFFF, 0xFFFF,    28,    26, 0xFFFF, 0xFFFF,     7, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8,    22, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    24,     1, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF,     3,    10,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9,    15, 0xFFFF,     0, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,    17, 0xFFFF,    30,    20, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 19;
+static const uint16_t kTableIdSlotBuildVersion = 29;
+static const uint16_t kTableIdSlotVocabulary = 30;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +479,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOCKHOME_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +826,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +869,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2284,10 +2491,10 @@ BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2298,9 +2505,9 @@ BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xdbae65ca25b4f315ull: // thickness
+            case 4: // thickness, id 0xdbae65ca25b4f315ull
             {
                 if ( kind != 11 )
                 {
@@ -2323,7 +2530,7 @@ BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & va
                 value.thickness = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0x026f7568983161e0ull: // material
+            case 5: // material, id 0x026f7568983161e0ull
             {
                 if ( kind != 8 )
                 {
@@ -2349,7 +2556,7 @@ BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & va
                 value.material = decoded_v;
                 break;
             }
-            case 0x84e39fec29768c56ull: // layer
+            case 6: // layer, id 0x84e39fec29768c56ull
             {
                 if ( kind != 6 )
                 {
@@ -2764,10 +2971,10 @@ BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2778,9 +2985,9 @@ BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x538b8c566e9e4b38ull: // front
+            case 0: // front, id 0x538b8c566e9e4b38ull
             {
                 if ( kind != 13 )
                 {
@@ -2804,7 +3011,7 @@ BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4ce65d1fbfdde703ull: // rear
+            case 1: // rear, id 0x4ce65d1fbfdde703ull
             {
                 if ( kind != 13 )
                 {
@@ -2828,7 +3035,7 @@ BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4e79ecbefe5ff4d0ull: // rating
+            case 2: // rating, id 0x4e79ecbefe5ff4d0ull
             {
                 if ( kind != 10 )
                 {
@@ -2842,7 +3049,7 @@ BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & 
                 value.rating = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x1e6f84ef2eb65989ull: // tier
+            case 3: // tier, id 0x1e6f84ef2eb65989ull
             {
                 if ( kind != 6 )
                 {
@@ -3229,10 +3436,10 @@ BLOCKHOME_TABLE_INLINE bool FiringGroupLoadBody( TableReader & r, FiringGroup & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3243,9 +3450,9 @@ BLOCKHOME_TABLE_INLINE bool FiringGroupLoadBody( TableReader & r, FiringGroup & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x8ece059ad360b651ull: // barrel
+            case 7: // barrel, id 0x8ece059ad360b651ull
             {
                 if ( kind != 8 )
                 {
@@ -3271,7 +3478,7 @@ BLOCKHOME_TABLE_INLINE bool FiringGroupLoadBody( TableReader & r, FiringGroup & 
                 value.barrel = decoded_v;
                 break;
             }
-            case 0xdc2cbe6953343d48ull: // cooldown
+            case 8: // cooldown, id 0xdc2cbe6953343d48ull
             {
                 if ( kind != 10 )
                 {
@@ -3684,10 +3891,10 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3698,9 +3905,9 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x260b8ca6b0c3db7full: // firing_groups
+            case 9: // firing_groups, id 0x260b8ca6b0c3db7full
             {
                 if ( kind != 14 )
                 {
@@ -3758,7 +3965,7 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x3c99105aa087f6bcull: // missile_groups
+            case 10: // missile_groups, id 0x3c99105aa087f6bcull
             {
                 if ( kind != 14 )
                 {
@@ -3816,7 +4023,7 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xad9b64728ea52486ull: // reload_seconds
+            case 11: // reload_seconds, id 0xad9b64728ea52486ull
             {
                 if ( kind != 10 )
                 {
@@ -3830,7 +4037,7 @@ BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 value.reload_seconds = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xbd9be53180256e02ull: // gunner_id
+            case 12: // gunner_id, id 0xbd9be53180256e02ull
             {
                 if ( kind != 8 )
                 {

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -378,6 +378,100 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 31;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x1069e6a57e06665dull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x538b8c566e9e4b38ull, 0x4ce65d1fbfdde703ull, 0x4e79ecbefe5ff4d0ull, 0x1e6f84ef2eb65989ull,
+    0xdbae65ca25b4f315ull, 0x026f7568983161e0ull, 0x84e39fec29768c56ull, 0x8ece059ad360b651ull,
+    0xdc2cbe6953343d48ull, 0x260b8ca6b0c3db7full, 0x3c99105aa087f6bcull, 0xad9b64728ea52486ull,
+    0xbd9be53180256e02ull, 0xbb62c62c9808ea37ull, 0x0c519da7a1f958c5ull, 0xd19988b67e699194ull,
+    0x40dbb648c0cd44aaull, 0x04d6206b33415104ull, 0x6a771618f6fe31d1ull, 0xffffffffffffffffull,
+    0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x7ca1b7fd9e3a2fb1ull,
+    0x27c461282640b1f0ull, 0x6993400379bdc520ull, 0x98a368eb20d65c7dull, 0xb76842b2253337afull,
+    0xe8a7e2d995bb4cd2ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     6,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    27,
+    0xFFFF,    12, 0xFFFF,     2, 0xFFFF, 0xFFFF,    28,    26, 0xFFFF, 0xFFFF,     7, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8,    22, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    24,     1, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF,     3,    10,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9,    15, 0xFFFF,     0, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,    17, 0xFFFF,    30,    20, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 19;
+static const uint16_t kTableIdSlotBuildVersion = 29;
+static const uint16_t kTableIdSlotVocabulary = 30;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -386,16 +480,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    BLOCKHOME_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -715,6 +827,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -746,16 +870,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2330,10 +2537,10 @@ BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2344,9 +2551,9 @@ BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd19988b67e699194ull: // armor
+            case 15: // armor, id 0xd19988b67e699194ull
             {
                 if ( kind != 13 )
                 {
@@ -2370,7 +2577,7 @@ BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x40dbb648c0cd44aaull: // gunner
+            case 16: // gunner, id 0x40dbb648c0cd44aaull
             {
                 if ( kind != 13 )
                 {
@@ -2394,7 +2601,7 @@ BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x04d6206b33415104ull: // part_id
+            case 17: // part_id, id 0x04d6206b33415104ull
             {
                 if ( kind != 8 )
                 {
@@ -2420,7 +2627,7 @@ BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
                 value.part_id = decoded_v;
                 break;
             }
-            case 0x6a771618f6fe31d1ull: // slot
+            case 18: // slot, id 0x6a771618f6fe31d1ull
             {
                 if ( kind != 6 )
                 {
@@ -2847,10 +3054,10 @@ BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2861,9 +3068,9 @@ BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xbb62c62c9808ea37ull: // version
+            case 13: // version, id 0xbb62c62c9808ea37ull
             {
                 if ( kind != 9 )
                 {
@@ -2889,7 +3096,7 @@ BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & valu
                 value.version = decoded_v;
                 break;
             }
-            case 0x0c519da7a1f958c5ull: // parts
+            case 14: // parts, id 0x0c519da7a1f958c5ull
             {
                 if ( kind != 14 )
                 {

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2583,10 +2897,10 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2597,9 +2911,9 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x6580790b036f0c6full: // active
+            case 31: // active, id 0x6580790b036f0c6full
             {
                 if ( kind != 1 )
                 {
@@ -2613,7 +2927,7 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 value.active = r.get8() != 0;
                 break;
             }
-            case 0x2281498aa0200e40ull: // speed
+            case 32: // speed, id 0x2281498aa0200e40ull
             {
                 if ( kind != 10 )
                 {
@@ -2627,7 +2941,7 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 value.speed = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x247f0e7f55aacfbdull: // has_target
+            case 33: // has_target, id 0x247f0e7f55aacfbdull
             {
                 if ( kind != 1 )
                 {
@@ -2641,7 +2955,7 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 value.has_target = r.get8() != 0;
                 break;
             }
-            case 0xb7bc9ac015a25050ull: // target_id
+            case 34: // target_id, id 0xb7bc9ac015a25050ull
             {
                 if ( kind != 4 )
                 {
@@ -2671,7 +2985,7 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 value.target_id = decoded_v;
                 break;
             }
-            case 0xb8c758d8bd1845d4ull: // wander
+            case 35: // wander, id 0xb8c758d8bd1845d4ull
             {
                 if ( kind != 10 )
                 {
@@ -2685,7 +2999,7 @@ TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
                 value.wander = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x3bf8fbbad1587cddull: // note
+            case 36: // note, id 0x3bf8fbbad1587cddull
             {
                 if ( kind != 12 )
                 {

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2526,6 +2840,16 @@ inline bool TableEnumValue( uint64_t id, Weapon & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Weapon & out )
+{
+    switch ( slot )
+    {
+        case 124: out = Weapon::Cannon; return true; // id 0x5854debe3b2e767cull
+        case 125: out = Weapon::Missile; return true; // id 0xb528592e5a4583e3ull
+        case 126: out = Weapon::Mine; return true; // id 0x04dc16aea8ff5276ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_WEAPON
 
 // Team on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2589,6 +2913,16 @@ inline bool TableEnumValue( uint64_t id, Team & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Team & out )
+{
+    switch ( slot )
+    {
+        case 121: out = Team::Red; return true; // id 0x9ff1de19feac1b7cull
+        case 122: out = Team::Blue; return true; // id 0xecf3d3a7c1693e2dull
+        case 123: out = Team::Green; return true; // id 0xcf00d78fd5953f1cull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_TEAM
 
 // Hull on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2650,6 +2984,16 @@ inline bool TableEnumValue( uint64_t id, Hull & out )
         case 0x334d24e1420dbc1full: out = Hull::Gunship; return true;
         case 0x6c2321a3d00e23dbull: out = Hull::Freighter; return true;
         default: return false; // an id this build cannot name
+    }
+}
+inline bool TableEnumValueAt( uint16_t slot, Hull & out )
+{
+    switch ( slot )
+    {
+        case 115: out = Hull::Interceptor; return true; // id 0xae61a6cbe88c2cf4ull
+        case 116: out = Hull::Gunship; return true; // id 0x334d24e1420dbc1full
+        case 117: out = Hull::Freighter; return true; // id 0x6c2321a3d00e23dbull
+        default: return false; // a slot this build cannot name
     }
 }
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_HULL
@@ -2798,10 +3142,10 @@ TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2812,9 +3156,9 @@ TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xceec99e2d65db674ull: // spawn_count
+            case 97: // spawn_count, id 0xceec99e2d65db674ull
             {
                 if ( kind != 4 )
                 {
@@ -2844,7 +3188,7 @@ TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & va
                 value.spawn_count = decoded_v;
                 break;
             }
-            case 0xbca0dab1c7a00ccfull: // banner
+            case 98: // banner, id 0xbca0dab1c7a00ccfull
             {
                 if ( kind != 12 )
                 {
@@ -3209,10 +3553,10 @@ TABLEDEMO_TABLE_INLINE bool GunnerConfigLoadBody( TableReader & r, GunnerConfig 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3223,9 +3567,9 @@ TABLEDEMO_TABLE_INLINE bool GunnerConfigLoadBody( TableReader & r, GunnerConfig 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb75aa3662201646aull: // reaction
+            case 10: // reaction, id 0xb75aa3662201646aull
             {
                 if ( kind != 10 )
                 {
@@ -3239,7 +3583,7 @@ TABLEDEMO_TABLE_INLINE bool GunnerConfigLoadBody( TableReader & r, GunnerConfig 
                 value.reaction = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xa6bf719a4602b0bcull: // tracking
+            case 11: // tracking, id 0xa6bf719a4602b0bcull
             {
                 if ( kind != 1 )
                 {
@@ -3567,10 +3911,10 @@ TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3581,9 +3925,9 @@ TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 99: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 10 )
                 {
@@ -3597,7 +3941,7 @@ TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig 
                 value.damage = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xdc2cbe6953343d48ull: // cooldown
+            case 100: // cooldown, id 0xdc2cbe6953343d48ull
             {
                 if ( kind != 10 )
                 {
@@ -3611,7 +3955,7 @@ TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig 
                 value.cooldown = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x40dbb648c0cd44aaull: // gunner
+            case 96: // gunner, id 0x40dbb648c0cd44aaull
             {
                 if ( kind != 13 )
                 {
@@ -4041,10 +4385,10 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4055,9 +4399,9 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7f69d4b5288ba9cfull: // health
+            case 13: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 10 )
                 {
@@ -4071,7 +4415,7 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
                 value.health = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x1f3757a2ce7b0ab1ull: // mass
+            case 14: // mass, id 0x1f3757a2ce7b0ab1ull
             {
                 if ( kind != 10 )
                 {
@@ -4085,7 +4429,7 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
                 value.mass = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x84f8260bc283608cull: // turrets
+            case 15: // turrets, id 0x84f8260bc283608cull
             {
                 if ( kind != 16 )
                 {
@@ -4122,7 +4466,7 @@ TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & va
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Weapon slot = Weapon::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -4674,10 +5018,10 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4688,9 +5032,9 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xbaaeb048a5a8fa6dull: // teams
+            case 16: // teams, id 0xbaaeb048a5a8fa6dull
             {
                 if ( kind != 16 )
                 {
@@ -4727,7 +5071,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Team slot = Team::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -4744,7 +5088,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0xce0ac3c25694d8ffull: // hulls
+            case 17: // hulls, id 0xce0ac3c25694d8ffull
             {
                 if ( kind != 16 )
                 {
@@ -4781,7 +5125,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Hull slot = Hull::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -4798,7 +5142,7 @@ TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & 
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x01986b0b27400fb2ull: // scores
+            case 18: // scores, id 0x01986b0b27400fb2ull
             {
                 if ( kind != 13 )
                 {
@@ -5309,10 +5653,10 @@ TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5323,9 +5667,9 @@ TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xf10fad739a0e1660ull: // per_team
+            case 93: // per_team, id 0xf10fad739a0e1660ull
             {
                 if ( kind != 16 )
                 {
@@ -5365,7 +5709,7 @@ TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & va
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Team slot = Team::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -5403,7 +5747,7 @@ TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & va
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Team slot = Team::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -396,6 +396,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -404,16 +605,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -733,6 +952,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -764,16 +995,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2519,10 +2833,10 @@ TABLEDEMO_TABLE_INLINE bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2533,9 +2847,9 @@ TABLEDEMO_TABLE_INLINE bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa354fd1ff0c467c5ull: // root
+            case 0: // root, id 0xa354fd1ff0c467c5ull
             {
                 if ( kind != 13 )
                 {
@@ -2559,7 +2873,7 @@ TABLEDEMO_TABLE_INLINE bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfi
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xb1e5e28e4479a274ull: // count
+            case 1: // count, id 0xb1e5e28e4479a274ull
             {
                 if ( kind != 4 )
                 {

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2529,6 +2843,16 @@ inline bool TableEnumValue( uint64_t id, Difficulty & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Difficulty & out )
+{
+    switch ( slot )
+    {
+        case 109: out = Difficulty::Easy; return true; // id 0x483d9e6c1ccd1f9bull
+        case 110: out = Difficulty::Normal; return true; // id 0x9ff3121d30f88d52ull
+        case 111: out = Difficulty::Hard; return true; // id 0x58c7b5d87587287cull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_DIFFICULTY
 
 // ShipType on the TABLE wire: a value rides under its OWN kind 30, carrying the
@@ -2590,6 +2914,16 @@ inline bool TableEnumValue( uint64_t id, ShipType & out )
         case 0xa8216aa1c554cb8aull: out = ShipType::Bomber; return true;
         case 0x7d573c625719c1a5ull: out = ShipType::Scout; return true;
         default: return false; // an id this build cannot name
+    }
+}
+inline bool TableEnumValueAt( uint16_t slot, ShipType & out )
+{
+    switch ( slot )
+    {
+        case 118: out = ShipType::Fighter; return true; // id 0xd011f7c3c15285c2ull
+        case 119: out = ShipType::Bomber; return true; // id 0xa8216aa1c554cb8aull
+        case 120: out = ShipType::Scout; return true; // id 0x7d573c625719c1a5ull
+        default: return false; // a slot this build cannot name
     }
 }
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_SHIPTYPE
@@ -2731,10 +3065,10 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2745,9 +3079,9 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb75aa3662201646aull: // reaction
+            case 10: // reaction, id 0xb75aa3662201646aull
             {
                 if ( kind != 10 )
                 {
@@ -2761,7 +3095,7 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 value.reaction = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xa6bf719a4602b0bcull: // tracking
+            case 11: // tracking, id 0xa6bf719a4602b0bcull
             {
                 if ( kind != 1 )
                 {
@@ -2775,7 +3109,7 @@ TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSetti
                 value.tracking = r.get8() != 0;
                 break;
             }
-            case 0x5bc44627b9848818ull: // callsign
+            case 12: // callsign, id 0x5bc44627b9848818ull
             {
                 if ( kind != 12 )
                 {
@@ -3191,10 +3525,10 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3205,9 +3539,9 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x2d21d7cd66bd5a5dull: // display_name
+            case 94: // display_name, id 0x2d21d7cd66bd5a5dull
             {
                 if ( kind != 12 )
                 {
@@ -3236,7 +3570,7 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7f69d4b5288ba9cfull: // health
+            case 13: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 10 )
                 {
@@ -3250,7 +3584,7 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 value.health = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x1f3757a2ce7b0ab1ull: // mass
+            case 14: // mass, id 0x1f3757a2ce7b0ab1ull
             {
                 if ( kind != 10 )
                 {
@@ -3264,7 +3598,7 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 value.mass = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x95d0cce09ca82b73ull: // hardpoints
+            case 95: // hardpoints, id 0x95d0cce09ca82b73ull
             {
                 if ( kind != 14 )
                 {
@@ -3341,7 +3675,7 @@ TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & valu
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x40dbb648c0cd44aaull: // gunner
+            case 96: // gunner, id 0x40dbb648c0cd44aaull
             {
                 if ( kind != 13 )
                 {
@@ -3914,10 +4248,10 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3928,9 +4262,9 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa65f859b617deaf3ull: // tick_rate
+            case 6: // tick_rate, id 0xa65f859b617deaf3ull
             {
                 if ( kind != 8 )
                 {
@@ -3960,7 +4294,7 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
                 value.tick_rate = decoded_v;
                 break;
             }
-            case 0x467f35a74c6e4a70ull: // difficulty
+            case 7: // difficulty, id 0x467f35a74c6e4a70ull
             {
                 if ( kind != 30 )
                 {
@@ -3974,14 +4308,14 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.difficulty = Difficulty::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.difficulty ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.difficulty ) )
                 {
                     value.difficulty = Difficulty::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0x14ec921cc2549d60ull: // build_note
+            case 8: // build_note, id 0x14ec921cc2549d60ull
             {
                 if ( kind != 12 )
                 {
@@ -4010,7 +4344,7 @@ TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSetti
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x09ae5613b0051271ull: // spawn_delays
+            case 9: // spawn_delays, id 0x09ae5613b0051271ull
             {
                 if ( kind != 14 )
                 {
@@ -4657,10 +4991,10 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4671,9 +5005,9 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xbb62c62c9808ea37ull: // version
+            case 26: // version, id 0xbb62c62c9808ea37ull
             {
                 if ( kind != 8 )
                 {
@@ -4699,7 +5033,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                 value.version = decoded_v;
                 break;
             }
-            case 0x7fb43557b54149ceull: // global
+            case 27: // global, id 0x7fb43557b54149ceull
             {
                 if ( kind != 13 )
                 {
@@ -4723,7 +5057,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x294a5c4913e1ad44ull: // ships
+            case 28: // ships, id 0x294a5c4913e1ad44ull
             {
                 if ( kind != 16 )
                 {
@@ -4760,7 +5094,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         ShipType slot = ShipType::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -4777,7 +5111,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x9cda940a344e1571ull: // thresholds
+            case 29: // thresholds, id 0x9cda940a344e1571ull
             {
                 if ( kind != 16 )
                 {
@@ -4817,7 +5151,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Difficulty slot = Difficulty::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -4855,7 +5189,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Difficulty slot = Difficulty::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -4876,7 +5210,7 @@ TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & va
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x77707fccd201c228ull: // reserves
+            case 30: // reserves, id 0x77707fccd201c228ull
             {
                 if ( kind != 14 )
                 {

--- a/testdata/golden/tables/examples/RangesTable.h
+++ b/testdata/golden/tables/examples/RangesTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2723,10 +3037,10 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2737,9 +3051,9 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x48121511bf702eb5ull: // i8_span
+            case 50: // i8_span, id 0x48121511bf702eb5ull
             {
                 if ( kind != 2 )
                 {
@@ -2754,7 +3068,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i8_span = decoded_v;
                 break;
             }
-            case 0x942bfe3168090f7dull: // i8_low
+            case 51: // i8_low, id 0x942bfe3168090f7dull
             {
                 if ( kind != 2 )
                 {
@@ -2770,7 +3084,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i8_low = decoded_v;
                 break;
             }
-            case 0xd182acd105b55dd1ull: // i8_high
+            case 52: // i8_high, id 0xd182acd105b55dd1ull
             {
                 if ( kind != 2 )
                 {
@@ -2786,7 +3100,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i8_high = decoded_v;
                 break;
             }
-            case 0xef9ded23c8912a81ull: // i8_inside
+            case 53: // i8_inside, id 0xef9ded23c8912a81ull
             {
                 if ( kind != 2 )
                 {
@@ -2803,7 +3117,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i8_inside = decoded_v;
                 break;
             }
-            case 0xb655574ea23760b4ull: // i16_span
+            case 54: // i16_span, id 0xb655574ea23760b4ull
             {
                 if ( kind != 3 )
                 {
@@ -2829,7 +3143,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i16_span = decoded_v;
                 break;
             }
-            case 0xd217b3af8d7a2bdeull: // i16_low
+            case 55: // i16_low, id 0xd217b3af8d7a2bdeull
             {
                 if ( kind != 3 )
                 {
@@ -2857,7 +3171,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i16_low = decoded_v;
                 break;
             }
-            case 0x90652f70c9127900ull: // i16_high
+            case 56: // i16_high, id 0x90652f70c9127900ull
             {
                 if ( kind != 3 )
                 {
@@ -2885,7 +3199,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i16_high = decoded_v;
                 break;
             }
-            case 0x6a659d7c354db158ull: // i16_inside
+            case 57: // i16_inside, id 0x6a659d7c354db158ull
             {
                 if ( kind != 3 )
                 {
@@ -2915,7 +3229,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i16_inside = decoded_v;
                 break;
             }
-            case 0xe693bd88532c91d6ull: // i32_span
+            case 58: // i32_span, id 0xe693bd88532c91d6ull
             {
                 if ( kind != 4 )
                 {
@@ -2941,7 +3255,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i32_span = decoded_v;
                 break;
             }
-            case 0x065ee827cf99fbb4ull: // i32_low
+            case 59: // i32_low, id 0x065ee827cf99fbb4ull
             {
                 if ( kind != 4 )
                 {
@@ -2969,7 +3283,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i32_low = decoded_v;
                 break;
             }
-            case 0xc9b121c4c2a186eeull: // i32_high
+            case 60: // i32_high, id 0xc9b121c4c2a186eeull
             {
                 if ( kind != 4 )
                 {
@@ -2997,7 +3311,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i32_high = decoded_v;
                 break;
             }
-            case 0xd363dfa465acf27aull: // i32_inside
+            case 61: // i32_inside, id 0xd363dfa465acf27aull
             {
                 if ( kind != 4 )
                 {
@@ -3027,7 +3341,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i32_inside = decoded_v;
                 break;
             }
-            case 0x7549c70700c49d6full: // i64_span
+            case 62: // i64_span, id 0x7549c70700c49d6full
             {
                 if ( kind != 5 )
                 {
@@ -3053,7 +3367,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i64_span = decoded_v;
                 break;
             }
-            case 0x1cce6617419771dbull: // i64_low
+            case 63: // i64_low, id 0x1cce6617419771dbull
             {
                 if ( kind != 5 )
                 {
@@ -3081,7 +3395,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i64_low = decoded_v;
                 break;
             }
-            case 0x3b54fa60620b5597ull: // i64_high
+            case 64: // i64_high, id 0x3b54fa60620b5597ull
             {
                 if ( kind != 5 )
                 {
@@ -3109,7 +3423,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i64_high = decoded_v;
                 break;
             }
-            case 0xd308fcb98ece5d23ull: // i64_inside
+            case 65: // i64_inside, id 0xd308fcb98ece5d23ull
             {
                 if ( kind != 5 )
                 {
@@ -3139,7 +3453,7 @@ TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned 
                 value.i64_inside = decoded_v;
                 break;
             }
-            case 0xc70cde6b85b6197dull: // edges
+            case 66: // edges, id 0xc70cde6b85b6197dull
             {
                 if ( kind != 14 )
                 {
@@ -4537,10 +4851,10 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4551,9 +4865,9 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x0f8897557f37c021ull: // u8_span
+            case 67: // u8_span, id 0x0f8897557f37c021ull
             {
                 if ( kind != 6 )
                 {
@@ -4568,7 +4882,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u8_span = decoded_v;
                 break;
             }
-            case 0x2e17553f8200a2a1ull: // u8_low
+            case 68: // u8_low, id 0x2e17553f8200a2a1ull
             {
                 if ( kind != 6 )
                 {
@@ -4584,7 +4898,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u8_low = decoded_v;
                 break;
             }
-            case 0xa0e5c60df9301b7dull: // u8_high
+            case 69: // u8_high, id 0xa0e5c60df9301b7dull
             {
                 if ( kind != 6 )
                 {
@@ -4600,7 +4914,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u8_high = decoded_v;
                 break;
             }
-            case 0x1cb2c073a6f5844dull: // u8_inside
+            case 70: // u8_inside, id 0x1cb2c073a6f5844dull
             {
                 if ( kind != 6 )
                 {
@@ -4617,7 +4931,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u8_inside = decoded_v;
                 break;
             }
-            case 0x4ca0c150b1790960ull: // u16_span
+            case 71: // u16_span, id 0x4ca0c150b1790960ull
             {
                 if ( kind != 7 )
                 {
@@ -4643,7 +4957,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u16_span = decoded_v;
                 break;
             }
-            case 0xf252136836b04cb2ull: // u16_low
+            case 72: // u16_low, id 0xf252136836b04cb2ull
             {
                 if ( kind != 7 )
                 {
@@ -4671,7 +4985,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u16_low = decoded_v;
                 break;
             }
-            case 0x4f37e1f216e7610cull: // u16_high
+            case 73: // u16_high, id 0x4f37e1f216e7610cull
             {
                 if ( kind != 7 )
                 {
@@ -4699,7 +5013,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u16_high = decoded_v;
                 break;
             }
-            case 0xd176b605978f3304ull: // u16_inside
+            case 74: // u16_inside, id 0xd176b605978f3304ull
             {
                 if ( kind != 7 )
                 {
@@ -4729,7 +5043,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u16_inside = decoded_v;
                 break;
             }
-            case 0x200b924de7479cdaull: // u32_span
+            case 75: // u32_span, id 0x200b924de7479cdaull
             {
                 if ( kind != 8 )
                 {
@@ -4755,7 +5069,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u32_span = decoded_v;
                 break;
             }
-            case 0xa53d2f2a31b5acb0ull: // u32_low
+            case 76: // u32_low, id 0xa53d2f2a31b5acb0ull
             {
                 if ( kind != 8 )
                 {
@@ -4783,7 +5097,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u32_low = decoded_v;
                 break;
             }
-            case 0x9759be8ea1a4e3d2ull: // u32_high
+            case 77: // u32_high, id 0x9759be8ea1a4e3d2ull
             {
                 if ( kind != 8 )
                 {
@@ -4811,7 +5125,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u32_high = decoded_v;
                 break;
             }
-            case 0x8dc515fc082e3c0eull: // u32_inside
+            case 78: // u32_inside, id 0x8dc515fc082e3c0eull
             {
                 if ( kind != 8 )
                 {
@@ -4841,7 +5155,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u32_inside = decoded_v;
                 break;
             }
-            case 0xbeecef11dbdf8973ull: // u64_span
+            case 79: // u64_span, id 0xbeecef11dbdf8973ull
             {
                 if ( kind != 9 )
                 {
@@ -4867,7 +5181,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u64_span = decoded_v;
                 break;
             }
-            case 0x0117ad66e0fff227ull: // u64_low
+            case 80: // u64_low, id 0x0117ad66e0fff227ull
             {
                 if ( kind != 9 )
                 {
@@ -4895,7 +5209,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u64_low = decoded_v;
                 break;
             }
-            case 0xf2b45af3b50689dbull: // u64_high
+            case 81: // u64_high, id 0xf2b45af3b50689dbull
             {
                 if ( kind != 9 )
                 {
@@ -4923,7 +5237,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u64_high = decoded_v;
                 break;
             }
-            case 0x713e12017eebcaf7ull: // u64_inside
+            case 82: // u64_inside, id 0x713e12017eebcaf7ull
             {
                 if ( kind != 9 )
                 {
@@ -4953,7 +5267,7 @@ TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsig
                 value.u64_inside = decoded_v;
                 break;
             }
-            case 0xc341febe5aae51e5ull: // counts
+            case 83: // counts, id 0xc341febe5aae51e5ull
             {
                 if ( kind != 14 )
                 {
@@ -6104,10 +6418,10 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6118,9 +6432,9 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x08a60c07b54d8dc7ull: // b8
+            case 84: // b8, id 0x08a60c07b54d8dc7ull
             {
                 if ( kind != 6 )
                 {
@@ -6135,7 +6449,7 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
                 value.b8 = decoded_v;
                 break;
             }
-            case 0xff95701912ad97beull: // b16
+            case 85: // b16, id 0xff95701912ad97beull
             {
                 if ( kind != 7 )
                 {
@@ -6161,7 +6475,7 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
                 value.b16 = decoded_v;
                 break;
             }
-            case 0xff9c5c1912b39470ull: // b32
+            case 86: // b32, id 0xff9c5c1912b39470ull
             {
                 if ( kind != 8 )
                 {
@@ -6187,7 +6501,7 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
                 value.b32 = decoded_v;
                 break;
             }
-            case 0xff92701912ab61e7ull: // b64
+            case 87: // b64, id 0xff92701912ab61e7ull
             {
                 if ( kind != 9 )
                 {
@@ -6213,7 +6527,7 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
                 value.b64 = decoded_v;
                 break;
             }
-            case 0xff95741912ad9e8aull: // b12
+            case 88: // b12, id 0xff95741912ad9e8aull
             {
                 if ( kind != 7 )
                 {
@@ -6241,7 +6555,7 @@ TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths 
                 value.b12 = decoded_v;
                 break;
             }
-            case 0xff8b681912a535a1ull: // b48
+            case 89: // b48, id 0xff8b681912a535a1ull
             {
                 if ( kind != 9 )
                 {

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2550,6 +2864,16 @@ inline bool TableEnumValue( uint64_t id, Grade & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Grade & out )
+{
+    switch ( slot )
+    {
+        case 112: out = Grade::Bronze; return true; // id 0xc4927739aac4c591ull
+        case 113: out = Grade::Silver; return true; // id 0xc3e51adeeaf12580ull
+        case 114: out = Grade::Gold; return true; // id 0xc416c97e0d3218b3ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_GRADE
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2807,10 +3131,10 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2821,9 +3145,9 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7f6308be8ab37fc0ull: // damage
+            case 99: // damage, id 0x7f6308be8ab37fc0ull
             {
                 if ( kind != 10 )
                 {
@@ -2837,7 +3161,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 value.damage = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x1733055702acb1d2ull: // speed
+            case 101: // speed, id 0x1733055702acb1d2ull
             {
                 if ( kind != 10 )
                 {
@@ -2851,7 +3175,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 value.speed = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x4f31c5309e13e932ull: // penetration
+            case 102: // penetration, id 0x4f31c5309e13e932ull
             {
                 if ( kind != 4 )
                 {
@@ -2881,7 +3205,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 value.penetration = decoded_v;
                 break;
             }
-            case 0xa5013e9ad5caeda4ull: // channel
+            case 103: // channel, id 0xa5013e9ad5caeda4ull
             {
                 if ( kind != 6 )
                 {
@@ -2897,7 +3221,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 value.channel = decoded_v;
                 break;
             }
-            case 0xad6587bc602e3f59ull: // homing
+            case 104: // homing, id 0xad6587bc602e3f59ull
             {
                 if ( kind != 1 )
                 {
@@ -2911,7 +3235,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 value.homing = r.get8() != 0;
                 break;
             }
-            case 0x36c1c83b51f24394ull: // effect
+            case 105: // effect, id 0x36c1c83b51f24394ull
             {
                 if ( kind != 15 )
                 {
@@ -2925,16 +3249,16 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.effect.type = EffectType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xffb5be9be2e469ccull: // buff
+                        case 127: // buff, id 0xffb5be9be2e469ccull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -2949,7 +3273,7 @@ TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig 
                             if ( sub.offset != sub.size ) { value.effect.type = EffectType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x13cdc5ede73d2fd7ull: // debuff
+                        case 128: // debuff, id 0x13cdc5ede73d2fd7ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -3695,10 +4019,10 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3709,9 +4033,9 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x32a89b2977c48ad4ull: // grade
+            case 19: // grade, id 0x32a89b2977c48ad4ull
             {
                 if ( kind != 30 )
                 {
@@ -3725,14 +4049,14 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.grade = Grade::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.grade ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.grade ) )
                 {
                     value.grade = Grade::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xd90a4e7682f799c5ull: // grades
+            case 20: // grades, id 0xd90a4e7682f799c5ull
             {
                 if ( kind != 14 )
                 {
@@ -3776,7 +4100,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                             if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                             if ( variant_ref == 0 ) { value.grades[(int32_t) i] = Grade::None; } // the zero reference is the enum's None
                             else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                            else if ( !TableEnumValue( r.ids->at( variant_ref ), value.grades[(int32_t) i] ) )
+                            else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.grades[(int32_t) i] ) )
                             {
                                 value.grades[(int32_t) i] = Grade::None;
                                 r.report->unknown++;
@@ -3793,7 +4117,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xb46ff45a23d72549ull: // podium
+            case 21: // podium, id 0xb46ff45a23d72549ull
             {
                 if ( kind != 14 )
                 {
@@ -3835,7 +4159,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                             if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                             if ( variant_ref == 0 ) { value.podium[(int32_t) i] = Grade::None; } // the zero reference is the enum's None
                             else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                            else if ( !TableEnumValue( r.ids->at( variant_ref ), value.podium[(int32_t) i] ) )
+                            else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.podium[(int32_t) i] ) )
                             {
                                 value.podium[(int32_t) i] = Grade::None;
                                 r.report->unknown++;
@@ -3847,7 +4171,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x4b06f5847096e54aull: // perks
+            case 22: // perks, id 0x4b06f5847096e54aull
             {
                 if ( kind != 9 )
                 {
@@ -3873,7 +4197,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 value.perks = decoded_v;
                 break;
             }
-            case 0xbf31137ff783e939ull: // primary
+            case 23: // primary, id 0xbf31137ff783e939ull
             {
                 if ( kind != 13 )
                 {
@@ -3897,7 +4221,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xde28f0f5118acc24ull: // backups
+            case 24: // backups, id 0xde28f0f5118acc24ull
             {
                 if ( kind != 14 )
                 {
@@ -3948,7 +4272,7 @@ TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfi
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xf901aa0340249a41ull: // attachments
+            case 25: // attachments, id 0xf901aa0340249a41ull
             {
                 if ( kind != 14 )
                 {
@@ -4731,10 +5055,10 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4745,9 +5069,9 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 37: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -4776,7 +5100,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xdbff4cc56c2092f0ull: // icon
+            case 38: // icon, id 0xdbff4cc56c2092f0ull
             {
                 if ( kind != 14 )
                 {
@@ -4825,7 +5149,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xab8b6d521f80b969ull: // experience
+            case 39: // experience, id 0xab8b6d521f80b969ull
             {
                 if ( kind != 8 )
                 {
@@ -4851,7 +5175,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.experience = decoded_v;
                 break;
             }
-            case 0x1e5088ef2e9bafc6ull: // tilt
+            case 40: // tilt, id 0x1e5088ef2e9bafc6ull
             {
                 if ( kind != 2 )
                 {
@@ -4866,7 +5190,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.tilt = decoded_v;
                 break;
             }
-            case 0xb128829190ca0f75ull: // heading
+            case 41: // heading, id 0xb128829190ca0f75ull
             {
                 if ( kind != 3 )
                 {
@@ -4892,7 +5216,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.heading = decoded_v;
                 break;
             }
-            case 0x5ddc92338ef53403ull: // timestamp
+            case 42: // timestamp, id 0x5ddc92338ef53403ull
             {
                 if ( kind != 5 )
                 {
@@ -4918,7 +5242,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.timestamp = decoded_v;
                 break;
             }
-            case 0x10bda981fe095518ull: // badge
+            case 43: // badge, id 0x10bda981fe095518ull
             {
                 if ( kind != 6 )
                 {
@@ -4933,7 +5257,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.badge = decoded_v;
                 break;
             }
-            case 0x8c2cdb0da8933fa6ull: // port
+            case 44: // port, id 0x8c2cdb0da8933fa6ull
             {
                 if ( kind != 7 )
                 {
@@ -4959,7 +5283,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.port = decoded_v;
                 break;
             }
-            case 0xfc9697d1196e6ba6ull: // epoch
+            case 45: // epoch, id 0xfc9697d1196e6ba6ull
             {
                 if ( kind != 9 )
                 {
@@ -4985,7 +5309,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.epoch = decoded_v;
                 break;
             }
-            case 0x288427f5babd05f7ull: // precision
+            case 46: // precision, id 0x288427f5babd05f7ull
             {
                 if ( kind != 11 )
                 {
@@ -5008,7 +5332,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.precision = table_bits_to_double( r.get64() );
                 break;
             }
-            case 0xb921eb8a3d0cb0f9ull: // ratings
+            case 47: // ratings, id 0xb921eb8a3d0cb0f9ull
             {
                 if ( kind != 14 )
                 {
@@ -5053,7 +5377,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xa06f5e0a148e253cull: // has_loadout
+            case 48: // has_loadout, id 0xa06f5e0a148e253cull
             {
                 if ( kind != 1 )
                 {
@@ -5067,7 +5391,7 @@ TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfi
                 value.has_loadout = r.get8() != 0;
                 break;
             }
-            case 0x5759ce7586bbb5a3ull: // loadout
+            case 49: // loadout, id 0x5759ce7586bbb5a3ull
             {
                 if ( kind != 13 )
                 {
@@ -5992,10 +6316,10 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6006,9 +6330,9 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x8a67c9728746d394ull: // version_note
+            case 90: // version_note, id 0x8a67c9728746d394ull
             {
                 if ( kind != 12 )
                 {
@@ -6037,7 +6361,7 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x41cbd901b87fabb6ull: // weapons
+            case 91: // weapons, id 0x41cbd901b87fabb6ull
             {
                 if ( kind != 14 )
                 {
@@ -6095,7 +6419,7 @@ TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x8181e61fc0436767ull: // profiles
+            case 92: // profiles, id 0x8181e61fc0436767ull
             {
                 if ( kind != 14 )
                 {
@@ -6543,10 +6867,10 @@ TABLEDEMO_TABLE_INLINE bool AttachmentLoadBody( TableReader & r, Attachment & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6557,9 +6881,9 @@ TABLEDEMO_TABLE_INLINE bool AttachmentLoadBody( TableReader & r, Attachment & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x6a771618f6fe31d1ull: // slot
+            case 2: // slot, id 0x6a771618f6fe31d1ull
             {
                 if ( kind != 4 )
                 {
@@ -6589,7 +6913,7 @@ TABLEDEMO_TABLE_INLINE bool AttachmentLoadBody( TableReader & r, Attachment & va
                 value.slot = decoded_v;
                 break;
             }
-            case 0xeef9d1358ae7b4e6ull: // power
+            case 3: // power, id 0xeef9d1358ae7b4e6ull
             {
                 if ( kind != 10 )
                 {
@@ -6932,10 +7256,10 @@ TABLEDEMO_TABLE_INLINE bool BuffLoadBody( TableReader & r, Buff & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6946,9 +7270,9 @@ TABLEDEMO_TABLE_INLINE bool BuffLoadBody( TableReader & r, Buff & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x9adc623a805c87c6ull: // multiplier
+            case 4: // multiplier, id 0x9adc623a805c87c6ull
             {
                 if ( kind != 10 )
                 {
@@ -7231,10 +7555,10 @@ TABLEDEMO_TABLE_INLINE bool DebuffLoadBody( TableReader & r, Debuff & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7245,9 +7569,9 @@ TABLEDEMO_TABLE_INLINE bool DebuffLoadBody( TableReader & r, Debuff & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x8113fe7ea2b16969ull: // amount
+            case 5: // amount, id 0x8113fe7ea2b16969ull
             {
                 if ( kind != 4 )
                 {

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -395,6 +395,207 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 158;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 1024;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0xcbad05ba5de18dbbull;
+static const uint32_t kTableIdSlotShift = 54;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xa354fd1ff0c467c5ull, 0xb1e5e28e4479a274ull, 0x6a771618f6fe31d1ull, 0xeef9d1358ae7b4e6ull,
+    0x9adc623a805c87c6ull, 0x8113fe7ea2b16969ull, 0xa65f859b617deaf3ull, 0x467f35a74c6e4a70ull,
+    0x14ec921cc2549d60ull, 0x09ae5613b0051271ull, 0xb75aa3662201646aull, 0xa6bf719a4602b0bcull,
+    0x5bc44627b9848818ull, 0x7f69d4b5288ba9cfull, 0x1f3757a2ce7b0ab1ull, 0x84f8260bc283608cull,
+    0xbaaeb048a5a8fa6dull, 0xce0ac3c25694d8ffull, 0x01986b0b27400fb2ull, 0x32a89b2977c48ad4ull,
+    0xd90a4e7682f799c5ull, 0xb46ff45a23d72549ull, 0x4b06f5847096e54aull, 0xbf31137ff783e939ull,
+    0xde28f0f5118acc24ull, 0xf901aa0340249a41ull, 0xbb62c62c9808ea37ull, 0x7fb43557b54149ceull,
+    0x294a5c4913e1ad44ull, 0x9cda940a344e1571ull, 0x77707fccd201c228ull, 0x6580790b036f0c6full,
+    0x2281498aa0200e40ull, 0x247f0e7f55aacfbdull, 0xb7bc9ac015a25050ull, 0xb8c758d8bd1845d4ull,
+    0x3bf8fbbad1587cddull, 0xc4bcadba8e631b86ull, 0xdbff4cc56c2092f0ull, 0xab8b6d521f80b969ull,
+    0x1e5088ef2e9bafc6ull, 0xb128829190ca0f75ull, 0x5ddc92338ef53403ull, 0x10bda981fe095518ull,
+    0x8c2cdb0da8933fa6ull, 0xfc9697d1196e6ba6ull, 0x288427f5babd05f7ull, 0xb921eb8a3d0cb0f9ull,
+    0xa06f5e0a148e253cull, 0x5759ce7586bbb5a3ull, 0x48121511bf702eb5ull, 0x942bfe3168090f7dull,
+    0xd182acd105b55dd1ull, 0xef9ded23c8912a81ull, 0xb655574ea23760b4ull, 0xd217b3af8d7a2bdeull,
+    0x90652f70c9127900ull, 0x6a659d7c354db158ull, 0xe693bd88532c91d6ull, 0x065ee827cf99fbb4ull,
+    0xc9b121c4c2a186eeull, 0xd363dfa465acf27aull, 0x7549c70700c49d6full, 0x1cce6617419771dbull,
+    0x3b54fa60620b5597ull, 0xd308fcb98ece5d23ull, 0xc70cde6b85b6197dull, 0x0f8897557f37c021ull,
+    0x2e17553f8200a2a1ull, 0xa0e5c60df9301b7dull, 0x1cb2c073a6f5844dull, 0x4ca0c150b1790960ull,
+    0xf252136836b04cb2ull, 0x4f37e1f216e7610cull, 0xd176b605978f3304ull, 0x200b924de7479cdaull,
+    0xa53d2f2a31b5acb0ull, 0x9759be8ea1a4e3d2ull, 0x8dc515fc082e3c0eull, 0xbeecef11dbdf8973ull,
+    0x0117ad66e0fff227ull, 0xf2b45af3b50689dbull, 0x713e12017eebcaf7ull, 0xc341febe5aae51e5ull,
+    0x08a60c07b54d8dc7ull, 0xff95701912ad97beull, 0xff9c5c1912b39470ull, 0xff92701912ab61e7ull,
+    0xff95741912ad9e8aull, 0xff8b681912a535a1ull, 0x8a67c9728746d394ull, 0x41cbd901b87fabb6ull,
+    0x8181e61fc0436767ull, 0xf10fad739a0e1660ull, 0x2d21d7cd66bd5a5dull, 0x95d0cce09ca82b73ull,
+    0x40dbb648c0cd44aaull, 0xceec99e2d65db674ull, 0xbca0dab1c7a00ccfull, 0x7f6308be8ab37fc0ull,
+    0xdc2cbe6953343d48ull, 0x1733055702acb1d2ull, 0x4f31c5309e13e932ull, 0xa5013e9ad5caeda4ull,
+    0xad6587bc602e3f59ull, 0x36c1c83b51f24394ull, 0x39f7fcec8fcb623dull, 0xcfb8a9d063b5e9e5ull,
+    0xe3b1ca6a3b48dddcull, 0x483d9e6c1ccd1f9bull, 0x9ff3121d30f88d52ull, 0x58c7b5d87587287cull,
+    0xc4927739aac4c591ull, 0xc3e51adeeaf12580ull, 0xc416c97e0d3218b3ull, 0xae61a6cbe88c2cf4ull,
+    0x334d24e1420dbc1full, 0x6c2321a3d00e23dbull, 0xd011f7c3c15285c2ull, 0xa8216aa1c554cb8aull,
+    0x7d573c625719c1a5ull, 0x9ff1de19feac1b7cull, 0xecf3d3a7c1693e2dull, 0xcf00d78fd5953f1cull,
+    0x5854debe3b2e767cull, 0xb528592e5a4583e3ull, 0x04dc16aea8ff5276ull, 0xffb5be9be2e469ccull,
+    0x13cdc5ede73d2fd7ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x413e7bcf261bc3c7ull, 0xffb1dfb1f6ce215bull, 0x5fcbe04615411b64ull,
+    0xb76842b2253337afull, 0x3066b130dfbd7890ull, 0xd6633ae4e94deecfull, 0xa6aa0caea28dcca1ull,
+    0xd02d825db114336eull, 0x1c182e1c2529027bull, 0x19fffcb7859da778ull, 0xec79751dda28be2eull,
+    0x031ec0c4b7d28bf1ull, 0xbf59694e9e4f5ed7ull, 0x5f4843f6def45e87ull, 0x1d1a9911da171a29ull,
+    0x1cf8555d11fb113aull, 0x469dba0c16b2ad15ull, 0x0577780d86c4b0c3ull, 0xab6a6961d3366451ull,
+    0x2a43bfa7e454ddacull, 0x38b429bf239b38dbull, 0x52bb98fcd979eab7ull, 0xddfc86d2b1251528ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       84, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   147,   111, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   107, 0xFFFF, 0xFFFF,   134, 0xFFFF,    94, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   118, 0xFFFF, 0xFFFF,   150, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      100, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    55, 0xFFFF, 0xFFFF,    66, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    57,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       59, 0xFFFF, 0xFFFF,    86,    76, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63, 0xFFFF,
+       65, 0xFFFF, 0xFFFF,    82, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   113, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    70,    98, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,   131, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   136, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    51, 0xFFFF,   116, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,
+       43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   154, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   110, 0xFFFF, 0xFFFF,   129, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+      128, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       87, 0xFFFF, 0xFFFF, 0xFFFF,   126, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    83, 0xFFFF,    64, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   142,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    72, 0xFFFF, 0xFFFF,   145, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     7, 0xFFFF,    48, 0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF,     0,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       96,   137, 0xFFFF,   123, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF,   101, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      135, 0xFFFF,    99, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   106,   152,
+    0xFFFF,    31,   148, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,   115, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   112, 0xFFFF,    29,   156,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      109, 0xFFFF, 0xFFFF, 0xFFFF,   103, 0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   124, 0xFFFF, 0xFFFF,   144, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       14,    58, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,   133, 0xFFFF, 0xFFFF, 0xFFFF,
+       27,   104, 0xFFFF,    30,    34, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    92, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+      146, 0xFFFF,    25, 0xFFFF,    54, 0xFFFF, 0xFFFF,    78, 0xFFFF,    60,   151, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    68, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF,
+      105, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    11,    81, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    62,    44, 0xFFFF, 0xFFFF, 0xFFFF,    91, 0xFFFF,    24, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   141, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   157, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    93, 0xFFFF, 0xFFFF, 0xFFFF,
+      108,   127, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   122, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    52, 0xFFFF, 0xFFFF,    80, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF,
+       15, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    88, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   143, 0xFFFF, 0xFFFF,   102,
+      119, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   155, 0xFFFF,
+       41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    89, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      138, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   117, 0xFFFF,
+    0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    32,    35, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    95,   153, 0xFFFF,    79, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,     8, 0xFFFF,
+    0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   140, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF,    85, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   139, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   125, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   114, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+      120, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    22, 0xFFFF, 0xFFFF, 0xFFFF,    69,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,   130, 0xFFFF,    90, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    74,   149, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    75,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF,    49, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    97, 0xFFFF, 0xFFFF,   132, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,   121,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 155;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 129;
+static const uint16_t kTableIdSlotBuildVersion = 156;
+static const uint16_t kTableIdSlotVocabulary = 157;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -403,16 +604,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    TABLEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -732,6 +951,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 512;
+static const int32_t kTableIdProbeShift = 55;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -763,16 +994,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2547,10 +2861,10 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2561,9 +2875,9 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 106: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -2592,7 +2906,7 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xcfb8a9d063b5e9e5ull: // payload
+            case 107: // payload, id 0xcfb8a9d063b5e9e5ull
             {
                 if ( kind != 14 )
                 {
@@ -2641,7 +2955,7 @@ TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xe3b1ca6a3b48dddcull: // samples
+            case 108: // samples, id 0xe3b1ca6a3b48dddcull
             {
                 if ( kind != 14 )
                 {

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -435,6 +435,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 63;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7c9dd540002d2fffull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x40b1d94aff3ab130ull, 0xaa19a78e404dea20ull, 0x7848019b0c02a926ull, 0xbf82010f6f71eae9ull,
+    0x3e7884bf4f412c6full, 0x56d7ab194448a4f3ull, 0x855b556730a34a05ull, 0x81b46a69304ee2c9ull,
+    0x21277bcf1a4d67fbull, 0xb1e5e28e4479a274ull, 0x1e7683ef2ebc7684ull, 0xd90a4e7682f799c5ull,
+    0x4af2ed8470862ea8ull, 0x732dfbcc9b0cf0bbull, 0x52f60c4caef0b768ull, 0xdbdacd932fd1e9bfull,
+    0x17720bf67d347222ull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0x9de543933e6e703aull,
+    0x39f7fcec8fcb623dull, 0xaf63eb4c86020609ull, 0xd24733aa574d4b09ull, 0x125073191daf5431ull,
+    0x01986b0b27400fb2ull, 0xa3a7061ff10a8138ull, 0x5f82477707ad620full, 0x1c84390d304f4f42ull,
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xc4bcadba8e631b86ull, 0xaf63fc4c860222ecull,
+    0xaf63ff4c86022805ull, 0xaf63fe4c86022652ull, 0x73feab3544c345b1ull, 0x7f6308be8ab37fc0ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x06e2378b553a9e84ull, 0x0acac10912f5892aull, 0xeeeea7adc131a244ull,
+    0xd043187343bfcfe8ull, 0x91638659f8f6ad42ull, 0x2034c5d17c00ceb7ull, 0x52cfa1d198476806ull,
+    0x5e781536ac58825full, 0xbb86c6c96f598bb8ull, 0xf1a78dd2508964c3ull, 0x41f721f1b93aea80ull,
+    0x8a439296ced9ed11ull, 0xa013e119fec906fbull, 0xdc40d61254c70aa7ull, 0x33f85f24c0f5f008ull,
+    0x0cc9e0af9a85fbc8ull, 0xec07a2f760550a91ull, 0x2ec2f34386026d8bull, 0x8f26e0f086cc2787ull,
+    0xaf05dfb30c5ca3deull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF,    55, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22,    25, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF,    54, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,    13,     7, 0xFFFF,
+       51, 0xFFFF,    26,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    43, 0xFFFF,    24,    27, 0xFFFF,    11, 0xFFFF,     8, 0xFFFF,     9,
+    0xFFFF, 0xFFFF,     3,    41, 0xFFFF, 0xFFFF, 0xFFFF,    10,    42, 0xFFFF,    45,    31,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,    59,
+    0xFFFF,    44, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+    0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF,     5,    52, 0xFFFF,
+    0xFFFF, 0xFFFF,    48,    28, 0xFFFF,    29,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       21, 0xFFFF,    19,     2, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF,    56,    20, 0xFFFF,
+    0xFFFF,    57, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    15, 0xFFFF, 0xFFFF,    38, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23,    40, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF,
+       60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 36;
+static const uint16_t kTableIdSlotBuildVersion = 61;
+static const uint16_t kTableIdSlotVocabulary = 62;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +556,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    LISTDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +903,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +946,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6731,10 +6957,10 @@ inline SquadRosterEntryKeyRead SquadRosterEntryReadKey( const uint8_t * body, in
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 28 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 6; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6839,10 +7065,10 @@ LISTDEMO_TABLE_INLINE bool SampleLoadBody( TableReader & r, Sample & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6853,9 +7079,9 @@ LISTDEMO_TABLE_INLINE bool SampleLoadBody( TableReader & r, Sample & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 21: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -7209,10 +7435,10 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7223,9 +7449,9 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -7286,7 +7512,7 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x39f7fcec8fcb623dull: // label
+            case 20: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 4 )
                 {
@@ -7312,7 +7538,7 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
                 value.label = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7626,10 +7852,10 @@ inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7640,9 +7866,9 @@ inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa3a7061ff10a8138ull: // rows
+            case 25: // rows, id 0xa3a7061ff10a8138ull
             {
                 if ( kind != 14 )
                 {
@@ -7704,7 +7930,7 @@ inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x5f82477707ad620full: // pinned
+            case 26: // pinned, id 0x5f82477707ad620full
             {
                 if ( kind != 17 )
                 {
@@ -7724,7 +7950,7 @@ inline bool SheetLoadBody( TableReader & r, const TableNodeMap & nodes, Sheet & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7963,10 +8189,10 @@ LISTDEMO_TABLE_INLINE bool ItemLoadBody( TableReader & r, Item & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7977,9 +8203,9 @@ LISTDEMO_TABLE_INLINE bool ItemLoadBody( TableReader & r, Item & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb1e5e28e4479a274ull: // count
+            case 9: // count, id 0xb1e5e28e4479a274ull
             {
                 if ( kind != 4 )
                 {
@@ -8295,10 +8521,10 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoste
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8309,9 +8535,9 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoste
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 28: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -8326,7 +8552,7 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoste
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 29: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -8557,10 +8783,10 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8571,9 +8797,9 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1c84390d304f4f42ull: // roster
+            case 27: // roster, id 0x1c84390d304f4f42ull
             {
                 if ( kind != 14 )
                 {
@@ -8661,7 +8887,7 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xc4bcadba8e631b86ull: // name
+            case 30: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 4 )
                 {
@@ -8687,7 +8913,7 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
                 value.name = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9020,10 +9246,10 @@ inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9034,9 +9260,9 @@ inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7848019b0c02a926ull: // squads
+            case 2: // squads, id 0x7848019b0c02a926ull
             {
                 if ( kind != 14 )
                 {
@@ -9098,7 +9324,7 @@ inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9124,7 +9350,7 @@ inline bool ArmyLoadBody( TableReader & r, const TableNodeMap & nodes, Army & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9414,10 +9640,10 @@ inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9428,9 +9654,9 @@ inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x81b46a69304ee2c9ull: // hands
+            case 7: // hands, id 0x81b46a69304ee2c9ull
             {
                 if ( kind != 14 )
                 {
@@ -9489,7 +9715,7 @@ inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9515,7 +9741,7 @@ inline bool DeckLoadBody( TableReader & r, const TableNodeMap & nodes, Deck & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9741,10 +9967,10 @@ inline bool RowWireExtent( const uint8_t * body, int64_t length, int64_t & at, c
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3e7884bf4f412c6full && field_kind == 14 ) // items: an unbounded array
+        if ( field_slot == 4 && field_kind == 14 ) // items: an unbounded array, id 0x3e7884bf4f412c6full
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9819,10 +10045,10 @@ inline bool SheetWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xa3a7061ff10a8138ull && field_kind == 14 ) // rows: an unbounded array
+        if ( field_slot == 25 && field_kind == 14 ) // rows: an unbounded array, id 0xa3a7061ff10a8138ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9905,10 +10131,10 @@ inline bool SquadWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x1c84390d304f4f42ull && field_kind == 14 ) // roster
+        if ( field_slot == 27 && field_kind == 14 ) // roster, id 0x1c84390d304f4f42ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -9985,10 +10211,10 @@ inline bool ArmyWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x7848019b0c02a926ull && field_kind == 14 ) // squads: an unbounded array
+        if ( field_slot == 2 && field_kind == 14 ) // squads: an unbounded array, id 0x7848019b0c02a926ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -10071,10 +10297,10 @@ inline bool DeckWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x81b46a69304ee2c9ull && field_kind == 14 ) // hands: a nesting that holds a list or a map
+        if ( field_slot == 7 && field_kind == 14 ) // hands: a nesting that holds a list or a map, id 0x81b46a69304ee2c9ull
         {
             uint64_t nested_len = 0;
             if ( !r.getleb( nested_len ) || !r.room( nested_len ) ) { return true; }
@@ -15249,10 +15475,11 @@ LISTDEMO_TABLE_INLINE bool SampleLoadBodyRetain( TableReader & r, Sample & value
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15263,9 +15490,9 @@ LISTDEMO_TABLE_INLINE bool SampleLoadBodyRetain( TableReader & r, Sample & value
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 21: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -15485,10 +15712,11 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15499,9 +15727,9 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -15565,7 +15793,7 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x39f7fcec8fcb623dull: // label
+            case 20: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 4 )
                 {
@@ -15591,7 +15819,7 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
                 value.label = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -15837,10 +16065,11 @@ inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sh
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15851,9 +16080,9 @@ inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sh
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa3a7061ff10a8138ull: // rows
+            case 25: // rows, id 0xa3a7061ff10a8138ull
             {
                 if ( kind != 14 )
                 {
@@ -15918,7 +16147,7 @@ inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sh
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x5f82477707ad620full: // pinned
+            case 26: // pinned, id 0x5f82477707ad620full
             {
                 if ( kind != 17 )
                 {
@@ -15938,7 +16167,7 @@ inline bool SheetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sh
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -16079,10 +16308,11 @@ LISTDEMO_TABLE_INLINE bool ItemLoadBodyRetain( TableReader & r, Item & value, Ta
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16093,9 +16323,9 @@ LISTDEMO_TABLE_INLINE bool ItemLoadBodyRetain( TableReader & r, Item & value, Ta
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb1e5e28e4479a274ull: // count
+            case 9: // count, id 0xb1e5e28e4479a274ull
             {
                 if ( kind != 4 )
                 {
@@ -16277,10 +16507,11 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squa
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16291,9 +16522,9 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squa
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 28: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -16308,7 +16539,7 @@ LISTDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squa
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 29: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -16513,10 +16744,11 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16527,9 +16759,9 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1c84390d304f4f42ull: // roster
+            case 27: // roster, id 0x1c84390d304f4f42ull
             {
                 if ( kind != 14 )
                 {
@@ -16620,7 +16852,7 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xc4bcadba8e631b86ull: // name
+            case 30: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 4 )
                 {
@@ -16646,7 +16878,7 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
                 value.name = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -16909,10 +17141,11 @@ inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Arm
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16923,9 +17156,9 @@ inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Arm
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7848019b0c02a926ull: // squads
+            case 2: // squads, id 0x7848019b0c02a926ull
             {
                 if ( kind != 14 )
                 {
@@ -16990,7 +17223,7 @@ inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Arm
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -17016,7 +17249,7 @@ inline bool ArmyLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Arm
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -17237,10 +17470,11 @@ inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Dec
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -17251,9 +17485,9 @@ inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Dec
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x81b46a69304ee2c9ull: // hands
+            case 7: // hands, id 0x81b46a69304ee2c9ull
             {
                 if ( kind != 14 )
                 {
@@ -17315,7 +17549,7 @@ inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Dec
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -17341,7 +17575,7 @@ inline bool DeckLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Dec
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -435,6 +435,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 63;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7c9dd540002d2fffull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x40b1d94aff3ab130ull, 0xaa19a78e404dea20ull, 0x7848019b0c02a926ull, 0xbf82010f6f71eae9ull,
+    0x3e7884bf4f412c6full, 0x56d7ab194448a4f3ull, 0x855b556730a34a05ull, 0x81b46a69304ee2c9ull,
+    0x21277bcf1a4d67fbull, 0xb1e5e28e4479a274ull, 0x1e7683ef2ebc7684ull, 0xd90a4e7682f799c5ull,
+    0x4af2ed8470862ea8ull, 0x732dfbcc9b0cf0bbull, 0x52f60c4caef0b768ull, 0xdbdacd932fd1e9bfull,
+    0x17720bf67d347222ull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0x9de543933e6e703aull,
+    0x39f7fcec8fcb623dull, 0xaf63eb4c86020609ull, 0xd24733aa574d4b09ull, 0x125073191daf5431ull,
+    0x01986b0b27400fb2ull, 0xa3a7061ff10a8138ull, 0x5f82477707ad620full, 0x1c84390d304f4f42ull,
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xc4bcadba8e631b86ull, 0xaf63fc4c860222ecull,
+    0xaf63ff4c86022805ull, 0xaf63fe4c86022652ull, 0x73feab3544c345b1ull, 0x7f6308be8ab37fc0ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x06e2378b553a9e84ull, 0x0acac10912f5892aull, 0xeeeea7adc131a244ull,
+    0xd043187343bfcfe8ull, 0x91638659f8f6ad42ull, 0x2034c5d17c00ceb7ull, 0x52cfa1d198476806ull,
+    0x5e781536ac58825full, 0xbb86c6c96f598bb8ull, 0xf1a78dd2508964c3ull, 0x41f721f1b93aea80ull,
+    0x8a439296ced9ed11ull, 0xa013e119fec906fbull, 0xdc40d61254c70aa7ull, 0x33f85f24c0f5f008ull,
+    0x0cc9e0af9a85fbc8ull, 0xec07a2f760550a91ull, 0x2ec2f34386026d8bull, 0x8f26e0f086cc2787ull,
+    0xaf05dfb30c5ca3deull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF,    55, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22,    25, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF,    54, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,    13,     7, 0xFFFF,
+       51, 0xFFFF,    26,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    43, 0xFFFF,    24,    27, 0xFFFF,    11, 0xFFFF,     8, 0xFFFF,     9,
+    0xFFFF, 0xFFFF,     3,    41, 0xFFFF, 0xFFFF, 0xFFFF,    10,    42, 0xFFFF,    45,    31,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,    59,
+    0xFFFF,    44, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+    0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF,     5,    52, 0xFFFF,
+    0xFFFF, 0xFFFF,    48,    28, 0xFFFF,    29,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       21, 0xFFFF,    19,     2, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF,    56,    20, 0xFFFF,
+    0xFFFF,    57, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    15, 0xFFFF, 0xFFFF,    38, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23,    40, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF,
+       60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 36;
+static const uint16_t kTableIdSlotBuildVersion = 61;
+static const uint16_t kTableIdSlotVocabulary = 62;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +556,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    LISTDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +903,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +946,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6521,10 +6747,10 @@ LISTDEMO_TABLE_INLINE bool UnitLoadBody( TableReader & r, Unit & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6535,9 +6761,9 @@ LISTDEMO_TABLE_INLINE bool UnitLoadBody( TableReader & r, Unit & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 21: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -6890,10 +7116,10 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBody( TableReader & r, Bounded & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6904,9 +7130,9 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBody( TableReader & r, Bounded & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -6964,7 +7190,7 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBody( TableReader & r, Bounded & value )
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 5: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 4 )
                 {
@@ -7375,10 +7601,10 @@ inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7389,9 +7615,9 @@ inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -7452,7 +7678,7 @@ inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbo
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 5: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 4 )
                 {
@@ -7478,7 +7704,7 @@ inline bool UnboundedLoadBody( TableReader & r, const TableNodeMap & nodes, Unbo
                 value.tag = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7705,10 +7931,10 @@ inline bool UnboundedWireExtent( const uint8_t * body, int64_t length, int64_t &
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3e7884bf4f412c6full && field_kind == 14 ) // items: an unbounded array
+        if ( field_slot == 4 && field_kind == 14 ) // items: an unbounded array, id 0x3e7884bf4f412c6full
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8784,10 +9010,11 @@ LISTDEMO_TABLE_INLINE bool UnitLoadBodyRetain( TableReader & r, Unit & value, Ta
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8798,9 +9025,9 @@ LISTDEMO_TABLE_INLINE bool UnitLoadBodyRetain( TableReader & r, Unit & value, Ta
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63eb4c86020609ull: // v
+            case 21: // v, id 0xaf63eb4c86020609ull
             {
                 if ( kind != 4 )
                 {
@@ -9000,10 +9227,11 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBodyRetain( TableReader & r, Bounded & val
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9014,9 +9242,9 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBodyRetain( TableReader & r, Bounded & val
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -9077,7 +9305,7 @@ LISTDEMO_TABLE_INLINE bool BoundedLoadBodyRetain( TableReader & r, Bounded & val
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 5: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 4 )
                 {
@@ -9332,10 +9560,11 @@ inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9346,9 +9575,9 @@ inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3e7884bf4f412c6full: // items
+            case 4: // items, id 0x3e7884bf4f412c6full
             {
                 if ( kind != 14 )
                 {
@@ -9412,7 +9641,7 @@ inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 5: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 4 )
                 {
@@ -9438,7 +9667,7 @@ inline bool UnboundedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes
                 value.tag = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -435,6 +435,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 63;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7c9dd540002d2fffull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x40b1d94aff3ab130ull, 0xaa19a78e404dea20ull, 0x7848019b0c02a926ull, 0xbf82010f6f71eae9ull,
+    0x3e7884bf4f412c6full, 0x56d7ab194448a4f3ull, 0x855b556730a34a05ull, 0x81b46a69304ee2c9ull,
+    0x21277bcf1a4d67fbull, 0xb1e5e28e4479a274ull, 0x1e7683ef2ebc7684ull, 0xd90a4e7682f799c5ull,
+    0x4af2ed8470862ea8ull, 0x732dfbcc9b0cf0bbull, 0x52f60c4caef0b768ull, 0xdbdacd932fd1e9bfull,
+    0x17720bf67d347222ull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0x9de543933e6e703aull,
+    0x39f7fcec8fcb623dull, 0xaf63eb4c86020609ull, 0xd24733aa574d4b09ull, 0x125073191daf5431ull,
+    0x01986b0b27400fb2ull, 0xa3a7061ff10a8138ull, 0x5f82477707ad620full, 0x1c84390d304f4f42ull,
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xc4bcadba8e631b86ull, 0xaf63fc4c860222ecull,
+    0xaf63ff4c86022805ull, 0xaf63fe4c86022652ull, 0x73feab3544c345b1ull, 0x7f6308be8ab37fc0ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x06e2378b553a9e84ull, 0x0acac10912f5892aull, 0xeeeea7adc131a244ull,
+    0xd043187343bfcfe8ull, 0x91638659f8f6ad42ull, 0x2034c5d17c00ceb7ull, 0x52cfa1d198476806ull,
+    0x5e781536ac58825full, 0xbb86c6c96f598bb8ull, 0xf1a78dd2508964c3ull, 0x41f721f1b93aea80ull,
+    0x8a439296ced9ed11ull, 0xa013e119fec906fbull, 0xdc40d61254c70aa7ull, 0x33f85f24c0f5f008ull,
+    0x0cc9e0af9a85fbc8ull, 0xec07a2f760550a91ull, 0x2ec2f34386026d8bull, 0x8f26e0f086cc2787ull,
+    0xaf05dfb30c5ca3deull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF,    55, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22,    25, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF,    54, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,    13,     7, 0xFFFF,
+       51, 0xFFFF,    26,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    43, 0xFFFF,    24,    27, 0xFFFF,    11, 0xFFFF,     8, 0xFFFF,     9,
+    0xFFFF, 0xFFFF,     3,    41, 0xFFFF, 0xFFFF, 0xFFFF,    10,    42, 0xFFFF,    45,    31,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,    59,
+    0xFFFF,    44, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+    0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF,     5,    52, 0xFFFF,
+    0xFFFF, 0xFFFF,    48,    28, 0xFFFF,    29,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       21, 0xFFFF,    19,     2, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF,    56,    20, 0xFFFF,
+    0xFFFF,    57, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    15, 0xFFFF, 0xFFFF,    38, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23,    40, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF,
+       60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 36;
+static const uint16_t kTableIdSlotBuildVersion = 61;
+static const uint16_t kTableIdSlotVocabulary = 62;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +556,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    LISTDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +903,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +946,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6568,10 +6794,10 @@ inline bool BytesLoadBody( TableReader & r, const TableNodeMap & nodes, Bytes & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6582,9 +6808,9 @@ inline bool BytesLoadBody( TableReader & r, const TableNodeMap & nodes, Bytes & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x855b556730a34a05ull: // data
+            case 6: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 14 )
                 {
@@ -6640,7 +6866,7 @@ inline bool BytesLoadBody( TableReader & r, const TableNodeMap & nodes, Bytes & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -6666,7 +6892,7 @@ inline bool BytesLoadBody( TableReader & r, const TableNodeMap & nodes, Bytes & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6958,10 +7184,10 @@ inline bool IntsLoadBody( TableReader & r, const TableNodeMap & nodes, Ints & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6972,9 +7198,9 @@ inline bool IntsLoadBody( TableReader & r, const TableNodeMap & nodes, Ints & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x21277bcf1a4d67fbull: // values
+            case 8: // values, id 0x21277bcf1a4d67fbull
             {
                 if ( kind != 14 )
                 {
@@ -7060,7 +7286,7 @@ inline bool IntsLoadBody( TableReader & r, const TableNodeMap & nodes, Ints & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7086,7 +7312,7 @@ inline bool IntsLoadBody( TableReader & r, const TableNodeMap & nodes, Ints & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7380,10 +7606,10 @@ inline bool FloatsLoadBody( TableReader & r, const TableNodeMap & nodes, Floats 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7394,9 +7620,9 @@ inline bool FloatsLoadBody( TableReader & r, const TableNodeMap & nodes, Floats 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x21277bcf1a4d67fbull: // values
+            case 8: // values, id 0x21277bcf1a4d67fbull
             {
                 if ( kind != 14 )
                 {
@@ -7451,7 +7677,7 @@ inline bool FloatsLoadBody( TableReader & r, const TableNodeMap & nodes, Floats 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7477,7 +7703,7 @@ inline bool FloatsLoadBody( TableReader & r, const TableNodeMap & nodes, Floats 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7715,10 +7941,10 @@ inline bool BytesWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x855b556730a34a05ull && field_kind == 14 ) // data: an unbounded array
+        if ( field_slot == 6 && field_kind == 14 ) // data: an unbounded array, id 0x855b556730a34a05ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -7793,10 +8019,10 @@ inline bool IntsWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x21277bcf1a4d67fbull && field_kind == 14 ) // values: an unbounded array
+        if ( field_slot == 8 && field_kind == 14 ) // values: an unbounded array, id 0x21277bcf1a4d67fbull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -7871,10 +8097,10 @@ inline bool FloatsWireExtent( const uint8_t * body, int64_t length, int64_t & at
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x21277bcf1a4d67fbull && field_kind == 14 ) // values: an unbounded array
+        if ( field_slot == 8 && field_kind == 14 ) // values: an unbounded array, id 0x21277bcf1a4d67fbull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -10953,10 +11179,11 @@ inline bool BytesLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, By
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10967,9 +11194,9 @@ inline bool BytesLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, By
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x855b556730a34a05ull: // data
+            case 6: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 14 )
                 {
@@ -11025,7 +11252,7 @@ inline bool BytesLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, By
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -11051,7 +11278,7 @@ inline bool BytesLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, By
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -11274,10 +11501,11 @@ inline bool IntsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Int
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11288,9 +11516,9 @@ inline bool IntsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Int
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x21277bcf1a4d67fbull: // values
+            case 8: // values, id 0x21277bcf1a4d67fbull
             {
                 if ( kind != 14 )
                 {
@@ -11376,7 +11604,7 @@ inline bool IntsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Int
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -11402,7 +11630,7 @@ inline bool IntsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Int
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -11630,10 +11858,11 @@ inline bool FloatsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, F
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11644,9 +11873,9 @@ inline bool FloatsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, F
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x21277bcf1a4d67fbull: // values
+            case 8: // values, id 0x21277bcf1a4d67fbull
             {
                 if ( kind != 14 )
                 {
@@ -11701,7 +11930,7 @@ inline bool FloatsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, F
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -11727,7 +11956,7 @@ inline bool FloatsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, F
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -435,6 +435,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 63;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7c9dd540002d2fffull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x40b1d94aff3ab130ull, 0xaa19a78e404dea20ull, 0x7848019b0c02a926ull, 0xbf82010f6f71eae9ull,
+    0x3e7884bf4f412c6full, 0x56d7ab194448a4f3ull, 0x855b556730a34a05ull, 0x81b46a69304ee2c9ull,
+    0x21277bcf1a4d67fbull, 0xb1e5e28e4479a274ull, 0x1e7683ef2ebc7684ull, 0xd90a4e7682f799c5ull,
+    0x4af2ed8470862ea8ull, 0x732dfbcc9b0cf0bbull, 0x52f60c4caef0b768ull, 0xdbdacd932fd1e9bfull,
+    0x17720bf67d347222ull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0x9de543933e6e703aull,
+    0x39f7fcec8fcb623dull, 0xaf63eb4c86020609ull, 0xd24733aa574d4b09ull, 0x125073191daf5431ull,
+    0x01986b0b27400fb2ull, 0xa3a7061ff10a8138ull, 0x5f82477707ad620full, 0x1c84390d304f4f42ull,
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xc4bcadba8e631b86ull, 0xaf63fc4c860222ecull,
+    0xaf63ff4c86022805ull, 0xaf63fe4c86022652ull, 0x73feab3544c345b1ull, 0x7f6308be8ab37fc0ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x06e2378b553a9e84ull, 0x0acac10912f5892aull, 0xeeeea7adc131a244ull,
+    0xd043187343bfcfe8ull, 0x91638659f8f6ad42ull, 0x2034c5d17c00ceb7ull, 0x52cfa1d198476806ull,
+    0x5e781536ac58825full, 0xbb86c6c96f598bb8ull, 0xf1a78dd2508964c3ull, 0x41f721f1b93aea80ull,
+    0x8a439296ced9ed11ull, 0xa013e119fec906fbull, 0xdc40d61254c70aa7ull, 0x33f85f24c0f5f008ull,
+    0x0cc9e0af9a85fbc8ull, 0xec07a2f760550a91ull, 0x2ec2f34386026d8bull, 0x8f26e0f086cc2787ull,
+    0xaf05dfb30c5ca3deull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF,    55, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22,    25, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF,    54, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,    13,     7, 0xFFFF,
+       51, 0xFFFF,    26,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    43, 0xFFFF,    24,    27, 0xFFFF,    11, 0xFFFF,     8, 0xFFFF,     9,
+    0xFFFF, 0xFFFF,     3,    41, 0xFFFF, 0xFFFF, 0xFFFF,    10,    42, 0xFFFF,    45,    31,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,    59,
+    0xFFFF,    44, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+    0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF,     5,    52, 0xFFFF,
+    0xFFFF, 0xFFFF,    48,    28, 0xFFFF,    29,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       21, 0xFFFF,    19,     2, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF,    56,    20, 0xFFFF,
+    0xFFFF,    57, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    15, 0xFFFF, 0xFFFF,    38, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23,    40, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF,
+       60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 36;
+static const uint16_t kTableIdSlotBuildVersion = 61;
+static const uint16_t kTableIdSlotVocabulary = 62;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +556,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    LISTDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +903,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +946,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6506,6 +6732,16 @@ inline bool TableEnumValue( uint64_t id, Grade & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Grade & out )
+{
+    switch ( slot )
+    {
+        case 31: out = Grade::A; return true; // id 0xaf63fc4c860222ecull
+        case 32: out = Grade::B; return true; // id 0xaf63ff4c86022805ull
+        case 33: out = Grade::C; return true; // id 0xaf63fe4c86022652ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // LISTDEMO_SCHEMA_TABLE_ENUM_GRADE
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -6765,10 +7001,10 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBody( TableReader & r, Placement & value
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6779,9 +7015,9 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBody( TableReader & r, Placement & value
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 17: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 10 )
                 {
@@ -6795,7 +7031,7 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBody( TableReader & r, Placement & value
                 value.x = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 18: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 10 )
                 {
@@ -6809,7 +7045,7 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBody( TableReader & r, Placement & value
                 value.y = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x9de543933e6e703aull: // model
+            case 19: // model, id 0x9de543933e6e703aull
             {
                 if ( kind != 8 )
                 {
@@ -7192,10 +7428,10 @@ LISTDEMO_TABLE_INLINE bool LogEntryLoadBody( TableReader & r, LogEntry & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7206,9 +7442,9 @@ LISTDEMO_TABLE_INLINE bool LogEntryLoadBody( TableReader & r, LogEntry & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1e7683ef2ebc7684ull: // tick
+            case 10: // tick, id 0x1e7683ef2ebc7684ull
             {
                 if ( kind != 8 )
                 {
@@ -7622,10 +7858,10 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7636,9 +7872,9 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd24733aa574d4b09ull: // placements
+            case 22: // placements, id 0xd24733aa574d4b09ull
             {
                 if ( kind != 14 )
                 {
@@ -7699,7 +7935,7 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x125073191daf5431ull: // log
+            case 23: // log, id 0x125073191daf5431ull
             {
                 if ( kind != 14 )
                 {
@@ -7757,7 +7993,7 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x01986b0b27400fb2ull: // scores
+            case 24: // scores, id 0x01986b0b27400fb2ull
             {
                 if ( kind != 14 )
                 {
@@ -7843,7 +8079,7 @@ inline bool SaveLoadBody( TableReader & r, const TableNodeMap & nodes, Save & va
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8199,10 +8435,10 @@ LISTDEMO_TABLE_INLINE bool PointLoadBody( TableReader & r, Point & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8213,9 +8449,9 @@ LISTDEMO_TABLE_INLINE bool PointLoadBody( TableReader & r, Point & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 17: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 4 )
                 {
@@ -8241,7 +8477,7 @@ LISTDEMO_TABLE_INLINE bool PointLoadBody( TableReader & r, Point & value )
                 value.x = decoded_v;
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 18: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 4 )
                 {
@@ -8829,10 +9065,10 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8843,9 +9079,9 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd90a4e7682f799c5ull: // grades
+            case 11: // grades, id 0xd90a4e7682f799c5ull
             {
                 if ( kind != 14 )
                 {
@@ -8893,7 +9129,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                                     if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                                     if ( variant_ref == 0 ) { ( *slot ) = Grade::None; } // the zero reference is the enum's None
                                     else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                    else if ( !TableEnumValue( r.ids->at( variant_ref ), ( *slot ) ) )
+                                    else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), ( *slot ) ) )
                                     {
                                         ( *slot ) = Grade::None;
                                         r.report->unknown++;
@@ -8909,7 +9145,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x4af2ed8470862ea8ull: // perms
+            case 12: // perms, id 0x4af2ed8470862ea8ull
             {
                 if ( kind != 14 )
                 {
@@ -8995,7 +9231,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x732dfbcc9b0cf0bbull: // hits
+            case 13: // hits, id 0x732dfbcc9b0cf0bbull
             {
                 if ( kind != 14 )
                 {
@@ -9045,15 +9281,15 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                                     if ( elem_arm_ref_hits != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_hits > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_hits = r.ids->at( elem_arm_ref_hits );
+                                        const uint16_t elem_arm_slot_hits = r.ids->slot_of( elem_arm_ref_hits );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_hits = sub.get8();
                                         uint64_t elem_arm_len_hits = 0;
                                         if ( !sub.getleb( elem_arm_len_hits ) || !sub.room( elem_arm_len_hits ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_hits( sub.buffer + sub.offset, (int64_t) elem_arm_len_hits, r.report, r.ids );
-                                        switch ( elem_arm_id_hits ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_hits ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x73feab3544c345b1ull: // point
+                                            case 34: // point, id 0x73feab3544c345b1ull
                                             {
                                                 if ( elem_arm_kind_hits != 13 )
                                                 {
@@ -9064,7 +9300,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                                                 if ( elem_arm_hits.offset != elem_arm_hits.size ) { ( *slot ).type = HitType::None; r.report->malformed = true; break; }
                                                 break;
                                             }
-                                            case 0x7f6308be8ab37fc0ull: // damage
+                                            case 35: // damage, id 0x7f6308be8ab37fc0ull
                                             {
                                                 if ( elem_arm_kind_hits != 4 )
                                                 {
@@ -9106,7 +9342,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x52f60c4caef0b768ull: // bounds
+            case 14: // bounds, id 0x52f60c4caef0b768ull
             {
                 if ( kind != 14 )
                 {
@@ -9196,7 +9432,7 @@ inline bool MixedLoadBody( TableReader & r, const TableNodeMap & nodes, Mixed & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9753,10 +9989,10 @@ inline bool SaveWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xd24733aa574d4b09ull && field_kind == 14 ) // placements: an unbounded array
+        if ( field_slot == 22 && field_kind == 14 ) // placements: an unbounded array, id 0xd24733aa574d4b09ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9765,7 +10001,7 @@ inline bool SaveWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
             if ( !TableListWireExtent( list_body, (int64_t) list_len, at, (int64_t) sizeof( Placement ), (int64_t) alignof( Placement ), 13, 2, NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x125073191daf5431ull && field_kind == 14 ) // log: an unbounded array
+        if ( field_slot == 23 && field_kind == 14 ) // log: an unbounded array, id 0x125073191daf5431ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9774,7 +10010,7 @@ inline bool SaveWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
             if ( !TableListWireExtent( list_body, (int64_t) list_len, at, (int64_t) sizeof( TableRef ), (int64_t) alignof( TableRef ), 17, 1, NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x01986b0b27400fb2ull && field_kind == 14 ) // scores: an unbounded array
+        if ( field_slot == 24 && field_kind == 14 ) // scores: an unbounded array, id 0x01986b0b27400fb2ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9893,10 +10129,10 @@ inline bool MixedWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xd90a4e7682f799c5ull && field_kind == 14 ) // grades: an unbounded array
+        if ( field_slot == 11 && field_kind == 14 ) // grades: an unbounded array, id 0xd90a4e7682f799c5ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9905,7 +10141,7 @@ inline bool MixedWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableListWireExtent( list_body, (int64_t) list_len, at, (int64_t) sizeof( Grade ), (int64_t) alignof( Grade ), 30, 1, NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x4af2ed8470862ea8ull && field_kind == 14 ) // perms: an unbounded array
+        if ( field_slot == 12 && field_kind == 14 ) // perms: an unbounded array, id 0x4af2ed8470862ea8ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9914,7 +10150,7 @@ inline bool MixedWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableListWireExtent( list_body, (int64_t) list_len, at, (int64_t) sizeof( Perm ), (int64_t) alignof( Perm ), 9, 8, NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x732dfbcc9b0cf0bbull && field_kind == 14 ) // hits: an unbounded array
+        if ( field_slot == 13 && field_kind == 14 ) // hits: an unbounded array, id 0x732dfbcc9b0cf0bbull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -9923,7 +10159,7 @@ inline bool MixedWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableListWireExtent( list_body, (int64_t) list_len, at, (int64_t) sizeof( Hit ), (int64_t) alignof( Hit ), 15, 1, NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x52f60c4caef0b768ull && field_kind == 14 ) // bounds: an unbounded array
+        if ( field_slot == 14 && field_kind == 14 ) // bounds: an unbounded array, id 0x52f60c4caef0b768ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -12349,10 +12585,11 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBodyRetain( TableReader & r, Placement &
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12363,9 +12600,9 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBodyRetain( TableReader & r, Placement &
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 17: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 10 )
                 {
@@ -12379,7 +12616,7 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBodyRetain( TableReader & r, Placement &
                 value.x = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 18: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 10 )
                 {
@@ -12393,7 +12630,7 @@ LISTDEMO_TABLE_INLINE bool PlacementLoadBodyRetain( TableReader & r, Placement &
                 value.y = table_bits_to_float( r.get32() );
                 break;
             }
-            case 0x9de543933e6e703aull: // model
+            case 19: // model, id 0x9de543933e6e703aull
             {
                 if ( kind != 8 )
                 {
@@ -12603,10 +12840,11 @@ LISTDEMO_TABLE_INLINE bool LogEntryLoadBodyRetain( TableReader & r, LogEntry & v
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12617,9 +12855,9 @@ LISTDEMO_TABLE_INLINE bool LogEntryLoadBodyRetain( TableReader & r, LogEntry & v
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1e7683ef2ebc7684ull: // tick
+            case 10: // tick, id 0x1e7683ef2ebc7684ull
             {
                 if ( kind != 8 )
                 {
@@ -12899,10 +13137,11 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12913,9 +13152,9 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd24733aa574d4b09ull: // placements
+            case 22: // placements, id 0xd24733aa574d4b09ull
             {
                 if ( kind != 14 )
                 {
@@ -12979,7 +13218,7 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x125073191daf5431ull: // log
+            case 23: // log, id 0x125073191daf5431ull
             {
                 if ( kind != 14 )
                 {
@@ -13037,7 +13276,7 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x01986b0b27400fb2ull: // scores
+            case 24: // scores, id 0x01986b0b27400fb2ull
             {
                 if ( kind != 14 )
                 {
@@ -13123,7 +13362,7 @@ inline bool SaveLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sav
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -13327,10 +13566,11 @@ LISTDEMO_TABLE_INLINE bool PointLoadBodyRetain( TableReader & r, Point & value, 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13341,9 +13581,9 @@ LISTDEMO_TABLE_INLINE bool PointLoadBodyRetain( TableReader & r, Point & value, 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 17: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 4 )
                 {
@@ -13369,7 +13609,7 @@ LISTDEMO_TABLE_INLINE bool PointLoadBodyRetain( TableReader & r, Point & value, 
                 value.x = decoded_v;
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 18: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 4 )
                 {
@@ -13813,10 +14053,11 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13827,9 +14068,9 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd90a4e7682f799c5ull: // grades
+            case 11: // grades, id 0xd90a4e7682f799c5ull
             {
                 if ( kind != 14 )
                 {
@@ -13877,7 +14118,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                                     if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                                     if ( variant_ref == 0 ) { ( *slot ) = Grade::None; } // the zero reference is the enum's None
                                     else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                    else if ( !TableEnumValue( r.ids->at( variant_ref ), ( *slot ) ) )
+                                    else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), ( *slot ) ) )
                                     {
                                         ( *slot ) = Grade::None;
                                         r.report->unknown++; r.report->retain_lost++;
@@ -13893,7 +14134,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x4af2ed8470862ea8ull: // perms
+            case 12: // perms, id 0x4af2ed8470862ea8ull
             {
                 if ( kind != 14 )
                 {
@@ -13979,7 +14220,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x732dfbcc9b0cf0bbull: // hits
+            case 13: // hits, id 0x732dfbcc9b0cf0bbull
             {
                 if ( kind != 14 )
                 {
@@ -14032,15 +14273,15 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                                     if ( elem_arm_ref_hits != 0 ) // the zero reference is a None element in its place
                                     {
                                         if ( elem_arm_ref_hits > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                        const uint64_t elem_arm_id_hits = r.ids->at( elem_arm_ref_hits );
+                                        const uint16_t elem_arm_slot_hits = r.ids->slot_of( elem_arm_ref_hits );
                                         if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                         const uint8_t elem_arm_kind_hits = sub.get8();
                                         uint64_t elem_arm_len_hits = 0;
                                         if ( !sub.getleb( elem_arm_len_hits ) || !sub.room( elem_arm_len_hits ) ) { r.report->malformed = true; break; }
                                         TableReader elem_arm_hits( sub.buffer + sub.offset, (int64_t) elem_arm_len_hits, r.report, r.ids );
-                                        switch ( elem_arm_id_hits ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                        switch ( elem_arm_slot_hits ) // the arm's name, at its compile-time SLOT (§3, §5)
                                         {
-                                            case 0x73feab3544c345b1ull: // point
+                                            case 34: // point, id 0x73feab3544c345b1ull
                                             {
                                                 if ( elem_arm_kind_hits != 13 )
                                                 {
@@ -14051,7 +14292,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                                                 if ( elem_arm_hits.offset != elem_arm_hits.size ) { ( *slot ).type = HitType::None; r.report->malformed = true; break; }
                                                 break;
                                             }
-                                            case 0x7f6308be8ab37fc0ull: // damage
+                                            case 35: // damage, id 0x7f6308be8ab37fc0ull
                                             {
                                                 if ( elem_arm_kind_hits != 4 )
                                                 {
@@ -14093,7 +14334,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0x52f60c4caef0b768ull: // bounds
+            case 14: // bounds, id 0x52f60c4caef0b768ull
             {
                 if ( kind != 14 )
                 {
@@ -14183,7 +14424,7 @@ inline bool MixedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Mi
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -435,6 +435,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 63;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7c9dd540002d2fffull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x40b1d94aff3ab130ull, 0xaa19a78e404dea20ull, 0x7848019b0c02a926ull, 0xbf82010f6f71eae9ull,
+    0x3e7884bf4f412c6full, 0x56d7ab194448a4f3ull, 0x855b556730a34a05ull, 0x81b46a69304ee2c9ull,
+    0x21277bcf1a4d67fbull, 0xb1e5e28e4479a274ull, 0x1e7683ef2ebc7684ull, 0xd90a4e7682f799c5ull,
+    0x4af2ed8470862ea8ull, 0x732dfbcc9b0cf0bbull, 0x52f60c4caef0b768ull, 0xdbdacd932fd1e9bfull,
+    0x17720bf67d347222ull, 0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0x9de543933e6e703aull,
+    0x39f7fcec8fcb623dull, 0xaf63eb4c86020609ull, 0xd24733aa574d4b09ull, 0x125073191daf5431ull,
+    0x01986b0b27400fb2ull, 0xa3a7061ff10a8138ull, 0x5f82477707ad620full, 0x1c84390d304f4f42ull,
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xc4bcadba8e631b86ull, 0xaf63fc4c860222ecull,
+    0xaf63ff4c86022805ull, 0xaf63fe4c86022652ull, 0x73feab3544c345b1ull, 0x7f6308be8ab37fc0ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x06e2378b553a9e84ull, 0x0acac10912f5892aull, 0xeeeea7adc131a244ull,
+    0xd043187343bfcfe8ull, 0x91638659f8f6ad42ull, 0x2034c5d17c00ceb7ull, 0x52cfa1d198476806ull,
+    0x5e781536ac58825full, 0xbb86c6c96f598bb8ull, 0xf1a78dd2508964c3ull, 0x41f721f1b93aea80ull,
+    0x8a439296ced9ed11ull, 0xa013e119fec906fbull, 0xdc40d61254c70aa7ull, 0x33f85f24c0f5f008ull,
+    0x0cc9e0af9a85fbc8ull, 0xec07a2f760550a91ull, 0x2ec2f34386026d8bull, 0x8f26e0f086cc2787ull,
+    0xaf05dfb30c5ca3deull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF, 0xFFFF, 0xFFFF,    55, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22,    25, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    37, 0xFFFF,    54, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,    13,     7, 0xFFFF,
+       51, 0xFFFF,    26,    32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    43, 0xFFFF,    24,    27, 0xFFFF,    11, 0xFFFF,     8, 0xFFFF,     9,
+    0xFFFF, 0xFFFF,     3,    41, 0xFFFF, 0xFFFF, 0xFFFF,    10,    42, 0xFFFF,    45,    31,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF,    59,
+    0xFFFF,    44, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    36,
+    0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    62, 0xFFFF, 0xFFFF,     5,    52, 0xFFFF,
+    0xFFFF, 0xFFFF,    48,    28, 0xFFFF,    29,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    46,    49, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       21, 0xFFFF,    19,     2, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF,    56,    20, 0xFFFF,
+    0xFFFF,    57, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF,    15, 0xFFFF, 0xFFFF,    38, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    23,    40, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF,
+       60, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,
+    0xFFFF,    30, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 36;
+static const uint16_t kTableIdSlotBuildVersion = 61;
+static const uint16_t kTableIdSlotVocabulary = 62;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +556,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    LISTDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +903,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +946,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6539,10 +6765,10 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBody( TableReader & r, Photo & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6553,9 +6779,9 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBody( TableReader & r, Photo & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xdbdacd932fd1e9bfull: // width
+            case 15: // width, id 0xdbdacd932fd1e9bfull
             {
                 if ( kind != 8 )
                 {
@@ -6581,7 +6807,7 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBody( TableReader & r, Photo & value )
                 value.width = decoded_v;
                 break;
             }
-            case 0x17720bf67d347222ull: // height
+            case 16: // height, id 0x17720bf67d347222ull
             {
                 if ( kind != 8 )
                 {
@@ -6992,10 +7218,10 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7006,9 +7232,9 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x40b1d94aff3ab130ull: // photos
+            case 0: // photos, id 0x40b1d94aff3ab130ull
             {
                 if ( kind != 14 )
                 {
@@ -7066,7 +7292,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xaa19a78e404dea20ull: // cover
+            case 1: // cover, id 0xaa19a78e404dea20ull
             {
                 if ( kind != 17 )
                 {
@@ -7086,7 +7312,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7328,10 +7554,10 @@ inline bool AlbumWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x40b1d94aff3ab130ull && field_kind == 14 ) // photos: an unbounded array
+        if ( field_slot == 0 && field_kind == 14 ) // photos: an unbounded array, id 0x40b1d94aff3ab130ull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -8641,10 +8867,11 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBodyRetain( TableReader & r, Photo & value, 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8655,9 +8882,9 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBodyRetain( TableReader & r, Photo & value, 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xdbdacd932fd1e9bfull: // width
+            case 15: // width, id 0xdbdacd932fd1e9bfull
             {
                 if ( kind != 8 )
                 {
@@ -8683,7 +8910,7 @@ LISTDEMO_TABLE_INLINE bool PhotoLoadBodyRetain( TableReader & r, Photo & value, 
                 value.width = decoded_v;
                 break;
             }
-            case 0x17720bf67d347222ull: // height
+            case 16: // height, id 0x17720bf67d347222ull
             {
                 if ( kind != 8 )
                 {
@@ -8950,10 +9177,11 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8964,9 +9192,9 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x40b1d94aff3ab130ull: // photos
+            case 0: // photos, id 0x40b1d94aff3ab130ull
             {
                 if ( kind != 14 )
                 {
@@ -9024,7 +9252,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xaa19a78e404dea20ull: // cover
+            case 1: // cover, id 0xaa19a78e404dea20ull
             {
                 if ( kind != 17 )
                 {
@@ -9044,7 +9272,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -435,6 +435,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +581,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +928,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +971,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6673,10 +6924,10 @@ inline CellsRowsEntryKeyRead CellsRowsEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6772,10 +7023,10 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBody( TableReader & r, CellsRowsEntr
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6786,9 +7037,9 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBody( TableReader & r, CellsRowsEntr
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -6817,7 +7068,7 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBody( TableReader & r, CellsRowsEntr
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -7180,10 +7431,10 @@ inline bool CellsLoadBody( TableReader & r, const TableNodeMap & nodes, Cells & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7194,9 +7445,9 @@ inline bool CellsLoadBody( TableReader & r, const TableNodeMap & nodes, Cells & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa3a7061ff10a8138ull: // rows
+            case 2: // rows, id 0xa3a7061ff10a8138ull
             {
                 if ( kind != 14 )
                 {
@@ -7284,7 +7535,7 @@ inline bool CellsLoadBody( TableReader & r, const TableNodeMap & nodes, Cells & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7310,7 +7561,7 @@ inline bool CellsLoadBody( TableReader & r, const TableNodeMap & nodes, Cells & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7574,10 +7825,10 @@ inline bool CellsWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xa3a7061ff10a8138ull && field_kind == 14 ) // rows
+        if ( field_slot == 2 && field_kind == 14 ) // rows, id 0xa3a7061ff10a8138ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8753,10 +9004,11 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBodyRetain( TableReader & r, CellsRo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8767,9 +9019,9 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBodyRetain( TableReader & r, CellsRo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -8798,7 +9050,7 @@ MAPDEMO_TABLE_INLINE bool CellsRowsEntryLoadBodyRetain( TableReader & r, CellsRo
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9124,10 +9376,11 @@ inline bool CellsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ce
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9138,9 +9391,9 @@ inline bool CellsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ce
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xa3a7061ff10a8138ull: // rows
+            case 2: // rows, id 0xa3a7061ff10a8138ull
             {
                 if ( kind != 14 )
                 {
@@ -9231,7 +9484,7 @@ inline bool CellsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ce
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9257,7 +9510,7 @@ inline bool CellsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ce
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -435,6 +435,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +581,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +928,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +971,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6671,10 +6922,10 @@ inline ChunksBlobsEntryKeyRead ChunksBlobsEntryReadKey( const uint8_t * body, in
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 4 && TableKindWidens( field_kind, 4 ) )
             {
@@ -6775,10 +7026,10 @@ inline bool ChunksBlobsEntryLoadBody( TableReader & r, const TableNodeMap & node
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6789,9 +7040,9 @@ inline bool ChunksBlobsEntryLoadBody( TableReader & r, const TableNodeMap & node
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -6816,7 +7067,7 @@ inline bool ChunksBlobsEntryLoadBody( TableReader & r, const TableNodeMap & node
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -6836,7 +7087,7 @@ inline bool ChunksBlobsEntryLoadBody( TableReader & r, const TableNodeMap & node
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7083,10 +7334,10 @@ inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7097,9 +7348,9 @@ inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x14e2eaab9cde925bull: // blobs
+            case 4: // blobs, id 0x14e2eaab9cde925bull
             {
                 if ( kind != 14 )
                 {
@@ -7188,7 +7439,7 @@ inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7214,7 +7465,7 @@ inline bool ChunksLoadBody( TableReader & r, const TableNodeMap & nodes, Chunks 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7513,10 +7764,10 @@ inline bool ChunksWireExtent( const uint8_t * body, int64_t length, int64_t & at
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x14e2eaab9cde925bull && field_kind == 14 ) // blobs
+        if ( field_slot == 4 && field_kind == 14 ) // blobs, id 0x14e2eaab9cde925bull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8837,10 +9088,11 @@ inline bool ChunksBlobsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8851,9 +9103,9 @@ inline bool ChunksBlobsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -8878,7 +9130,7 @@ inline bool ChunksBlobsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -8898,7 +9150,7 @@ inline bool ChunksBlobsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9111,10 +9363,11 @@ inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, C
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9125,9 +9378,9 @@ inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, C
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x14e2eaab9cde925bull: // blobs
+            case 4: // blobs, id 0x14e2eaab9cde925bull
             {
                 if ( kind != 14 )
                 {
@@ -9219,7 +9472,7 @@ inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, C
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9245,7 +9498,7 @@ inline bool ChunksLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, C
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6670,10 +6921,10 @@ inline CrewsMembersEntryKeyRead CrewsMembersEntryReadKey( const uint8_t * body, 
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 8 && TableKindWidens( field_kind, 8 ) )
             {
@@ -6795,10 +7046,10 @@ inline bool CrewsMembersEntryLoadBody( TableReader & r, const TableNodeMap & nod
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6809,9 +7060,9 @@ inline bool CrewsMembersEntryLoadBody( TableReader & r, const TableNodeMap & nod
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -6836,7 +7087,7 @@ inline bool CrewsMembersEntryLoadBody( TableReader & r, const TableNodeMap & nod
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -6891,7 +7142,7 @@ inline bool CrewsMembersEntryLoadBody( TableReader & r, const TableNodeMap & nod
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7146,10 +7397,10 @@ inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7160,9 +7411,9 @@ inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x79d594675e391090ull: // members
+            case 5: // members, id 0x79d594675e391090ull
             {
                 if ( kind != 14 )
                 {
@@ -7251,7 +7502,7 @@ inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7277,7 +7528,7 @@ inline bool CrewsLoadBody( TableReader & r, const TableNodeMap & nodes, Crews & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7576,10 +7827,10 @@ inline bool CrewsWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x79d594675e391090ull && field_kind == 14 ) // members
+        if ( field_slot == 5 && field_kind == 14 ) // members, id 0x79d594675e391090ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8948,10 +9199,11 @@ inline bool CrewsMembersEntryLoadBodyRetain( TableReader & r, const TableNodeMap
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8962,9 +9214,9 @@ inline bool CrewsMembersEntryLoadBodyRetain( TableReader & r, const TableNodeMap
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -8989,7 +9241,7 @@ inline bool CrewsMembersEntryLoadBodyRetain( TableReader & r, const TableNodeMap
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9044,7 +9296,7 @@ inline bool CrewsMembersEntryLoadBodyRetain( TableReader & r, const TableNodeMap
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9265,10 +9517,11 @@ inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cr
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9279,9 +9532,9 @@ inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cr
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x79d594675e391090ull: // members
+            case 5: // members, id 0x79d594675e391090ull
             {
                 if ( kind != 14 )
                 {
@@ -9373,7 +9626,7 @@ inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cr
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9399,7 +9652,7 @@ inline bool CrewsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Cr
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6608,6 +6859,15 @@ inline bool TableEnumValue( uint64_t id, Slot & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Slot & out )
+{
+    switch ( slot )
+    {
+        case 29: out = Slot::Alpha; return true; // id 0x4fda04cbc245e18bull
+        case 30: out = Slot::Beta; return true; // id 0xa0b562a796b69487ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // MAPDEMO_SCHEMA_TABLE_ENUM_SLOT
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -6804,10 +7064,10 @@ inline SquadRosterEntryKeyRead SquadRosterEntryReadKey( const uint8_t * body, in
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 6; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6890,10 +7150,10 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoster
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6904,9 +7164,9 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoster
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -6921,7 +7181,7 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBody( TableReader & r, SquadRoster
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -7146,10 +7406,10 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7160,9 +7420,9 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1c84390d304f4f42ull: // roster
+            case 26: // roster, id 0x1c84390d304f4f42ull
             {
                 if ( kind != 14 )
                 {
@@ -7250,7 +7510,7 @@ inline bool SquadLoadBody( TableReader & r, const TableNodeMap & nodes, Squad & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7656,10 +7916,10 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7670,9 +7930,9 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1a08aa1921ca5cafull: // one
+            case 6: // one, id 0x1a08aa1921ca5cafull
             {
                 if ( kind != 13 )
                 {
@@ -7697,7 +7957,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x1f6459a2cea1fc02ull: // many
+            case 7: // many, id 0x1f6459a2cea1fc02ull
             {
                 if ( kind != 14 )
                 {
@@ -7756,7 +8016,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x70551ff29550f15dull: // keyed
+            case 8: // keyed, id 0x70551ff29550f15dull
             {
                 if ( kind != 16 )
                 {
@@ -7793,7 +8053,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Slot slot = Slot::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -7811,7 +8071,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0xe756c0190570ccb5ull: // arm
+            case 9: // arm, id 0xe756c0190570ccb5ull
             {
                 if ( kind != 15 )
                 {
@@ -7825,16 +8085,16 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.arm.type = ForceType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xd5c2bb95d63e6331ull: // squad
+                        case 31: // squad, id 0xd5c2bb95d63e6331ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -7850,7 +8110,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                             if ( sub.offset != sub.size ) { value.arm.type = ForceType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 32: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -7895,7 +8155,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7921,7 +8181,7 @@ inline bool DepthLoadBody( TableReader & r, const TableNodeMap & nodes, Depth & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8441,10 +8701,10 @@ inline bool SquadWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x1c84390d304f4f42ull && field_kind == 14 ) // roster
+        if ( field_slot == 26 && field_kind == 14 ) // roster, id 0x1c84390d304f4f42ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8521,10 +8781,10 @@ inline bool DepthWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x1a08aa1921ca5cafull && field_kind == 13 ) // one: a nesting that holds a list or a map
+        if ( field_slot == 6 && field_kind == 13 ) // one: a nesting that holds a list or a map, id 0x1a08aa1921ca5cafull
         {
             uint64_t nested_len = 0;
             if ( !r.getleb( nested_len ) || !r.room( nested_len ) ) { return true; }
@@ -8533,7 +8793,7 @@ inline bool DepthWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !SquadWireExtent( nested_body, (int64_t) nested_len, at, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x1f6459a2cea1fc02ull && field_kind == 14 ) // many: a nesting that holds a list or a map
+        if ( field_slot == 7 && field_kind == 14 ) // many: a nesting that holds a list or a map, id 0x1f6459a2cea1fc02ull
         {
             uint64_t nested_len = 0;
             if ( !r.getleb( nested_len ) || !r.room( nested_len ) ) { return true; }
@@ -8542,7 +8802,7 @@ inline bool DepthWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableWireExtentElements( nested_body, (int64_t) nested_len, at, &SquadWireExtent, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x70551ff29550f15dull && field_kind == 16 ) // keyed: a nesting that holds a list or a map
+        if ( field_slot == 8 && field_kind == 16 ) // keyed: a nesting that holds a list or a map, id 0x70551ff29550f15dull
         {
             uint64_t nested_len = 0;
             if ( !r.getleb( nested_len ) || !r.room( nested_len ) ) { return true; }
@@ -8551,7 +8811,7 @@ inline bool DepthWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableWireExtentKeyed( nested_body, (int64_t) nested_len, at, &SquadWireExtent, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0xe756c0190570ccb5ull && field_kind == 15 ) // arm: a union arm that holds a list or a map
+        if ( field_slot == 9 && field_kind == 15 ) // arm: a union arm that holds a list or a map, id 0xe756c0190570ccb5ull
         {
             if ( !ForceWireArmExtent( r, at, reason ) ) { return false; }
             continue;
@@ -8642,16 +8902,16 @@ inline bool ForceWireArmExtent( TableReader & r, int64_t & at, TableRefuseReason
     if ( !r.getleb( arm_ref ) ) { r.offset = r.size; return true; }
     if ( arm_ref == 0 ) { return true; } // None: the reference is the whole payload
     if ( r.ids == NULL || arm_ref > (uint64_t) r.ids->count ) { r.offset = r.size; return true; }
-    const uint64_t arm_id = r.ids->at( arm_ref );
+    const uint16_t arm_slot = r.ids->slot_of( arm_ref );
     if ( !r.has( 1 ) ) { r.offset = r.size; return true; }
     r.offset += 1; // the arm's kind byte
     uint64_t arm_len = 0;
     if ( !r.getleb( arm_len ) || !r.room( arm_len ) ) { r.offset = r.size; return true; }
     const uint8_t * arm_body = r.buffer + r.offset;
     r.offset += (int64_t) arm_len;
-    switch ( arm_id )
+    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
     {
-        case 0xd5c2bb95d63e6331ull: if ( !SquadWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // squad
+        case 31: if ( !SquadWireExtent( arm_body, (int64_t) arm_len, at, r.ids, reason ) ) { return false; } break; // squad, id 0xd5c2bb95d63e6331ull
         default: break; // an arm this reader cannot name reads None
     }
     return true;
@@ -10787,10 +11047,11 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squad
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10801,9 +11062,9 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squad
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -10818,7 +11079,7 @@ MAPDEMO_TABLE_INLINE bool SquadRosterEntryLoadBodyRetain( TableReader & r, Squad
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -11017,10 +11278,11 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11031,9 +11293,9 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1c84390d304f4f42ull: // roster
+            case 26: // roster, id 0x1c84390d304f4f42ull
             {
                 if ( kind != 14 )
                 {
@@ -11124,7 +11386,7 @@ inline bool SquadLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sq
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -11470,10 +11732,11 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11484,9 +11747,9 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1a08aa1921ca5cafull: // one
+            case 6: // one, id 0x1a08aa1921ca5cafull
             {
                 if ( kind != 13 )
                 {
@@ -11512,7 +11775,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x1f6459a2cea1fc02ull: // many
+            case 7: // many, id 0x1f6459a2cea1fc02ull
             {
                 if ( kind != 14 )
                 {
@@ -11574,7 +11837,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x70551ff29550f15dull: // keyed
+            case 8: // keyed, id 0x70551ff29550f15dull
             {
                 if ( kind != 16 )
                 {
@@ -11611,7 +11874,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Slot slot = Slot::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; r.report->retain_lost++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -11629,7 +11892,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0xe756c0190570ccb5ull: // arm
+            case 9: // arm, id 0xe756c0190570ccb5ull
             {
                 if ( kind != 15 )
                 {
@@ -11644,16 +11907,16 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.arm.type = ForceType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xd5c2bb95d63e6331ull: // squad
+                        case 31: // squad, id 0xd5c2bb95d63e6331ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -11669,7 +11932,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                             if ( sub.offset != sub.size ) { value.arm.type = ForceType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfd4d194e1652b207ull: // plain
+                        case 32: // plain, id 0xfd4d194e1652b207ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -11714,7 +11977,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -11740,7 +12003,7 @@ inline bool DepthLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -435,6 +435,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +581,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +928,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +971,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6681,10 +6932,10 @@ inline DocsPagesEntryKeyRead DocsPagesEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6785,10 +7036,10 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6799,9 +7050,9 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -6830,7 +7081,7 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -6850,7 +7101,7 @@ inline bool DocsPagesEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7078,10 +7329,10 @@ inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7092,9 +7343,9 @@ inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xab01daa76a48769full: // pages
+            case 10: // pages, id 0xab01daa76a48769full
             {
                 if ( kind != 14 )
                 {
@@ -7183,7 +7434,7 @@ inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & va
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7209,7 +7460,7 @@ inline bool DocsLoadBody( TableReader & r, const TableNodeMap & nodes, Docs & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7508,10 +7759,10 @@ inline bool DocsWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xab01daa76a48769full && field_kind == 14 ) // pages
+        if ( field_slot == 10 && field_kind == 14 ) // pages, id 0xab01daa76a48769full
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8855,10 +9106,11 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8869,9 +9121,9 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -8900,7 +9152,7 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -8920,7 +9172,7 @@ inline bool DocsPagesEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9108,10 +9360,11 @@ inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Doc
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9122,9 +9375,9 @@ inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Doc
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xab01daa76a48769full: // pages
+            case 10: // pages, id 0xab01daa76a48769full
             {
                 if ( kind != 14 )
                 {
@@ -9216,7 +9469,7 @@ inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Doc
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9242,7 +9495,7 @@ inline bool DocsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Doc
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -435,6 +435,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +581,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +928,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +971,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -7098,10 +7349,10 @@ inline FleetLoadoutsEntryValueEntryKeyRead FleetLoadoutsEntryValueEntryReadKey( 
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 6; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -7180,10 +7431,10 @@ inline FleetShipsEntryKeyRead FleetShipsEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -7256,10 +7507,10 @@ inline FleetByIdEntryKeyRead FleetByIdEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 8 && TableKindWidens( field_kind, 8 ) )
             {
@@ -7349,10 +7600,10 @@ inline FleetLoadoutsEntryKeyRead FleetLoadoutsEntryReadKey( const uint8_t * body
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -7423,10 +7674,10 @@ inline FleetTiersEntryKeyRead FleetTiersEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 3 && TableKindWidens( field_kind, 3 ) )
             {
@@ -7547,10 +7798,10 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBody( TableReader & r, ShipConfig & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7561,9 +7812,9 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBody( TableReader & r, ShipConfig & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 22: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -7592,7 +7843,7 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBody( TableReader & r, ShipConfig & valu
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7f69d4b5288ba9cfull: // health
+            case 23: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 4 )
                 {
@@ -7948,10 +8199,10 @@ MAPDEMO_TABLE_INLINE bool ItemLoadBody( TableReader & r, Item & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7962,9 +8213,9 @@ MAPDEMO_TABLE_INLINE bool ItemLoadBody( TableReader & r, Item & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb1e5e28e4479a274ull: // count
+            case 18: // count, id 0xb1e5e28e4479a274ull
             {
                 if ( kind != 4 )
                 {
@@ -8283,10 +8534,10 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBody( TableReader & r, FleetShipsEn
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8297,9 +8548,9 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBody( TableReader & r, FleetShipsEn
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -8328,7 +8579,7 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBody( TableReader & r, FleetShipsEn
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -8545,10 +8796,10 @@ inline bool FleetByIdEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8559,9 +8810,9 @@ inline bool FleetByIdEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -8586,7 +8837,7 @@ inline bool FleetByIdEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -8606,7 +8857,7 @@ inline bool FleetByIdEntryLoadBody( TableReader & r, const TableNodeMap & nodes,
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8808,10 +9059,10 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBody( TableReader & r,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8822,9 +9073,9 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBody( TableReader & r,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -8839,7 +9090,7 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBody( TableReader & r,
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -9073,10 +9324,10 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9087,9 +9338,9 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -9118,7 +9369,7 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9206,7 +9457,7 @@ inline bool FleetLoadoutsEntryLoadBody( TableReader & r, const TableNodeMap & no
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9485,10 +9736,10 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBody( TableReader & r, FleetTiersEn
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9499,9 +9750,9 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBody( TableReader & r, FleetTiersEn
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 3 )
                 {
@@ -9526,7 +9777,7 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBody( TableReader & r, FleetTiersEn
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -9928,10 +10179,10 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9942,9 +10193,9 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x294a5c4913e1ad44ull: // ships
+            case 13: // ships, id 0x294a5c4913e1ad44ull
             {
                 if ( kind != 14 )
                 {
@@ -10032,7 +10283,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x7b024c46e98d3404ull: // by_id
+            case 14: // by_id, id 0x7b024c46e98d3404ull
             {
                 if ( kind != 14 )
                 {
@@ -10121,7 +10372,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x63dfa0c4a4b3815dull: // flagship
+            case 15: // flagship, id 0x63dfa0c4a4b3815dull
             {
                 if ( kind != 17 )
                 {
@@ -10141,7 +10392,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                 }
                 break;
             }
-            case 0x294fa1b3f0f5f070ull: // loadouts
+            case 16: // loadouts, id 0x294fa1b3f0f5f070ull
             {
                 if ( kind != 14 )
                 {
@@ -10230,7 +10481,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x6dd8dc6c5fdae3ceull: // tiers
+            case 17: // tiers, id 0x6dd8dc6c5fdae3ceull
             {
                 if ( kind != 14 )
                 {
@@ -10318,7 +10569,7 @@ inline bool FleetLoadBody( TableReader & r, const TableNodeMap & nodes, Fleet & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -10983,10 +11234,10 @@ inline bool FleetLoadoutsEntryWireExtent( const uint8_t * body, int64_t length, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x7ce4fd9430e80ceaull && field_kind == 14 ) // value
+        if ( field_slot == 1 && field_kind == 14 ) // value, id 0x7ce4fd9430e80ceaull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -11063,10 +11314,10 @@ inline bool FleetWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x294a5c4913e1ad44ull && field_kind == 14 ) // ships
+        if ( field_slot == 13 && field_kind == 14 ) // ships, id 0x294a5c4913e1ad44ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -11075,7 +11326,7 @@ inline bool FleetWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( FleetShipsEntry ), (int64_t) alignof( FleetShipsEntry ), NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x7b024c46e98d3404ull && field_kind == 14 ) // by_id
+        if ( field_slot == 14 && field_kind == 14 ) // by_id, id 0x7b024c46e98d3404ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -11084,7 +11335,7 @@ inline bool FleetWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( FleetByIdEntry ), (int64_t) alignof( FleetByIdEntry ), NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x294fa1b3f0f5f070ull && field_kind == 14 ) // loadouts
+        if ( field_slot == 16 && field_kind == 14 ) // loadouts, id 0x294fa1b3f0f5f070ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -11093,7 +11344,7 @@ inline bool FleetWireExtent( const uint8_t * body, int64_t length, int64_t & at,
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( FleetLoadoutsEntry ), (int64_t) alignof( FleetLoadoutsEntry ), &FleetLoadoutsEntryWireExtent, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x6dd8dc6c5fdae3ceull && field_kind == 14 ) // tiers
+        if ( field_slot == 17 && field_kind == 14 ) // tiers, id 0x6dd8dc6c5fdae3ceull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -13093,10 +13344,11 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBodyRetain( TableReader & r, ShipConfig 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13107,9 +13359,9 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBodyRetain( TableReader & r, ShipConfig 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 22: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -13138,7 +13390,7 @@ MAPDEMO_TABLE_INLINE bool ShipConfigLoadBodyRetain( TableReader & r, ShipConfig 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7f69d4b5288ba9cfull: // health
+            case 23: // health, id 0x7f69d4b5288ba9cfull
             {
                 if ( kind != 4 )
                 {
@@ -13325,10 +13577,11 @@ MAPDEMO_TABLE_INLINE bool ItemLoadBodyRetain( TableReader & r, Item & value, Tab
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13339,9 +13592,9 @@ MAPDEMO_TABLE_INLINE bool ItemLoadBodyRetain( TableReader & r, Item & value, Tab
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xb1e5e28e4479a274ull: // count
+            case 18: // count, id 0xb1e5e28e4479a274ull
             {
                 if ( kind != 4 )
                 {
@@ -13526,10 +13779,11 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBodyRetain( TableReader & r, FleetS
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13540,9 +13794,9 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBodyRetain( TableReader & r, FleetS
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -13571,7 +13825,7 @@ MAPDEMO_TABLE_INLINE bool FleetShipsEntryLoadBodyRetain( TableReader & r, FleetS
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -13756,10 +14010,11 @@ inline bool FleetByIdEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13770,9 +14025,9 @@ inline bool FleetByIdEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -13797,7 +14052,7 @@ inline bool FleetByIdEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 17 )
                 {
@@ -13817,7 +14072,7 @@ inline bool FleetByIdEntryLoadBodyRetain( TableReader & r, const TableNodeMap & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -13985,10 +14240,11 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBodyRetain( TableReade
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13999,9 +14255,9 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBodyRetain( TableReade
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -14016,7 +14272,7 @@ MAPDEMO_TABLE_INLINE bool FleetLoadoutsEntryValueEntryLoadBodyRetain( TableReade
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -14224,10 +14480,11 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14238,9 +14495,9 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -14269,7 +14526,7 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -14360,7 +14617,7 @@ inline bool FleetLoadoutsEntryLoadBodyRetain( TableReader & r, const TableNodeMa
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -14563,10 +14820,11 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBodyRetain( TableReader & r, FleetT
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14577,9 +14835,9 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBodyRetain( TableReader & r, FleetT
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 3 )
                 {
@@ -14604,7 +14862,7 @@ MAPDEMO_TABLE_INLINE bool FleetTiersEntryLoadBodyRetain( TableReader & r, FleetT
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -14980,10 +15238,11 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14994,9 +15253,9 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x294a5c4913e1ad44ull: // ships
+            case 13: // ships, id 0x294a5c4913e1ad44ull
             {
                 if ( kind != 14 )
                 {
@@ -15087,7 +15346,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x7b024c46e98d3404ull: // by_id
+            case 14: // by_id, id 0x7b024c46e98d3404ull
             {
                 if ( kind != 14 )
                 {
@@ -15179,7 +15438,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x63dfa0c4a4b3815dull: // flagship
+            case 15: // flagship, id 0x63dfa0c4a4b3815dull
             {
                 if ( kind != 17 )
                 {
@@ -15199,7 +15458,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                 }
                 break;
             }
-            case 0x294fa1b3f0f5f070ull: // loadouts
+            case 16: // loadouts, id 0x294fa1b3f0f5f070ull
             {
                 if ( kind != 14 )
                 {
@@ -15291,7 +15550,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x6dd8dc6c5fdae3ceull: // tiers
+            case 17: // tiers, id 0x6dd8dc6c5fdae3ceull
             {
                 if ( kind != 14 )
                 {
@@ -15382,7 +15641,7 @@ inline bool FleetLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fl
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6667,10 +6918,10 @@ inline PairsSlotsEntryKeyRead PairsSlotsEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 8 && TableKindWidens( field_kind, 8 ) )
             {
@@ -6798,10 +7049,10 @@ inline bool PairsSlotsEntryLoadBody( TableReader & r, const TableNodeMap & nodes
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6812,9 +7063,9 @@ inline bool PairsSlotsEntryLoadBody( TableReader & r, const TableNodeMap & nodes
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -6839,7 +7090,7 @@ inline bool PairsSlotsEntryLoadBody( TableReader & r, const TableNodeMap & nodes
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -6887,7 +7138,7 @@ inline bool PairsSlotsEntryLoadBody( TableReader & r, const TableNodeMap & nodes
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7145,10 +7396,10 @@ inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7159,9 +7410,9 @@ inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xe68c2e6bb1ee5646ull: // slots
+            case 19: // slots, id 0xe68c2e6bb1ee5646ull
             {
                 if ( kind != 14 )
                 {
@@ -7250,7 +7501,7 @@ inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7276,7 +7527,7 @@ inline bool PairsLoadBody( TableReader & r, const TableNodeMap & nodes, Pairs & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7575,10 +7826,10 @@ inline bool PairsWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xe68c2e6bb1ee5646ull && field_kind == 14 ) // slots
+        if ( field_slot == 19 && field_kind == 14 ) // slots, id 0xe68c2e6bb1ee5646ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8953,10 +9204,11 @@ inline bool PairsSlotsEntryLoadBodyRetain( TableReader & r, const TableNodeMap &
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8967,9 +9219,9 @@ inline bool PairsSlotsEntryLoadBodyRetain( TableReader & r, const TableNodeMap &
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -8994,7 +9246,7 @@ inline bool PairsSlotsEntryLoadBodyRetain( TableReader & r, const TableNodeMap &
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9042,7 +9294,7 @@ inline bool PairsSlotsEntryLoadBodyRetain( TableReader & r, const TableNodeMap &
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9262,10 +9514,11 @@ inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pa
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9276,9 +9529,9 @@ inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pa
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xe68c2e6bb1ee5646ull: // slots
+            case 19: // slots, id 0xe68c2e6bb1ee5646ull
             {
                 if ( kind != 14 )
                 {
@@ -9370,7 +9623,7 @@ inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pa
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9396,7 +9649,7 @@ inline bool PairsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Pa
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6956,10 +7207,10 @@ inline RowEntriesEntryKeyRead RowEntriesEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -7030,10 +7281,10 @@ inline WideRowEntriesEntryKeyRead WideRowEntriesEntryReadKey( const uint8_t * bo
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 8 && TableKindWidens( field_kind, 8 ) )
             {
@@ -7121,10 +7372,10 @@ inline EdgeRowNamesEntryKeyRead EdgeRowNamesEntryReadKey( const uint8_t * body, 
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -7195,10 +7446,10 @@ inline EdgeRowIdsEntryKeyRead EdgeRowIdsEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 9 && TableKindWidens( field_kind, 9 ) )
             {
@@ -7310,10 +7561,10 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBody( TableReader & r, RowEntriesEn
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7324,9 +7575,9 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBody( TableReader & r, RowEntriesEn
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -7355,7 +7606,7 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBody( TableReader & r, RowEntriesEn
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -7594,10 +7845,10 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7608,9 +7859,9 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 20: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -7698,7 +7949,7 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7724,7 +7975,7 @@ inline bool RowLoadBody( TableReader & r, const TableNodeMap & nodes, Row & valu
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8022,10 +8273,10 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBody( TableReader & r, WideRowE
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8036,9 +8287,9 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBody( TableReader & r, WideRowE
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -8063,7 +8314,7 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBody( TableReader & r, WideRowE
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -8309,10 +8560,10 @@ inline bool WideRowLoadBody( TableReader & r, const TableNodeMap & nodes, WideRo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8323,9 +8574,9 @@ inline bool WideRowLoadBody( TableReader & r, const TableNodeMap & nodes, WideRo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 20: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -8413,7 +8664,7 @@ inline bool WideRowLoadBody( TableReader & r, const TableNodeMap & nodes, WideRo
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -8439,7 +8690,7 @@ inline bool WideRowLoadBody( TableReader & r, const TableNodeMap & nodes, WideRo
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8740,10 +8991,10 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBody( TableReader & r, EdgeRowNam
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8754,9 +9005,9 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBody( TableReader & r, EdgeRowNam
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -8785,7 +9036,7 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBody( TableReader & r, EdgeRowNam
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -8988,10 +9239,10 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBody( TableReader & r, EdgeRowIdsEn
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9002,9 +9253,9 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBody( TableReader & r, EdgeRowIdsEn
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 9 )
                 {
@@ -9029,7 +9280,7 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBody( TableReader & r, EdgeRowIdsEn
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -9316,10 +9567,10 @@ inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9330,9 +9581,9 @@ inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafb728fff268814full: // names
+            case 11: // names, id 0xafb728fff268814full
             {
                 if ( kind != 14 )
                 {
@@ -9420,7 +9671,7 @@ inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRo
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x2b7dea192bb7be29ull: // ids
+            case 12: // ids, id 0x2b7dea192bb7be29ull
             {
                 if ( kind != 14 )
                 {
@@ -9508,7 +9759,7 @@ inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRo
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9534,7 +9785,7 @@ inline bool EdgeRowLoadBody( TableReader & r, const TableNodeMap & nodes, EdgeRo
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9904,10 +10155,10 @@ inline bool RowWireExtent( const uint8_t * body, int64_t length, int64_t & at, c
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xc5b2a72c0845a253ull && field_kind == 14 ) // entries
+        if ( field_slot == 20 && field_kind == 14 ) // entries, id 0xc5b2a72c0845a253ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -9984,10 +10235,10 @@ inline bool WideRowWireExtent( const uint8_t * body, int64_t length, int64_t & a
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xc5b2a72c0845a253ull && field_kind == 14 ) // entries
+        if ( field_slot == 20 && field_kind == 14 ) // entries, id 0xc5b2a72c0845a253ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -10064,10 +10315,10 @@ inline bool EdgeRowWireExtent( const uint8_t * body, int64_t length, int64_t & a
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xafb728fff268814full && field_kind == 14 ) // names
+        if ( field_slot == 11 && field_kind == 14 ) // names, id 0xafb728fff268814full
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -10076,7 +10327,7 @@ inline bool EdgeRowWireExtent( const uint8_t * body, int64_t length, int64_t & a
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( EdgeRowNamesEntry ), (int64_t) alignof( EdgeRowNamesEntry ), NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x2b7dea192bb7be29ull && field_kind == 14 ) // ids
+        if ( field_slot == 12 && field_kind == 14 ) // ids, id 0x2b7dea192bb7be29ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -13447,10 +13698,11 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBodyRetain( TableReader & r, RowEnt
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13461,9 +13713,9 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBodyRetain( TableReader & r, RowEnt
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -13492,7 +13744,7 @@ MAPDEMO_TABLE_INLINE bool RowEntriesEntryLoadBodyRetain( TableReader & r, RowEnt
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -13699,10 +13951,11 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -13713,9 +13966,9 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 20: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -13806,7 +14059,7 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -13832,7 +14085,7 @@ inline bool RowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Row 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -14060,10 +14313,11 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBodyRetain( TableReader & r, Wi
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14074,9 +14328,9 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBodyRetain( TableReader & r, Wi
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -14101,7 +14355,7 @@ MAPDEMO_TABLE_INLINE bool WideRowEntriesEntryLoadBodyRetain( TableReader & r, Wi
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -14321,10 +14575,11 @@ inline bool WideRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14335,9 +14590,9 @@ inline bool WideRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc5b2a72c0845a253ull: // entries
+            case 20: // entries, id 0xc5b2a72c0845a253ull
             {
                 if ( kind != 14 )
                 {
@@ -14428,7 +14683,7 @@ inline bool WideRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -14454,7 +14709,7 @@ inline bool WideRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -14685,10 +14940,11 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBodyRetain( TableReader & r, Edge
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14699,9 +14955,9 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBodyRetain( TableReader & r, Edge
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -14730,7 +14986,7 @@ MAPDEMO_TABLE_INLINE bool EdgeRowNamesEntryLoadBodyRetain( TableReader & r, Edge
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -14901,10 +15157,11 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBodyRetain( TableReader & r, EdgeRo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -14915,9 +15172,9 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBodyRetain( TableReader & r, EdgeRo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 9 )
                 {
@@ -14942,7 +15199,7 @@ MAPDEMO_TABLE_INLINE bool EdgeRowIdsEntryLoadBodyRetain( TableReader & r, EdgeRo
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 13 )
                 {
@@ -15203,10 +15460,11 @@ inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15217,9 +15475,9 @@ inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafb728fff268814full: // names
+            case 11: // names, id 0xafb728fff268814full
             {
                 if ( kind != 14 )
                 {
@@ -15310,7 +15568,7 @@ inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x2b7dea192bb7be29ull: // ids
+            case 12: // ids, id 0x2b7dea192bb7be29ull
             {
                 if ( kind != 14 )
                 {
@@ -15401,7 +15659,7 @@ inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -15427,7 +15685,7 @@ inline bool EdgeRowLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6664,10 +6915,10 @@ inline RunsSpansEntryKeyRead RunsSpansEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 7 && TableKindWidens( field_kind, 7 ) )
             {
@@ -6772,10 +7023,10 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBody( TableReader & r, RunsSpansEntr
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6786,9 +7037,9 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBody( TableReader & r, RunsSpansEntr
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 7 )
                 {
@@ -6813,7 +7064,7 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBody( TableReader & r, RunsSpansEntr
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -7118,10 +7369,10 @@ inline bool RunsLoadBody( TableReader & r, const TableNodeMap & nodes, Runs & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7132,9 +7383,9 @@ inline bool RunsLoadBody( TableReader & r, const TableNodeMap & nodes, Runs & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x437dfc8ab2566816ull: // spans
+            case 21: // spans, id 0x437dfc8ab2566816ull
             {
                 if ( kind != 14 )
                 {
@@ -7222,7 +7473,7 @@ inline bool RunsLoadBody( TableReader & r, const TableNodeMap & nodes, Runs & va
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7248,7 +7499,7 @@ inline bool RunsLoadBody( TableReader & r, const TableNodeMap & nodes, Runs & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7512,10 +7763,10 @@ inline bool RunsWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x437dfc8ab2566816ull && field_kind == 14 ) // spans
+        if ( field_slot == 21 && field_kind == 14 ) // spans, id 0x437dfc8ab2566816ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8694,10 +8945,11 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBodyRetain( TableReader & r, RunsSpa
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8708,9 +8960,9 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBodyRetain( TableReader & r, RunsSpa
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 7 )
                 {
@@ -8735,7 +8987,7 @@ MAPDEMO_TABLE_INLINE bool RunsSpansEntryLoadBodyRetain( TableReader & r, RunsSpa
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9011,10 +9263,11 @@ inline bool RunsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Run
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9025,9 +9278,9 @@ inline bool RunsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Run
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x437dfc8ab2566816ull: // spans
+            case 21: // spans, id 0x437dfc8ab2566816ull
             {
                 if ( kind != 14 )
                 {
@@ -9118,7 +9371,7 @@ inline bool RunsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Run
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9144,7 +9397,7 @@ inline bool RunsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Run
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6555,6 +6806,15 @@ inline bool TableEnumValue( uint64_t id, Slot & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Slot & out )
+{
+    switch ( slot )
+    {
+        case 29: out = Slot::Alpha; return true; // id 0x4fda04cbc245e18bull
+        case 30: out = Slot::Beta; return true; // id 0xa0b562a796b69487ull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // MAPDEMO_SCHEMA_TABLE_ENUM_SLOT
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -6729,10 +6989,10 @@ inline SlotsSeatsEntryKeyRead SlotsSeatsEntryReadKey( const uint8_t * body, int6
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 4 && TableKindWidens( field_kind, 4 ) )
             {
@@ -6851,10 +7111,10 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBody( TableReader & r, SlotsSeatsEn
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6865,9 +7125,9 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBody( TableReader & r, SlotsSeatsEn
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -6892,7 +7152,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBody( TableReader & r, SlotsSeatsEn
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 16 )
                 {
@@ -6932,7 +7192,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBody( TableReader & r, SlotsSeatsEn
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Slot slot = Slot::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -6968,7 +7228,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBody( TableReader & r, SlotsSeatsEn
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Slot slot = Slot::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -7286,10 +7546,10 @@ inline bool SlotsLoadBody( TableReader & r, const TableNodeMap & nodes, Slots & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7300,9 +7560,9 @@ inline bool SlotsLoadBody( TableReader & r, const TableNodeMap & nodes, Slots & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7f6548303072b061ull: // seats
+            case 24: // seats, id 0x7f6548303072b061ull
             {
                 if ( kind != 14 )
                 {
@@ -7390,7 +7650,7 @@ inline bool SlotsLoadBody( TableReader & r, const TableNodeMap & nodes, Slots & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7416,7 +7676,7 @@ inline bool SlotsLoadBody( TableReader & r, const TableNodeMap & nodes, Slots & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7680,10 +7940,10 @@ inline bool SlotsWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x7f6548303072b061ull && field_kind == 14 ) // seats
+        if ( field_slot == 24 && field_kind == 14 ) // seats, id 0x7f6548303072b061ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8876,10 +9136,11 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBodyRetain( TableReader & r, SlotsS
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8890,9 +9151,9 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBodyRetain( TableReader & r, SlotsS
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -8917,7 +9178,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBodyRetain( TableReader & r, SlotsS
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 16 )
                 {
@@ -8957,7 +9218,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBodyRetain( TableReader & r, SlotsS
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Slot slot = Slot::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; r.report->retain_lost++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -8993,7 +9254,7 @@ MAPDEMO_TABLE_INLINE bool SlotsSeatsEntryLoadBodyRetain( TableReader & r, SlotsS
                             uint64_t elem_len = 0;
                             if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                             Slot slot = Slot::None;
-                            if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                            if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                             {
                                 r.report->unknown++; r.report->retain_lost++; // a slot this reader cannot name
                                 sub.offset += (int64_t) elem_len;
@@ -9251,10 +9512,11 @@ inline bool SlotsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sl
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9265,9 +9527,9 @@ inline bool SlotsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sl
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7f6548303072b061ull: // seats
+            case 24: // seats, id 0x7f6548303072b061ull
             {
                 if ( kind != 14 )
                 {
@@ -9358,7 +9620,7 @@ inline bool SlotsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sl
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9384,7 +9646,7 @@ inline bool SlotsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sl
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6668,10 +6919,10 @@ inline SpansTracksEntryKeyRead SpansTracksEntryReadKey( const uint8_t * body, in
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 6; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6788,10 +7039,10 @@ inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & node
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6802,9 +7053,9 @@ inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & node
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -6819,7 +7070,7 @@ inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & node
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -6880,7 +7131,7 @@ inline bool SpansTracksEntryLoadBody( TableReader & r, const TableNodeMap & node
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7150,10 +7401,10 @@ inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7164,9 +7415,9 @@ inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x755332609c470fbdull: // tracks
+            case 25: // tracks, id 0x755332609c470fbdull
             {
                 if ( kind != 14 )
                 {
@@ -7255,7 +7506,7 @@ inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7281,7 +7532,7 @@ inline bool SpansLoadBody( TableReader & r, const TableNodeMap & nodes, Spans & 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7545,10 +7796,10 @@ inline bool SpansTracksEntryWireExtent( const uint8_t * body, int64_t length, in
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x7ce4fd9430e80ceaull && field_kind == 14 ) // value: an unbounded array
+        if ( field_slot == 1 && field_kind == 14 ) // value: an unbounded array, id 0x7ce4fd9430e80ceaull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -7623,10 +7874,10 @@ inline bool SpansWireExtent( const uint8_t * body, int64_t length, int64_t & at,
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x755332609c470fbdull && field_kind == 14 ) // tracks
+        if ( field_slot == 25 && field_kind == 14 ) // tracks, id 0x755332609c470fbdull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8914,10 +9165,11 @@ inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8928,9 +9180,9 @@ inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 6 )
                 {
@@ -8945,7 +9197,7 @@ inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9009,7 +9261,7 @@ inline bool SpansTracksEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9211,10 +9463,11 @@ inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sp
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9225,9 +9478,9 @@ inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sp
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x755332609c470fbdull: // tracks
+            case 25: // tracks, id 0x755332609c470fbdull
             {
                 if ( kind != 14 )
                 {
@@ -9319,7 +9572,7 @@ inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sp
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9345,7 +9598,7 @@ inline bool SpansLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sp
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -435,6 +435,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -443,16 +581,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -772,6 +928,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -803,16 +971,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6837,10 +7088,10 @@ inline TextNamesEntryKeyRead TextNamesEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             out.kind_bad = field_kind != 12; // THE KEY KIND IS THE READER'S DECLARATION
             out.found = !out.kind_bad;
@@ -6915,10 +7166,10 @@ inline TextWideEntryKeyRead TextWideEntryReadKey( const uint8_t * body, int64_t 
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 7 && TableKindWidens( field_kind, 7 ) )
             {
@@ -6996,10 +7247,10 @@ inline TextBlobsEntryKeyRead TextBlobsEntryReadKey( const uint8_t * body, int64_
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 4 && TableKindWidens( field_kind, 4 ) )
             {
@@ -7086,10 +7337,10 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7100,9 +7351,9 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -7131,7 +7382,7 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBody( TableReader & r, TextNamesEntr
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 12 )
                 {
@@ -7337,10 +7588,10 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBody( TableReader & r, TextWideEntry 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7351,9 +7602,9 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBody( TableReader & r, TextWideEntry 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 7 )
                 {
@@ -7378,7 +7629,7 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBody( TableReader & r, TextWideEntry 
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 33 )
                 {
@@ -7608,10 +7859,10 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBody( TableReader & r, TextBlobsEntr
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7622,9 +7873,9 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBody( TableReader & r, TextBlobsEntr
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -7649,7 +7900,7 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBody( TableReader & r, TextBlobsEntr
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -8028,10 +8279,10 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8042,9 +8293,9 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafb728fff268814full: // names
+            case 11: // names, id 0xafb728fff268814full
             {
                 if ( kind != 14 )
                 {
@@ -8132,7 +8383,7 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xa633f1f655715ccaull: // wide
+            case 27: // wide, id 0xa633f1f655715ccaull
             {
                 if ( kind != 14 )
                 {
@@ -8220,7 +8471,7 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x14e2eaab9cde925bull: // blobs
+            case 4: // blobs, id 0x14e2eaab9cde925bull
             {
                 if ( kind != 14 )
                 {
@@ -8308,7 +8559,7 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -8334,7 +8585,7 @@ inline bool TextLoadBody( TableReader & r, const TableNodeMap & nodes, Text & va
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8810,10 +9061,10 @@ inline bool TextWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0xafb728fff268814full && field_kind == 14 ) // names
+        if ( field_slot == 11 && field_kind == 14 ) // names, id 0xafb728fff268814full
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8822,7 +9073,7 @@ inline bool TextWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( TextNamesEntry ), (int64_t) alignof( TextNamesEntry ), NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0xa633f1f655715ccaull && field_kind == 14 ) // wide
+        if ( field_slot == 27 && field_kind == 14 ) // wide, id 0xa633f1f655715ccaull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -8831,7 +9082,7 @@ inline bool TextWireExtent( const uint8_t * body, int64_t length, int64_t & at, 
             if ( !TableMapWireExtent( map_body, (int64_t) map_len, at, (int64_t) sizeof( TextWideEntry ), (int64_t) alignof( TextWideEntry ), NULL, ids, reason ) ) { return false; }
             continue;
         }
-        if ( field_id == 0x14e2eaab9cde925bull && field_kind == 14 ) // blobs
+        if ( field_slot == 4 && field_kind == 14 ) // blobs, id 0x14e2eaab9cde925bull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -10217,10 +10468,11 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10231,9 +10483,9 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 12 )
                 {
@@ -10262,7 +10514,7 @@ MAPDEMO_TABLE_INLINE bool TextNamesEntryLoadBodyRetain( TableReader & r, TextNam
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 12 )
                 {
@@ -10436,10 +10688,11 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBodyRetain( TableReader & r, TextWide
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10450,9 +10703,9 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBodyRetain( TableReader & r, TextWide
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 7 )
                 {
@@ -10477,7 +10730,7 @@ MAPDEMO_TABLE_INLINE bool TextWideEntryLoadBodyRetain( TableReader & r, TextWide
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 33 )
                 {
@@ -10684,10 +10937,11 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBodyRetain( TableReader & r, TextBlo
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10698,9 +10952,9 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBodyRetain( TableReader & r, TextBlo
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 4 )
                 {
@@ -10725,7 +10979,7 @@ MAPDEMO_TABLE_INLINE bool TextBlobsEntryLoadBodyRetain( TableReader & r, TextBlo
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -11078,10 +11332,11 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -11092,9 +11347,9 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xafb728fff268814full: // names
+            case 11: // names, id 0xafb728fff268814full
             {
                 if ( kind != 14 )
                 {
@@ -11185,7 +11440,7 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xa633f1f655715ccaull: // wide
+            case 27: // wide, id 0xa633f1f655715ccaull
             {
                 if ( kind != 14 )
                 {
@@ -11276,7 +11531,7 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0x14e2eaab9cde925bull: // blobs
+            case 4: // blobs, id 0x14e2eaab9cde925bull
             {
                 if ( kind != 14 )
                 {
@@ -11367,7 +11622,7 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -11393,7 +11648,7 @@ inline bool TextLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Tex
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -436,6 +436,144 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 79;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 512;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x377b2fd56a5b15b5ull;
+static const uint32_t kTableIdSlotShift = 55;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x3dc94a19365b10ecull, 0x7ce4fd9430e80ceaull, 0xa3a7061ff10a8138ull, 0xbf82010f6f71eae9ull,
+    0x14e2eaab9cde925bull, 0x79d594675e391090ull, 0x1a08aa1921ca5cafull, 0x1f6459a2cea1fc02ull,
+    0x70551ff29550f15dull, 0xe756c0190570ccb5ull, 0xab01daa76a48769full, 0xafb728fff268814full,
+    0x2b7dea192bb7be29ull, 0x294a5c4913e1ad44ull, 0x7b024c46e98d3404ull, 0x63dfa0c4a4b3815dull,
+    0x294fa1b3f0f5f070ull, 0x6dd8dc6c5fdae3ceull, 0xb1e5e28e4479a274ull, 0xe68c2e6bb1ee5646ull,
+    0xc5b2a72c0845a253ull, 0x437dfc8ab2566816ull, 0xc4bcadba8e631b86ull, 0x7f69d4b5288ba9cfull,
+    0x7f6548303072b061ull, 0x755332609c470fbdull, 0x1c84390d304f4f42ull, 0xa633f1f655715ccaull,
+    0x124250ad5a5b6d14ull, 0x4fda04cbc245e18bull, 0xa0b562a796b69487ull, 0xd5c2bb95d63e6331ull,
+    0xfd4d194e1652b207ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull,
+    0x5f299db0267bd4c7ull, 0x1f781dc01a2b5152ull, 0x816c207ba6213983ull, 0xc85b940060088651ull,
+    0x3231d0dc6fe30d4aull, 0x036ffe7360826852ull, 0xe8130af045a036f8ull, 0x0a53e00afba279afull,
+    0x52cfa1d198476806ull, 0x1404200dab337086ull, 0xa013e119fec906fbull, 0xea7bdd2b70c8c2bbull,
+    0x758252d2d1b14f0dull, 0xf96b15cd3921d4a6ull, 0x033de3f1246bba76ull, 0xec07a2f760550a91ull,
+    0x2492f5fb1b05b45eull, 0xb4578774a78fb150ull, 0xb413964e3571a316ull, 0x099d588c4981296dull,
+    0x0c2643993e3ece2eull, 0x11e7ec757c03c70aull, 0x18691a70a0e3fe31ull, 0x29cf72329075c5aaull,
+    0x3e8426f7e349c9dcull, 0x5de00b6a76064442ull, 0x610dcbb318a2e4faull, 0x7d015e53d7cb2c7cull,
+    0x8119d921e2250c6aull, 0x8dc5f55c70e0f637ull, 0x8ec370bd37dc5e06ull, 0x9b18b54fbe8e2161ull,
+    0xaf05dfb30c5ca3deull, 0xbc08b7f228c93506ull, 0xda73c178dfcf57b7ull, 0xdcdbddf89c9310a1ull,
+    0xde1c38d5bac1485dull, 0xe1185043515c812bull, 0xf03923dbb2943618ull, 0xfa903574575fc678ull,
+    0xfedcb40b5d600538ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,    29,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    54,    40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       74,    13, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,    38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,    30, 0xFFFF,    22,
+    0xFFFF, 0xFFFF, 0xFFFF,    50, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF,    48,
+       65, 0xFFFF, 0xFFFF,    64, 0xFFFF, 0xFFFF,    53, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    78,
+    0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    59,
+    0xFFFF, 0xFFFF, 0xFFFF,    36,    35, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+       60, 0xFFFF,    62, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34,    55, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28,    56, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    70,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    73, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    77, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    20,    75, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    63,    68, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+    0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       15, 0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    67,    72, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    31, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26,    46, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF, 0xFFFF,    11,    66, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       41, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    51, 0xFFFF, 0xFFFF,    76, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19,
+       71, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    25, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    69, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF,    47, 0xFFFF,    10, 0xFFFF, 0xFFFF,    12,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 33;
+static const uint16_t kTableIdSlotBuildVersion = 77;
+static const uint16_t kTableIdSlotVocabulary = 78;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -444,16 +582,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MAPDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -773,6 +929,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -804,16 +972,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -6669,10 +6920,10 @@ inline TrailsStepsEntryKeyRead TrailsStepsEntryReadKey( const uint8_t * body, in
         if ( !r.getleb( field_ref ) ) { out.malformed = true; return out; }
         if ( field_ref == 0 ) { out.malformed = r.offset != r.size; return out; } // the terminator consumes the entry's L
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { out.malformed = true; return out; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { out.malformed = true; return out; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x3dc94a19365b10ecull ) // `key`, the ordinary hash of an ordinary name
+        if ( field_slot == 0 ) // `key`, at its slot; the id is the ordinary hash of an ordinary name
         {
             if ( field_kind != 8 && TableKindWidens( field_kind, 8 ) )
             {
@@ -6801,10 +7052,10 @@ inline bool TrailsStepsEntryLoadBody( TableReader & r, const TableNodeMap & node
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6815,9 +7066,9 @@ inline bool TrailsStepsEntryLoadBody( TableReader & r, const TableNodeMap & node
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -6842,7 +7093,7 @@ inline bool TrailsStepsEntryLoadBody( TableReader & r, const TableNodeMap & node
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -6900,7 +7151,7 @@ inline bool TrailsStepsEntryLoadBody( TableReader & r, const TableNodeMap & node
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7184,10 +7435,10 @@ inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7198,9 +7449,9 @@ inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x124250ad5a5b6d14ull: // steps
+            case 28: // steps, id 0x124250ad5a5b6d14ull
             {
                 if ( kind != 14 )
                 {
@@ -7289,7 +7540,7 @@ inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails 
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -7315,7 +7566,7 @@ inline bool TrailsLoadBody( TableReader & r, const TableNodeMap & nodes, Trails 
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7579,10 +7830,10 @@ inline bool TrailsStepsEntryWireExtent( const uint8_t * body, int64_t length, in
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x7ce4fd9430e80ceaull && field_kind == 14 ) // value: an unbounded array
+        if ( field_slot == 1 && field_kind == 14 ) // value: an unbounded array, id 0x7ce4fd9430e80ceaull
         {
             uint64_t list_len = 0;
             if ( !r.getleb( list_len ) || !r.room( list_len ) ) { return true; }
@@ -7657,10 +7908,10 @@ inline bool TrailsWireExtent( const uint8_t * body, int64_t length, int64_t & at
         if ( !r.getleb( field_ref ) ) { return true; }
         if ( field_ref == 0 ) { return true; }
         if ( ids == NULL || field_ref > (uint64_t) ids->count ) { return true; }
-        const uint64_t field_id = ids->at( field_ref );
+        const uint16_t field_slot = ids->slot_of( field_ref ); // the trailer resolved ONCE, at open (§3)
         if ( !r.has( 1 ) ) { return true; }
         uint8_t field_kind = r.get8();
-        if ( field_id == 0x124250ad5a5b6d14ull && field_kind == 14 ) // steps
+        if ( field_slot == 28 && field_kind == 14 ) // steps, id 0x124250ad5a5b6d14ull
         {
             uint64_t map_len = 0;
             if ( !r.getleb( map_len ) || !r.room( map_len ) ) { return true; }
@@ -9077,10 +9328,11 @@ inline bool TrailsStepsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9091,9 +9343,9 @@ inline bool TrailsStepsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x3dc94a19365b10ecull: // key
+            case 0: // key, id 0x3dc94a19365b10ecull
             {
                 if ( kind != 8 )
                 {
@@ -9118,7 +9370,7 @@ inline bool TrailsStepsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 value.key = decoded_v;
                 break;
             }
-            case 0x7ce4fd9430e80ceaull: // value
+            case 1: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 14 )
                 {
@@ -9176,7 +9428,7 @@ inline bool TrailsStepsEntryLoadBodyRetain( TableReader & r, const TableNodeMap 
                 r.offset = body_end; // excess bytes and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9391,10 +9643,11 @@ inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, T
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9405,9 +9658,9 @@ inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, T
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x124250ad5a5b6d14ull: // steps
+            case 28: // steps, id 0x124250ad5a5b6d14ull
             {
                 if ( kind != 14 )
                 {
@@ -9499,7 +9752,7 @@ inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, T
                 r.offset = body_end; // the remaining entries skip by the map's L
                 break;
             }
-            case 0xbf82010f6f71eae9ull: // after
+            case 3: // after, id 0xbf82010f6f71eae9ull
             {
                 if ( kind != 4 )
                 {
@@ -9525,7 +9778,7 @@ inline bool TrailsLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, T
                 value.after = decoded_v;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -377,6 +377,119 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 62;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x6701a78c0591a26dull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xbf4ba5ad694f5907ull, 0x5f531287628bf287ull, 0xd6a4dbc46c8e8658ull, 0xcd4de79bc6c93295ull,
+    0x089c4e07b545a968ull, 0xfa04f4ef1995407eull, 0xb9eae4fe785a14cfull, 0x4437d86681113b74ull,
+    0x9de526933e6e3ef3ull, 0x03c52d0debd70676ull, 0x0d3deba2c41dadb2ull, 0xf927453fbe6252efull,
+    0x73a94c71d60dc0d8ull, 0x8b7dc019093cd0e1ull, 0xe75ad8afb3eeebe4ull, 0xee5d97ad45ad251full,
+    0xc2f00318f053500aull, 0xaa38aca481f528a8ull, 0x33428945bbd5f2ffull, 0xdec59ea6c4eb9aeeull,
+    0x9077d4a4e1726e29ull, 0x65e8d7f3474f2639ull, 0x9478d06b697549e6ull, 0x52dea0d6eeb5083cull,
+    0x028afa1c4d757704ull, 0x99dc6354a681403aull, 0xc4bcadba8e631b86ull, 0x740d542bbe696de5ull,
+    0x78f9fa174282015cull, 0x7271c68759916228ull, 0xfff83d536a1d457dull, 0xb1e5e28e4479a274ull,
+    0xc573b39bc29148caull, 0x7d6780e4032b48f2ull, 0xacfc82293c04634aull, 0x77af701956600122ull,
+    0x3bf8fbbad1587cddull, 0xf84f97b4633670e9ull, 0x096a5e18bf857c28ull, 0xed96bbf4dc6ff587ull,
+    0xbf30e00dc53307a9ull, 0xb55a6b90e87557f8ull, 0x437dfc8ab2566816ull, 0xe723c21905457682ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0x64ef2a6c2dd1d3d1ull, 0xc2bc8586715e0d0full, 0x4f5eaa531cc1bf10ull, 0xc50005cdd3cb6ec6ull,
+    0x295e3e03c7cac1e1ull, 0x9565553d163fc92aull, 0x0380652457f8ba15ull, 0x0c9280db78a0a306ull,
+    0xad3178c504edf043ull, 0xa48f81f001b893d2ull, 0x3815184eb09f0dcfull, 0xe9bee119c6a37b89ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF,     4,    28, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF,
+        3, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF,    17,
+       50, 0xFFFF, 0xFFFF, 0xFFFF,    56, 0xFFFF,    29, 0xFFFF, 0xFFFF,    30, 0xFFFF, 0xFFFF,
+       55,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    60,    59, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    58, 0xFFFF, 0xFFFF, 0xFFFF,
+       16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    52, 0xFFFF, 0xFFFF,    23,    54,
+    0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF,     2,    24, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF,
+       13,    47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    42, 0xFFFF,    10,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       31,     6, 0xFFFF,    43, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    38, 0xFFFF,    37, 0xFFFF, 0xFFFF, 0xFFFF,
+       21,    35, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    57, 0xFFFF, 0xFFFF,    12,    44, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    39,
+    0xFFFF, 0xFFFF,    40,    53, 0xFFFF, 0xFFFF, 0xFFFF,     7,    15, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    46, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF,
+       26,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF,    61, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    34, 0xFFFF, 0xFFFF,    22,    51, 0xFFFF, 0xFFFF,
+    0xFFFF,    25,    27, 0xFFFF, 0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF,    18, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       36, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    33, 0xFFFF, 0xFFFF,
+    0xFFFF,    41, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 44;
+static const uint16_t kTableIdSlotBuildVersion = 60;
+static const uint16_t kTableIdSlotVocabulary = 61;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +498,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    MESSAGEDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +845,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +888,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2526,6 +2752,15 @@ inline bool TableEnumValue( uint64_t id, Mode & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Mode & out )
+{
+    switch ( slot )
+    {
+        case 27: out = Mode::Read; return true; // id 0x740d542bbe696de5ull
+        case 28: out = Mode::Write; return true; // id 0x78f9fa174282015cull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // MESSAGEDEMO_SCHEMA_TABLE_ENUM_MODE
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2762,10 +2997,10 @@ MESSAGEDEMO_TABLE_INLINE bool UserLoadBody( TableReader & r, User & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2776,9 +3011,9 @@ MESSAGEDEMO_TABLE_INLINE bool UserLoadBody( TableReader & r, User & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 26: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -3086,10 +3321,10 @@ MESSAGEDEMO_TABLE_INLINE bool ScriptLoadBody( TableReader & r, Script & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3100,9 +3335,9 @@ MESSAGEDEMO_TABLE_INLINE bool ScriptLoadBody( TableReader & r, Script & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x03c52d0debd70676ull: // path
+            case 9: // path, id 0x03c52d0debd70676ull
             {
                 if ( kind != 12 )
                 {
@@ -3131,7 +3366,7 @@ MESSAGEDEMO_TABLE_INLINE bool ScriptLoadBody( TableReader & r, Script & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xbf4ba5ad694f5907ull: // line
+            case 0: // line, id 0xbf4ba5ad694f5907ull
             {
                 if ( kind != 8 )
                 {
@@ -3509,10 +3744,10 @@ MESSAGEDEMO_TABLE_INLINE bool SelectionLoadBody( TableReader & r, Selection & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3523,9 +3758,9 @@ MESSAGEDEMO_TABLE_INLINE bool SelectionLoadBody( TableReader & r, Selection & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xee5d97ad45ad251full: // start
+            case 15: // start, id 0xee5d97ad45ad251full
             {
                 if ( kind != 13 )
                 {
@@ -3549,7 +3784,7 @@ MESSAGEDEMO_TABLE_INLINE bool SelectionLoadBody( TableReader & r, Selection & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xc2f00318f053500aull: // end
+            case 16: // end, id 0xc2f00318f053500aull
             {
                 if ( kind != 13 )
                 {
@@ -4210,10 +4445,10 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4224,9 +4459,9 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x089c4e07b545a968ull: // at
+            case 4: // at, id 0x089c4e07b545a968ull
             {
                 if ( kind != 13 )
                 {
@@ -4250,7 +4485,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xfa04f4ef1995407eull: // text
+            case 5: // text, id 0xfa04f4ef1995407eull
             {
                 if ( kind != 12 )
                 {
@@ -4279,7 +4514,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xb9eae4fe785a14cfull: // origin
+            case 6: // origin, id 0xb9eae4fe785a14cfull
             {
                 if ( kind != 15 )
                 {
@@ -4293,16 +4528,16 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.origin.type = OriginType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x7d6780e4032b48f2ull: // user
+                        case 33: // user, id 0x7d6780e4032b48f2ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -4317,7 +4552,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                             if ( sub.offset != sub.size ) { value.origin.type = OriginType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xacfc82293c04634aull: // script
+                        case 34: // script, id 0xacfc82293c04634aull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -4332,7 +4567,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                             if ( sub.offset != sub.size ) { value.origin.type = OriginType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x77af701956600122ull: // pid
+                        case 35: // pid, id 0x77af701956600122ull
                         {
                             if ( arm_kind != 8 )
                             {
@@ -4365,7 +4600,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                             value.origin.pid = decoded_v;
                             break;
                         }
-                        case 0x3bf8fbbad1587cddull: // note
+                        case 36: // note, id 0x3bf8fbbad1587cddull
                         {
                             if ( arm_kind != 12 )
                             {
@@ -4404,7 +4639,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4437d86681113b74ull: // origins
+            case 7: // origins, id 0x4437d86681113b74ull
             {
                 if ( kind != 14 )
                 {
@@ -4450,15 +4685,15 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x7d6780e4032b48f2ull: // user
+                                    case 33: // user, id 0x7d6780e4032b48f2ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -4469,7 +4704,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                                         if ( elem_arm.offset != elem_arm.size ) { value.origins[(int32_t) i].type = OriginType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xacfc82293c04634aull: // script
+                                    case 34: // script, id 0xacfc82293c04634aull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -4480,7 +4715,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                                         if ( elem_arm.offset != elem_arm.size ) { value.origins[(int32_t) i].type = OriginType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0x77af701956600122ull: // pid
+                                    case 35: // pid, id 0x77af701956600122ull
                                     {
                                         if ( elem_arm_kind != 8 )
                                         {
@@ -4509,7 +4744,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                                         value.origins[(int32_t) i].pid = decoded_v;
                                         break;
                                     }
-                                    case 0x3bf8fbbad1587cddull: // note
+                                    case 36: // note, id 0x3bf8fbbad1587cddull
                                     {
                                         if ( elem_arm_kind != 12 )
                                         {
@@ -4546,7 +4781,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x9de526933e6e3ef3ull: // modes
+            case 8: // modes, id 0x9de526933e6e3ef3ull
             {
                 if ( kind != 14 )
                 {
@@ -4590,7 +4825,7 @@ MESSAGEDEMO_TABLE_INLINE bool InsertTextLoadBody( TableReader & r, InsertText & 
                             if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                             if ( variant_ref == 0 ) { value.modes[(int32_t) i] = Mode::None; } // the zero reference is the enum's None
                             else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                            else if ( !TableEnumValue( r.ids->at( variant_ref ), value.modes[(int32_t) i] ) )
+                            else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.modes[(int32_t) i] ) )
                             {
                                 value.modes[(int32_t) i] = Mode::None;
                                 r.report->unknown++;
@@ -5422,10 +5657,10 @@ MESSAGEDEMO_TABLE_INLINE bool RemoveTextLoadBody( TableReader & r, RemoveText & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5436,9 +5671,9 @@ MESSAGEDEMO_TABLE_INLINE bool RemoveTextLoadBody( TableReader & r, RemoveText & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x8b7dc019093cd0e1ull: // span
+            case 13: // span, id 0x8b7dc019093cd0e1ull
             {
                 if ( kind != 13 )
                 {
@@ -5883,10 +6118,10 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5897,9 +6132,9 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xd6a4dbc46c8e8658ull: // revision
+            case 2: // revision, id 0xd6a4dbc46c8e8658ull
             {
                 if ( kind != 8 )
                 {
@@ -5925,7 +6160,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                 value.revision = decoded_v;
                 break;
             }
-            case 0xcd4de79bc6c93295ull: // body
+            case 3: // body, id 0xcd4de79bc6c93295ull
             {
                 if ( kind != 15 )
                 {
@@ -5939,16 +6174,16 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.body.type = EditBodyType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x7271c68759916228ull: // insert
+                        case 29: // insert, id 0x7271c68759916228ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5963,7 +6198,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             if ( sub.offset != sub.size ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xfff83d536a1d457dull: // remove
+                        case 30: // remove, id 0xfff83d536a1d457dull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -5978,7 +6213,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             if ( sub.offset != sub.size ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // tally
+                        case 31: // tally, id 0xb1e5e28e4479a274ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -6013,7 +6248,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             value.body.tally = decoded_v;
                             break;
                         }
-                        case 0x9077d4a4e1726e29ull: // marks
+                        case 20: // marks, id 0x9077d4a4e1726e29ull
                         {
                             if ( arm_kind != 14 )
                             {
@@ -6066,7 +6301,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             }
                             break;
                         }
-                        case 0xc573b39bc29148caull: // blob
+                        case 32: // blob, id 0xc573b39bc29148caull
                         {
                             if ( arm_kind != 14 )
                             {
@@ -6092,7 +6327,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             }
                             break;
                         }
-                        case 0x0d3deba2c41dadb2ull: // mode
+                        case 10: // mode, id 0x0d3deba2c41dadb2ull
                         {
                             if ( arm_kind != 30 )
                             {
@@ -6108,7 +6343,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                                 if ( !sub.getleb( variant_ref ) ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                                 if ( variant_ref == 0 ) { value.body.mode = Mode::None; } // the zero reference is the enum's None
                                 else if ( variant_ref > (uint64_t) r.ids->count ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
-                                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.body.mode ) )
+                                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.body.mode ) )
                                 {
                                     value.body.mode = Mode::None;
                                     r.report->unknown++;
@@ -6754,10 +6989,10 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6768,9 +7003,9 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x03c52d0debd70676ull: // path
+            case 9: // path, id 0x03c52d0debd70676ull
             {
                 if ( kind != 12 )
                 {
@@ -6799,7 +7034,7 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x0d3deba2c41dadb2ull: // mode
+            case 10: // mode, id 0x0d3deba2c41dadb2ull
             {
                 if ( kind != 30 )
                 {
@@ -6813,14 +7048,14 @@ MESSAGEDEMO_TABLE_INLINE bool OpenDocumentLoadBody( TableReader & r, OpenDocumen
                 if ( !r.getleb( variant_ref ) ) { r.report->malformed = true; return false; }
                 if ( variant_ref == 0 ) { value.mode = Mode::None; } // the zero reference is the enum's None
                 else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                else if ( !TableEnumValue( r.ids->at( variant_ref ), value.mode ) )
+                else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.mode ) )
                 {
                     value.mode = Mode::None;
                     r.report->unknown++;
                 }
                 break;
             }
-            case 0xf927453fbe6252efull: // cursor
+            case 11: // cursor, id 0xf927453fbe6252efull
             {
                 if ( kind != 13 )
                 {
@@ -7192,10 +7427,10 @@ MESSAGEDEMO_TABLE_INLINE bool SaveDocumentLoadBody( TableReader & r, SaveDocumen
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7206,9 +7441,9 @@ MESSAGEDEMO_TABLE_INLINE bool SaveDocumentLoadBody( TableReader & r, SaveDocumen
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x03c52d0debd70676ull: // path
+            case 9: // path, id 0x03c52d0debd70676ull
             {
                 if ( kind != 12 )
                 {
@@ -7237,7 +7472,7 @@ MESSAGEDEMO_TABLE_INLINE bool SaveDocumentLoadBody( TableReader & r, SaveDocumen
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xe75ad8afb3eeebe4ull: // force
+            case 14: // force, id 0xe75ad8afb3eeebe4ull
             {
                 if ( kind != 1 )
                 {
@@ -7907,10 +8142,10 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7921,9 +8156,9 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x65e8d7f3474f2639ull: // reason
+            case 21: // reason, id 0x65e8d7f3474f2639ull
             {
                 if ( kind != 12 )
                 {
@@ -7952,7 +8187,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x9478d06b697549e6ull: // edits
+            case 22: // edits, id 0x9478d06b697549e6ull
             {
                 if ( kind != 14 )
                 {
@@ -8010,7 +8245,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x52dea0d6eeb5083cull: // pending
+            case 23: // pending, id 0x52dea0d6eeb5083cull
             {
                 if ( kind != 14 )
                 {
@@ -8054,15 +8289,15 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0x7271c68759916228ull: // insert
+                                    case 29: // insert, id 0x7271c68759916228ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -8073,7 +8308,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         if ( elem_arm.offset != elem_arm.size ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xfff83d536a1d457dull: // remove
+                                    case 30: // remove, id 0xfff83d536a1d457dull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -8084,7 +8319,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         if ( elem_arm.offset != elem_arm.size ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xb1e5e28e4479a274ull: // tally
+                                    case 31: // tally, id 0xb1e5e28e4479a274ull
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -8115,7 +8350,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         value.pending[(int32_t) i].tally = decoded_v;
                                         break;
                                     }
-                                    case 0x9077d4a4e1726e29ull: // marks
+                                    case 20: // marks, id 0x9077d4a4e1726e29ull
                                     {
                                         if ( elem_arm_kind != 14 )
                                         {
@@ -8164,7 +8399,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         }
                                         break;
                                     }
-                                    case 0xc573b39bc29148caull: // blob
+                                    case 32: // blob, id 0xc573b39bc29148caull
                                     {
                                         if ( elem_arm_kind != 14 )
                                         {
@@ -8186,7 +8421,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         }
                                         break;
                                     }
-                                    case 0x0d3deba2c41dadb2ull: // mode
+                                    case 10: // mode, id 0x0d3deba2c41dadb2ull
                                     {
                                         if ( elem_arm_kind != 30 )
                                         {
@@ -8198,7 +8433,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                             if ( !elem_arm.getleb( variant_ref ) ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                             if ( variant_ref == 0 ) { value.pending[(int32_t) i].mode = Mode::None; } // the zero reference is the enum's None
                                             else if ( variant_ref > (uint64_t) r.ids->count ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
-                                            else if ( !TableEnumValue( r.ids->at( variant_ref ), value.pending[(int32_t) i].mode ) )
+                                            else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.pending[(int32_t) i].mode ) )
                                             {
                                                 value.pending[(int32_t) i].mode = Mode::None;
                                                 r.report->unknown++;
@@ -8218,7 +8453,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x028afa1c4d757704ull: // checkpoints
+            case 24: // checkpoints, id 0x028afa1c4d757704ull
             {
                 if ( kind != 14 )
                 {
@@ -8282,7 +8517,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                 value.checkpoints_present = true;
                 break;
             }
-            case 0x99dc6354a681403aull: // snapshots
+            case 25: // snapshots, id 0x99dc6354a681403aull
             {
                 if ( kind != 14 )
                 {
@@ -10091,10 +10326,10 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -10105,9 +10340,9 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaa38aca481f528a8ull: // sequence
+            case 17: // sequence, id 0xaa38aca481f528a8ull
             {
                 if ( kind != 8 )
                 {
@@ -10133,7 +10368,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                 value.sequence = decoded_v;
                 break;
             }
-            case 0xcd4de79bc6c93295ull: // body
+            case 3: // body, id 0xcd4de79bc6c93295ull
             {
                 if ( kind != 15 )
                 {
@@ -10147,16 +10382,16 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.body.type = ToolBodyType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xf84f97b4633670e9ull: // open
+                        case 37: // open, id 0xf84f97b4633670e9ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -10171,7 +10406,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( sub.offset != sub.size ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x096a5e18bf857c28ull: // save
+                        case 38: // save, id 0x096a5e18bf857c28ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -10186,7 +10421,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( sub.offset != sub.size ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xed96bbf4dc6ff587ull: // transact
+                        case 39: // transact, id 0xed96bbf4dc6ff587ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -10201,7 +10436,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( sub.offset != sub.size ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xbf30e00dc53307a9ull: // ping
+                        case 40: // ping, id 0xbf30e00dc53307a9ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -10216,7 +10451,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( sub.offset != sub.size ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xb55a6b90e87557f8ull: // caps
+                        case 41: // caps, id 0xb55a6b90e87557f8ull
                         {
                             if ( arm_kind != 9 )
                             {
@@ -10247,7 +10482,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             value.body.caps = decoded_v;
                             break;
                         }
-                        case 0x437dfc8ab2566816ull: // spans
+                        case 42: // spans, id 0x437dfc8ab2566816ull
                         {
                             if ( arm_kind != 14 )
                             {
@@ -10297,7 +10532,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             }
                             break;
                         }
-                        case 0xb9eae4fe785a14cfull: // origin
+                        case 6: // origin, id 0xb9eae4fe785a14cfull
                         {
                             if ( arm_kind != 15 )
                             {
@@ -10315,15 +10550,15 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                 if ( arm_inner_ref != 0 ) // the zero reference is the inner union's None
                                 {
                                     if ( arm_inner_ref > (uint64_t) r.ids->count ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
-                                    const uint64_t arm_inner_id = r.ids->at( arm_inner_ref );
+                                    const uint16_t arm_inner_slot = r.ids->slot_of( arm_inner_ref );
                                     if ( !sub.has( 1 ) ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                                     const uint8_t arm_inner_kind = sub.get8();
                                     uint64_t arm_inner_len = 0;
                                     if ( !sub.getleb( arm_inner_len ) || !sub.room( arm_inner_len ) ) { value.body.type = ToolBodyType::None; r.report->malformed = true; break; }
                                     TableReader arm_inner( sub.buffer + sub.offset, (int64_t) arm_inner_len, r.report, r.ids );
-                                    switch ( arm_inner_id ) // the arm's NAME hash (§5)
+                                    switch ( arm_inner_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                     {
-                                        case 0x7d6780e4032b48f2ull: // user
+                                        case 33: // user, id 0x7d6780e4032b48f2ull
                                         {
                                             if ( arm_inner_kind != 13 )
                                             {
@@ -10334,7 +10569,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                             if ( arm_inner.offset != arm_inner.size ) { value.body.origin.type = OriginType::None; r.report->malformed = true; break; }
                                             break;
                                         }
-                                        case 0xacfc82293c04634aull: // script
+                                        case 34: // script, id 0xacfc82293c04634aull
                                         {
                                             if ( arm_inner_kind != 13 )
                                             {
@@ -10345,7 +10580,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                             if ( arm_inner.offset != arm_inner.size ) { value.body.origin.type = OriginType::None; r.report->malformed = true; break; }
                                             break;
                                         }
-                                        case 0x77af701956600122ull: // pid
+                                        case 35: // pid, id 0x77af701956600122ull
                                         {
                                             if ( arm_inner_kind != 8 )
                                             {
@@ -10374,7 +10609,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                             value.body.origin.pid = decoded_v;
                                             break;
                                         }
-                                        case 0x3bf8fbbad1587cddull: // note
+                                        case 36: // note, id 0x3bf8fbbad1587cddull
                                         {
                                             if ( arm_inner_kind != 12 )
                                             {
@@ -10402,7 +10637,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             }
                             break;
                         }
-                        case 0xe723c21905457682ull: // ack
+                        case 43: // ack, id 0xe723c21905457682ull
                         {
                             if ( arm_kind != 32 )
                             {
@@ -10430,7 +10665,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x33428945bbd5f2ffull: // history
+            case 18: // history, id 0x33428945bbd5f2ffull
             {
                 if ( kind != 14 )
                 {
@@ -10476,15 +10711,15 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( elem_arm_ref != 0 ) // the zero reference is a None element in its place
                             {
                                 if ( elem_arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                                const uint64_t elem_arm_id = r.ids->at( elem_arm_ref );
+                                const uint16_t elem_arm_slot = r.ids->slot_of( elem_arm_ref );
                                 if ( !sub.has( 1 ) ) { r.report->malformed = true; break; }
                                 const uint8_t elem_arm_kind = sub.get8();
                                 uint64_t elem_arm_len = 0;
                                 if ( !sub.getleb( elem_arm_len ) || !sub.room( elem_arm_len ) ) { r.report->malformed = true; break; }
                                 TableReader elem_arm( sub.buffer + sub.offset, (int64_t) elem_arm_len, r.report, r.ids );
-                                switch ( elem_arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                                switch ( elem_arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                                 {
-                                    case 0xf84f97b4633670e9ull: // open
+                                    case 37: // open, id 0xf84f97b4633670e9ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -10495,7 +10730,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         if ( elem_arm.offset != elem_arm.size ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0x096a5e18bf857c28ull: // save
+                                    case 38: // save, id 0x096a5e18bf857c28ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -10506,7 +10741,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         if ( elem_arm.offset != elem_arm.size ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xed96bbf4dc6ff587ull: // transact
+                                    case 39: // transact, id 0xed96bbf4dc6ff587ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -10517,7 +10752,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         if ( elem_arm.offset != elem_arm.size ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xbf30e00dc53307a9ull: // ping
+                                    case 40: // ping, id 0xbf30e00dc53307a9ull
                                     {
                                         if ( elem_arm_kind != 13 )
                                         {
@@ -10528,7 +10763,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         if ( elem_arm.offset != elem_arm.size ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xb55a6b90e87557f8ull: // caps
+                                    case 41: // caps, id 0xb55a6b90e87557f8ull
                                     {
                                         if ( elem_arm_kind != 9 )
                                         {
@@ -10555,7 +10790,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         value.history[(int32_t) i].caps = decoded_v;
                                         break;
                                     }
-                                    case 0x437dfc8ab2566816ull: // spans
+                                    case 42: // spans, id 0x437dfc8ab2566816ull
                                     {
                                         if ( elem_arm_kind != 14 )
                                         {
@@ -10601,7 +10836,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         }
                                         break;
                                     }
-                                    case 0xb9eae4fe785a14cfull: // origin
+                                    case 6: // origin, id 0xb9eae4fe785a14cfull
                                     {
                                         if ( elem_arm_kind != 15 )
                                         {
@@ -10615,15 +10850,15 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                             if ( arm_inner_refa != 0 ) // the zero reference is the inner union's None
                                             {
                                                 if ( arm_inner_refa > (uint64_t) r.ids->count ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
-                                                const uint64_t arm_inner_ida = r.ids->at( arm_inner_refa );
+                                                const uint16_t arm_inner_slota = r.ids->slot_of( arm_inner_refa );
                                                 if ( !elem_arm.has( 1 ) ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                                 const uint8_t arm_inner_kinda = elem_arm.get8();
                                                 uint64_t arm_inner_lena = 0;
                                                 if ( !elem_arm.getleb( arm_inner_lena ) || !elem_arm.room( arm_inner_lena ) ) { value.history[(int32_t) i].type = ToolBodyType::None; r.report->malformed = true; break; }
                                                 TableReader arm_innera( elem_arm.buffer + elem_arm.offset, (int64_t) arm_inner_lena, r.report, r.ids );
-                                                switch ( arm_inner_ida ) // the arm's NAME hash (§5)
+                                                switch ( arm_inner_slota ) // the arm's name, at its compile-time SLOT (§3, §5)
                                                 {
-                                                    case 0x7d6780e4032b48f2ull: // user
+                                                    case 33: // user, id 0x7d6780e4032b48f2ull
                                                     {
                                                         if ( arm_inner_kinda != 13 )
                                                         {
@@ -10634,7 +10869,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                                         if ( arm_innera.offset != arm_innera.size ) { value.history[(int32_t) i].origin.type = OriginType::None; r.report->malformed = true; break; }
                                                         break;
                                                     }
-                                                    case 0xacfc82293c04634aull: // script
+                                                    case 34: // script, id 0xacfc82293c04634aull
                                                     {
                                                         if ( arm_inner_kinda != 13 )
                                                         {
@@ -10645,7 +10880,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                                         if ( arm_innera.offset != arm_innera.size ) { value.history[(int32_t) i].origin.type = OriginType::None; r.report->malformed = true; break; }
                                                         break;
                                                     }
-                                                    case 0x77af701956600122ull: // pid
+                                                    case 35: // pid, id 0x77af701956600122ull
                                                     {
                                                         if ( arm_inner_kinda != 8 )
                                                         {
@@ -10674,7 +10909,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                                         value.history[(int32_t) i].origin.pid = decoded_v;
                                                         break;
                                                     }
-                                                    case 0x3bf8fbbad1587cddull: // note
+                                                    case 36: // note, id 0x3bf8fbbad1587cddull
                                                     {
                                                         if ( arm_inner_kinda != 12 )
                                                         {
@@ -10702,7 +10937,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                                         }
                                         break;
                                     }
-                                    case 0xe723c21905457682ull: // ack
+                                    case 43: // ack, id 0xe723c21905457682ull
                                     {
                                         if ( elem_arm_kind != 32 )
                                         {
@@ -10728,7 +10963,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xdec59ea6c4eb9aeeull: // trace
+            case 19: // trace, id 0xdec59ea6c4eb9aeeull
             {
                 if ( kind != 14 )
                 {
@@ -10787,7 +11022,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                 value.trace_present = true;
                 break;
             }
-            case 0x9077d4a4e1726e29ull: // marks
+            case 20: // marks, id 0x9077d4a4e1726e29ull
             {
                 if ( kind != 14 )
                 {
@@ -10829,7 +11064,7 @@ MESSAGEDEMO_TABLE_INLINE bool ToolMessageLoadBody( TableReader & r, ToolMessage 
                             if ( !sub.getleb( variant_ref ) ) { r.report->malformed = true; break; }
                             if ( variant_ref == 0 ) { value.marks[(int32_t) i] = Mode::None; } // the zero reference is the enum's None
                             else if ( variant_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; break; }
-                            else if ( !TableEnumValue( r.ids->at( variant_ref ), value.marks[(int32_t) i] ) )
+                            else if ( !TableEnumValueAt( r.ids->slot_of( variant_ref ), value.marks[(int32_t) i] ) )
                             {
                                 value.marks[(int32_t) i] = Mode::None;
                                 r.report->unknown++;
@@ -12289,10 +12524,10 @@ MESSAGEDEMO_TABLE_INLINE bool CursorLoadBody( TableReader & r, Cursor & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12303,9 +12538,9 @@ MESSAGEDEMO_TABLE_INLINE bool CursorLoadBody( TableReader & r, Cursor & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xbf4ba5ad694f5907ull: // line
+            case 0: // line, id 0xbf4ba5ad694f5907ull
             {
                 if ( kind != 8 )
                 {
@@ -12331,7 +12566,7 @@ MESSAGEDEMO_TABLE_INLINE bool CursorLoadBody( TableReader & r, Cursor & value )
                 value.line = decoded_v;
                 break;
             }
-            case 0x5f531287628bf287ull: // column
+            case 1: // column, id 0x5f531287628bf287ull
             {
                 if ( kind != 8 )
                 {
@@ -12682,10 +12917,10 @@ MESSAGEDEMO_TABLE_INLINE bool PingLoadBody( TableReader & r, Ping & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -12696,9 +12931,9 @@ MESSAGEDEMO_TABLE_INLINE bool PingLoadBody( TableReader & r, Ping & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x73a94c71d60dc0d8ull: // nonce
+            case 12: // nonce, id 0x73a94c71d60dc0d8ull
             {
                 if ( kind != 8 )
                 {

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -431,6 +431,116 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 50;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xc4bcadba8e631b86ull, 0x1e4984ef2e958a4cull, 0xee7ba9ad45c64144ull, 0xeddcb72b15486e77ull,
+    0x77af761956600b54ull, 0x0a8f12cc5f9a0c03ull, 0xaf63ef4c86020cd5ull, 0xaf63da4c8601e926ull,
+    0xaf63df4c8601f1a5ull, 0xdd9eb981e152e90cull, 0x4339ee8ab21c8380ull, 0x75d8e97600b296eaull,
+    0x7ce4fd9430e80ceaull, 0xe5316cbaa025f028ull, 0x39f7fcec8fcb623dull, 0x3bf8fbbad1587cddull,
+    0x802517e298c70b03ull, 0x56d7ab194448a4f3ull, 0xbb62c62c9808ea37ull, 0x5b25b8ef511eb395ull,
+    0xee5f6d7b48b44de8ull, 0x509220bb65a646b7ull, 0x60839e2395be697eull, 0x4554e34a747022dfull,
+    0x4320e9a2e32eac38ull, 0x7a8060916400fe66ull, 0x823b8a195ce2133cull, 0x732dfbcc9b0cf0bbull,
+    0x24b070ada2041cb0ull, 0x76aaaa535714d805ull, 0x24f3a319b88552c1ull, 0x9deeefd89ca8a81dull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x327fe6dc702553fdull, 0x9d167ef77aed79b6ull, 0xf60ec899a5a69fa9ull,
+    0xd6458a3eef83d457ull, 0x6dadeaaee49d6d18ull, 0x4a9a31623ab5f213ull, 0x9d8b8aa2b404c2c8ull,
+    0xae3b9113b7db93a4ull, 0x69ff34904242a73dull, 0xb97e90a3784c431dull, 0x7e9d0b96d39e517dull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       37, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF,    36, 0xFFFF, 0xFFFF, 0xFFFF,    34,
+       38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,    46, 0xFFFF, 0xFFFF, 0xFFFF,    15,
+       22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,
+    0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF,     2, 0xFFFF,
+    0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF,    33, 0xFFFF,    23,    25, 0xFFFF,
+        6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF,    31, 0xFFFF,
+    0xFFFF,    11,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    13,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    30,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17,    40,
+    0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 32;
+static const uint16_t kTableIdSlotBuildVersion = 48;
+static const uint16_t kTableIdSlotVocabulary = 49;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -439,16 +549,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    GRAPHDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -768,6 +896,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -799,16 +939,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5235,6 +5458,15 @@ inline bool TableEnumValue( uint64_t id, Tier & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Tier & out )
+{
+    switch ( slot )
+    {
+        case 30: out = Tier::Low; return true; // id 0x24f3a319b88552c1ull
+        case 31: out = Tier::High; return true; // id 0x9deeefd89ca8a81dull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // GRAPHDEMO_SCHEMA_TABLE_ENUM_TIER
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -5650,10 +5882,10 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5664,9 +5896,9 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x802517e298c70b03ull: // build
+            case 16: // build, id 0x802517e298c70b03ull
             {
                 if ( kind != 4 )
                 {
@@ -5696,7 +5928,7 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
                 value.build = decoded_v;
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 17: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 12 )
                 {
@@ -6064,10 +6296,10 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6078,9 +6310,9 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7a8060916400fe66ull: // quality
+            case 25: // quality, id 0x7a8060916400fe66ull
             {
                 if ( kind != 4 )
                 {
@@ -6110,7 +6342,7 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value 
                 value.quality = decoded_v;
                 break;
             }
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -6492,10 +6724,10 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6506,9 +6738,9 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7ce4fd9430e80ceaull: // value
+            case 12: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 4 )
                 {
@@ -6534,7 +6766,7 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
                 value.value = decoded_v;
                 break;
             }
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -6563,7 +6795,7 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 13: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -6583,7 +6815,7 @@ inline bool ListNodeLoadBody( TableReader & r, const TableNodeMap & nodes, ListN
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6878,10 +7110,10 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6892,9 +7124,9 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -6923,7 +7155,7 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x24b070ada2041cb0ull: // left
+            case 28: // left, id 0x24b070ada2041cb0ull
             {
                 if ( kind != 17 )
                 {
@@ -6943,7 +7175,7 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
                 }
                 break;
             }
-            case 0x76aaaa535714d805ull: // right
+            case 29: // right, id 0x76aaaa535714d805ull
             {
                 if ( kind != 17 )
                 {
@@ -6963,7 +7195,7 @@ inline bool TreeNodeLoadBody( TableReader & r, const TableNodeMap & nodes, TreeN
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7209,10 +7441,10 @@ inline bool LayerLoadBody( TableReader & r, const TableNodeMap & nodes, Layer & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7223,9 +7455,9 @@ inline bool LayerLoadBody( TableReader & r, const TableNodeMap & nodes, Layer & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x75d8e97600b296eaull: // depth
+            case 11: // depth, id 0x75d8e97600b296eaull
             {
                 if ( kind != 4 )
                 {
@@ -7255,7 +7487,7 @@ inline bool LayerLoadBody( TableReader & r, const TableNodeMap & nodes, Layer & 
                 value.depth = decoded_v;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -7275,7 +7507,7 @@ inline bool LayerLoadBody( TableReader & r, const TableNodeMap & nodes, Layer & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -7661,10 +7893,10 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7675,9 +7907,9 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -7706,7 +7938,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xbb62c62c9808ea37ull: // version
+            case 18: // version, id 0xbb62c62c9808ea37ull
             {
                 if ( kind != 4 )
                 {
@@ -7736,7 +7968,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 value.version = decoded_v;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -7756,7 +7988,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 }
                 break;
             }
-            case 0x5b25b8ef511eb395ull: // tree
+            case 19: // tree, id 0x5b25b8ef511eb395ull
             {
                 if ( kind != 17 )
                 {
@@ -7776,7 +8008,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 }
                 break;
             }
-            case 0xee5f6d7b48b44de8ull: // settings
+            case 20: // settings, id 0xee5f6d7b48b44de8ull
             {
                 if ( kind != 17 )
                 {
@@ -7796,7 +8028,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 }
                 break;
             }
-            case 0x509220bb65a646b7ull: // alias
+            case 21: // alias, id 0x509220bb65a646b7ull
             {
                 if ( kind != 17 )
                 {
@@ -7816,7 +8048,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 }
                 break;
             }
-            case 0x60839e2395be697eull: // ground
+            case 22: // ground, id 0x60839e2395be697eull
             {
                 if ( kind != 13 )
                 {
@@ -7840,7 +8072,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4554e34a747022dfull: // layers
+            case 23: // layers, id 0x4554e34a747022dfull
             {
                 if ( kind != 14 )
                 {
@@ -7898,7 +8130,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x4320e9a2e32eac38ull: // meta
+            case 24: // meta, id 0x4320e9a2e32eac38ull
             {
                 if ( kind != 13 )
                 {
@@ -7922,7 +8154,7 @@ inline bool SceneLoadBody( TableReader & r, const TableNodeMap & nodes, Scene & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -8504,10 +8736,10 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -8518,9 +8750,9 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -8549,7 +8781,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xdd9eb981e152e90cull: // banks
+            case 9: // banks, id 0xdd9eb981e152e90cull
             {
                 if ( kind != 16 )
                 {
@@ -8586,7 +8818,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Tier slot = Tier::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -8603,7 +8835,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x4339ee8ab21c8380ull: // spare
+            case 10: // spare, id 0x4339ee8ab21c8380ull
             {
                 if ( kind != 13 )
                 {
@@ -8628,7 +8860,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 value.spare_present = true;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -8648,7 +8880,7 @@ inline bool DepotLoadBody( TableReader & r, const TableNodeMap & nodes, Depot & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9062,10 +9294,10 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9076,9 +9308,9 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -9107,7 +9339,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x1e4984ef2e958a4cull: // tint
+            case 1: // tint, id 0x1e4984ef2e958a4cull
             {
                 if ( kind != 13 )
                 {
@@ -9131,7 +9363,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xee7ba9ad45c64144ull: // stamp
+            case 2: // stamp, id 0xee7ba9ad45c64144ull
             {
                 if ( kind != 13 )
                 {
@@ -9155,7 +9387,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xeddcb72b15486e77ull: // marker
+            case 3: // marker, id 0xeddcb72b15486e77ull
             {
                 if ( kind != 13 )
                 {
@@ -9179,7 +9411,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x77af761956600b54ull: // pin
+            case 4: // pin, id 0x77af761956600b54ull
             {
                 if ( kind != 17 )
                 {
@@ -9199,7 +9431,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 }
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -9219,7 +9451,7 @@ inline bool AlbumLoadBody( TableReader & r, const TableNodeMap & nodes, Album & 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -15690,10 +15922,11 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBodyRetain( TableReader & r, Meta & value, T
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15704,9 +15937,9 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBodyRetain( TableReader & r, Meta & value, T
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x802517e298c70b03ull: // build
+            case 16: // build, id 0x802517e298c70b03ull
             {
                 if ( kind != 4 )
                 {
@@ -15736,7 +15969,7 @@ GRAPHDEMO_TABLE_INLINE bool MetaLoadBodyRetain( TableReader & r, Meta & value, T
                 value.build = decoded_v;
                 break;
             }
-            case 0x56d7ab194448a4f3ull: // tag
+            case 17: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 12 )
                 {
@@ -15935,10 +16168,11 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBodyRetain( TableReader & r, Settings & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -15949,9 +16183,9 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBodyRetain( TableReader & r, Settings & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7a8060916400fe66ull: // quality
+            case 25: // quality, id 0x7a8060916400fe66ull
             {
                 if ( kind != 4 )
                 {
@@ -15981,7 +16215,7 @@ GRAPHDEMO_TABLE_INLINE bool SettingsLoadBodyRetain( TableReader & r, Settings & 
                 value.quality = decoded_v;
                 break;
             }
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -16213,10 +16447,11 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16227,9 +16462,9 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x7ce4fd9430e80ceaull: // value
+            case 12: // value, id 0x7ce4fd9430e80ceaull
             {
                 if ( kind != 4 )
                 {
@@ -16255,7 +16490,7 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 value.value = decoded_v;
                 break;
             }
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -16284,7 +16519,7 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 13: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -16304,7 +16539,7 @@ inline bool ListNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -16549,10 +16784,11 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16563,9 +16799,9 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -16594,7 +16830,7 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x24b070ada2041cb0ull: // left
+            case 28: // left, id 0x24b070ada2041cb0ull
             {
                 if ( kind != 17 )
                 {
@@ -16614,7 +16850,7 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 }
                 break;
             }
-            case 0x76aaaa535714d805ull: // right
+            case 29: // right, id 0x76aaaa535714d805ull
             {
                 if ( kind != 17 )
                 {
@@ -16634,7 +16870,7 @@ inline bool TreeNodeLoadBodyRetain( TableReader & r, const TableNodeMap & nodes,
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -16820,10 +17056,11 @@ inline bool LayerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, La
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -16834,9 +17071,9 @@ inline bool LayerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, La
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x75d8e97600b296eaull: // depth
+            case 11: // depth, id 0x75d8e97600b296eaull
             {
                 if ( kind != 4 )
                 {
@@ -16866,7 +17103,7 @@ inline bool LayerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, La
                 value.depth = decoded_v;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -16886,7 +17123,7 @@ inline bool LayerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, La
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -17238,10 +17475,11 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -17252,9 +17490,9 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -17283,7 +17521,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xbb62c62c9808ea37ull: // version
+            case 18: // version, id 0xbb62c62c9808ea37ull
             {
                 if ( kind != 4 )
                 {
@@ -17313,7 +17551,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 value.version = decoded_v;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -17333,7 +17571,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 }
                 break;
             }
-            case 0x5b25b8ef511eb395ull: // tree
+            case 19: // tree, id 0x5b25b8ef511eb395ull
             {
                 if ( kind != 17 )
                 {
@@ -17353,7 +17591,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 }
                 break;
             }
-            case 0xee5f6d7b48b44de8ull: // settings
+            case 20: // settings, id 0xee5f6d7b48b44de8ull
             {
                 if ( kind != 17 )
                 {
@@ -17373,7 +17611,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 }
                 break;
             }
-            case 0x509220bb65a646b7ull: // alias
+            case 21: // alias, id 0x509220bb65a646b7ull
             {
                 if ( kind != 17 )
                 {
@@ -17393,7 +17631,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 }
                 break;
             }
-            case 0x60839e2395be697eull: // ground
+            case 22: // ground, id 0x60839e2395be697eull
             {
                 if ( kind != 13 )
                 {
@@ -17418,7 +17656,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4554e34a747022dfull: // layers
+            case 23: // layers, id 0x4554e34a747022dfull
             {
                 if ( kind != 14 )
                 {
@@ -17479,7 +17717,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x4320e9a2e32eac38ull: // meta
+            case 24: // meta, id 0x4320e9a2e32eac38ull
             {
                 if ( kind != 13 )
                 {
@@ -17504,7 +17742,7 @@ inline bool SceneLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Sc
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -17920,10 +18158,11 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -17934,9 +18173,9 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -17965,7 +18204,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xdd9eb981e152e90cull: // banks
+            case 9: // banks, id 0xdd9eb981e152e90cull
             {
                 if ( kind != 16 )
                 {
@@ -18002,7 +18241,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Tier slot = Tier::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; r.report->retain_lost++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -18019,7 +18258,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x4339ee8ab21c8380ull: // spare
+            case 10: // spare, id 0x4339ee8ab21c8380ull
             {
                 if ( kind != 13 )
                 {
@@ -18045,7 +18284,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 value.spare_present = true;
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -18065,7 +18304,7 @@ inline bool DepotLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, De
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -18368,10 +18607,11 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -18382,9 +18622,9 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 0: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -18413,7 +18653,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x1e4984ef2e958a4cull: // tint
+            case 1: // tint, id 0x1e4984ef2e958a4cull
             {
                 if ( kind != 13 )
                 {
@@ -18438,7 +18678,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xee7ba9ad45c64144ull: // stamp
+            case 2: // stamp, id 0xee7ba9ad45c64144ull
             {
                 if ( kind != 13 )
                 {
@@ -18463,7 +18703,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0xeddcb72b15486e77ull: // marker
+            case 3: // marker, id 0xeddcb72b15486e77ull
             {
                 if ( kind != 13 )
                 {
@@ -18488,7 +18728,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x77af761956600b54ull: // pin
+            case 4: // pin, id 0x77af761956600b54ull
             {
                 if ( kind != 17 )
                 {
@@ -18508,7 +18748,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 }
                 break;
             }
-            case 0x0a8f12cc5f9a0c03ull: // head
+            case 5: // head, id 0x0a8f12cc5f9a0c03ull
             {
                 if ( kind != 17 )
                 {
@@ -18528,7 +18768,7 @@ inline bool AlbumLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Al
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -428,6 +428,116 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 50;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xc4bcadba8e631b86ull, 0x1e4984ef2e958a4cull, 0xee7ba9ad45c64144ull, 0xeddcb72b15486e77ull,
+    0x77af761956600b54ull, 0x0a8f12cc5f9a0c03ull, 0xaf63ef4c86020cd5ull, 0xaf63da4c8601e926ull,
+    0xaf63df4c8601f1a5ull, 0xdd9eb981e152e90cull, 0x4339ee8ab21c8380ull, 0x75d8e97600b296eaull,
+    0x7ce4fd9430e80ceaull, 0xe5316cbaa025f028ull, 0x39f7fcec8fcb623dull, 0x3bf8fbbad1587cddull,
+    0x802517e298c70b03ull, 0x56d7ab194448a4f3ull, 0xbb62c62c9808ea37ull, 0x5b25b8ef511eb395ull,
+    0xee5f6d7b48b44de8ull, 0x509220bb65a646b7ull, 0x60839e2395be697eull, 0x4554e34a747022dfull,
+    0x4320e9a2e32eac38ull, 0x7a8060916400fe66ull, 0x823b8a195ce2133cull, 0x732dfbcc9b0cf0bbull,
+    0x24b070ada2041cb0ull, 0x76aaaa535714d805ull, 0x24f3a319b88552c1ull, 0x9deeefd89ca8a81dull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x327fe6dc702553fdull, 0x9d167ef77aed79b6ull, 0xf60ec899a5a69fa9ull,
+    0xd6458a3eef83d457ull, 0x6dadeaaee49d6d18ull, 0x4a9a31623ab5f213ull, 0x9d8b8aa2b404c2c8ull,
+    0xae3b9113b7db93a4ull, 0x69ff34904242a73dull, 0xb97e90a3784c431dull, 0x7e9d0b96d39e517dull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       37, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF,    36, 0xFFFF, 0xFFFF, 0xFFFF,    34,
+       38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,    46, 0xFFFF, 0xFFFF, 0xFFFF,    15,
+       22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,
+    0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF,     2, 0xFFFF,
+    0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF,    33, 0xFFFF,    23,    25, 0xFFFF,
+        6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF,    31, 0xFFFF,
+    0xFFFF,    11,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    13,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    30,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17,    40,
+    0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 32;
+static const uint16_t kTableIdSlotBuildVersion = 48;
+static const uint16_t kTableIdSlotVocabulary = 49;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -436,16 +546,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    GRAPHDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -765,6 +893,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -796,16 +936,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5294,10 +5517,10 @@ GRAPHDEMO_TABLE_INLINE bool TallyLoadBody( TableReader & r, Tally & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5308,9 +5531,9 @@ GRAPHDEMO_TABLE_INLINE bool TallyLoadBody( TableReader & r, Tally & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x732dfbcc9b0cf0bbull: // hits
+            case 27: // hits, id 0x732dfbcc9b0cf0bbull
             {
                 if ( kind != 4 )
                 {
@@ -5646,10 +5869,10 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5660,9 +5883,9 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -5691,7 +5914,7 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x3bf8fbbad1587cddull: // note
+            case 15: // note, id 0x3bf8fbbad1587cddull
             {
                 if ( kind != 17 )
                 {
@@ -5711,7 +5934,7 @@ inline bool MarkerLoadBody( TableReader & r, const TableNodeMap & nodes, Marker 
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6877,10 +7100,11 @@ GRAPHDEMO_TABLE_INLINE bool TallyLoadBodyRetain( TableReader & r, Tally & value,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6891,9 +7115,9 @@ GRAPHDEMO_TABLE_INLINE bool TallyLoadBodyRetain( TableReader & r, Tally & value,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x732dfbcc9b0cf0bbull: // hits
+            case 27: // hits, id 0x732dfbcc9b0cf0bbull
             {
                 if ( kind != 4 )
                 {
@@ -7095,10 +7319,11 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -7109,9 +7334,9 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 14: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 12 )
                 {
@@ -7140,7 +7365,7 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x3bf8fbbad1587cddull: // note
+            case 15: // note, id 0x3bf8fbbad1587cddull
             {
                 if ( kind != 17 )
                 {
@@ -7160,7 +7385,7 @@ inline bool MarkerLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, M
                 }
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -428,6 +428,116 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 50;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 2, so no lookup examines more than 3. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 3;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xc4bcadba8e631b86ull, 0x1e4984ef2e958a4cull, 0xee7ba9ad45c64144ull, 0xeddcb72b15486e77ull,
+    0x77af761956600b54ull, 0x0a8f12cc5f9a0c03ull, 0xaf63ef4c86020cd5ull, 0xaf63da4c8601e926ull,
+    0xaf63df4c8601f1a5ull, 0xdd9eb981e152e90cull, 0x4339ee8ab21c8380ull, 0x75d8e97600b296eaull,
+    0x7ce4fd9430e80ceaull, 0xe5316cbaa025f028ull, 0x39f7fcec8fcb623dull, 0x3bf8fbbad1587cddull,
+    0x802517e298c70b03ull, 0x56d7ab194448a4f3ull, 0xbb62c62c9808ea37ull, 0x5b25b8ef511eb395ull,
+    0xee5f6d7b48b44de8ull, 0x509220bb65a646b7ull, 0x60839e2395be697eull, 0x4554e34a747022dfull,
+    0x4320e9a2e32eac38ull, 0x7a8060916400fe66ull, 0x823b8a195ce2133cull, 0x732dfbcc9b0cf0bbull,
+    0x24b070ada2041cb0ull, 0x76aaaa535714d805ull, 0x24f3a319b88552c1ull, 0x9deeefd89ca8a81dull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xd858c2cb7f1514ccull, 0x327fe6dc702553fdull, 0x9d167ef77aed79b6ull, 0xf60ec899a5a69fa9ull,
+    0xd6458a3eef83d457ull, 0x6dadeaaee49d6d18ull, 0x4a9a31623ab5f213ull, 0x9d8b8aa2b404c2c8ull,
+    0xae3b9113b7db93a4ull, 0x69ff34904242a73dull, 0xb97e90a3784c431dull, 0x7e9d0b96d39e517dull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+       37, 0xFFFF, 0xFFFF, 0xFFFF,    39, 0xFFFF, 0xFFFF, 0xFFFF,    48, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    28, 0xFFFF,    36, 0xFFFF, 0xFFFF, 0xFFFF,    34,
+       38, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    18,    46, 0xFFFF, 0xFFFF, 0xFFFF,    15,
+       22, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    21, 0xFFFF,
+    0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    24, 0xFFFF,     2, 0xFFFF,
+    0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    45, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    29, 0xFFFF,    33, 0xFFFF,    23,    25, 0xFFFF,
+        6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF,    31, 0xFFFF,
+    0xFFFF,    11,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    43, 0xFFFF,
+       32, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF,    49, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,     8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    13,     7, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    44, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    41, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    42, 0xFFFF, 0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    35, 0xFFFF,    47, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    30,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17,    40,
+    0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 32;
+static const uint16_t kTableIdSlotBuildVersion = 48;
+static const uint16_t kTableIdSlotVocabulary = 49;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -436,16 +546,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    GRAPHDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -765,6 +893,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -796,16 +936,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5204,10 +5427,10 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5218,9 +5441,9 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x56d7ab194448a4f3ull: // tag
+            case 17: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 12 )
                 {
@@ -5249,7 +5472,7 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x823b8a195ce2133cull: // seq
+            case 26: // seq, id 0x823b8a195ce2133cull
             {
                 if ( kind != 4 )
                 {
@@ -5621,10 +5844,10 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5635,9 +5858,9 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63ef4c86020cd5ull: // r
+            case 6: // r, id 0xaf63ef4c86020cd5ull
             {
                 if ( kind != 6 )
                 {
@@ -5652,7 +5875,7 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value )
                 value.r = decoded_v;
                 break;
             }
-            case 0xaf63da4c8601e926ull: // g
+            case 7: // g, id 0xaf63da4c8601e926ull
             {
                 if ( kind != 6 )
                 {
@@ -5667,7 +5890,7 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value )
                 value.g = decoded_v;
                 break;
             }
-            case 0xaf63df4c8601f1a5ull: // b
+            case 8: // b, id 0xaf63df4c8601f1a5ull
             {
                 if ( kind != 6 )
                 {
@@ -6007,10 +6230,11 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBodyRetain( TableReader & r, Stamp & value,
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6021,9 +6245,9 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBodyRetain( TableReader & r, Stamp & value,
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x56d7ab194448a4f3ull: // tag
+            case 17: // tag, id 0x56d7ab194448a4f3ull
             {
                 if ( kind != 12 )
                 {
@@ -6052,7 +6276,7 @@ GRAPHDEMO_TABLE_INLINE bool StampLoadBodyRetain( TableReader & r, Stamp & value,
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x823b8a195ce2133cull: // seq
+            case 26: // seq, id 0x823b8a195ce2133cull
             {
                 if ( kind != 4 )
                 {
@@ -6255,10 +6479,11 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBodyRetain( TableReader & r, Colour & valu
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6269,9 +6494,9 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBodyRetain( TableReader & r, Colour & valu
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63ef4c86020cd5ull: // r
+            case 6: // r, id 0xaf63ef4c86020cd5ull
             {
                 if ( kind != 6 )
                 {
@@ -6286,7 +6511,7 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBodyRetain( TableReader & r, Colour & valu
                 value.r = decoded_v;
                 break;
             }
-            case 0xaf63da4c8601e926ull: // g
+            case 7: // g, id 0xaf63da4c8601e926ull
             {
                 if ( kind != 6 )
                 {
@@ -6301,7 +6526,7 @@ GRAPHDEMO_TABLE_INLINE bool ColourLoadBodyRetain( TableReader & r, Colour & valu
                 value.g = decoded_v;
                 break;
             }
-            case 0xaf63df4c8601f1a5ull: // b
+            case 8: // b, id 0xaf63df4c8601f1a5ull
             {
                 if ( kind != 6 )
                 {

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -396,6 +396,112 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 34;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 256;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0x9a7f8d639c6974c9ull;
+static const uint32_t kTableIdSlotShift = 56;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xaf63f54c86021707ull, 0xaf63f44c86021554ull, 0xb128829190ca0f75ull, 0x1e5088ef2e9bafc6ull,
+    0x401ab8cd06158638ull, 0x4cbf3a26fca1d74aull, 0x891da1f305deb858ull, 0x7fd9266c6a3e25b5ull,
+    0xfbc924118177ade4ull, 0x2281498aa0200e40ull, 0x8b7dc019093cd0e1ull, 0x1f3757a2ce7b0ab1ull,
+    0x23e5906728b4e66full, 0xd61bdd7908af2642ull, 0xf2fd4f9140ef2f15ull, 0x23fcfd6678e36712ull,
+    0x6aacb9fbb71a1d91ull, 0xe3b1ca6a3b48dddcull, 0xb1494b6ef08a411eull, 0x32969e840d9c67b8ull,
+    0x5af1ac301b4ae16dull, 0x8c2fd80da8957064ull, 0x4328f78ab20e1f98ull, 0xaf64154c86024d67ull,
+    0xaf64144c86024bb4ull, 0xaf64174c860250cdull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull,
+    0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0xde526b2d99a4f0c9ull, 0xb357d919a722bb44ull,
+    0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF,    19, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     2,
+    0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    22, 0xFFFF,
+    0xFFFF, 0xFFFF,    21, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       33, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    15, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    30,
+    0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    26, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF,
+    0xFFFF,    18, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    27, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF,    17,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     4,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     8,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    25, 0xFFFF,    12, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF,    32,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF,
+    0xFFFF, 0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF,    31, 0xFFFF,    23, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF,
+       24, 0xFFFF,    29, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    28, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 26;
+static const uint16_t kTableIdSlotBuildVersion = 32;
+static const uint16_t kTableIdSlotVocabulary = 33;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -404,16 +510,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    SCALARDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -733,6 +857,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -764,16 +900,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2428,6 +2647,16 @@ inline bool TableEnumValue( uint64_t id, Axis & out )
         default: return false; // an id this build cannot name
     }
 }
+inline bool TableEnumValueAt( uint16_t slot, Axis & out )
+{
+    switch ( slot )
+    {
+        case 23: out = Axis::X; return true; // id 0xaf64154c86024d67ull
+        case 24: out = Axis::Y; return true; // id 0xaf64144c86024bb4ull
+        case 25: out = Axis::Z; return true; // id 0xaf64174c860250cdull
+        default: return false; // a slot this build cannot name
+    }
+}
 #endif // SCALARDEMO_SCHEMA_TABLE_ENUM_AXIS
 
 // ---- prefill: the declared defaults, in place (docs/SPEC-TABLES.md) ----
@@ -2766,10 +2995,10 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2780,9 +3009,9 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x1e5088ef2e9bafc6ull: // tilt
+            case 3: // tilt, id 0x1e5088ef2e9bafc6ull
             {
                 if ( kind != 20 )
                 {
@@ -2798,7 +3027,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.tilt = decoded_v;
                 break;
             }
-            case 0x401ab8cd06158638ull: // angle
+            case 4: // angle, id 0x401ab8cd06158638ull
             {
                 if ( kind != 22 )
                 {
@@ -2815,7 +3044,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.angle = decoded_v;
                 break;
             }
-            case 0x4cbf3a26fca1d74aull: // position
+            case 5: // position, id 0x4cbf3a26fca1d74aull
             {
                 if ( kind != 23 )
                 {
@@ -2832,7 +3061,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.position = decoded_v;
                 break;
             }
-            case 0x891da1f305deb858ull: // reach
+            case 6: // reach, id 0x891da1f305deb858ull
             {
                 if ( kind != 24 )
                 {
@@ -2850,7 +3079,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.reach = decoded_v;
                 break;
             }
-            case 0x7fd9266c6a3e25b5ull: // ticks
+            case 7: // ticks, id 0x7fd9266c6a3e25b5ull
             {
                 if ( kind != 22 )
                 {
@@ -2867,7 +3096,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.ticks = decoded_v;
                 break;
             }
-            case 0xfbc924118177ade4ull: // ratio
+            case 8: // ratio, id 0xfbc924118177ade4ull
             {
                 if ( kind != 25 )
                 {
@@ -2883,7 +3112,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.ratio = decoded_v;
                 break;
             }
-            case 0x2281498aa0200e40ull: // speed
+            case 9: // speed, id 0x2281498aa0200e40ull
             {
                 if ( kind != 27 )
                 {
@@ -2899,7 +3128,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.speed = decoded_v;
                 break;
             }
-            case 0x8b7dc019093cd0e1ull: // span
+            case 10: // span, id 0x8b7dc019093cd0e1ull
             {
                 if ( kind != 28 )
                 {
@@ -2915,7 +3144,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.span = decoded_v;
                 break;
             }
-            case 0x1f3757a2ce7b0ab1ull: // mass
+            case 11: // mass, id 0x1f3757a2ce7b0ab1ull
             {
                 if ( kind != 29 )
                 {
@@ -2932,7 +3161,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.mass = decoded_v;
                 break;
             }
-            case 0x23e5906728b4e66full: // frames
+            case 12: // frames, id 0x23e5906728b4e66full
             {
                 if ( kind != 27 )
                 {
@@ -2947,7 +3176,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.frames = decoded_v;
                 break;
             }
-            case 0xd61bdd7908af2642ull: // flux
+            case 13: // flux, id 0xd61bdd7908af2642ull
             {
                 if ( kind != 18 )
                 {
@@ -2978,7 +3207,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.flux = decoded_v;
                 break;
             }
-            case 0xf2fd4f9140ef2f15ull: // energy
+            case 14: // energy, id 0xf2fd4f9140ef2f15ull
             {
                 if ( kind != 18 )
                 {
@@ -3009,7 +3238,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.energy = decoded_v;
                 break;
             }
-            case 0x23fcfd6678e36712ull: // entity_id
+            case 15: // entity_id, id 0x23fcfd6678e36712ull
             {
                 if ( kind != 19 )
                 {
@@ -3036,7 +3265,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.entity_id = decoded_v;
                 break;
             }
-            case 0x6aacb9fbb71a1d91ull: // scale
+            case 16: // scale, id 0x6aacb9fbb71a1d91ull
             {
                 if ( kind != 22 )
                 {
@@ -3053,7 +3282,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 value.scale = decoded_v;
                 break;
             }
-            case 0xe3b1ca6a3b48dddcull: // samples
+            case 17: // samples, id 0xe3b1ca6a3b48dddcull
             {
                 if ( kind != 14 )
                 {
@@ -3101,7 +3330,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xb1494b6ef08a411eull: // weights
+            case 18: // weights, id 0xb1494b6ef08a411eull
             {
                 if ( kind != 14 )
                 {
@@ -3155,7 +3384,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x32969e840d9c67b8ull: // axes
+            case 19: // axes, id 0x32969e840d9c67b8ull
             {
                 if ( kind != 16 )
                 {
@@ -3192,7 +3421,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                         uint64_t elem_len = 0;
                         if ( !sub.getleb( elem_len ) || !sub.room( elem_len ) ) { r.report->malformed = true; break; }
                         Axis slot = Axis::None;
-                        if ( !TableEnumValue( r.ids->at( key_ref ), slot ) )
+                        if ( !TableEnumValueAt( r.ids->slot_of( key_ref ), slot ) )
                         {
                             r.report->unknown++; // a slot this reader cannot name
                             sub.offset += (int64_t) elem_len;
@@ -3212,7 +3441,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 r.offset = body_end; // unread triples and slack skip via the length
                 break;
             }
-            case 0x5af1ac301b4ae16dull: // seeds
+            case 20: // seeds, id 0x5af1ac301b4ae16dull
             {
                 if ( kind != 14 )
                 {
@@ -3286,7 +3515,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x8c2fd80da8957064ull: // pose
+            case 21: // pose, id 0x8c2fd80da8957064ull
             {
                 if ( kind != 13 )
                 {
@@ -3310,7 +3539,7 @@ SCALARDEMO_TABLE_INLINE bool SimStateLoadBody( TableReader & r, SimState & value
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x4328f78ab20e1f98ull: // spawn
+            case 22: // spawn, id 0x4328f78ab20e1f98ull
             {
                 if ( kind != 13 )
                 {
@@ -4522,10 +4751,10 @@ SCALARDEMO_TABLE_INLINE bool PoseLoadBody( TableReader & r, Pose & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -4536,9 +4765,9 @@ SCALARDEMO_TABLE_INLINE bool PoseLoadBody( TableReader & r, Pose & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xaf63f54c86021707ull: // x
+            case 0: // x, id 0xaf63f54c86021707ull
             {
                 if ( kind != 23 )
                 {
@@ -4555,7 +4784,7 @@ SCALARDEMO_TABLE_INLINE bool PoseLoadBody( TableReader & r, Pose & value )
                 value.x = decoded_v;
                 break;
             }
-            case 0xaf63f44c86021554ull: // y
+            case 1: // y, id 0xaf63f44c86021554ull
             {
                 if ( kind != 23 )
                 {
@@ -4572,7 +4801,7 @@ SCALARDEMO_TABLE_INLINE bool PoseLoadBody( TableReader & r, Pose & value )
                 value.y = decoded_v;
                 break;
             }
-            case 0xb128829190ca0f75ull: // heading
+            case 2: // heading, id 0xb128829190ca0f75ull
             {
                 if ( kind != 27 )
                 {

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -410,6 +410,98 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 21;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0xae5d669c4ded3d95ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0x855b556730a34a05ull, 0xe5316cbaa025f028ull, 0x5cc201a9f1b8274eull, 0x08b72e07b55c3ac0ull,
+    0xd8d4335628b35226ull, 0x0c519da7a1f958c5ull, 0x0369250deb889a31ull, 0xc4bcadba8e631b86ull,
+    0x3a506cb501761960ull, 0x0f838176873c8e22ull, 0xbf4b9bad694f4809ull, 0x56d7ab194448a4f3ull,
+    0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull, 0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull,
+    0xcf4368dcf951e082ull, 0x3a8fe3852a245245ull, 0x75d83fc3f0cfab40ull, 0xfffffffffffffffeull,
+    0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,     1, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        5, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       18, 0xFFFF, 0xFFFF, 0xFFFF,    12, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,    11, 0xFFFF, 0xFFFF,     8, 0xFFFF,    15, 0xFFFF, 0xFFFF,    19, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF,    16, 0xFFFF, 0xFFFF, 0xFFFF,     7,
+    0xFFFF,     3, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF,     2,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF,    20, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 12;
+static const uint16_t kTableIdSlotBuildVersion = 19;
+static const uint16_t kTableIdSlotVocabulary = 20;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -418,16 +510,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    STREAMDEMO_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -747,6 +857,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -778,16 +900,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -5200,10 +5405,10 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBody( TableReader & r, Header & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5214,9 +5419,9 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBody( TableReader & r, Header & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 7: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -5582,10 +5787,10 @@ inline bool ChunkLoadBody( TableReader & r, const TableNodeMap & nodes, Chunk & 
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -5596,9 +5801,9 @@ inline bool ChunkLoadBody( TableReader & r, const TableNodeMap & nodes, Chunk & 
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x855b556730a34a05ull: // data
+            case 0: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 14 )
                 {
@@ -5647,7 +5852,7 @@ inline bool ChunkLoadBody( TableReader & r, const TableNodeMap & nodes, Chunk & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 1: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -5667,7 +5872,7 @@ inline bool ChunkLoadBody( TableReader & r, const TableNodeMap & nodes, Chunk & 
                 }
                 break;
             }
-            case 0x5cc201a9f1b8274eull: // links
+            case 2: // links, id 0x5cc201a9f1b8274eull
             {
                 if ( kind != 14 )
                 {
@@ -5722,7 +5927,7 @@ inline bool ChunkLoadBody( TableReader & r, const TableNodeMap & nodes, Chunk & 
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -6175,10 +6380,10 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -6189,9 +6394,9 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x08b72e07b55c3ac0ull: // id
+            case 3: // id, id 0x08b72e07b55c3ac0ull
             {
                 if ( kind != 8 )
                 {
@@ -6217,7 +6422,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                 value.id = decoded_v;
                 break;
             }
-            case 0xd8d4335628b35226ull: // frame
+            case 4: // frame, id 0xd8d4335628b35226ull
             {
                 if ( kind != 15 )
                 {
@@ -6231,16 +6436,16 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.frame.type = FrameType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x3a506cb501761960ull: // header
+                        case 8: // header, id 0x3a506cb501761960ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6255,7 +6460,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                             if ( sub.offset != sub.size ) { value.frame.type = FrameType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x0f838176873c8e22ull: // chunk
+                        case 9: // chunk, id 0x0f838176873c8e22ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -6270,7 +6475,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                             if ( sub.offset != sub.size ) { value.frame.type = FrameType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xbf4b9bad694f4809ull: // link
+                        case 10: // link, id 0xbf4b9bad694f4809ull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -6289,7 +6494,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                             }
                             break;
                         }
-                        case 0x56d7ab194448a4f3ull: // tag
+                        case 11: // tag, id 0x56d7ab194448a4f3ull
                         {
                             if ( arm_kind != 8 )
                             {
@@ -6334,7 +6539,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x0c519da7a1f958c5ull: // parts
+            case 5: // parts, id 0x0c519da7a1f958c5ull
             {
                 if ( kind != 14 )
                 {
@@ -6389,7 +6594,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x0369250deb889a31ull: // pair
+            case 6: // pair, id 0x0369250deb889a31ull
             {
                 if ( kind != 14 )
                 {
@@ -6437,7 +6642,7 @@ inline bool FeedLoadBody( TableReader & r, const TableNodeMap & nodes, Feed & va
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9080,10 +9285,11 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBodyRetain( TableReader & r, Header & val
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9094,9 +9300,9 @@ STREAMDEMO_TABLE_INLINE bool HeaderLoadBodyRetain( TableReader & r, Header & val
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xc4bcadba8e631b86ull: // name
+            case 7: // name, id 0xc4bcadba8e631b86ull
             {
                 if ( kind != 12 )
                 {
@@ -9322,10 +9528,11 @@ inline bool ChunkLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9336,9 +9543,9 @@ inline bool ChunkLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x855b556730a34a05ull: // data
+            case 0: // data, id 0x855b556730a34a05ull
             {
                 if ( kind != 14 )
                 {
@@ -9387,7 +9594,7 @@ inline bool ChunkLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xe5316cbaa025f028ull: // next
+            case 1: // next, id 0xe5316cbaa025f028ull
             {
                 if ( kind != 17 )
                 {
@@ -9407,7 +9614,7 @@ inline bool ChunkLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                 }
                 break;
             }
-            case 0x5cc201a9f1b8274eull: // links
+            case 2: // links, id 0x5cc201a9f1b8274eull
             {
                 if ( kind != 14 )
                 {
@@ -9462,7 +9669,7 @@ inline bool ChunkLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Ch
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;
@@ -9855,10 +10062,11 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
+        const uint64_t field_id = r.ids->at( field_ref ); // the RAW id, which a retained record carries (§6.6)
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -9869,9 +10077,9 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x08b72e07b55c3ac0ull: // id
+            case 3: // id, id 0x08b72e07b55c3ac0ull
             {
                 if ( kind != 8 )
                 {
@@ -9897,7 +10105,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                 value.id = decoded_v;
                 break;
             }
-            case 0xd8d4335628b35226ull: // frame
+            case 4: // frame, id 0xd8d4335628b35226ull
             {
                 if ( kind != 15 )
                 {
@@ -9912,16 +10120,16 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.frame.type = FrameType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0x3a506cb501761960ull: // header
+                        case 8: // header, id 0x3a506cb501761960ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -9936,7 +10144,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                             if ( sub.offset != sub.size ) { value.frame.type = FrameType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0x0f838176873c8e22ull: // chunk
+                        case 9: // chunk, id 0x0f838176873c8e22ull
                         {
                             if ( arm_kind != 13 )
                             {
@@ -9951,7 +10159,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                             if ( sub.offset != sub.size ) { value.frame.type = FrameType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xbf4b9bad694f4809ull: // link
+                        case 10: // link, id 0xbf4b9bad694f4809ull
                         {
                             if ( arm_kind != 17 )
                             {
@@ -9970,7 +10178,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                             }
                             break;
                         }
-                        case 0x56d7ab194448a4f3ull: // tag
+                        case 11: // tag, id 0x56d7ab194448a4f3ull
                         {
                             if ( arm_kind != 8 )
                             {
@@ -10015,7 +10223,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x0c519da7a1f958c5ull: // parts
+            case 5: // parts, id 0x0c519da7a1f958c5ull
             {
                 if ( kind != 14 )
                 {
@@ -10070,7 +10278,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0x0369250deb889a31ull: // pair
+            case 6: // pair, id 0x0369250deb889a31ull
             {
                 if ( kind != 14 )
                 {
@@ -10118,7 +10326,7 @@ inline bool FeedLoadBodyRetain( TableReader & r, const TableNodeMap & nodes, Fee
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xffffffffffffffffull:
+            case kTableIdSlotNodeTable: // id 0xffffffffffffffffull
             {
                 if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
                 break;

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -377,6 +377,97 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 19;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xda31296c0c1b6029ull, 0xbf4ba5ad694f5907ull, 0x5ce3f9a9f1d5001cull, 0xcd4de79bc6c93295ull,
+    0xfa04f4ef1995407eull, 0x39f7fcec8fcb623dull, 0x823b8a195ce2133cull, 0xa633f1f655715ccaull,
+    0x96569b06f223c29aull, 0xb1e5e28e4479a274ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull,
+    0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x832ef3a7593a8b05ull, 0xae3b9113b7db93a4ull,
+    0x3cf8a6b47fddf8e7ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+    0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF,     5, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        2, 0xFFFF, 0xFFFF,    15, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       16, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 10;
+static const uint16_t kTableIdSlotBuildVersion = 17;
+static const uint16_t kTableIdSlotVocabulary = 18;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +476,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    WIDE_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +823,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +866,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2470,10 +2674,10 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2484,9 +2688,9 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xda31296c0c1b6029ull: // title
+            case 0: // title, id 0xda31296c0c1b6029ull
             {
                 if ( kind != 33 )
                 {
@@ -2514,7 +2718,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xbf4ba5ad694f5907ull: // line
+            case 1: // line, id 0xbf4ba5ad694f5907ull
             {
                 if ( kind != 13 )
                 {
@@ -2538,7 +2742,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x5ce3f9a9f1d5001cull: // lines
+            case 2: // lines, id 0x5ce3f9a9f1d5001cull
             {
                 if ( kind != 14 )
                 {
@@ -2596,7 +2800,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xcd4de79bc6c93295ull: // body
+            case 3: // body, id 0xcd4de79bc6c93295ull
             {
                 if ( kind != 15 )
                 {
@@ -2610,16 +2814,16 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.body.type = BodyType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xa633f1f655715ccaull: // wide
+                        case 7: // wide, id 0xa633f1f655715ccaull
                         {
                             if ( arm_kind != 33 )
                             {
@@ -2645,7 +2849,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0x96569b06f223c29aull: // narrow
+                        case 8: // narrow, id 0x96569b06f223c29aull
                         {
                             if ( arm_kind != 12 )
                             {
@@ -2670,7 +2874,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // tally
+                        case 9: // tally, id 0xb1e5e28e4479a274ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -3297,10 +3501,10 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3311,9 +3515,9 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 5: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 33 )
                 {
@@ -3341,7 +3545,7 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x823b8a195ce2133cull: // seq
+            case 6: // seq, id 0x823b8a195ce2133cull
             {
                 if ( kind != 8 )
                 {
@@ -3700,10 +3904,10 @@ WIDE_TABLE_INLINE bool LineLoadBody( TableReader & r, Line & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3714,9 +3918,9 @@ WIDE_TABLE_INLINE bool LineLoadBody( TableReader & r, Line & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xfa04f4ef1995407eull: // text
+            case 4: // text, id 0xfa04f4ef1995407eull
             {
                 if ( kind != 33 )
                 {

--- a/testdata/golden/tables/wide/WideTextTable.h
+++ b/testdata/golden/tables/wide/WideTextTable.h
@@ -377,6 +377,97 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 19;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xda31296c0c1b6029ull, 0xbf4ba5ad694f5907ull, 0x5ce3f9a9f1d5001cull, 0xcd4de79bc6c93295ull,
+    0xfa04f4ef1995407eull, 0x39f7fcec8fcb623dull, 0x823b8a195ce2133cull, 0xa633f1f655715ccaull,
+    0x96569b06f223c29aull, 0xb1e5e28e4479a274ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull,
+    0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x832ef3a7593a8b05ull, 0xae3b9113b7db93a4ull,
+    0x3cf8a6b47fddf8e7ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+    0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF,     5, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        2, 0xFFFF, 0xFFFF,    15, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       16, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 10;
+static const uint16_t kTableIdSlotBuildVersion = 17;
+static const uint16_t kTableIdSlotVocabulary = 18;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +476,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    WIDE_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +823,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +866,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -377,6 +377,97 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 19;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xda31296c0c1b6029ull, 0xbf4ba5ad694f5907ull, 0x5ce3f9a9f1d5001cull, 0xcd4de79bc6c93295ull,
+    0xfa04f4ef1995407eull, 0x39f7fcec8fcb623dull, 0x823b8a195ce2133cull, 0xa633f1f655715ccaull,
+    0x96569b06f223c29aull, 0xb1e5e28e4479a274ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull,
+    0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x832ef3a7593a8b05ull, 0xae3b9113b7db93a4ull,
+    0x3cf8a6b47fddf8e7ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+    0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF,     5, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        2, 0xFFFF, 0xFFFF,    15, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       16, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 10;
+static const uint16_t kTableIdSlotBuildVersion = 17;
+static const uint16_t kTableIdSlotVocabulary = 18;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +476,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    WIDE_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +823,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +866,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;
@@ -2470,10 +2674,10 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -2484,9 +2688,9 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xda31296c0c1b6029ull: // title
+            case 0: // title, id 0xda31296c0c1b6029ull
             {
                 if ( kind != 33 )
                 {
@@ -2514,7 +2718,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0xbf4ba5ad694f5907ull: // line
+            case 1: // line, id 0xbf4ba5ad694f5907ull
             {
                 if ( kind != 13 )
                 {
@@ -2538,7 +2742,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset += (int64_t) body_len;
                 break;
             }
-            case 0x5ce3f9a9f1d5001cull: // lines
+            case 2: // lines, id 0x5ce3f9a9f1d5001cull
             {
                 if ( kind != 14 )
                 {
@@ -2596,7 +2800,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 r.offset = body_end; // excess elements and slack skip via the length
                 break;
             }
-            case 0xcd4de79bc6c93295ull: // body
+            case 3: // body, id 0xcd4de79bc6c93295ull
             {
                 if ( kind != 15 )
                 {
@@ -2610,16 +2814,16 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                 if ( !r.getleb( arm_ref ) ) { r.report->malformed = true; return false; }
                 if ( arm_ref == 0 ) { value.body.type = BodyType::None; break; } // empty: the reference is the whole payload
                 if ( arm_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; }
-                const uint64_t arm_id = r.ids->at( arm_ref );
+                const uint16_t arm_slot = r.ids->slot_of( arm_ref );
                 if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
                 const uint8_t arm_kind = r.get8();
                 uint64_t body_len = 0;
                 if ( !r.getleb( body_len ) || !r.room( body_len ) ) { r.report->malformed = true; return false; }
                 {
                     TableReader sub( r.buffer + r.offset, (int64_t) body_len, r.report, r.ids );
-                    switch ( arm_id ) // the arm's NAME hash (docs/SPEC-TABLES.md §5)
+                    switch ( arm_slot ) // the arm's name, at its compile-time SLOT (§3, §5)
                     {
-                        case 0xa633f1f655715ccaull: // wide
+                        case 7: // wide, id 0xa633f1f655715ccaull
                         {
                             if ( arm_kind != 33 )
                             {
@@ -2645,7 +2849,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0x96569b06f223c29aull: // narrow
+                        case 8: // narrow, id 0x96569b06f223c29aull
                         {
                             if ( arm_kind != 12 )
                             {
@@ -2670,7 +2874,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // tally
+                        case 9: // tally, id 0xb1e5e28e4479a274ull
                         {
                             if ( arm_kind != 4 )
                             {
@@ -3297,10 +3501,10 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3311,9 +3515,9 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0x39f7fcec8fcb623dull: // label
+            case 5: // label, id 0x39f7fcec8fcb623dull
             {
                 if ( kind != 33 )
                 {
@@ -3341,7 +3545,7 @@ WIDE_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
                 r.offset += (int64_t) len;
                 break;
             }
-            case 0x823b8a195ce2133cull: // seq
+            case 6: // seq, id 0x823b8a195ce2133cull
             {
                 if ( kind != 8 )
                 {
@@ -3700,10 +3904,10 @@ WIDE_TABLE_INLINE bool LineLoadBody( TableReader & r, Line & value )
         if ( !r.getleb( field_ref ) ) { r.report->malformed = true; return false; }
         if ( field_ref == 0 ) return true; // the body ENDS AT ITS OWN ZERO REFERENCE
         if ( r.ids == NULL || field_ref > (uint64_t) r.ids->count ) { r.report->malformed = true; return false; } // a reference ABOVE the entry count
-        const uint64_t field_id = r.ids->at( field_ref );
+        const uint16_t field_slot = r.ids->slot_of( field_ref );
         if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
         uint8_t kind = r.get8();
-        if ( ( field_id == kTableNodeTableFieldId && r.nested ) || field_id == kTableBuildVersionFieldId || field_id == kTableMessageVocabularyFieldId )
+        if ( ( field_slot == kTableIdSlotNodeTable && r.nested ) || field_slot == kTableIdSlotBuildVersion || field_slot == kTableIdSlotVocabulary )
         {
             // A RESERVED ID IN ANY BODY BUT THE ONE WHOSE TRANSPORT IT IS,
             // IS MALFORMED (docs/SPEC-TABLES.md §3.1, §3.3). The node
@@ -3714,9 +3918,9 @@ WIDE_TABLE_INLINE bool LineLoadBody( TableReader & r, Line & value )
             r.report->malformed = true;
             return false;
         }
-        switch ( field_id )
+        switch ( field_slot )
         {
-            case 0xfa04f4ef1995407eull: // text
+            case 4: // text, id 0xfa04f4ef1995407eull
             {
                 if ( kind != 33 )
                 {

--- a/testdata/golden/wide/cpp/WideTextTable.h
+++ b/testdata/golden/wide/cpp/WideTextTable.h
@@ -377,6 +377,97 @@ inline void TableIdsWrite( TableWriter & w, const TableIds & ids )
     w.put64( uint64_t( ids.count ) );
 }
 
+
+// THE ID SLOT MAP, and it is the READ SIDE'S half of the id table
+// (docs/SPEC-TABLES.md §3). The spec leaves the shape to the reader — "an
+// array of the ids it read, a per-type array of resolved slots, a perfect
+// hash" — because nothing on the wire depends on it and no conformance case
+// can see the difference. This is the third with the second on top of it.
+//
+// THE SET IS A COMPILE-TIME FACT OF THE UNIT, exactly as TableIds::kCapacity
+// is: every id this closure can SPELL — every field's, every enum variant's,
+// every union arm's, every table's own name, the blob type ids and the three
+// the language holds back. Each takes a SLOT, numbered in the vocabulary's own
+// order so that a record's fields land in a run and its switch is dense.
+//
+// THE MAP NEVER SOFTENS AND NEVER COMPILES OUT. It decides nothing about
+// damage on its own: an id outside the set answers kTableIdSlotUnknown, which is
+// the arm the unknown counter already sat in, and every check that followed a
+// resolved id still follows a resolved slot.
+static const int32_t kTableIdSlotCount = 19;
+static const uint16_t kTableIdSlotUnknown = 0xFFFF;
+static const int32_t kTableIdSlotProbeSize = 128;
+// THE WORST CASE IS A CONSTANT OF THIS HEADER and not a property of the input:
+// the emitter searched the multipliers and this one leaves no run of occupied
+// probe slots longer than 1, so no lookup examines more than 2. A hostile
+// wire cannot lengthen a run, because the set that fills the table is the
+// unit's own and every id the wire brings is either in it or a miss.
+static const int32_t kTableIdSlotMaxProbe = 2;
+static const uint64_t kTableIdSlotMultiplier = 0x7be902917b70a2a9ull;
+static const uint32_t kTableIdSlotShift = 57;
+// kTableIdSlotUnknown IS NOT A SLOT, so the set may never grow into it
+static_assert( kTableIdSlotCount < 0xFFFF, "the id slot map outgrew its sentinel" );
+// the id each slot names, in slot order — what TableIdTable::at hands back,
+// settled at compile time instead of decoded from the wire
+static const uint64_t kTableIdSlotId[ kTableIdSlotCount ] = {
+    0xda31296c0c1b6029ull, 0xbf4ba5ad694f5907ull, 0x5ce3f9a9f1d5001cull, 0xcd4de79bc6c93295ull,
+    0xfa04f4ef1995407eull, 0x39f7fcec8fcb623dull, 0x823b8a195ce2133cull, 0xa633f1f655715ccaull,
+    0x96569b06f223c29aull, 0xb1e5e28e4479a274ull, 0xffffffffffffffffull, 0x2f2ec0474f1c4fe4ull,
+    0x704be0d8faaffc58ull, 0x5f299db0267bd4c7ull, 0x832ef3a7593a8b05ull, 0xae3b9113b7db93a4ull,
+    0x3cf8a6b47fddf8e7ull, 0xfffffffffffffffeull, 0xfffffffffffffffdull,
+};
+// the probe table: a SLOT number a slot, kTableIdSlotUnknown where nothing sits
+static const uint16_t kTableIdSlotProbe[ kTableIdSlotProbeSize ] = {
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    17, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    12,
+    0xFFFF, 0xFFFF, 0xFFFF,     4, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    14, 0xFFFF, 0xFFFF,     5, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF,    11, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF,     0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,    10, 0xFFFF, 0xFFFF, 0xFFFF,    18, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     7, 0xFFFF, 0xFFFF,     1, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        2, 0xFFFF, 0xFFFF,    15, 0xFFFF, 0xFFFF, 0xFFFF,     9, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+        8, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,     3, 0xFFFF,    13, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+       16, 0xFFFF, 0xFFFF,     6, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+};
+
+// TableIdSlotOf is the whole lookup: one multiply, one shift, and at most
+// kTableIdSlotMaxProbe slots examined. It runs ONCE A TRAILER ENTRY at open,
+// and on the ONE cold path where a trailer is larger than the reader resolves
+// (TableIdTable::slot_of below), never once a field on any ordinary wire. It
+// is a PLAIN inline and not the unit's force-inline: it carries a loop, and a
+// copy of it at every field's dispatch would cost the read path i-cache to
+// buy nothing a taken branch does not already buy.
+inline uint16_t TableIdSlotOf( uint64_t id )
+{
+    uint32_t i = uint32_t( ( id * kTableIdSlotMultiplier ) >> kTableIdSlotShift );
+    for ( int32_t p = 0; p < kTableIdSlotMaxProbe; p++ )
+    {
+        const uint16_t s = kTableIdSlotProbe[i];
+        if ( s == kTableIdSlotUnknown ) { return kTableIdSlotUnknown; } // an empty slot ENDS the run
+        if ( kTableIdSlotId[s] == id ) { return s; }
+        i = ( i + 1 ) & uint32_t( kTableIdSlotProbeSize - 1 );
+    }
+    return kTableIdSlotUnknown;
+}
+
+// THE TRAILER THE READER RESOLVES INTO SLOTS AT OPEN. Its bound is a
+// compile-time fact of the unit like every other: the id table this unit's own
+// writer can fill is kCapacity entries, so a wire this build wrote is always
+// under it, and the floor of 128 covers a foreign wire that names more.
+// A trailer ABOVE the bound is read exactly as it always was — the slot is
+// computed per reference instead of read from the array, and the DISTINCTNESS
+// walk falls back to the pairwise one — so the bound moves no verdict and no
+// byte, only where the work sits.
+static const int32_t kTableIdRefBound = 128;
+
+// THE THREE IDS THE LANGUAGE HOLDS BACK, at their slots (docs/SPEC-TABLES.md
+// §3.1, §3.3, §5). A body meeting one where it does not belong is MALFORMED,
+// and the read side tests that by slot like every other id.
+static const uint16_t kTableIdSlotNodeTable = 10;
+static const uint16_t kTableIdSlotBuildVersion = 17;
+static const uint16_t kTableIdSlotVocabulary = 18;
+
 // THE ID TABLE, READER SIDE (docs/SPEC-TABLES.md §3). A reader locates it from
 // the END of the wire and resolves it ONCE, at open: the entries are eight
 // bytes each and a body names them by position, so every field dispatches
@@ -385,16 +476,34 @@ struct TableIdTable
 {
     const uint8_t * entries = NULL;
     int64_t count = 0;
+    // RESOLVED ONCE, AT OPEN (docs/SPEC-TABLES.md §3, and the slot map above):
+    // entry k's compile-time SLOT at index k, counted from 1 exactly as the
+    // reference is, so a body's dispatch is one array load and a dense switch
+    // rather than an eight-byte decode and a chain of 64-bit compares.
+    // The flag is false for a trailer above kTableIdRefBound and for a table no
+    // TableOpen filled, and slot_of then hashes the id the way open would
+    // have: the SAME slot, computed later, and never a different answer.
+    bool resolved = false;
+    uint16_t slots[ kTableIdRefBound + 1 ];
 
     // the id a reference names. ref is 1-based and bounds-checked by the
     // caller: a reference ABOVE the entry count is framing damage on the body
-    // that carries it, and 0 names no id at all.
+    // that carries it, and 0 names no id at all. THE RAW ID IS STILL WHAT A
+    // REPORT, A RETAINED RECORD AND A DUMP WANT, so this stays exactly what it
+    // was and the slot rides beside it rather than in place of it.
     uint64_t at( uint64_t ref ) const
     {
         const uint8_t * e = entries + ( ref - 1 ) * 8;
         uint64_t lo = uint64_t( e[0] ) | uint64_t( e[1] ) << 8 | uint64_t( e[2] ) << 16 | uint64_t( e[3] ) << 24;
         uint64_t hi = uint64_t( e[4] ) | uint64_t( e[5] ) << 8 | uint64_t( e[6] ) << 16 | uint64_t( e[7] ) << 24;
         return lo | ( hi << 32 );
+    }
+
+    // the SLOT a reference names, which is what every read-side switch
+    // dispatches on. Same bounds contract as at().
+    WIDE_TABLE_INLINE uint16_t slot_of( uint64_t ref ) const
+    {
+        return resolved ? slots[ ref ] : TableIdSlotOf( at( ref ) );
     }
 };
 
@@ -714,6 +823,18 @@ static const uint64_t kTableNodeTableFieldId = 0xFFFFFFFFFFFFFFFFull;
 // refuses the wire by name and never reports damage.
 const uint8_t kTableWireForm = 1;
 
+// THE UNKNOWN-ID PROBE's two sizes (docs/SPEC-TABLES.md §3, and TableOpen
+// below). Only an id this build cannot NAME reaches it — a known id's repeat
+// is a repeated slot and costs one bit of a bitmap over the compile-time set —
+// so the probe carries the FOREIGN subset alone. It is a power of two, so the
+// mask is one AND, and TWICE kTableIdRefBound, so the foreign subset of any
+// trailer the reader resolves fits with the table never fuller than half:
+// the probe has no bound of its own and cannot overflow. Both are compile-time
+// facts of this header, like the id table's own capacity, and the slots are a
+// local of TableOpen: the probe allocates nothing.
+static const int32_t kTableIdProbeSlots = 256;
+static const int32_t kTableIdProbeShift = 56;
+
 // TableOpen reads the form byte and the trailer, in that order, and hands back
 // the ROOT BODY. It answers one of three verdicts, because five zero counters
 // and a false flag are what a clean read prints too:
@@ -745,16 +866,99 @@ inline TableOpenVerdict TableOpen( const uint8_t * buffer, int64_t bytes, TableI
     if ( span + 1 > bytes ) { return TableOpenDamaged; }
     table.entries = buffer + bytes - span;
     table.count = (int64_t) count;
+    // A READER RESOLVES THE TABLE ONCE, AT OPEN (docs/SPEC-TABLES.md §3), and
+    // this is that resolve: every entry becomes its compile-time SLOT here, so
+    // no body ever decodes an entry's eight bytes again. THE DISTINCTNESS
+    // CHECK RIDES IN THE SAME PASS, because a repeat of an id the unit can
+    // spell is a repeat of a SLOT and costs one bit of a bitmap over a set
+    // whose size is a compile-time fact.
+    //
     // THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
     // for the whole wire, because no wire this schema writes carries a repeat
     // and it would leave one more shape of table for a hostile writer to aim
     // at (docs/SPEC-TABLES.md §3).
-    for ( int64_t i = 1; i < table.count; i++ )
+    //
+    // The check is READ SIDE, so it is unconditional: it never compiles out
+    // under NDEBUG and it never softens. The arms below answer TableOpenDamaged
+    // on exactly the same tables and TableOpenOk on exactly the same tables —
+    // WHICH walk finds a repeat is settled by the entry count and by how many
+    // of the entries this build cannot name, and nothing else.
+    //
+    // A KNOWN id is exact by construction: the slot map is injective over the
+    // unit's set, so two distinct known ids never share a slot and one id
+    // repeated always does. AN UNKNOWN id has no slot, so the foreign subset
+    // goes through a PROBE by value — the same Fibonacci multiply TableIds
+    // interns with, taken at the top bits, then linear probing, with occupancy
+    // in a separate bitmap because AN ENTRY IS fnv1a64( name ) AND NOTHING
+    // ELSE (§3): a hash of 0 is an ordinary id and the wire holds back no
+    // 64-bit value to mean "no id".
+    //
+    // ABOVE kTableIdRefBound THE PAIRWISE WALK RUNS UNCHANGED, and nothing is
+    // ever charged for both. The ids are the writer's, so the worst case is
+    // the attacker's, and it is worth stating plainly: the probe's multiply is
+    // invertible, so a hostile writer can land every FOREIGN entry in one
+    // bucket, and a linear probe with no seed cannot be steered away from
+    // that. A cluster can be no longer than the entries already standing in
+    // it, so the nth insert probes at most n slots and the whole probe costs
+    // at most n(n+1)/2 slot comparisons at n = kTableIdRefBound, against the
+    // pairwise walk's n(n-1)/2. The probe therefore does NOT beat the pairwise
+    // walk on comparison count in the worst case, and against chosen ids no
+    // fixed hash could. What it beats, at every count and in the worst case
+    // exactly as much as in the best, is how often the check touches the WIRE:
+    // at() decodes eight bytes a call, and this pass makes EXACTLY n of them
+    // where the pairwise walk makes n(n-1)/2 inner decodes beside n-1 outer
+    // ones. The KNOWN ids do not even reach the probe: they cost one bitmap
+    // bit each, whatever a hostile writer does with them, because their slots
+    // were settled when this header was emitted.
+    //
+    // The SLOT MAP's own lookup cannot be steered either: it is bounded by
+    // kTableIdSlotMaxProbe, a compile-time property of the set the emitter
+    // placed, and a foreign id can only miss.
+    table.resolved = false;
+    if ( table.count <= (int64_t) kTableIdRefBound )
     {
-        const uint64_t id = table.at( uint64_t( i ) + 1 );
-        for ( int64_t j = 0; j < i; j++ )
+        uint64_t known[ ( kTableIdSlotCount + 63 ) / 64 ];
+        for ( int32_t w = 0; w < ( kTableIdSlotCount + 63 ) / 64; w++ ) { known[w] = 0; }
+        uint64_t seen[ kTableIdProbeSlots ];
+        uint64_t used[ kTableIdProbeSlots / 64 ];
+        for ( int32_t w = 0; w < kTableIdProbeSlots / 64; w++ ) { used[w] = 0; }
+        for ( int64_t i = 0; i < table.count; i++ )
         {
-            if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            const uint16_t s = TableIdSlotOf( id );
+            table.slots[ i + 1 ] = s;
+            if ( s != kTableIdSlotUnknown )
+            {
+                const uint64_t bit = 1ull << ( s & 63 );
+                if ( ( known[ s >> 6 ] & bit ) != 0 ) { return TableOpenDamaged; }
+                known[ s >> 6 ] |= bit;
+                continue;
+            }
+            uint32_t p = uint32_t( ( id * 0x9E3779B97F4A7C15ull ) >> kTableIdProbeShift ) & uint32_t( kTableIdProbeSlots - 1 );
+            for ( ;; )
+            {
+                const uint64_t bit = 1ull << ( p & 63 );
+                if ( ( used[ p >> 6 ] & bit ) == 0 )
+                {
+                    used[ p >> 6 ] |= bit;
+                    seen[p] = id;
+                    break;
+                }
+                if ( seen[p] == id ) { return TableOpenDamaged; }
+                p = ( p + 1 ) & uint32_t( kTableIdProbeSlots - 1 );
+            }
+        }
+        table.resolved = true;
+    }
+    else
+    {
+        for ( int64_t i = 1; i < table.count; i++ )
+        {
+            const uint64_t id = table.at( uint64_t( i ) + 1 );
+            for ( int64_t j = 0; j < i; j++ )
+            {
+                if ( table.at( uint64_t( j ) + 1 ) == id ) { return TableOpenDamaged; }
+            }
         }
     }
     body_bytes = bytes - span - 1;


### PR DESCRIPTION
The largest read-side candidate from the profile, licensed by name in docs/SPEC-TABLES.md §3 ("HOW a reader turns a reference into a decision is its own choice ... a per-type array of resolved slots, a perfect hash"). Read-side validation is unconditional and unchanged; every verdict identical on every input.

**The design.** The emitter already knows every id a unit's closure can spell (TableIds::kCapacity is that number on the write side). It now assigns each a slot and emits an open-addressed hash over that set into the header (kTableIdSlotId, kTableIdSlotProbe at four probe slots per id; the emitter searches 4096 deterministic multipliers and keeps the shortest run, so the worst case is a compile-time constant: kTableIdSlotMaxProbe is 2 or 3 in all 48 regenerated headers, and a hostile wire cannot lengthen a run because the set that fills the table is the unit's own; a foreign id can only miss). TableOpen resolves the whole trailer once into uint16_t slots[kTableIdRefBound+1]; every read-side switch dispatches on slot_of(ref): one array load and a dense switch where it decoded eight bytes and compared 64-bit constants. Slot numbering follows the vocabulary's order, so a record's fields land in a run (every emitted switch in tables/examples has span equal to its case count). kTableIdRefBound = max(128, kCapacity); above it, resolution is per reference and the pairwise distinctness walk runs unchanged. Converted: LoadBody, the three union-arm switches, the extent arm switch and field chain, the map key reader, enum and keyed-key resolution (a slot-keyed TableEnumValueAt for the file form; the message form has no trailer and keeps TableEnumValue). Deliberately not converted: node record type_id dispatch, because the directory stores the raw id the cook writes (§7.1). TableIdTable::at is untouched for reports, retain, node type ids and the dump.

**Distinctness, subsuming #772.** A known id's repeat is a repeated slot, one bit in a bitmap over the compile-time set (exact, the map is injective); the foreign subset alone goes through #772's hashed probe, sized 2×kTableIdRefBound; above the bound the pairwise walk alone, unchanged. Worst case stated in the emitted comment: the probe does not beat the pairwise walk on comparisons against hostile foreign ids; it wins wire decodes, exactly n against n(n-1)/2 + n-1.

**Instruction evidence** (-O3, arm64, the four root LoadBody walks of tables/examples forced out of line): TU 10,754 → 10,399 instructions; movk (64-bit constant materialisation) 901 → 55; a 24-field root's dispatch 768 → 623 (-18.9%). TableIdSlotOf is a plain inline, not force-inlined: force-inlining its loop at every dispatch grew the TU 20%.

**Proof.** #772's gate ported and extended (test/tables/distinct_main.cpp): the known set with a repeat at every position, all three reserved ids in every substitution, known and foreign interleaved with the repeat on either side, foreign ids aimed by inverting the multiplier at three homes of the probe on both sides of the bound, a trailer at the reader's maximum and one past it, and 34 read cases pressing an id the build cannot name at every kind the skip rules cover plus the four unskippable kinds; every accepted table also checks slot_of(k) == TableIdSlotOf(at(k)); green in debug, -DNDEBUG -O2 and ASan+UBSan. Three registered negative controls, each red on cue: the foreign probe's comparison, the slot bitmap's test, one entry's resolved slot dropped. Wire fuzz 171,387 mutants and retain 74,522, plain and ASan, 0 divergences, negative controls red; tables-cpp-release four legs × two builds, 651,387 and 554,522 mutants each, 0 divergences; conformance cpp every surface incl. forgery 12/12 and cook-forgery 113/113; schema_test_tables and ASan; bench gate OK at b51387f36d9b59c4; matched runner OK at 07c57b4fa34b2700; shape gate clean; golangci-lint v2.12.2 and modernize v0.23.0 clean. No clock, no timing claim.

Generated: 48 C++ Table headers; no other language moved. If #772 lands first this merges main and drops its bounded probe in favour of this map; if this lands first, #772 closes as superseded.

Drafted by a child of Rowan; verified by Rowan (emitted slot constants and the slot dispatch, at() and the unknown arm kept, the distinctness gate and the bitmap negative control, the bench gate). Reads owed before merge: Johnny (C++ cross-read) and one more; closer to be named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)