### PR TITLE
Go Fixed Table: fast-path one-byte writer values

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -408,6 +408,10 @@ func (w *TableWriter) Put128(lo, hi uint64) {
 }
 
 func (w *TableWriter) PutLeb(v uint64) {
+	if v < 128 {
+		w.Put8(uint8(v))
+		return
+	}
 	// Groups assemble in a ten-byte stack buffer and go to Raw once. Spelling
 	// is the old loop's, group for group. One Advance covers the value; raw's
 	// capacity test is untouched. A value that does not fit now leaves the

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -476,6 +476,10 @@ func (w *TableWriter) Put128(lo, hi uint64) {
 }
 
 func (w *TableWriter) PutLeb(v uint64) {
+	if v < 128 {
+		w.Put8(uint8(v))
+		return
+	}
 	// Groups assemble in a ten-byte stack buffer and go to Raw once. Spelling
 	// is the old loop's, group for group. One Advance covers the value; raw's
 	// capacity test is untouched. A value that does not fit now leaves the

--- a/internal/codegen/gotable/wire.go
+++ b/internal/codegen/gotable/wire.go
@@ -148,6 +148,10 @@ func (w *TableWriter) Put128(lo, hi uint64) {
 }
 
 func (w *TableWriter) PutLeb(v uint64) {
+	if v < 128 {
+		w.Put8(uint8(v))
+		return
+	}
 	// Groups assemble in a ten-byte stack buffer and go to Raw once. Spelling
 	// is the old loop's, group for group. One Advance covers the value; raw's
 	// capacity test is untouched. A value that does not fit now leaves the


### PR DESCRIPTION
For the common one-byte value, Go Fixed Table PutLeb now uses its existing Put8 directly. This avoids constructing and copying a temporary slice while preserving the same Advance(1), measuring, overflow and byte behavior. The general encoding loop is unchanged.

Validation: independent source review and existing expected-byte, measurement, short-buffer, allocation, message/default/optional-array, source-golden and matched Packet/Table gates passed on exact05e4e983 ARM64. All changed generated mirrors contain only the same fast path. Three alternating400000-operation diagnostic rounds showed write time4.05% lower and round-trip1.58% lower, with each candidate sample below its paired baseline. Background work was permitted; these are provisional diagnostics pending integrated controlled ARM and batched x64 measurements.
