### PR TITLE
C++ Fixed Table: reuse known enum ordinals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4610,14 +4610,15 @@ tables-ref-ordinal-negative-control:
 	@echo "negative control: a truncate that leaves the ordinal slot standing names a POPPED entry — the file stops round-tripping"
 
 # THE SECOND HALF OF THE SAME RULE. An id can be interned by the GENERAL path
-# first — an enum-keyed array interns its key before it measures the slot's
-# element, and a field's wire id is the same hash as a variant of the same name
-# — so the ref_at that follows only HITS. Record the ordinal on the miss alone
-# and truncate has nothing to clear when that slot elides: the next slot's
-# field header answers out of a stale cache and names the entry the popped one
-# was replaced by, which is the following KEY. The file stays self-consistent
-# and the value is silently gone, so compiler/tablerefordinal_test.go's
-# shared-id driver is what has to go RED.
+# first, so the ref_at that follows finds an existing entry. The shared-id
+# driver runs the emitted enum helper and a test-local copy that restores its
+# shared key to generic ref; enums now use their known ordinals in production.
+# Both copies use the same schema and values. Record the ordinal on the miss
+# alone and truncate has nothing to clear in the generic-key copy when that
+# slot elides: the next slot's field header answers out of a stale cache and
+# names the entry the popped one was replaced by, which is the following KEY.
+# The file stays self-consistent and the value is silently gone, so
+# compiler/tablerefordinal_test.go's generic-key driver must go RED.
 .PHONY: tables-ref-ordinal-shared-negative-control
 tables-ref-ordinal-shared-negative-control:
 	@rm -rf build/ref-ordinal-shared-nc && mkdir -p build/ref-ordinal-shared-nc
@@ -4636,7 +4637,7 @@ tables-ref-ordinal-shared-negative-control:
 		{ echo "NEGATIVE CONTROL FAILED: the driver went red, but not on the shared id"; \
 		  cat build/ref-ordinal-shared-nc/log; exit 1; }
 	@grep -m1 "VALUES MOVED" build/ref-ordinal-shared-nc/log
-	@echo "negative control: an ordinal recorded on the MISS alone loses the field an eliding keyed slot shares its id with"
+	@echo "negative control: an ordinal recorded on the MISS alone loses the field an eliding generic-key slot shares its id with"
 
 # THE C++ RELEASE GATE: the wire fuzzer at a long random pass, both builds,
 # and the retention leg beside it at the same length (docs/SPEC-TABLES.md

--- a/compiler/tablerefordinal_test.go
+++ b/compiler/tablerefordinal_test.go
@@ -151,7 +151,7 @@ static void build( Outer & v, int32_t many_count, int32_t few_count, int banks_s
         v.banks[ Slot::High ].z = 22;
         set_wide( v.banks[ Slot::Mid ].leaf, 130, 23 );
     }
-    // the union arm's own id, and an enum variant's, which stays on ref
+    // the union arm's own id and an enum variant's both use their known ordinal
     if ( many_count % 2 == 0 )
     {
         v.pick.type = PickType::Alpha;
@@ -332,12 +332,14 @@ func TestCppTableRefOrdinalBytes(t *testing.T) {
 // spells one name in both places gives ONE id and ordinal to two call sites:
 // the field header and TableEnumRef's switch on a runtime value.
 //
-// An enum-keyed array interns its key before it measures the slot's element,
-// and the ref_at that follows only HITS. Without a recorded ordinal, truncate
-// would have nothing to clear when the slot elides, and the NEXT slot's field
-// header would answer out of a stale cache: it would name the entry the popped
-// one was replaced by, which is the following KEY. The file stays
-// self-consistent and the value is silently gone.
+// An enum-keyed array interns its key before it measures the slot's element.
+// The enum helper now uses ref_at too. Run the same driver against the emitted
+// header and a test-local copy whose shared enum key uses generic ref, keeping
+// the original generic-ref/ref_at interaction covered. In that copy, the field's
+// ref_at finds an existing entry and must record its ordinal for truncate.
+// Without that record, the NEXT slot's field header would answer out of a stale
+// cache: it would name the entry the popped one was replaced by, which is the
+// following KEY. The file stays self-consistent and the value is silently gone.
 //
 // The schema below is the smallest shape that reaches it: an enum-keyed array
 // whose key `alpha` is also the name of the element's only field, one slot
@@ -417,7 +419,8 @@ int main()
 `
 
 // TestCppTableRefOrdinalSharedId checks that a key and field sharing one ID
-// share its cached ordinal and remain correct across elision and re-interning.
+// share its cached ordinal and remain correct across elision and re-interning,
+// both when the key uses its ordinal and when generic ref interns it first.
 func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
@@ -438,9 +441,15 @@ func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	header := string(files["ProbeTable.h"])
 	const shared = "0x8ac625bb85ed202bull" // TableWireId( "alpha" )
 	call := "ids.ref_at( 5, " + shared + " )"
-	if strings.Count(header, call) < 2 || !strings.Contains(header, "case Tag::alpha: ref = "+call+"; return true;") {
+	enumCall := "case Tag::alpha: ref = " + call + "; return true;"
+	if strings.Count(header, call) < 2 || strings.Count(header, enumCall) != 1 {
 		t.Fatalf("the schema no longer gives one id both a field header and an enum variant: this test would prove nothing")
 	}
+	// Restore only the existing driver's shared key to its old generic path in
+	// this test-local header. The exactly-one check above prevents a stale
+	// replacement from silently dropping the generic-ref/ref_at coverage.
+	genericHeader := strings.Replace(header, enumCall,
+		"case Tag::alpha: ref = ids.ref( "+shared+" ); return true;", 1)
 	// the driver must live BESIDE the header: an #include "..." searches the
 	// including file's own directory first, and a driver written elsewhere
 	// would quietly compile against some other tree's copy
@@ -448,17 +457,27 @@ func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	if err := os.WriteFile(main, []byte(refOrdinalCollisionDriver), 0600); err != nil {
 		t.Fatal(err)
 	}
-	bin := filepath.Join(dir, "collide")
-	args := []string{
-		"-std=c++17", "-O2", "-DNDEBUG", "-Wall", "-Wextra", "-Werror", "-Wshadow",
-		"-ffp-contract=off", "-I", dir, main, "-o", bin,
+	for _, setup := range []struct{ name, header string }{
+		{"enum-ordinal", header},
+		{"generic-key", genericHeader},
+	} {
+		t.Run(setup.name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, "ProbeTable.h"), []byte(setup.header), 0600); err != nil {
+				t.Fatal(err)
+			}
+			bin := filepath.Join(dir, "collide-"+setup.name)
+			args := []string{
+				"-std=c++17", "-O2", "-DNDEBUG", "-Wall", "-Wextra", "-Werror", "-Wshadow",
+				"-ffp-contract=off", "-I", dir, main, "-o", bin,
+			}
+			if out, err := exec.Command(cxx, args...).CombinedOutput(); err != nil {
+				t.Fatalf("compile: %v\n%s", err, out)
+			}
+			out, err := exec.Command(bin).CombinedOutput()
+			if err != nil {
+				t.Fatalf("a shared key/field id is not undone by truncate: %v\n%s", err, out)
+			}
+			t.Logf("%s", strings.TrimSpace(string(out)))
+		})
 	}
-	if out, err := exec.Command(cxx, args...).CombinedOutput(); err != nil {
-		t.Fatalf("compile: %v\n%s", err, out)
-	}
-	out, err := exec.Command(bin).CombinedOutput()
-	if err != nil {
-		t.Fatalf("a shared key/field id is not undone by truncate: %v\n%s", err, out)
-	}
-	t.Logf("%s", strings.TrimSpace(string(out)))
 }

--- a/compiler/tablerefordinal_test.go
+++ b/compiler/tablerefordinal_test.go
@@ -24,11 +24,10 @@
 //   - AN ENUM-KEYED ARRAY OF TABLES, held at every shape: all slots default
 //     (pairs == 0, the whole field elides after interning its own id and its
 //     keys), some slots default (a per-slot truncate inside a field that does
-//     ride) and none default. The keyed truncate is the one that pops a key
-//     interned through the general path beside elements interned through the
-//     cache, so both kinds of entry are popped in one call;
-//   - A UNION FIELD, whose arm name is a compile-time id of its own, and an
-//     ENUM FIELD, whose variant id is a RUNTIME value and stays on ref;
+//     ride) and none default. A keyed truncate pops cached key and field
+//     references together;
+//   - A UNION FIELD and an ENUM FIELD, whose selected arms each name a
+//     compile-time id and use that id's ordinal;
 //   - A NESTED TABLE OF 140 FIELDS, so the id table crosses 127 entries part
 //     way through the array and a reference's LEB128 spelling grows from one
 //     byte to two WHILE the elements are being written. A cache that answered
@@ -276,10 +275,9 @@ func TestCppTableRefOrdinalBytes(t *testing.T) {
 				t.Fatalf("the generated save path does not carry %q — this test would prove nothing", want)
 			}
 		}
-		// and the RUNTIME ids must still reach the general path: an enum's
-		// variant is a value, not a compile-time constant of the header
-		if !strings.Contains(header, "ids.ref( 0x") {
-			t.Fatal("no general-path ref survives: the enum identity's variant ids must not be cached by ordinal")
+		// Selection is dynamic, but the selected switch arm has a known ID.
+		if !strings.Contains(header, "case Slot::Low: ref = ids.ref_at(") {
+			t.Fatal("the enum switch does not use its known variant ordinal")
 		}
 	}
 	main := filepath.Join(dir, "main.cpp")
@@ -331,12 +329,11 @@ func TestCppTableRefOrdinalBytes(t *testing.T) {
 
 // AN ID BOTH PATHS CAN REACH (docs/SPEC-TABLES.md §3, §5). A field's wire id
 // and an enum variant's are the same hash over the same name, so a schema that
-// spells one name in both places gives ONE id two call sites: ref_at, from the
-// field header, and ref, from TableEnumRef's switch on a runtime value.
+// spells one name in both places gives ONE id and ordinal to two call sites:
+// the field header and TableEnumRef's switch on a runtime value.
 //
-// That id can therefore be interned by ref FIRST — an enum-keyed array interns
-// its key before it measures the slot's element — and the ref_at that follows
-// only HITS. If the hit did not record the ordinal beside the entry, truncate
+// An enum-keyed array interns its key before it measures the slot's element,
+// and the ref_at that follows only HITS. Without a recorded ordinal, truncate
 // would have nothing to clear when the slot elides, and the NEXT slot's field
 // header would answer out of a stale cache: it would name the entry the popped
 // one was replaced by, which is the following KEY. The file stays
@@ -419,9 +416,8 @@ int main()
 }
 `
 
-// TestCppTableRefOrdinalSharedId holds ref_at to recording the ordinal on the
-// HIT path as well as the miss, which is what lets truncate undo a cache entry
-// for an id the general path interned first.
+// TestCppTableRefOrdinalSharedId checks that a key and field sharing one ID
+// share its cached ordinal and remain correct across elision and re-interning.
 func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
@@ -441,7 +437,8 @@ func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	// exists for is not in the header at all
 	header := string(files["ProbeTable.h"])
 	const shared = "0x8ac625bb85ed202bull" // TableWireId( "alpha" )
-	if !strings.Contains(header, "ids.ref_at( 5, "+shared+" )") || !strings.Contains(header, "ids.ref( "+shared+" )") {
+	call := "ids.ref_at( 5, " + shared + " )"
+	if strings.Count(header, call) < 2 || !strings.Contains(header, "case Tag::alpha: ref = "+call+"; return true;") {
 		t.Fatalf("the schema no longer gives one id both a field header and an enum variant: this test would prove nothing")
 	}
 	// the driver must live BESIDE the header: an #include "..." searches the
@@ -461,7 +458,7 @@ func TestCppTableRefOrdinalSharedId(t *testing.T) {
 	}
 	out, err := exec.Command(bin).CombinedOutput()
 	if err != nil {
-		t.Fatalf("an id the general path interned first is not undone by truncate: %v\n%s", err, out)
+		t.Fatalf("a shared key/field id is not undone by truncate: %v\n%s", err, out)
 	}
 	t.Logf("%s", strings.TrimSpace(string(out)))
 }

--- a/generated/bench/paired/cpp/BenchTable.h
+++ b/generated/bench/paired/cpp/BenchTable.h
@@ -2378,21 +2378,21 @@ inline bool TableEnumRef( TableIds & ids, MixedWeapon value, uint64_t & ref )
     switch ( value )
     {
         case MixedWeapon::None: ref = 0; return true;
-        case MixedWeapon::Fists: ref = ids.ref( 0xa790eee12766cf0cull ); return true;
-        case MixedWeapon::Pistol: ref = ids.ref( 0x9fbfefa835da8476ull ); return true;
-        case MixedWeapon::Shotgun: ref = ids.ref( 0x188bbb1783928a95ull ); return true;
-        case MixedWeapon::Rifle: ref = ids.ref( 0x2c3667b9c2f272f1ull ); return true;
-        case MixedWeapon::Sniper: ref = ids.ref( 0x0ca8b41b00d755f6ull ); return true;
-        case MixedWeapon::Smg: ref = ids.ref( 0x985fc819fab21a4eull ); return true;
-        case MixedWeapon::Rocket: ref = ids.ref( 0x229d0447c3086a55ull ); return true;
-        case MixedWeapon::Grenade: ref = ids.ref( 0x011c7b49a7228f9dull ); return true;
-        case MixedWeapon::Plasma: ref = ids.ref( 0x89f7566e1123e15full ); return true;
-        case MixedWeapon::Railgun: ref = ids.ref( 0x8d7f25318b3b4469ull ); return true;
-        case MixedWeapon::Flamer: ref = ids.ref( 0xd9cd0dcc285b7816ull ); return true;
-        case MixedWeapon::Mine: ref = ids.ref( 0x04dc16aea8ff5276ull ); return true;
-        case MixedWeapon::Turret: ref = ids.ref( 0x35e53bc341129217ull ); return true;
-        case MixedWeapon::Drone: ref = ids.ref( 0x2cc8282fb0de8831ull ); return true;
-        case MixedWeapon::Repair: ref = ids.ref( 0x20bada21bc8cb334ull ); return true;
+        case MixedWeapon::Fists: ref = ids.ref_at( 55, 0xa790eee12766cf0cull ); return true;
+        case MixedWeapon::Pistol: ref = ids.ref_at( 51, 0x9fbfefa835da8476ull ); return true;
+        case MixedWeapon::Shotgun: ref = ids.ref_at( 8, 0x188bbb1783928a95ull ); return true;
+        case MixedWeapon::Rifle: ref = ids.ref_at( 12, 0x2c3667b9c2f272f1ull ); return true;
+        case MixedWeapon::Sniper: ref = ids.ref_at( 3, 0x0ca8b41b00d755f6ull ); return true;
+        case MixedWeapon::Smg: ref = ids.ref_at( 45, 0x985fc819fab21a4eull ); return true;
+        case MixedWeapon::Rocket: ref = ids.ref_at( 10, 0x229d0447c3086a55ull ); return true;
+        case MixedWeapon::Grenade: ref = ids.ref_at( 0, 0x011c7b49a7228f9dull ); return true;
+        case MixedWeapon::Plasma: ref = ids.ref_at( 41, 0x89f7566e1123e15full ); return true;
+        case MixedWeapon::Railgun: ref = ids.ref_at( 42, 0x8d7f25318b3b4469ull ); return true;
+        case MixedWeapon::Flamer: ref = ids.ref_at( 69, 0xd9cd0dcc285b7816ull ); return true;
+        case MixedWeapon::Mine: ref = ids.ref_at( 2, 0x04dc16aea8ff5276ull ); return true;
+        case MixedWeapon::Turret: ref = ids.ref_at( 17, 0x35e53bc341129217ull ); return true;
+        case MixedWeapon::Drone: ref = ids.ref_at( 13, 0x2cc8282fb0de8831ull ); return true;
+        case MixedWeapon::Repair: ref = ids.ref_at( 9, 0x20bada21bc8cb334ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -2446,21 +2446,21 @@ inline bool TableEnumRef( TableIds & ids, TableWeapon value, uint64_t & ref )
     switch ( value )
     {
         case TableWeapon::None: ref = 0; return true;
-        case TableWeapon::Fists: ref = ids.ref( 0xa790eee12766cf0cull ); return true;
-        case TableWeapon::Pistol: ref = ids.ref( 0x9fbfefa835da8476ull ); return true;
-        case TableWeapon::Shotgun: ref = ids.ref( 0x188bbb1783928a95ull ); return true;
-        case TableWeapon::Rifle: ref = ids.ref( 0x2c3667b9c2f272f1ull ); return true;
-        case TableWeapon::Sniper: ref = ids.ref( 0x0ca8b41b00d755f6ull ); return true;
-        case TableWeapon::Smg: ref = ids.ref( 0x985fc819fab21a4eull ); return true;
-        case TableWeapon::Rocket: ref = ids.ref( 0x229d0447c3086a55ull ); return true;
-        case TableWeapon::Grenade: ref = ids.ref( 0x011c7b49a7228f9dull ); return true;
-        case TableWeapon::Plasma: ref = ids.ref( 0x89f7566e1123e15full ); return true;
-        case TableWeapon::Railgun: ref = ids.ref( 0x8d7f25318b3b4469ull ); return true;
-        case TableWeapon::Flamer: ref = ids.ref( 0xd9cd0dcc285b7816ull ); return true;
-        case TableWeapon::Mine: ref = ids.ref( 0x04dc16aea8ff5276ull ); return true;
-        case TableWeapon::Turret: ref = ids.ref( 0x35e53bc341129217ull ); return true;
-        case TableWeapon::Drone: ref = ids.ref( 0x2cc8282fb0de8831ull ); return true;
-        case TableWeapon::Repair: ref = ids.ref( 0x20bada21bc8cb334ull ); return true;
+        case TableWeapon::Fists: ref = ids.ref_at( 57, 0xa790eee12766cf0cull ); return true;
+        case TableWeapon::Pistol: ref = ids.ref_at( 53, 0x9fbfefa835da8476ull ); return true;
+        case TableWeapon::Shotgun: ref = ids.ref_at( 8, 0x188bbb1783928a95ull ); return true;
+        case TableWeapon::Rifle: ref = ids.ref_at( 13, 0x2c3667b9c2f272f1ull ); return true;
+        case TableWeapon::Sniper: ref = ids.ref_at( 3, 0x0ca8b41b00d755f6ull ); return true;
+        case TableWeapon::Smg: ref = ids.ref_at( 48, 0x985fc819fab21a4eull ); return true;
+        case TableWeapon::Rocket: ref = ids.ref_at( 10, 0x229d0447c3086a55ull ); return true;
+        case TableWeapon::Grenade: ref = ids.ref_at( 0, 0x011c7b49a7228f9dull ); return true;
+        case TableWeapon::Plasma: ref = ids.ref_at( 44, 0x89f7566e1123e15full ); return true;
+        case TableWeapon::Railgun: ref = ids.ref_at( 45, 0x8d7f25318b3b4469ull ); return true;
+        case TableWeapon::Flamer: ref = ids.ref_at( 69, 0xd9cd0dcc285b7816ull ); return true;
+        case TableWeapon::Mine: ref = ids.ref_at( 2, 0x04dc16aea8ff5276ull ); return true;
+        case TableWeapon::Turret: ref = ids.ref_at( 19, 0x35e53bc341129217ull ); return true;
+        case TableWeapon::Drone: ref = ids.ref_at( 14, 0x2cc8282fb0de8831ull ); return true;
+        case TableWeapon::Repair: ref = ids.ref_at( 9, 0x20bada21bc8cb334ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -572,10 +572,9 @@ func (g *tableGen) emitEnumIdentity(e *ir.Enum) {
 	g.pf("    switch ( value )\n    {\n")
 	g.pf("        case %s::None: ref = 0; return true;\n", e.Name)
 	for i, v := range e.Variants {
-		// A VARIANT'S ID IS CHOSEN BY A VALUE, not by the header: the caller
-		// hands a runtime enum and this switch picks the id, so there is no
-		// one ordinal a call site could carry and the general path stands (§3, §5).
-		g.pf("        case %s::%s: ref = %s; return true;\n", e.Name, v, g.wireRefRuntime(ir.TableWireId(e.VariantWireName(i))))
+		// The switch chooses the variant at runtime, but each arm names one
+		// constant ID and can use that ID's known ordinal like a field header.
+		g.pf("        case %s::%s: ref = %s; return true;\n", e.Name, v, g.wireRef(ir.TableWireId(e.VariantWireName(i))))
 	}
 	g.pf("        default: return false; // no variant names this value: no wire identity\n")
 	g.pf("    }\n}\n")
@@ -588,7 +587,7 @@ func (g *tableGen) emitEnumIdentity(e *ir.Enum) {
 		g.pf("    switch ( value )\n    {\n")
 		g.pf("        case %s::None: ref = 0; return true;\n", e.Name)
 		for i, v := range e.Variants {
-			g.pf("        case %s::%s: ref = %s; return true;\n", e.Name, v, g.wireRefRuntime(ir.TableWireId(e.VariantWireName(i))))
+			g.pf("        case %s::%s: ref = %s; return true;\n", e.Name, v, g.wireRef(ir.TableWireId(e.VariantWireName(i))))
 		}
 		g.pf("        default: return false;\n")
 		g.pf("    }\n}\n")

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -258,14 +258,6 @@ func (g *tableGen) wireRef(id uint64) string {
 	return fmt.Sprintf("ids.ref_at( %d, 0x%016xull )", g.knownOrdinal(id), id)
 }
 
-// wireRefRuntime is the general path, for an id the header cannot spell as a
-// constant: an ENUM VARIANT's, which is chosen by a value at run time. It has
-// an ordinal like any other id in the vocabulary, but no call site with one
-// number to hand, so it interns the way it always did.
-func (g *tableGen) wireRefRuntime(id uint64) string {
-	return fmt.Sprintf("ids.ref( 0x%016xull )", id)
-}
-
 // wireIdOrdinals is the unit's id vocabulary as id -> ordinal. It is the same
 // ascending set TableIds::kCapacity counts and the retain family's
 // kTableRetainKnown lists (docs/SPEC-TABLES.md §3, §6.6).

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -2524,10 +2524,10 @@ inline bool TableEnumRef( TableIds & ids, Team value, uint64_t & ref )
     switch ( value )
     {
         case Team::None: ref = 0; return true;
-        case Team::Red: ref = ids.ref( 0x9ff1de19feac1b7cull ); return true;
-        case Team::Blue: ref = ids.ref( 0xecf3d3a7c1693e2dull ); return true;
-        case Team::Green: ref = ids.ref( 0xcf00d78fd5953f1cull ); return true;
-        case Team::Gold: ref = ids.ref( 0xc416c97e0d3218b3ull ); return true;
+        case Team::Red: ref = ids.ref_at( 46, 0x9ff1de19feac1b7cull ); return true;
+        case Team::Blue: ref = ids.ref_at( 80, 0xecf3d3a7c1693e2dull ); return true;
+        case Team::Green: ref = ids.ref_at( 69, 0xcf00d78fd5953f1cull ); return true;
+        case Team::Gold: ref = ids.ref_at( 63, 0xc416c97e0d3218b3ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -2634,9 +2634,9 @@ inline bool TableEnumRef( TableIds & ids, ShipType value, uint64_t & ref )
     switch ( value )
     {
         case ShipType::None: ref = 0; return true;
-        case ShipType::Fighter: ref = ids.ref( 0xd011f7c3c15285c2ull ); return true;
-        case ShipType::Bomber: ref = ids.ref( 0xa8216aa1c554cb8aull ); return true;
-        case ShipType::Freighter: ref = ids.ref( 0x6c2321a3d00e23dbull ); return true;
+        case ShipType::Fighter: ref = ids.ref_at( 71, 0xd011f7c3c15285c2ull ); return true;
+        case ShipType::Bomber: ref = ids.ref_at( 49, 0xa8216aa1c554cb8aull ); return true;
+        case ShipType::Freighter: ref = ids.ref_at( 33, 0x6c2321a3d00e23dbull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2697,10 +2697,10 @@ inline bool TableEnumRef( TableIds & ids, Team value, uint64_t & ref )
     switch ( value )
     {
         case Team::None: ref = 0; return true;
-        case Team::Red: ref = ids.ref( 0x9ff1de19feac1b7cull ); return true;
-        case Team::Blue: ref = ids.ref( 0xecf3d3a7c1693e2dull ); return true;
-        case Team::Green: ref = ids.ref( 0xcf00d78fd5953f1cull ); return true;
-        case Team::Gold: ref = ids.ref( 0xc416c97e0d3218b3ull ); return true;
+        case Team::Red: ref = ids.ref_at( 46, 0x9ff1de19feac1b7cull ); return true;
+        case Team::Blue: ref = ids.ref_at( 80, 0xecf3d3a7c1693e2dull ); return true;
+        case Team::Green: ref = ids.ref_at( 69, 0xcf00d78fd5953f1cull ); return true;
+        case Team::Gold: ref = ids.ref_at( 63, 0xc416c97e0d3218b3ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2765,8 +2765,8 @@ inline bool TableEnumRef( TableIds & ids, MissileType value, uint64_t & ref )
     switch ( value )
     {
         case MissileType::None: ref = 0; return true;
-        case MissileType::Seeker: ref = ids.ref( 0xf5d0a4d25a76afcaull ); return true;
-        case MissileType::Dumb: ref = ids.ref( 0x478d7972f6d9075dull ); return true;
+        case MissileType::Seeker: ref = ids.ref_at( 84, 0xf5d0a4d25a76afcaull ); return true;
+        case MissileType::Dumb: ref = ids.ref_at( 20, 0x478d7972f6d9075dull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2823,9 +2823,9 @@ inline bool TableEnumRef( TableIds & ids, PropType value, uint64_t & ref )
     switch ( value )
     {
         case PropType::None: ref = 0; return true;
-        case PropType::Rock: ref = ids.ref( 0xcaa6172bef74e234ull ); return true;
-        case PropType::Station: ref = ids.ref( 0x4f98acac2852d653ull ); return true;
-        case PropType::Beacon: ref = ids.ref( 0x7f3a7e4744ea3019ull ); return true;
+        case PropType::Rock: ref = ids.ref_at( 66, 0xcaa6172bef74e234ull ); return true;
+        case PropType::Station: ref = ids.ref_at( 24, 0x4f98acac2852d653ull ); return true;
+        case PropType::Beacon: ref = ids.ref_at( 37, 0x7f3a7e4744ea3019ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2886,8 +2886,8 @@ inline bool TableEnumRef( TableIds & ids, LaserType value, uint64_t & ref )
     switch ( value )
     {
         case LaserType::None: ref = 0; return true;
-        case LaserType::Pulse: ref = ids.ref( 0x94e8a172d8f4805eull ); return true;
-        case LaserType::Beam: ref = ids.ref( 0xa0745aa7967eeffaull ); return true;
+        case LaserType::Pulse: ref = ids.ref_at( 42, 0x94e8a172d8f4805eull ); return true;
+        case LaserType::Beam: ref = ids.ref_at( 47, 0xa0745aa7967eeffaull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2944,8 +2944,8 @@ inline bool TableEnumRef( TableIds & ids, ExplosionType value, uint64_t & ref )
     switch ( value )
     {
         case ExplosionType::None: ref = 0; return true;
-        case ExplosionType::Small: ref = ids.ref( 0x3d2cc8d952adebecull ); return true;
-        case ExplosionType::Large: ref = ids.ref( 0xc8736ef79380e634ull ); return true;
+        case ExplosionType::Small: ref = ids.ref_at( 17, 0x3d2cc8d952adebecull ); return true;
+        case ExplosionType::Large: ref = ids.ref_at( 65, 0xc8736ef79380e634ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -2605,9 +2605,9 @@ inline bool TableEnumRef( TableIds & ids, Weapon value, uint64_t & ref )
     switch ( value )
     {
         case Weapon::None: ref = 0; return true;
-        case Weapon::Cannon: ref = ids.ref( 0x5854debe3b2e767cull ); return true;
-        case Weapon::Missile: ref = ids.ref( 0xb528592e5a4583e3ull ); return true;
-        case Weapon::Mine: ref = ids.ref( 0x04dc16aea8ff5276ull ); return true;
+        case Weapon::Cannon: ref = ids.ref_at( 51, 0x5854debe3b2e767cull ); return true;
+        case Weapon::Missile: ref = ids.ref_at( 99, 0xb528592e5a4583e3ull ); return true;
+        case Weapon::Mine: ref = ids.ref_at( 3, 0x04dc16aea8ff5276ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2668,9 +2668,9 @@ inline bool TableEnumRef( TableIds & ids, Team value, uint64_t & ref )
     switch ( value )
     {
         case Team::None: ref = 0; return true;
-        case Team::Red: ref = ids.ref( 0x9ff1de19feac1b7cull ); return true;
-        case Team::Blue: ref = ids.ref( 0xecf3d3a7c1693e2dull ); return true;
-        case Team::Green: ref = ids.ref( 0xcf00d78fd5953f1cull ); return true;
+        case Team::Red: ref = ids.ref_at( 81, 0x9ff1de19feac1b7cull ); return true;
+        case Team::Blue: ref = ids.ref_at( 139, 0xecf3d3a7c1693e2dull ); return true;
+        case Team::Green: ref = ids.ref_at( 121, 0xcf00d78fd5953f1cull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2731,9 +2731,9 @@ inline bool TableEnumRef( TableIds & ids, Hull value, uint64_t & ref )
     switch ( value )
     {
         case Hull::None: ref = 0; return true;
-        case Hull::Interceptor: ref = ids.ref( 0xae61a6cbe88c2cf4ull ); return true;
-        case Hull::Gunship: ref = ids.ref( 0x334d24e1420dbc1full ); return true;
-        case Hull::Freighter: ref = ids.ref( 0x6c2321a3d00e23dbull ); return true;
+        case Hull::Interceptor: ref = ids.ref_at( 95, 0xae61a6cbe88c2cf4ull ); return true;
+        case Hull::Gunship: ref = ids.ref_at( 32, 0x334d24e1420dbc1full ); return true;
+        case Hull::Freighter: ref = ids.ref_at( 60, 0x6c2321a3d00e23dbull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -2608,9 +2608,9 @@ inline bool TableEnumRef( TableIds & ids, Difficulty value, uint64_t & ref )
     switch ( value )
     {
         case Difficulty::None: ref = 0; return true;
-        case Difficulty::Easy: ref = ids.ref( 0x483d9e6c1ccd1f9bull ); return true;
-        case Difficulty::Normal: ref = ids.ref( 0x9ff3121d30f88d52ull ); return true;
-        case Difficulty::Hard: ref = ids.ref( 0x58c7b5d87587287cull ); return true;
+        case Difficulty::Easy: ref = ids.ref_at( 44, 0x483d9e6c1ccd1f9bull ); return true;
+        case Difficulty::Normal: ref = ids.ref_at( 82, 0x9ff3121d30f88d52ull ); return true;
+        case Difficulty::Hard: ref = ids.ref_at( 52, 0x58c7b5d87587287cull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -2671,9 +2671,9 @@ inline bool TableEnumRef( TableIds & ids, ShipType value, uint64_t & ref )
     switch ( value )
     {
         case ShipType::None: ref = 0; return true;
-        case ShipType::Fighter: ref = ids.ref( 0xd011f7c3c15285c2ull ); return true;
-        case ShipType::Bomber: ref = ids.ref( 0xa8216aa1c554cb8aull ); return true;
-        case ShipType::Scout: ref = ids.ref( 0x7d573c625719c1a5ull ); return true;
+        case ShipType::Fighter: ref = ids.ref_at( 123, 0xd011f7c3c15285c2ull ); return true;
+        case ShipType::Bomber: ref = ids.ref_at( 91, 0xa8216aa1c554cb8aull ); return true;
+        case ShipType::Scout: ref = ids.ref_at( 65, 0x7d573c625719c1a5ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -2629,9 +2629,9 @@ inline bool TableEnumRef( TableIds & ids, Grade value, uint64_t & ref )
     switch ( value )
     {
         case Grade::None: ref = 0; return true;
-        case Grade::Bronze: ref = ids.ref( 0xc4927739aac4c591ull ); return true;
-        case Grade::Silver: ref = ids.ref( 0xc3e51adeeaf12580ull ); return true;
-        case Grade::Gold: ref = ids.ref( 0xc416c97e0d3218b3ull ); return true;
+        case Grade::Bronze: ref = ids.ref_at( 115, 0xc4927739aac4c591ull ); return true;
+        case Grade::Silver: ref = ids.ref_at( 113, 0xc3e51adeeaf12580ull ); return true;
+        case Grade::Gold: ref = ids.ref_at( 114, 0xc416c97e0d3218b3ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -6587,9 +6587,9 @@ inline bool TableEnumRef( TableIds & ids, Grade value, uint64_t & ref )
     switch ( value )
     {
         case Grade::None: ref = 0; return true;
-        case Grade::A: ref = ids.ref( 0xaf63fc4c860222ecull ); return true;
-        case Grade::B: ref = ids.ref( 0xaf63ff4c86022805ull ); return true;
-        case Grade::C: ref = ids.ref( 0xaf63fe4c86022652ull ); return true;
+        case Grade::A: ref = ids.ref_at( 43, 0xaf63fc4c860222ecull ); return true;
+        case Grade::B: ref = ids.ref_at( 45, 0xaf63ff4c86022805ull ); return true;
+        case Grade::C: ref = ids.ref_at( 44, 0xaf63fe4c86022652ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -6598,9 +6598,9 @@ inline bool TableEnumRef( TableRetainIds & ids, Grade value, uint64_t & ref )
     switch ( value )
     {
         case Grade::None: ref = 0; return true;
-        case Grade::A: ref = ids.ref( 0xaf63fc4c860222ecull ); return true;
-        case Grade::B: ref = ids.ref( 0xaf63ff4c86022805ull ); return true;
-        case Grade::C: ref = ids.ref( 0xaf63fe4c86022652ull ); return true;
+        case Grade::A: ref = ids.ref_at( 43, 0xaf63fc4c860222ecull ); return true;
+        case Grade::B: ref = ids.ref_at( 45, 0xaf63ff4c86022805ull ); return true;
+        case Grade::C: ref = ids.ref_at( 44, 0xaf63fe4c86022652ull ); return true;
         default: return false;
     }
 }

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -6695,8 +6695,8 @@ inline bool TableEnumRef( TableIds & ids, Slot value, uint64_t & ref )
     switch ( value )
     {
         case Slot::None: ref = 0; return true;
-        case Slot::Alpha: ref = ids.ref( 0x4fda04cbc245e18bull ); return true;
-        case Slot::Beta: ref = ids.ref( 0xa0b562a796b69487ull ); return true;
+        case Slot::Alpha: ref = ids.ref_at( 24, 0x4fda04cbc245e18bull ); return true;
+        case Slot::Beta: ref = ids.ref_at( 46, 0xa0b562a796b69487ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -6705,8 +6705,8 @@ inline bool TableEnumRef( TableRetainIds & ids, Slot value, uint64_t & ref )
     switch ( value )
     {
         case Slot::None: ref = 0; return true;
-        case Slot::Alpha: ref = ids.ref( 0x4fda04cbc245e18bull ); return true;
-        case Slot::Beta: ref = ids.ref( 0xa0b562a796b69487ull ); return true;
+        case Slot::Alpha: ref = ids.ref_at( 24, 0x4fda04cbc245e18bull ); return true;
+        case Slot::Beta: ref = ids.ref_at( 46, 0xa0b562a796b69487ull ); return true;
         default: return false;
     }
 }

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -6642,8 +6642,8 @@ inline bool TableEnumRef( TableIds & ids, Slot value, uint64_t & ref )
     switch ( value )
     {
         case Slot::None: ref = 0; return true;
-        case Slot::Alpha: ref = ids.ref( 0x4fda04cbc245e18bull ); return true;
-        case Slot::Beta: ref = ids.ref( 0xa0b562a796b69487ull ); return true;
+        case Slot::Alpha: ref = ids.ref_at( 24, 0x4fda04cbc245e18bull ); return true;
+        case Slot::Beta: ref = ids.ref_at( 46, 0xa0b562a796b69487ull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -6652,8 +6652,8 @@ inline bool TableEnumRef( TableRetainIds & ids, Slot value, uint64_t & ref )
     switch ( value )
     {
         case Slot::None: ref = 0; return true;
-        case Slot::Alpha: ref = ids.ref( 0x4fda04cbc245e18bull ); return true;
-        case Slot::Beta: ref = ids.ref( 0xa0b562a796b69487ull ); return true;
+        case Slot::Alpha: ref = ids.ref_at( 24, 0x4fda04cbc245e18bull ); return true;
+        case Slot::Beta: ref = ids.ref_at( 46, 0xa0b562a796b69487ull ); return true;
         default: return false;
     }
 }

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -2610,8 +2610,8 @@ inline bool TableEnumRef( TableIds & ids, Mode value, uint64_t & ref )
     switch ( value )
     {
         case Mode::None: ref = 0; return true;
-        case Mode::Read: ref = ids.ref( 0x740d542bbe696de5ull ); return true;
-        case Mode::Write: ref = ids.ref( 0x78f9fa174282015cull ); return true;
+        case Mode::Read: ref = ids.ref_at( 22, 0x740d542bbe696de5ull ); return true;
+        case Mode::Write: ref = ids.ref_at( 24, 0x78f9fa174282015cull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -5322,8 +5322,8 @@ inline bool TableEnumRef( TableIds & ids, Tier value, uint64_t & ref )
     switch ( value )
     {
         case Tier::None: ref = 0; return true;
-        case Tier::Low: ref = ids.ref( 0x24f3a319b88552c1ull ); return true;
-        case Tier::High: ref = ids.ref( 0x9deeefd89ca8a81dull ); return true;
+        case Tier::Low: ref = ids.ref_at( 3, 0x24f3a319b88552c1ull ); return true;
+        case Tier::High: ref = ids.ref_at( 30, 0x9deeefd89ca8a81dull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }
@@ -5332,8 +5332,8 @@ inline bool TableEnumRef( TableRetainIds & ids, Tier value, uint64_t & ref )
     switch ( value )
     {
         case Tier::None: ref = 0; return true;
-        case Tier::Low: ref = ids.ref( 0x24f3a319b88552c1ull ); return true;
-        case Tier::High: ref = ids.ref( 0x9deeefd89ca8a81dull ); return true;
+        case Tier::Low: ref = ids.ref_at( 3, 0x24f3a319b88552c1ull ); return true;
+        case Tier::High: ref = ids.ref_at( 30, 0x9deeefd89ca8a81dull ); return true;
         default: return false;
     }
 }

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -2507,9 +2507,9 @@ inline bool TableEnumRef( TableIds & ids, Axis value, uint64_t & ref )
     switch ( value )
     {
         case Axis::None: ref = 0; return true;
-        case Axis::X: ref = ids.ref( 0xaf64154c86024d67ull ); return true;
-        case Axis::Y: ref = ids.ref( 0xaf64144c86024bb4ull ); return true;
-        case Axis::Z: ref = ids.ref( 0xaf64174c860250cdull ); return true;
+        case Axis::X: ref = ids.ref_at( 20, 0xaf64154c86024d67ull ); return true;
+        case Axis::Y: ref = ids.ref_at( 19, 0xaf64144c86024bb4ull ); return true;
+        case Axis::Z: ref = ids.ref_at( 21, 0xaf64174c860250cdull ); return true;
         default: return false; // no variant names this value: no wire identity
     }
 }


### PR DESCRIPTION
Generated enum switch arms name constant wire IDs but still used the general vocabulary lookup. Reuse the existing ordinal cache for those arms, including the retain adapter, while keeping None, first-use ordering and the public wire bytes unchanged. This applies the same known-ID technique already used by field headers and the reviewed Go enum candidate.

The existing valid-value byte, shared-ID/elision, sizing-cache and closure-default tests pass, as do emitter/goldens and matched C++ Packet/Table gates over all 64 logical records. Runtime fixtures and pinned wire bytes are unchanged; two old source-shape assertions now reflect cached enum IDs. All affected generated mirrors are updated.

Three ARM diagnostic rounds with background work showed roughly 2.5% less median write time and no demonstrated round-trip gain. This is not a controlled performance claim; the final common batch will measure the integrated result. No new wire form or check removal.

The existing shared-ID cache check now runs both the optimized generated header and a test-local copy using its original generic-key setup, preserving generic Ref/RefAt rollback coverage after enum arms gained ordinals. The schema, values and byte pins are unchanged. Both affected compiler checks and both existing cache controls pass.
