### PR TITLE
Go Fixed Table: reuse known enum ordinals

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -1899,16 +1899,41 @@ func MixedEntitySaveBody(w *TableWriter, value *MixedEntity) bool {
 	{
 		if value.Weapon != MixedWeaponNone {
 			w.Header(w.Ids.RefAt(52, 0xa0b610205f2c6e01), 30)
-			{
-				id, named := value.Weapon.TableEnumId()
-				if !named {
-					return false
-				}
-				if value.Weapon == MixedWeaponNone {
-					w.PutLeb(0)
-				} else {
-					w.Id(id)
-				}
+			switch value.Weapon {
+			case MixedWeaponNone:
+				w.PutLeb(0)
+			case MixedWeaponFists:
+				w.IdAt(55, 0xa790eee12766cf0c)
+			case MixedWeaponPistol:
+				w.IdAt(51, 0x9fbfefa835da8476)
+			case MixedWeaponShotgun:
+				w.IdAt(8, 0x188bbb1783928a95)
+			case MixedWeaponRifle:
+				w.IdAt(12, 0x2c3667b9c2f272f1)
+			case MixedWeaponSniper:
+				w.IdAt(3, 0x0ca8b41b00d755f6)
+			case MixedWeaponSmg:
+				w.IdAt(45, 0x985fc819fab21a4e)
+			case MixedWeaponRocket:
+				w.IdAt(10, 0x229d0447c3086a55)
+			case MixedWeaponGrenade:
+				w.IdAt(0, 0x011c7b49a7228f9d)
+			case MixedWeaponPlasma:
+				w.IdAt(41, 0x89f7566e1123e15f)
+			case MixedWeaponRailgun:
+				w.IdAt(42, 0x8d7f25318b3b4469)
+			case MixedWeaponFlamer:
+				w.IdAt(69, 0xd9cd0dcc285b7816)
+			case MixedWeaponMine:
+				w.IdAt(2, 0x04dc16aea8ff5276)
+			case MixedWeaponTurret:
+				w.IdAt(17, 0x35e53bc341129217)
+			case MixedWeaponDrone:
+				w.IdAt(13, 0x2cc8282fb0de8831)
+			case MixedWeaponRepair:
+				w.IdAt(9, 0x20bada21bc8cb334)
+			default:
+				return false
 			}
 		}
 	}

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -1969,16 +1969,41 @@ func TableEntitySaveBody(w *TableWriter, value *TableEntity) bool {
 	{
 		if value.Weapon != TableWeaponNone {
 			w.Header(w.Ids.RefAt(54, 0xa0b610205f2c6e01), 30)
-			{
-				id, named := value.Weapon.TableEnumId()
-				if !named {
-					return false
-				}
-				if value.Weapon == TableWeaponNone {
-					w.PutLeb(0)
-				} else {
-					w.Id(id)
-				}
+			switch value.Weapon {
+			case TableWeaponNone:
+				w.PutLeb(0)
+			case TableWeaponFists:
+				w.IdAt(57, 0xa790eee12766cf0c)
+			case TableWeaponPistol:
+				w.IdAt(53, 0x9fbfefa835da8476)
+			case TableWeaponShotgun:
+				w.IdAt(8, 0x188bbb1783928a95)
+			case TableWeaponRifle:
+				w.IdAt(13, 0x2c3667b9c2f272f1)
+			case TableWeaponSniper:
+				w.IdAt(3, 0x0ca8b41b00d755f6)
+			case TableWeaponSmg:
+				w.IdAt(48, 0x985fc819fab21a4e)
+			case TableWeaponRocket:
+				w.IdAt(10, 0x229d0447c3086a55)
+			case TableWeaponGrenade:
+				w.IdAt(0, 0x011c7b49a7228f9d)
+			case TableWeaponPlasma:
+				w.IdAt(44, 0x89f7566e1123e15f)
+			case TableWeaponRailgun:
+				w.IdAt(45, 0x8d7f25318b3b4469)
+			case TableWeaponFlamer:
+				w.IdAt(69, 0xd9cd0dcc285b7816)
+			case TableWeaponMine:
+				w.IdAt(2, 0x04dc16aea8ff5276)
+			case TableWeaponTurret:
+				w.IdAt(19, 0x35e53bc341129217)
+			case TableWeaponDrone:
+				w.IdAt(14, 0x2cc8282fb0de8831)
+			case TableWeaponRepair:
+				w.IdAt(9, 0x20bada21bc8cb334)
+			default:
+				return false
 			}
 		}
 	}

--- a/internal/codegen/gotable/refat_test.go
+++ b/internal/codegen/gotable/refat_test.go
@@ -60,6 +60,29 @@ func TestRefAtSharedFieldAndEnumKeyId(t *testing.T) {
 	runGenerated(t, refAtSharedIdSchema, refAtSharedIdTest)
 }
 
+func TestEnumWriterUsesRefAt(t *testing.T) {
+	files := generate(t, refAtSharedIdSchema)
+	body := ""
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.go") {
+			body += string(data)
+		}
+	}
+	save := body
+	if i := strings.Index(save, "func RootSaveBody"); i >= 0 {
+		save = save[i:]
+		if j := strings.Index(save[1:], "\nfunc "); j >= 0 {
+			save = save[:j+1]
+		}
+	}
+	if !strings.Contains(save, "w.IdAt(") {
+		t.Fatal("enum field writer does not intern through IdAt")
+	}
+	if strings.Contains(save, "TableEnumId()") && strings.Contains(save, ".Id(id)") {
+		t.Fatal("enum field writer still hashes through TableEnumId then Id")
+	}
+}
+
 const refAtWireTest = `package probe
 import ("bytes"; "encoding/binary"; "testing")
 

--- a/internal/codegen/gotable/write.go
+++ b/internal/codegen/gotable/write.go
@@ -366,8 +366,15 @@ func (g *tableGen) emitWireUnion(un *ir.Union, expr, writer, ind string) {
 }
 
 func (g *tableGen) emitWireScalar(f *ir.Field, expr, writer, ind string) {
-	if enumRef(f) != nil {
-		g.pf("%s{ id, named := %s.TableEnumId(); if !named { return false }; if %s == %sNone { %s.PutLeb(0) } else { %s.Id(id) } }\n", ind, expr, expr, f.Type.Name, writer, writer)
+	if e := enumRef(f); e != nil {
+		// Each arm is a compile-time id, so RefAt is one load and one
+		// compare. None is still reference zero and is not interned.
+		g.pf("%sswitch %s {\n%scase %sNone: %s.PutLeb(0)\n", ind, expr, ind, e.Name, writer)
+		for i, v := range e.Variants {
+			id := ir.TableWireId(e.VariantWireName(i))
+			g.pf("%scase %s%s: %s.IdAt(%d, 0x%016x)\n", ind, e.Name, v, writer, g.knownOrdinal(id), id)
+		}
+		g.pf("%sdefault: return false\n%s}\n", ind, ind)
 		return
 	}
 	kind := ir.TableWireScalarKind(f)


### PR DESCRIPTION
Generated Go Table enum writes already select a concrete schema variant, but each selected variant still repeated a general identity lookup. Emit the existing ordinal-aware IdAt call in each enum arm, reusing the same path as known field identities. None still writes reference zero; unnamed values still fail; first-use identity order is unchanged.

Validation: independent source review and existing enum, keyed, message, allocation and golden checks from original3312bbcf reused because the relevant source is identical. Current-main integration8470eec4 passes refreshed generated mirrors and matched Go Packet/Table gates with the C++ oracle across64 identical records on ARM64. No performance claim until integrated measurements. Original Johnny attribution is preserved.
