### PR TITLE
C Fixed Table: coalesce 64-bit writes

### DIFF
--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -302,7 +302,9 @@ static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_put32( TableWri
 }
 static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -303,7 +303,9 @@ static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_put32( TableWri
 }
 static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -289,7 +289,9 @@ static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE void table_writer_put32( Tab
 }
 static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -78,7 +78,9 @@ static SCHEMA_UNUSED @INLINE@ void table_writer_put32( TableWriter * w, uint32_t
 }
 static SCHEMA_UNUSED @INLINE@ void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -292,7 +292,9 @@ static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -292,7 +292,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -291,7 +291,9 @@ static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -299,7 +299,9 @@ static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -297,7 +297,9 @@ static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -297,7 +297,9 @@ static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put32( Tabl
 }
 static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_put64( TableWriter * w, uint64_t v )
 {
-    table_writer_put32( w, (uint32_t) v ); table_writer_put32( w, (uint32_t) (v >> 32) );
+    uint8_t b[8]; int i;
+    for ( i = 0; i < 8; i++ ) { b[i] = (uint8_t) (v >> (8*i)); }
+    table_writer_raw( w, b, 8 );
 }
 static SCHEMA_UNUSED void table_writer_leb( TableWriter * w, uint64_t v )
 {


### PR DESCRIPTION
Fixed Table C wrote each64-bit value using two32-bit writes. Assemble the same eight little-endian bytes and send them through the existing raw writer once, reusing the C++ primitive. Successful wire bytes and Measure behavior are unchanged; insufficient space still makes Save return-1. A failed individual word write now leaves the whole word unwritten instead of potentially copying its low half.

Validation: independent source review, C codegen and source goldens, existing focused compiler checks, native variable-table round trip, and matched C Packet/Table gates with C++ oracle for64 records on exact0f81f869 ARM64. Fifteen generated headers differ only by this primitive replacement. An alternating three-round diagnostic against the approved38 batch suggested about3.2% lower write and round-trip cost; background work was permitted, so this is provisional evidence and will be rechecked in the integrated product run.
