### PR TITLE
C# Fixed Table: index vocabulary checks and fast-path short LEB values

### DIFF
--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -4625,6 +4625,40 @@ namespace Bench
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4643,12 +4677,7 @@ namespace Bench
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -2584,6 +2584,7 @@ namespace Bench
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2617,6 +2618,16 @@ namespace Bench
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -2668,6 +2668,7 @@ namespace Benchtable
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2701,6 +2702,16 @@ namespace Benchtable
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -4709,6 +4709,40 @@ namespace Benchtable
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4727,12 +4761,7 @@ namespace Benchtable
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/internal/codegen/cstable/leb_test.go
+++ b/internal/codegen/cstable/leb_test.go
@@ -1,0 +1,26 @@
+package cstable
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCsharpLebFastPathShape(t *testing.T) {
+	requiredPatterns := []string{
+		"if (v < 128) { Byte((byte)v); return; }",
+		"if ((uint)Offset < (uint)Buffer.Length)",
+		"byte b0 = Buffer[Offset];",
+		"if (b0 < 128)",
+		"Offset++;",
+		"v = b0;",
+		"return true;",
+		"for (int i = 0; i < 10; i++)",
+		"if (i == 9 && b > 1)",
+		"if (b < 128) { if (i == 0 || b != 0) { return true; }",
+	}
+	for _, pattern := range requiredPatterns {
+		if !strings.Contains(tableWireSource, pattern) {
+			t.Fatalf("tableWireSource missing expected LEB pattern: %q", pattern)
+		}
+	}
+}

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -182,6 +182,7 @@ public static partial class TableWire
         }
         public void Var(ulong v)
         {
+            if (v < 128) { Byte((byte)v); return; }
             while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
             Byte((byte)v);
         }
@@ -215,6 +216,16 @@ public static partial class TableWire
         }
         public bool Var(out ulong v)
         {
+            if ((uint)Offset < (uint)Buffer.Length)
+            {
+                byte b0 = Buffer[Offset];
+                if (b0 < 128)
+                {
+                    Offset++;
+                    v = b0;
+                    return true;
+                }
+            }
             v = 0;
             int start = Offset;
             for (int i = 0; i < 10; i++)

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -907,6 +907,40 @@ public static partial class TableWire
             if (field.Optional && placed) { field.SetPresent(value, true); }
         }
     }
+    static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+    {
+        int count = vocabulary.Length / 8;
+        if (count >= 16 && count <= 256)
+        {
+            // One KiB, independent of the input's claimed count. Slots store
+            // ordinal+1, so the identity zero remains an ordinary identity.
+            // At most 256 entries occupy 512 slots: even deliberately colliding
+            // identities reach an empty slot after at most 256 occupied probes.
+            Span<ushort> slots = stackalloc ushort[512];
+            slots.Clear();
+            for (int i = 0; i < count; i++)
+            {
+                ulong id = Read64(vocabulary, i * 8);
+                int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                while (slots[slot] != 0)
+                {
+                    if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                    slot = (slot + 1) & 511;
+                }
+                slots[slot] = (ushort)(i + 1);
+            }
+            return true;
+        }
+        // Tiny vocabularies avoid scratch initialization. Larger foreign
+        // vocabularies keep the existing allocation-free validation path.
+        for (int i = 0; i < vocabulary.Length; i += 8)
+        {
+            ulong id = Read64(vocabulary, i);
+            for (int j = 0; j < i; j += 8)
+            { if (id == Read64(vocabulary, j)) { return false; } }
+        }
+        return true;
+    }
     static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
     public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
     {
@@ -925,12 +959,7 @@ public static partial class TableWire
         if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
         int end = bytes.Length - 8 - (int)count * 8;
         ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-        for (int i = 0; i < vocabulary.Length; i += 8)
-        {
-            ulong id = Read64(vocabulary, i);
-            for (int j = 0; j < i; j += 8)
-            { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-        }
+        if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
         Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
         if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
         if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/test/cs-tables/src/LebChecks.cs
+++ b/test/cs-tables/src/LebChecks.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using V1 = Tblv1;
+
+static partial class Program
+{
+    static void TestLebWireContracts()
+    {
+        V1.Cfg target = new V1.Cfg();
+
+        // 1. One-byte LEB field references and scalar values:
+        // Canonical 1-byte LEB reference (1) with int32 value 42.
+        byte[] oneByteWire = Fixture(new byte[] { 1, 4, 42, 0, 0, 0, 0 }, "a");
+        DirtyResetTarget(target);
+        V1.TableReport report = new V1.TableReport();
+        var verdict = V1.Schema.CfgLoadVerdict(target, oneByteWire, report);
+        Check(verdict == V1.Schema.TableWire.Verdict.Ok && !report.Malformed && target.A == 42,
+            "leb fastpath: 1-byte reference and scalar value");
+
+        // 2. Multi-byte LEB field reference (reference 128 = 0x80, 0x01):
+        // Construct a vocabulary with 128 names, where name 128 is "a".
+        string[] names128 = new string[128];
+        for (int i = 0; i < 127; i++) { names128[i] = "unused" + i; }
+        names128[127] = "a";
+        byte[] multiByteRefWire = Fixture(Join(new byte[] { 0x80, 0x01, 4 }, U32(100), new byte[] { 0 }), names128);
+        DirtyResetTarget(target);
+        report = new V1.TableReport();
+        verdict = V1.Schema.CfgLoadVerdict(target, multiByteRefWire, report);
+        Check(verdict == V1.Schema.TableWire.Verdict.Ok && !report.Malformed && target.A == 100,
+            "leb multi-byte fallback: reference 128");
+
+        // 3. Multi-byte LEB array length and element counts:
+        // Csids.WideIds has 140 elements, which crosses the 127/128 boundary on both write and read.
+        Csids.WideIds wide = new Csids.WideIds();
+        string[] wideNames = new string[141]; wideNames[0] = "words";
+        using (MemoryStream elements = new MemoryStream())
+        {
+            for (int i = 0; i < 140; i++)
+            {
+                wide.Words[i] = (Csids.Word)(i + 1);
+                wideNames[i + 1] = "V" + (i + 1).ToString("D3");
+                elements.Write(Var((ulong)i + 2));
+            }
+            byte[] payload = Join(new byte[] { 30 }, Var(140), elements.ToArray());
+            byte[] expected = Fixture(Join(new byte[] { 1, 14 }, Var((ulong)payload.Length), payload, new byte[] { 0 }), wideNames);
+            byte[] actual = new byte[expected.Length];
+            Check(Csids.Schema.WideIdsSave(wide, actual) == expected.Length && actual.AsSpan().SequenceEqual(expected),
+                "leb save: 140 elements crossing 127/128 boundary");
+            Csids.WideIds decoded = new Csids.WideIds();
+            Csids.TableReport wideReport = new Csids.TableReport();
+            Check(Csids.Schema.WideIdsLoad(decoded, expected, wideReport) && decoded.Words[139] == (Csids.Word)140,
+                "leb load: 140 elements crossing 127/128 boundary");
+        }
+
+        // 4. Non-canonical multi-byte zero rejection:
+        // [0x80, 0x00] is a 2-byte encoding of zero (redundant continuation bit).
+        report = new V1.TableReport();
+        Check(!V1.Schema.CfgLoad(target, Fixture(new byte[] { 0x80, 0x00 }), report) &&
+            report.Malformed, "leb rejection: redundant 2-byte zero [0x80, 0x00]");
+
+        // [0x80, 0x80, 0x00] is a 3-byte encoding of zero.
+        report = new V1.TableReport();
+        Check(!V1.Schema.CfgLoad(target, Fixture(new byte[] { 0x80, 0x80, 0x00 }), report) &&
+            report.Malformed, "leb rejection: redundant 3-byte zero [0x80, 0x80, 0x00]");
+
+        // 5. Truncated LEB rejection:
+        // [0x80] at EOF has continuation set with no following byte.
+        report = new V1.TableReport();
+        Check(!V1.Schema.CfgLoad(target, Fixture(new byte[] { 0x80 }), report) &&
+            report.Malformed, "leb rejection: truncated LEB [0x80] at EOF");
+
+        // 6. 10th-byte overflow rejection:
+        // 10 bytes with b > 1 on the 10th byte (overflows uint64):
+        byte[] overflowLeb = new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02 };
+        report = new V1.TableReport();
+        Check(!V1.Schema.CfgLoad(target, Fixture(overflowLeb), report) &&
+            report.Malformed, "leb rejection: 10th byte overflow");
+
+        // 7. Allocation check across 1-byte fastpath and multi-byte paths:
+        for (int i = 0; i < 1000; i++)
+        {
+            V1.Schema.CfgLoadVerdict(target, oneByteWire, report);
+            V1.Schema.CfgLoadVerdict(target, multiByteRefWire, report);
+        }
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 5000; i++)
+        {
+            V1.Schema.CfgLoadVerdict(target, oneByteWire, report);
+            V1.Schema.CfgLoadVerdict(target, multiByteRefWire, report);
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Check(allocated == 0, "leb load paths allocate zero bytes after warmup: " + allocated);
+    }
+}

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -1761,6 +1761,7 @@ static partial class Program
         goldenDir = FindGoldenDir();
 
         TestWireContracts();
+        TestVocabularyDistinctness();
         TestRootPayloadSizes();
         TestRootReset();
         TestUnionContracts();

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -1762,6 +1762,7 @@ static partial class Program
 
         TestWireContracts();
         TestVocabularyDistinctness();
+        TestLebWireContracts();
         TestRootPayloadSizes();
         TestRootReset();
         TestUnionContracts();

--- a/test/cs-tables/src/VocabularyDistinctnessChecks.cs
+++ b/test/cs-tables/src/VocabularyDistinctnessChecks.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using V1 = Tblv1;
+
+static partial class Program
+{
+    static byte[] VocabularyFixture(ulong[] ids)
+    {
+        byte[] bytes = new byte[10 + ids.Length * 8];
+        bytes[0] = 1; // form 1; byte 1 is the empty body's terminator
+        for (int i = 0; i < ids.Length; i++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(2 + i * 8), ids[i]);
+        }
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(bytes.Length - 8), (ulong)ids.Length);
+        return bytes;
+    }
+
+    static void TestVocabularyDistinctness()
+    {
+        V1.Cfg target = new V1.Cfg();
+        void CheckIds(ulong[] ids, string label)
+        {
+            // The expected verdict comes from an independent set, including
+            // unused and zero identities; no generated hash is the oracle.
+            bool distinct = new HashSet<ulong>(ids).Count == ids.Length;
+            byte[] wire = VocabularyFixture(ids);
+            byte[] padded = new byte[wire.Length + 5];
+            wire.CopyTo(padded, 3);
+            DirtyResetTarget(target);
+            V1.TableReport report = new V1.TableReport();
+            var expected = distinct ? V1.Schema.TableWire.Verdict.Ok : V1.Schema.TableWire.Verdict.Damaged;
+            var verdict = V1.Schema.CfgLoadVerdict(target, padded.AsSpan(3, wire.Length), report);
+            Check(verdict == expected && report.Verdict == expected && report.Malformed == !distinct &&
+                !report.Refused && report.Reason == null && report.Unknown == 0 && report.KindMismatch == 0 &&
+                report.Clamped == 0 && report.Widened == 0 && report.Duplicate == 0,
+                "vocabulary verdict and report: " + label);
+            Check(ResetTargetDefaults(target, 5), "vocabulary preserves root defaults: " + label);
+            Check(padded.AsSpan(3, wire.Length).SequenceEqual(wire), "vocabulary never mutates input: " + label);
+        }
+
+        foreach (int count in new int[] { 0, 1, 2, 8, 15, 16, 17, 127, 128, 255, 256, 257, 512, 1025 })
+        {
+            ulong[] ids = new ulong[count];
+            for (int i = 0; i < count; i++) { ids[i] = (ulong)i; }
+            if (count > 1) { ids[1] = ulong.MaxValue; }
+            CheckIds(ids, "distinct count " + count);
+            if (count > 1)
+            {
+                ids[count - 1] = ids[0];
+                CheckIds(ids, "duplicate zero at end count " + count);
+                ids[0] = ulong.MaxValue;
+                ids[count - 1] = ulong.MaxValue;
+                CheckIds(ids, "duplicate maximum identity count " + count);
+            }
+        }
+
+        // Force the maximum fast-path probe chain, crossing slot 511 to zero.
+        // The arithmetic only selects stress inputs; HashSet still supplies
+        // the verdict. A collision must never be mistaken for a duplicate.
+        ulong[] collisions = new ulong[256];
+        for (ulong id = 0, found = 0; found < (ulong)collisions.Length; id++)
+        {
+            if ((unchecked(id * 0x9e3779b97f4a7c15ul) >> 55) == 511)
+            {
+                collisions[(int)found++] = id;
+            }
+        }
+        CheckIds(collisions, "256 distinct identities in one bucket with wraparound");
+        collisions[255] = collisions[254];
+        CheckIds(collisions, "duplicate after longest probe chain");
+
+        Random random = new Random(731049);
+        byte[] randomBytes = new byte[8];
+        for (int sample = 0; sample < 300; sample++)
+        {
+            ulong[] ids = new ulong[random.Next(0, 400)];
+            for (int i = 0; i < ids.Length; i++)
+            {
+                random.NextBytes(randomBytes);
+                ids[i] = BinaryPrimitives.ReadUInt64LittleEndian(randomBytes);
+            }
+            if (ids.Length > 1 && sample % 2 == 0)
+            {
+                int first = random.Next(ids.Length - 1);
+                ids[random.Next(first + 1, ids.Length)] = ids[first];
+            }
+            CheckIds(ids, "independent randomized set " + sample);
+        }
+
+        byte[] valid = VocabularyFixture(new ulong[16]);
+        for (int i = 0; i < 16; i++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(valid.AsSpan(2 + i * 8), (ulong)i);
+        }
+        byte[] forgedCount = (byte[])valid.Clone();
+        BinaryPrimitives.WriteUInt64LittleEndian(forgedCount.AsSpan(forgedCount.Length - 8), ulong.MaxValue);
+        DirtyResetTarget(target);
+        V1.TableReport forgedReport = new V1.TableReport();
+        Check(V1.Schema.CfgLoadVerdict(target, forgedCount, forgedReport) == V1.Schema.TableWire.Verdict.Damaged &&
+            forgedReport.Malformed && !forgedReport.Refused && ResetTargetDefaults(target, 5),
+            "forged maximum vocabulary count is rejected before indexing or hashing");
+        V1.TableReport allocationReport = new V1.TableReport();
+        for (int i = 0; i < 1000; i++) { V1.Schema.CfgLoadVerdict(target, valid, allocationReport); }
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        bool allValid = true;
+        for (int i = 0; i < 1000; i++)
+        {
+            allValid &= V1.Schema.CfgLoadVerdict(target, valid, allocationReport) == V1.Schema.TableWire.Verdict.Ok;
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Check(allValid && allocated == 0, "vocabulary validation allocates zero bytes after warmup: " + allocated);
+    }
+}

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -2700,6 +2700,7 @@ namespace Blockdemo
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2733,6 +2734,16 @@ namespace Blockdemo
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -4741,6 +4741,40 @@ namespace Blockdemo
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4759,12 +4793,7 @@ namespace Blockdemo
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -4625,6 +4625,40 @@ namespace Blockhome
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4643,12 +4677,7 @@ namespace Blockhome
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -2584,6 +2584,7 @@ namespace Blockhome
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2617,6 +2618,16 @@ namespace Blockhome
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -4741,6 +4741,40 @@ namespace Tabledemo
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4759,12 +4793,7 @@ namespace Tabledemo
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -2700,6 +2700,7 @@ namespace Tabledemo
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2733,6 +2734,16 @@ namespace Tabledemo
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -2584,6 +2584,7 @@ namespace Wide
                 }
                 public void Var(ulong v)
                 {
+                    if (v < 128) { Byte((byte)v); return; }
                     while (v >= 128) { Byte((byte)(v | 128)); v >>= 7; }
                     Byte((byte)v);
                 }
@@ -2617,6 +2618,16 @@ namespace Wide
                 }
                 public bool Var(out ulong v)
                 {
+                    if ((uint)Offset < (uint)Buffer.Length)
+                    {
+                        byte b0 = Buffer[Offset];
+                        if (b0 < 128)
+                        {
+                            Offset++;
+                            v = b0;
+                            return true;
+                        }
+                    }
                     v = 0;
                     int start = Offset;
                     for (int i = 0; i < 10; i++)

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -4625,6 +4625,40 @@ namespace Wide
                     if (field.Optional && placed) { field.SetPresent(value, true); }
                 }
             }
+            static bool DistinctVocabulary(ReadOnlySpan<byte> vocabulary)
+            {
+                int count = vocabulary.Length / 8;
+                if (count >= 16 && count <= 256)
+                {
+                    // One KiB, independent of the input's claimed count. Slots store
+                    // ordinal+1, so the identity zero remains an ordinary identity.
+                    // At most 256 entries occupy 512 slots: even deliberately colliding
+                    // identities reach an empty slot after at most 256 occupied probes.
+                    Span<ushort> slots = stackalloc ushort[512];
+                    slots.Clear();
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong id = Read64(vocabulary, i * 8);
+                        int slot = (int)(unchecked(id * 0x9e3779b97f4a7c15ul) >> 55);
+                        while (slots[slot] != 0)
+                        {
+                            if (id == Read64(vocabulary, (slots[slot] - 1) * 8)) { return false; }
+                            slot = (slot + 1) & 511;
+                        }
+                        slots[slot] = (ushort)(i + 1);
+                    }
+                    return true;
+                }
+                // Tiny vocabularies avoid scratch initialization. Larger foreign
+                // vocabularies keep the existing allocation-free validation path.
+                for (int i = 0; i < vocabulary.Length; i += 8)
+                {
+                    ulong id = Read64(vocabulary, i);
+                    for (int j = 0; j < i; j += 8)
+                    { if (id == Read64(vocabulary, j)) { return false; } }
+                }
+                return true;
+            }
             static Verdict Finish(TableReport report, Verdict verdict) { report.Verdict = verdict; return verdict; }
             public static Verdict Load(object value, TableTypeInfo type, ReadOnlySpan<byte> bytes, TableReport report)
             {
@@ -4643,12 +4677,7 @@ namespace Wide
                 if (count > (ulong)(bytes.Length - 9) / 8) { Damage(report); return Finish(report, Verdict.Damaged); }
                 int end = bytes.Length - 8 - (int)count * 8;
                 ReadOnlySpan<byte> vocabulary = bytes.Slice(end, (int)count * 8);
-                for (int i = 0; i < vocabulary.Length; i += 8)
-                {
-                    ulong id = Read64(vocabulary, i);
-                    for (int j = 0; j < i; j += 8)
-                    { if (id == Read64(vocabulary, j)) { Damage(report); return Finish(report, Verdict.Damaged); } }
-                }
+                if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 Reader r = new Reader(bytes.Slice(1, end - 1), vocabulary);
                 if (EndsEarly(r)) { Damage(report); return Finish(report, Verdict.Damaged); }
                 if (type.Variable) { if (LoadMeasure(type, bytes, out _) < 0) { Damage(report); return Finish(report, Verdict.Damaged); } r.Graph = ReadGraph(r, value, type, report); }

--- a/tools/sabotage/table_cs.go
+++ b/tools/sabotage/table_cs.go
@@ -10,8 +10,10 @@ func init() {
 		new: `extent=checked(extent+(long)count*f.NativeElementSize); if(w.Bytes==null && count>0) { extent--; } // SABOTAGED: the probe consumes one byte too few`,
 	}}
 	sabotages["table-cs-duplicate-ids"] = []edit{{
-		old: `if (id == Read64(vocabulary, j))`,
-		new: `if (id == Read64(vocabulary, j) && report.Refused) /* SABOTAGED: duplicate identities pass */`,
+		// Target Load's verdict, where report lives, rather than a comparison
+		// inside the vocabulary helper's small or hashed validation path.
+		old: `if (!DistinctVocabulary(vocabulary)) { Damage(report); return Finish(report, Verdict.Damaged); }`,
+		new: `if (!DistinctVocabulary(vocabulary) && report.Refused) { Damage(report); return Finish(report, Verdict.Damaged); } /* SABOTAGED: duplicate identities pass */`,
 	}}
 	sabotages["table-cs-json-field"] = []edit{{
 		old: `TableFieldInfo f = info.Fields[index];`,


### PR DESCRIPTION
Fixed Table loads repeatedly validate the vocabulary and decode short LEB values. This change uses a bounded stack index for eligible vocabularies and handles one-byte LEB values directly in the reader and writer. It preserves the wire format, reports, reused-target behavior and zero-allocation contract, retaining the existing fallback paths.

Independent source review found no correctness blocker. Debug and Release table suites, zero-allocation assertions, emitter/golden checks, and the matched C# Packet/Table gates pass. The paired C++ oracle verifies all 64 logical records. After integration onto current main, all 542 C# source/test/generated hashes match the tested version and the paired gates pass again. Performance measurement remains pending; no speedup is claimed here.

Includes Stella's vocabulary-reader checkpoint and Emma's LEB change, with original authorship retained. Review/integration head: e56d2dade76bc0ca0d490f4e0efab79fa89fe7a6.
