### PR TITLE
cs tables: index ReadBody field ids like the writer indexes vocabulary

### DIFF
--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -230,6 +230,10 @@ namespace Bench
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2882,8 +2886,8 @@ namespace Bench
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3458,8 +3462,7 @@ namespace Bench
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3723,7 +3726,7 @@ namespace Bench
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4602,6 +4605,52 @@ namespace Bench
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4614,8 +4663,7 @@ namespace Bench
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)
@@ -5065,6 +5113,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5099,6 +5148,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5135,6 +5185,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5169,6 +5220,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5203,6 +5255,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5262,6 +5315,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/generated/bench/paired/cs/BenchView.cs
+++ b/generated/bench/paired/cs/BenchView.cs
@@ -127,6 +127,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -185,6 +186,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -247,6 +249,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/generated/bench/paired/cs/FixedTableTable.cs
+++ b/generated/bench/paired/cs/FixedTableTable.cs
@@ -85,6 +85,7 @@ namespace Bench
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -230,6 +230,10 @@ namespace Benchtable
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2966,8 +2970,8 @@ namespace Benchtable
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3542,8 +3546,7 @@ namespace Benchtable
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3807,7 +3810,7 @@ namespace Benchtable
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4686,6 +4689,52 @@ namespace Benchtable
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4698,8 +4747,7 @@ namespace Benchtable
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)
@@ -5150,6 +5198,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5184,6 +5233,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5244,6 +5294,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5280,6 +5331,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5314,6 +5366,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -5348,6 +5401,7 @@ namespace Benchtable
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/internal/codegen/cstable/codecs.go
+++ b/internal/codegen/cstable/codecs.go
@@ -652,6 +652,7 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 	g.pf("    info.Doc = %s;\n", doc)
 	g.pf("    info.NumTags = %s;\n", numTags)
 	g.pf("    info.Tags = %s;\n", tags)
+	g.pf("    TableWire.IndexFields(info);\n")
 	g.pf("    return info;\n")
 	g.indent = ""
 	g.pf("    }\n")

--- a/internal/codegen/cstable/cstable.go
+++ b/internal/codegen/cstable/cstable.go
@@ -844,6 +844,10 @@ public sealed class TableTypeInfo
     public ulong Id;            // full wire identity of the table name
     public int NumFields;
     public TableFieldInfo[] Fields;
+    // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+    // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+    internal TableFieldInfo[] IdIndex;
+    internal int IdMask;
     // put one instance back at its declared defaults, in place. A generic
     // walker that FILLS a value has to establish the defaults an absent field
     // takes, and it holds no type to spell — this is the one thing the columns

--- a/internal/codegen/cstable/measure.go
+++ b/internal/codegen/cstable/measure.go
@@ -6,8 +6,8 @@ const tableLoadMeasureSource = `
     {
         while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
         {
-            byte kind = r.Byte(); TableFieldInfo field = null;
-            foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+            byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+            if (field != null && Kind(field) != kind) { field = null; }
             if (field == null) { if (!r.Skip(kind)) { break; } continue; }
             if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
         }

--- a/internal/codegen/cstable/messagemeasure.go
+++ b/internal/codegen/cstable/messagemeasure.go
@@ -9,7 +9,7 @@ const tableMessageMeasureSource = `
             if (reference == 0) { return true; }
             TableFieldInfo field = null;
             if (type != null)
-            { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+            { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
             if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
             else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
         }

--- a/internal/codegen/cstable/messageread.go
+++ b/internal/codegen/cstable/messageread.go
@@ -131,8 +131,7 @@ const tableMessageReadSource = `
             if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
             if (reference == 0) { return true; }
             if (Reserved(entry.Id)) { return false; }
-            TableFieldInfo field = null;
-            foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+            TableFieldInfo field = FindField(type, entry.Id);
             if (field == null)
             { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
             if (!MessageCompatible(entry, field, out bool widened))

--- a/internal/codegen/cstable/region.go
+++ b/internal/codegen/cstable/region.go
@@ -537,8 +537,7 @@ const tableRegionSource = `
             if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
             if (!r.Has(1)) { return Damage(report); }
             byte kind = r.Byte();
-            TableFieldInfo field = null;
-            foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+            TableFieldInfo field = FindField(type, id);
             if (!nested && id == ulong.MaxValue && type.Variable)
             { if (!r.Skip(kind)) { return Damage(report); } continue; }
             if (field == null)

--- a/internal/codegen/cstable/regionmessage.go
+++ b/internal/codegen/cstable/regionmessage.go
@@ -9,8 +9,7 @@ const tableRegionMessageReadSource = `
             if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
             if (reference == 0) { return true; }
             if (Reserved(entry.Id)) { return false; }
-            TableFieldInfo field = null;
-            foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+            TableFieldInfo field = FindField(type, entry.Id);
             if (field == null)
             { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
             if (!MessageCompatible(entry, field, out bool widened))

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -884,6 +884,52 @@ public static partial class TableWire
         }
         return ReadElement(ref r, value, f, 0, kind, report, true);
     }
+    // IndexFields builds a power-of-two open-addressing table over Fields using
+    // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+    // before publishing Instance, so ARM64 sees the index with the descriptor.
+    internal static void IndexFields(TableTypeInfo type)
+    {
+        TableFieldInfo[] fields = type.Fields;
+        if (fields == null || fields.Length == 0)
+        {
+            type.IdIndex = Array.Empty<TableFieldInfo>();
+            type.IdMask = 0;
+            return;
+        }
+        int slots = 1;
+        while (slots < fields.Length * 2) { slots <<= 1; }
+        TableFieldInfo[] index = new TableFieldInfo[slots];
+        int mask = slots - 1;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            TableFieldInfo f = fields[i];
+            int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+            while (index[slot] != null) { slot = (slot + 1) & mask; }
+            index[slot] = f;
+        }
+        type.IdIndex = index;
+        type.IdMask = mask;
+    }
+    internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+    {
+        TableFieldInfo[] index = type.IdIndex;
+        if (index != null)
+        {
+            if (index.Length == 0) { return null; }
+            int mask = type.IdMask;
+            int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+            for (;;)
+            {
+                TableFieldInfo f = index[slot];
+                if (f == null) { return null; }
+                if (f.Id == id) { return f; }
+                slot = (slot + 1) & mask;
+            }
+        }
+        if (type.Fields == null) { return null; }
+        foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+        return null;
+    }
     static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
     {
         // Load resets the root before even the framing checks. Every nested
@@ -896,8 +942,7 @@ public static partial class TableWire
             if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
             if (!r.Has(1)) { return Damage(report); }
             byte kind = r.Byte();
-            TableFieldInfo field = null;
-            foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+            TableFieldInfo field = FindField(type, id);
             if (!nested && id == ulong.MaxValue && type.Variable)
             { if (!r.Skip(kind)) { return Damage(report); } continue; }
             if (field == null)

--- a/test/cs-tables/src/WireChecks.cs
+++ b/test/cs-tables/src/WireChecks.cs
@@ -58,6 +58,12 @@ static partial class Program
         Check(V1.Schema.CfgLoad(cfg, zeroId, report) && cfg.A == 42 && report.Unknown == 3 && !report.Malformed,
             "zero identity and unknown future kinds skip without swallowing the next field");
 
+        V1.TableTypeInfo cfgType = V1.Schema.CfgTableType();
+        Check(V1.Schema.TableWire.FindField(cfgType, cfgType.Fields[0].Id) == cfgType.Fields[0],
+            "indexed field lookup hits the declared id");
+        Check(V1.Schema.TableWire.FindField(cfgType, 1ul) == null,
+            "indexed field lookup misses an unknown id");
+
         // C++ reads a fixed array's count at the enclosing cursor before
         // bounding elements by L. The next field reference completes count 128;
         // its bool kind mismatches the same array field. No element may be

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -346,6 +346,10 @@ namespace Blockdemo
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2998,8 +3002,8 @@ namespace Blockdemo
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3574,8 +3578,7 @@ namespace Blockdemo
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3839,7 +3842,7 @@ namespace Blockdemo
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4718,6 +4721,52 @@ namespace Blockdemo
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4730,8 +4779,7 @@ namespace Blockdemo
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)

--- a/testdata/golden/tables/block-cs/PaddedTable.cs
+++ b/testdata/golden/tables/block-cs/PaddedTable.cs
@@ -174,6 +174,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -210,6 +211,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/block-cs/RenderTable.cs
+++ b/testdata/golden/tables/block-cs/RenderTable.cs
@@ -931,6 +931,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -969,6 +970,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1012,6 +1014,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1053,6 +1056,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1092,6 +1096,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1131,6 +1136,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1170,6 +1176,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1210,6 +1217,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1248,6 +1256,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1287,6 +1296,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1322,6 +1332,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -1358,6 +1369,7 @@ namespace Blockdemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -230,6 +230,10 @@ namespace Blockhome
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2882,8 +2886,8 @@ namespace Blockhome
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3458,8 +3462,7 @@ namespace Blockhome
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3723,7 +3726,7 @@ namespace Blockhome
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4602,6 +4605,52 @@ namespace Blockhome
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4614,8 +4663,7 @@ namespace Blockhome
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -205,6 +205,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -241,6 +242,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -275,6 +277,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -311,6 +314,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -152,6 +152,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -186,6 +187,7 @@ namespace Blockhome
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/GuardedTable.cs
+++ b/testdata/golden/tables/examples-cs/GuardedTable.cs
@@ -114,6 +114,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/KeyedTable.cs
+++ b/testdata/golden/tables/examples-cs/KeyedTable.cs
@@ -421,6 +421,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -455,6 +456,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -490,6 +492,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -525,6 +528,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -560,6 +564,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -593,6 +598,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/NestedTable.cs
+++ b/testdata/golden/tables/examples-cs/NestedTable.cs
@@ -88,6 +88,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/PackTable.cs
+++ b/testdata/golden/tables/examples-cs/PackTable.cs
@@ -324,6 +324,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -361,6 +362,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -397,6 +399,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -434,6 +437,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/RangesTable.cs
+++ b/testdata/golden/tables/examples-cs/RangesTable.cs
@@ -265,6 +265,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -314,6 +315,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -352,6 +354,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -346,6 +346,10 @@ namespace Tabledemo
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2998,8 +3002,8 @@ namespace Tabledemo
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3574,8 +3578,7 @@ namespace Tabledemo
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3839,7 +3842,7 @@ namespace Tabledemo
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4718,6 +4721,52 @@ namespace Tabledemo
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4730,8 +4779,7 @@ namespace Tabledemo
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -459,6 +459,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -500,6 +501,7 @@ namespace Tabledemo
                 info.Doc = "One weapon's tuning. A designer edits this table and nothing else.";
                 info.NumTags = 1;
                 info.Tags = WeaponConfigTableTags;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -539,6 +541,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -584,6 +587,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -618,6 +622,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -651,6 +656,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -684,6 +690,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/tables/examples-cs/WideTable.cs
+++ b/testdata/golden/tables/examples-cs/WideTable.cs
@@ -97,6 +97,7 @@ namespace Tabledemo
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/wide/cs/CaptionTable.cs
+++ b/testdata/golden/wide/cs/CaptionTable.cs
@@ -227,6 +227,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -261,6 +262,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -294,6 +296,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -230,6 +230,10 @@ namespace Wide
         public ulong Id;            // full wire identity of the table name
         public int NumFields;
         public TableFieldInfo[] Fields;
+        // open-addressing over Fields, same mix as TableWire.Ids.Slot. Built once
+        // in TableType() so a ReadBody id lookup is not a linear scan of Fields.
+        internal TableFieldInfo[] IdIndex;
+        internal int IdMask;
         // put one instance back at its declared defaults, in place. A generic
         // walker that FILLS a value has to establish the defaults an absent field
         // takes, and it holds no type to spell — this is the one thing the columns
@@ -2882,8 +2886,8 @@ namespace Wide
             {
                 while (r.Ref(out ulong reference, out ulong id) && reference != 0 && r.Has(1))
                 {
-                    byte kind = r.Byte(); TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id && Kind(f) == kind) { field = f; break; } }
+                    byte kind = r.Byte(); TableFieldInfo field = FindField(type, id);
+                    if (field != null && Kind(field) != kind) { field = null; }
                     if (field == null) { if (!r.Skip(kind)) { break; } continue; }
                     if (!ExtentField(ref r, field, true, ref at, ref reason)) { return false; }
                 }
@@ -3458,8 +3462,7 @@ namespace Wide
                     if (!MessageReference(ref r, d, out ulong reference, out TableMessageEntry entry)) { return false; }
                     if (reference == 0) { return true; }
                     if (Reserved(entry.Id)) { return false; }
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, entry.Id);
                     if (field == null)
                     { d.Report.Unknown++; if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } continue; }
                     if (!MessageCompatible(entry, field, out bool widened))
@@ -3723,7 +3726,7 @@ namespace Wide
                     if (reference == 0) { return true; }
                     TableFieldInfo field = null;
                     if (type != null)
-                    { foreach (TableFieldInfo f in type.Fields) { if (f.Id == entry.Id && MessageCompatible(entry,f,out _)) { field = f; break; } } }
+                    { field = FindField(type, entry.Id); if (field != null && !MessageCompatible(entry,field,out _)) { field = null; } }
                     if (field == null) { if (!MessageSkip(ref r, d, entry.Kind, entry.Shape)) { return false; } }
                     else if (!MessageExtentField(ref r, d, field, entry.Kind, entry.Shape, ref extent)) { return false; }
                 }
@@ -4602,6 +4605,52 @@ namespace Wide
                 }
                 return ReadElement(ref r, value, f, 0, kind, report, true);
             }
+            // IndexFields builds a power-of-two open-addressing table over Fields using
+            // the same mix as Ids.Slot. Nested static TableType() Build() calls it
+            // before publishing Instance, so ARM64 sees the index with the descriptor.
+            internal static void IndexFields(TableTypeInfo type)
+            {
+                TableFieldInfo[] fields = type.Fields;
+                if (fields == null || fields.Length == 0)
+                {
+                    type.IdIndex = Array.Empty<TableFieldInfo>();
+                    type.IdMask = 0;
+                    return;
+                }
+                int slots = 1;
+                while (slots < fields.Length * 2) { slots <<= 1; }
+                TableFieldInfo[] index = new TableFieldInfo[slots];
+                int mask = slots - 1;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    TableFieldInfo f = fields[i];
+                    int slot = unchecked((int)(f.Id ^ (f.Id >> 32))) & mask;
+                    while (index[slot] != null) { slot = (slot + 1) & mask; }
+                    index[slot] = f;
+                }
+                type.IdIndex = index;
+                type.IdMask = mask;
+            }
+            internal static TableFieldInfo FindField(TableTypeInfo type, ulong id)
+            {
+                TableFieldInfo[] index = type.IdIndex;
+                if (index != null)
+                {
+                    if (index.Length == 0) { return null; }
+                    int mask = type.IdMask;
+                    int slot = unchecked((int)(id ^ (id >> 32))) & mask;
+                    for (;;)
+                    {
+                        TableFieldInfo f = index[slot];
+                        if (f == null) { return null; }
+                        if (f.Id == id) { return f; }
+                        slot = (slot + 1) & mask;
+                    }
+                }
+                if (type.Fields == null) { return null; }
+                foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { return f; } }
+                return null;
+            }
             static bool ReadBody(ref Reader r, object value, TableTypeInfo type, TableReport report, bool nested)
             {
                 // Load resets the root before even the framing checks. Every nested
@@ -4614,8 +4663,7 @@ namespace Wide
                     if ((nested && id == ulong.MaxValue) || id == ulong.MaxValue - 1 || id == ulong.MaxValue - 2) { return Damage(report); }
                     if (!r.Has(1)) { return Damage(report); }
                     byte kind = r.Byte();
-                    TableFieldInfo field = null;
-                    foreach (TableFieldInfo f in type.Fields) { if (f.Id == id) { field = f; break; } }
+                    TableFieldInfo field = FindField(type, id);
                     if (!nested && id == ulong.MaxValue && type.Variable)
                     { if (!r.Skip(kind)) { return Damage(report); } continue; }
                     if (field == null)

--- a/testdata/golden/wide/cs/WideView.cs
+++ b/testdata/golden/wide/cs/WideView.cs
@@ -114,6 +114,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -155,6 +156,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -196,6 +198,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }
@@ -237,6 +240,7 @@ namespace Wide
                 info.Doc = TableDocNone;
                 info.NumTags = 0;
                 info.Tags = null;
+                TableWire.IndexFields(info);
                 return info;
             }
         }


### PR DESCRIPTION
## Comparison

Packet C# is generated straight-line field access. Go and C++ Fixed Table generate a `switch` on the 64-bit field id. C# Table is a shared interpreter: `ReadBody`, `NativeReadBody`, `MessageReadBody`, `NativeMessageReadBody`, `ExtentBody`, and the message-measure twin each linear-scanned `type.Fields` once per wire field.

That is the owned C# lookup hotspot from merged #778 at `54f1962d`. This does not duplicate Emma's LEB. It does not take Stella's unkeyed sizing experiment.

## Change

Reuse the #765 writer mix (`id ^ id>>32`, power-of-two open addressing). `TableType()` builds the index once inside the nested static holder so ARM64 sees it with the descriptor. `FindField` is the ReadBody lookup. Extent still requires kind match after the id hit; unknown ids still skip.

## Local gates

- `tables-cs-leg` Debug and Release green
- wire-fuzz seed 1 N=2000: 154842 mutants, 0 divergences
- `TestGoldenTableSource` / `TestGoldenWideSource` re-pinned for C# only

I do not merge this.

Johnny Grok.