### PR TITLE
C Fixed Table: reuse bounded vocabulary lookup

### DIFF
--- a/compiler/tablesc_test.go
+++ b/compiler/tablesc_test.go
@@ -225,6 +225,39 @@ func TestCForceInlineStopsAtTheVariableClass(t *testing.T) {
 	}
 }
 
+// TestCTableOpenDistinctnessIsBounded pins the read-side identity check:
+// a bounded stack open-addressed table for count<=256, id compare rather than
+// hash-only, and the pairwise walk kept as the fallback. Count is attacker-
+// controlled up to bytes/8; the bound is what keeps the stack finite.
+func TestCTableOpenDistinctnessIsBounded(t *testing.T) {
+	files, err := New().Generate(unitFromSource(t, runtimeSrc), "c", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := ""
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.h") {
+			header = string(data)
+			break
+		}
+	}
+	if header == "" {
+		t.Fatal("no Table.h")
+	}
+	for _, want := range []string{
+		"count > 256",
+		"uint64_t seen[512]",
+		"uint8_t used[512]",
+		"probes < 512",
+		"seen[slot] == id",
+		"for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {",
+	} {
+		if !strings.Contains(header, want) {
+			t.Errorf("table_wire_open is missing %q", want)
+		}
+	}
+}
+
 // cMacroSrc names every declaration with the same distinctive prefix, so a
 // macro in the emitted C that does NOT carry it is one the GENERATOR owns
 // rather than one the schema asked for. That is what makes the scan below

--- a/compiler/tablescwire_test.go
+++ b/compiler/tablescwire_test.go
@@ -145,6 +145,82 @@ func runCTableWireProbe(t *testing.T, u *ir.Unit, source string) {
 	}
 }
 
+func tableOpenMixSlot(id uint64) uint32 {
+	h := id
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	return uint32(h) & 511
+}
+
+// TestCTableOpenDistinctnessVerdict is the same verdict as pairwise: a
+// repeated id is malformed, distinct ids including a hash-slot collision and
+// a count above the 256-slot bound are not.
+func TestCTableOpenDistinctnessVerdict(t *testing.T) {
+	var collideA, collideB uint64
+	found := false
+	for a := uint64(1); a < 4096 && !found; a++ {
+		for b := a + 1; b < 4096; b++ {
+			if tableOpenMixSlot(a) == tableOpenMixSlot(b) {
+				collideA, collideB = a, b
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatal("could not find two ids that share a 512-slot mix")
+	}
+	u := unitFromSource(t, `package probe
+table Leaf { x uint32 }
+`)
+	source := fmt.Sprintf(`#include "ProbeTable.h"
+#include <stdio.h>
+#define CHECK(x) do { if (!(x)) { fprintf(stderr, "line %%d: %%s\n", __LINE__, #x); return 1; } } while (0)
+static void put_le64(uint8_t *p, uint64_t v)
+{
+    int i; for ( i = 0; i < 8; i++ ) { p[i] = (uint8_t)(v >> (8 * i)); }
+}
+static int load_ids(const uint64_t *ids, uint64_t n, TableReport *report)
+{
+    uint8_t buf[4096];
+    int64_t o = 0;
+    uint64_t i;
+    Leaf value;
+    CHECK(n <= 257);
+    buf[o++] = 1;
+    buf[o++] = 0;
+    for ( i = 0; i < n; i++ ) { put_le64(buf + o, ids[i]); o += 8; }
+    put_le64(buf + o, n); o += 8;
+    memset(report, 0, sizeof(*report));
+    return leaf_load(&value, buf, o, report);
+}
+int main(void)
+{
+    TableReport report;
+    uint64_t two_ok[2] = { 1, 2 };
+    uint64_t two_dup[2] = { 1, 1 };
+    uint64_t zero_dup[2] = { 0, 0 };
+    uint64_t collide[2] = { %dull, %dull };
+    uint64_t over[257];
+    uint64_t i;
+    CHECK(load_ids(two_ok, 2, &report) && !report.malformed && !report.refused);
+    CHECK(!load_ids(two_dup, 2, &report) && report.malformed && !report.refused);
+    CHECK(!load_ids(zero_dup, 2, &report) && report.malformed && !report.refused);
+    CHECK(load_ids(collide, 2, &report) && !report.malformed && !report.refused);
+    for ( i = 0; i < 257; i++ ) { over[i] = i + 1; }
+    CHECK(load_ids(over, 257, &report) && !report.malformed && !report.refused);
+    over[256] = 1;
+    CHECK(!load_ids(over, 257, &report) && report.malformed && !report.refused);
+    over[256] = 257;
+    over[0] = 2;
+    CHECK(!load_ids(over, 256, &report) && report.malformed && !report.refused);
+    return 0;
+}
+`, collideA, collideB)
+	runCTableWireProbe(t, u, source)
+}
+
 // Clamps must happen after promoting the source-width integer. NaN widening
 // must preserve its sign and payload without quieting a signaling NaN.
 func TestCTableWireWidening(t *testing.T) {

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -465,9 +465,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -466,9 +466,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -452,9 +452,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -241,9 +241,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -455,9 +455,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -455,9 +455,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -454,9 +454,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -462,9 +462,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -460,9 +460,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -460,9 +460,46 @@ static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffe
     span = (int64_t) count * 8 + 8;
     *r = table_reader_make( buffer + 1, bytes - span - 1, report );
     r->ids = buffer + bytes - span; r->id_count = count; r->nested = 0;
-    for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
-        if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
-    } }
+    /* THE ENTRIES ARE DISTINCT: a table that carries one id twice is malformed
+       for the whole wire (docs/SPEC-TABLES.md §3). Count is attacker-controlled
+       up to (bytes-9)/8; an unbounded stack table is a stack-overflow primitive.
+       The open-addressed path therefore runs only at count<=256 with 512 slots.
+       A slot occupied by a different id is not a duplicate: compare the stored
+       id, not the hash. Probe length is capped at the slot count so a colliding
+       attacker-chosen set cannot walk forever. Exhausted probes and counts
+       above the bound keep the pairwise walk, which is the same verdict. The
+       mix is table_writer_id's. */
+    if ( count > 1 )
+    {
+        int pairwise = count > 256;
+        if ( !pairwise )
+        {
+            uint64_t seen[512];
+            uint8_t used[512];
+            memset( used, 0, sizeof( used ) );
+            for ( i = 0; i < count; i++ )
+            {
+                uint64_t id = table_reader_id_at( r, i + 1 );
+                uint64_t hash = id;
+                uint32_t slot, probes;
+                hash ^= hash >> 33; hash *= UINT64_C(0xff51afd7ed558ccd); hash ^= hash >> 33;
+                slot = (uint32_t) hash & 511u;
+                for ( probes = 0; probes < 512; probes++ )
+                {
+                    if ( !used[slot] ) { used[slot] = 1; seen[slot] = id; break; }
+                    if ( seen[slot] == id ) { report->malformed = 1; return 0; }
+                    slot = (slot + 1) & 511u;
+                }
+                if ( probes == 512 ) { pairwise = 1; break; }
+            }
+        }
+        if ( pairwise )
+        {
+            for ( i = 1; i < count; i++ ) { for ( j = 0; j < i; j++ ) {
+                if ( table_reader_id_at( r, i+1 ) == table_reader_id_at( r, j+1 ) ) { report->malformed = 1; return 0; }
+            } }
+        }
+    }
     /* Root slack invalidates the whole file before any overlay. A stopped
        body is different: its successfully decoded prefix must survive. */
     tail = *r;


### PR DESCRIPTION
Fixed Table C spent a quadratic scan checking ordinary vocabularies before reading a body. Reuse Johnny’s already reviewed bounded identity set for small vocabularies, retaining the existing fallback and wire behavior. The integration preserves original authorship and only regenerates the two paired benchmark headers introduced since that work.

Validation: reused 58 passing compiler checks because production C and existing added checks are identical to reviewed cc9f2078; refreshed C codegen/goldens, native variable-table checks, and the matched C Packet/Table gates with the C++ oracle for all 64 records on exact head68649cea. No performance claim is attached to this integration PR; ARM and batched x64 product measurements follow integration.
