### PR TITLE
Coalesce cached C table field headers

### DIFF
--- a/compiler/ctablerefordinal_test.go
+++ b/compiler/ctablerefordinal_test.go
@@ -312,7 +312,7 @@ func TestCTableRefOrdinalBytes(t *testing.T) {
 			"int32_t slot[",
 			"ordinal_of[",
 			"void table_writer_id_at( TableWriter * w, int32_t ordinal, uint64_t id )",
-			"table_writer_id_at( w, ",
+			"table_writer_header_at( w, ",
 		} {
 			if !strings.Contains(header, want) {
 				t.Fatalf("the generated save path does not carry %q — this test would prove nothing", want)
@@ -469,7 +469,7 @@ func TestCTableRefOrdinalSharedId(t *testing.T) {
 	// exists for is not in the sources at all
 	header := string(files["ProbeTable.h"])
 	const shared = "0x8ac625bb85ed202bull" // TableWireId( "alpha" )
-	if !strings.Contains(header, "table_writer_id_at( w, 5, "+shared+" )") || !strings.Contains(header, "table_writer_id( w, "+shared+" )") {
+	if !strings.Contains(header, "table_writer_header_at( w, 5, "+shared+", ") || !strings.Contains(header, "table_writer_id( w, "+shared+" )") {
 		t.Fatalf("the schema no longer gives one id both a field header and an enum variant: this test would prove nothing")
 	}
 	out := runCRefOrdinal(t, files, cRefOrdinalCollisionDriver, "ccollide",

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -371,6 +371,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1785,7 +1793,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->entity_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 11, 0x23fcfd6678e36712ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 11, 0x23fcfd6678e36712ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->entity_id ) );
         }
     }
@@ -1793,7 +1801,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->pos_x == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 65, 0xcb4b37357667310eull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 65, 0xcb4b37357667310eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_x ) );
         }
     }
@@ -1801,7 +1809,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->pos_y == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 66, 0xcb4b3835766732c1ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 66, 0xcb4b3835766732c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_y ) );
         }
     }
@@ -1809,7 +1817,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->pos_z == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 64, 0xcb4b353576672da8ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 64, 0xcb4b353576672da8ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_z ) );
         }
     }
@@ -1817,7 +1825,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->yaw == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 58, 0xb54d8e19798e16e8ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 58, 0xb54d8e19798e16e8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->yaw ) );
         }
     }
@@ -1825,7 +1833,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->pitch == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 22, 0x53a9f665a90cc1b1ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 22, 0x53a9f665a90cc1b1ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->pitch ) );
         }
     }
@@ -1833,7 +1841,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->vel_x == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 27, 0x6cede6b6eb60ee67ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 27, 0x6cede6b6eb60ee67ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_x ) );
         }
     }
@@ -1841,7 +1849,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->vel_y == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 26, 0x6cede5b6eb60ecb4ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 26, 0x6cede5b6eb60ecb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_y ) );
         }
     }
@@ -1849,7 +1857,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->vel_z == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x6cede8b6eb60f1cdull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 28, 0x6cede8b6eb60f1cdull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_z ) );
         }
     }
@@ -1857,7 +1865,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->health == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0x7f69d4b5288ba9cfull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 37, 0x7f69d4b5288ba9cfull, 4 );
             table_writer_put32( w, (uint32_t) ( value->health ) );
         }
     }
@@ -1865,7 +1873,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->weapon == MIXED_WEAPON_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 52, 0xa0b610205f2c6e01ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 52, 0xa0b610205f2c6e01ull, 30 );
             switch ( value->weapon )
             {
                 case MIXED_WEAPON_NONE: table_writer_leb( w, 0 ); break;
@@ -1892,7 +1900,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->damage == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 36, 0x7f6308be8ab37fc0ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->damage ) );
         }
     }
@@ -1900,7 +1908,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->moving == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 5, 0x11a44fc1d1243da7ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 5, 0x11a44fc1d1243da7ull, 1 );
             table_writer_put8( w, value->moving ? 1 : 0 );
         }
     }
@@ -1908,7 +1916,7 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
         if ( !( value->firing == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 32, 0x7674cfd19b9031caull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 32, 0x7674cfd19b9031caull, 1 );
             table_writer_put8( w, value->firing ? 1 : 0 );
         }
     }
@@ -3413,7 +3421,7 @@ static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat 
         if ( !( value->stat_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 38, 0x80ab75f0866dbf65ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 38, 0x80ab75f0866dbf65ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->stat_id ) );
         }
     }
@@ -3421,7 +3429,7 @@ static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat 
         if ( !( value->delta == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x52076675ec13a0c1ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 21, 0x52076675ec13a0c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->delta ) );
         }
     }
@@ -3756,7 +3764,7 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
         if ( !( value->target_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 59, 0xb7bc9ac015a25050ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 59, 0xb7bc9ac015a25050ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->target_id ) );
         }
     }
@@ -3764,7 +3772,7 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
         if ( !( value->damage == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 36, 0x7f6308be8ab37fc0ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->damage ) );
         }
     }
@@ -3772,7 +3780,7 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
         if ( !( value->hit_kind == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x01fbc365b059b925ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 1, 0x01fbc365b059b925ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hit_kind ) );
         }
     }
@@ -3780,7 +3788,7 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
         if ( !( value->crit == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x126167908c9aa52dull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 6, 0x126167908c9aa52dull, 1 );
             table_writer_put8( w, value->crit ? 1 : 0 );
         }
     }
@@ -4292,7 +4300,7 @@ static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const Mixe
         if ( !( value->channel == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 54, 0xa5013e9ad5caeda4ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 54, 0xa5013e9ad5caeda4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->channel ) );
         }
     }
@@ -4300,7 +4308,7 @@ static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const Mixe
         if ( !( value->speaker == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 76, 0xfbf1ac4d96ebd022ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 76, 0xfbf1ac4d96ebd022ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->speaker ) );
         }
     }
@@ -4661,7 +4669,7 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const Mi
         if ( !( value->item_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 48, 0x9e7fd06d864fbd56ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 48, 0x9e7fd06d864fbd56ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->item_id ) );
         }
     }
@@ -4669,7 +4677,7 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const Mi
         if ( !( value->amount == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 39, 0x8113fe7ea2b16969ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 39, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
     }
@@ -5123,7 +5131,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xaa38aca481f528a8ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 56, 0xaa38aca481f528a8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->sequence ) );
         }
     }
@@ -5131,7 +5139,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->ack_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 4, 0x0dbe005c56697c3eull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 4, 0x0dbe005c56697c3eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->ack_sequence ) );
         }
     }
@@ -5139,7 +5147,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->ack_bits == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 46, 0x9bae0da8b829ee03ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 46, 0x9bae0da8b829ee03ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->ack_bits ) );
         }
     }
@@ -5147,7 +5155,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->session_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 60, 0xb7d7b5650a590b05ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 60, 0xb7d7b5650a590b05ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->session_id ) );
         }
     }
@@ -5155,7 +5163,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->client_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 29, 0x6d7b98e2d095967eull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 29, 0x6d7b98e2d095967eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->client_id ) );
         }
     }
@@ -5163,7 +5171,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->nonce == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x73a94c71d60dc0d8ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 31, 0x73a94c71d60dc0d8ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->nonce ) );
         }
     }
@@ -5171,7 +5179,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->world_time == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 20, 0x3eee6b51be54fc85ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 20, 0x3eee6b51be54fc85ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->world_time ) );
         }
     }
@@ -5179,7 +5187,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->frame_tick == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 34, 0x7bbc035f7b6d0112ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 34, 0x7bbc035f7b6d0112ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->frame_tick ) );
         }
     }
@@ -5187,7 +5195,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->server_time == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 18, 0x3c460475f9be69c6ull ); table_writer_put8( w, 22 );
+            table_writer_header_at( w, 18, 0x3c460475f9be69c6ull, 22 );
             table_writer_put32( w, (uint32_t) ( value->server_time ) );
         }
     }
@@ -5196,7 +5204,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( value->entities_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 43, 0x935d0fb07bb3822aull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 43, 0x935d0fb07bb3822aull, 14 );
             int64_t element_sizes[8]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -5218,7 +5226,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( value->stats_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 74, 0xee639cad45b1994cull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 74, 0xee639cad45b1994cull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -5239,7 +5247,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( value->game_event.type != MIXED_EVENT_TYPE_NONE )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 14, 0x2e35dc5321aa5790ull ); table_writer_put8( w, 15 );
+            table_writer_header_at( w, 14, 0x2e35dc5321aa5790ull, 15 );
             if ( !schema_bench_mixed_event_wire_save_( w, &value->game_event ) ) { return 0; }
         }
     }
@@ -5249,7 +5257,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 24, 0x5759ce7586bbb5a3ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 24, 0x5759ce7586bbb5a3ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5270,7 +5278,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( value->player_name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x13a62f542cf8e86eull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 7, 0x13a62f542cf8e86eull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5291,7 +5299,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( value->payload_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 67, 0xcfb8a9d063b5e9e5ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 67, 0xcfb8a9d063b5e9e5ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5311,7 +5319,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->aim_x == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 72, 0xdbaf7be5e24296c9ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 72, 0xdbaf7be5e24296c9ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_x ) );
         }
     }
@@ -5319,7 +5327,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->aim_y == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 71, 0xdbaf7ae5e2429516ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 71, 0xdbaf7ae5e2429516ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_y ) );
         }
     }
@@ -5327,7 +5335,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->aim_z == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 70, 0xdbaf79e5e2429363ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 70, 0xdbaf79e5e2429363ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_z ) );
         }
     }
@@ -5335,7 +5343,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->recoil == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 47, 0x9cef31fff7e2e457ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 47, 0x9cef31fff7e2e457ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->recoil ) );
         }
     }
@@ -5343,7 +5351,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->drift == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 25, 0x5ab3f9c9341f6c04ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 25, 0x5ab3f9c9341f6c04ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->drift ) );
         }
     }
@@ -5351,7 +5359,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( serialize_uint128_equal( value->wide_key, serialize_uint128_make( 0ull, 0ull ) ) ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 53, 0xa3348580461faf16ull ); table_writer_put8( w, 19 );
+            table_writer_header_at( w, 53, 0xa3348580461faf16ull, 19 );
             table_writer_put64( w, (value->wide_key).lo ); table_writer_put64( w, (value->wide_key).hi );
         }
     }
@@ -5359,7 +5367,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( serialize_int128_equal( value->flux, serialize_int128_make( 0ull, 0ull ) ) ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 68, 0xd61bdd7908af2642ull ); table_writer_put8( w, 18 );
+            table_writer_header_at( w, 68, 0xd61bdd7908af2642ull, 18 );
             table_writer_put64( w, (value->flux).lo ); table_writer_put64( w, (value->flux).hi );
         }
     }
@@ -5367,7 +5375,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->ping == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 61, 0xbf30e00dc53307a9ull ); table_writer_put8( w, 26 );
+            table_writer_header_at( w, 61, 0xbf30e00dc53307a9ull, 26 );
             table_writer_put16( w, (uint16_t) ( value->ping ) );
         }
     }
@@ -5375,7 +5383,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->crc_hint == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 23, 0x560d6527ccd8515full ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 23, 0x560d6527ccd8515full, 8 );
             table_writer_put32( w, (uint32_t) ( value->crc_hint ) );
         }
     }
@@ -5383,7 +5391,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->has_extra == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 62, 0xc08292176cfd8672ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 62, 0xc08292176cfd8672ull, 1 );
             table_writer_put8( w, value->has_extra ? 1 : 0 );
         }
     }
@@ -5393,7 +5401,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->extra == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 77, 0xfd29ee12a979cb69ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 77, 0xfd29ee12a979cb69ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->extra ) );
         }
     }
@@ -5404,7 +5412,7 @@ static SCHEMA_UNUSED int bench_mixed_save_body( TableWriter * w, const BenchMixe
         if ( !( value->idle_ticks == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 33, 0x78101ac0aa8cbcfeull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 33, 0x78101ac0aa8cbcfeull, 4 );
             table_writer_put32( w, (uint32_t) ( value->idle_ticks ) );
         }
     }

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -372,6 +372,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_BENCH_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1458,7 +1466,7 @@ static SCHEMA_UNUSED int fixed_table_save_body( TableWriter * w, const FixedTabl
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 35, 0x7ce4fd9430e80ceaull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 35, 0x7ce4fd9430e80ceaull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -358,6 +358,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1845,7 +1853,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->entity_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 11, 0x23fcfd6678e36712ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 11, 0x23fcfd6678e36712ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->entity_id ) );
         }
     }
@@ -1853,7 +1861,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->pos_x == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 65, 0xcb4b37357667310eull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 65, 0xcb4b37357667310eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_x ) );
         }
     }
@@ -1861,7 +1869,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->pos_y == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 66, 0xcb4b3835766732c1ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 66, 0xcb4b3835766732c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_y ) );
         }
     }
@@ -1869,7 +1877,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->pos_z == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 64, 0xcb4b353576672da8ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 64, 0xcb4b353576672da8ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_z ) );
         }
     }
@@ -1877,7 +1885,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->yaw == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 59, 0xb54d8e19798e16e8ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 59, 0xb54d8e19798e16e8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->yaw ) );
         }
     }
@@ -1885,7 +1893,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->pitch == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 24, 0x53a9f665a90cc1b1ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 24, 0x53a9f665a90cc1b1ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->pitch ) );
         }
     }
@@ -1893,7 +1901,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->vel_x == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 30, 0x6cede6b6eb60ee67ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 30, 0x6cede6b6eb60ee67ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_x ) );
         }
     }
@@ -1901,7 +1909,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->vel_y == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 29, 0x6cede5b6eb60ecb4ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 29, 0x6cede5b6eb60ecb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_y ) );
         }
     }
@@ -1909,7 +1917,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->vel_z == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x6cede8b6eb60f1cdull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 31, 0x6cede8b6eb60f1cdull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_z ) );
         }
     }
@@ -1917,7 +1925,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->health == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 41, 0x7f69d4b5288ba9cfull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 41, 0x7f69d4b5288ba9cfull, 4 );
             table_writer_put32( w, (uint32_t) ( value->health ) );
         }
     }
@@ -1925,7 +1933,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->weapon == TABLE_WEAPON_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 54, 0xa0b610205f2c6e01ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 54, 0xa0b610205f2c6e01ull, 30 );
             switch ( value->weapon )
             {
                 case TABLE_WEAPON_NONE: table_writer_leb( w, 0 ); break;
@@ -1952,7 +1960,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->damage == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 40, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 40, 0x7f6308be8ab37fc0ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->damage ) );
         }
     }
@@ -1960,7 +1968,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->moving == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 5, 0x11a44fc1d1243da7ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 5, 0x11a44fc1d1243da7ull, 1 );
             table_writer_put8( w, value->moving ? 1 : 0 );
         }
     }
@@ -1968,7 +1976,7 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
         if ( !( value->firing == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0x7674cfd19b9031caull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 36, 0x7674cfd19b9031caull, 1 );
             table_writer_put8( w, value->firing ? 1 : 0 );
         }
     }
@@ -3473,7 +3481,7 @@ static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat 
         if ( !( value->stat_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 42, 0x80ab75f0866dbf65ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 42, 0x80ab75f0866dbf65ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->stat_id ) );
         }
     }
@@ -3481,7 +3489,7 @@ static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat 
         if ( !( value->delta == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 23, 0x52076675ec13a0c1ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 23, 0x52076675ec13a0c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->delta ) );
         }
     }
@@ -3899,7 +3907,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->protocol_magic == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x6a5a70d91aa115fdull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 28, 0x6a5a70d91aa115fdull, 7 );
             table_writer_put16( w, (uint16_t) ( value->protocol_magic ) );
         }
     }
@@ -3907,7 +3915,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 58, 0xaa38aca481f528a8ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 58, 0xaa38aca481f528a8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->sequence ) );
         }
     }
@@ -3915,7 +3923,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->ack_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 4, 0x0dbe005c56697c3eull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 4, 0x0dbe005c56697c3eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->ack_sequence ) );
         }
     }
@@ -3923,7 +3931,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->ack_bits == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 49, 0x9bae0da8b829ee03ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 49, 0x9bae0da8b829ee03ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->ack_bits ) );
         }
     }
@@ -3931,7 +3939,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->session_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 61, 0xb7d7b5650a590b05ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 61, 0xb7d7b5650a590b05ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->session_id ) );
         }
     }
@@ -3939,7 +3947,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->client_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 32, 0x6d7b98e2d095967eull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 32, 0x6d7b98e2d095967eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->client_id ) );
         }
     }
@@ -3947,7 +3955,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->nonce == 1ull ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 34, 0x73a94c71d60dc0d8ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 34, 0x73a94c71d60dc0d8ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->nonce ) );
         }
     }
@@ -3955,7 +3963,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->world_time == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x3eee6b51be54fc85ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 21, 0x3eee6b51be54fc85ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->world_time ) );
         }
     }
@@ -3963,7 +3971,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->frame_tick == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 39, 0x7bbc035f7b6d0112ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 39, 0x7bbc035f7b6d0112ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->frame_tick ) );
         }
     }
@@ -3971,7 +3979,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->server_time == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 20, 0x3c460475f9be69c6ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 20, 0x3c460475f9be69c6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->server_time ) );
         }
     }
@@ -3980,7 +3988,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->entities_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 46, 0x935d0fb07bb3822aull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 46, 0x935d0fb07bb3822aull, 14 );
             int64_t element_sizes[8]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -4002,7 +4010,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->stats_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 73, 0xee639cad45b1994cull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 73, 0xee639cad45b1994cull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -4023,7 +4031,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->game_event.type != TABLE_EVENT_TYPE_NONE )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 15, 0x2e35dc5321aa5790ull ); table_writer_put8( w, 15 );
+            table_writer_header_at( w, 15, 0x2e35dc5321aa5790ull, 15 );
             if ( !schema_benchtable_table_event_wire_save_( w, &value->game_event ) ) { return 0; }
         }
     }
@@ -4033,7 +4041,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 26, 0x5759ce7586bbb5a3ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 26, 0x5759ce7586bbb5a3ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4054,7 +4062,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->player_name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x13a62f542cf8e86eull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 7, 0x13a62f542cf8e86eull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4075,7 +4083,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->payload_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 67, 0xcfb8a9d063b5e9e5ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 67, 0xcfb8a9d063b5e9e5ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4095,7 +4103,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->aim_x == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 72, 0xdbaf7be5e24296c9ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 72, 0xdbaf7be5e24296c9ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_x ) );
         }
     }
@@ -4103,7 +4111,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->aim_y == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 71, 0xdbaf7ae5e2429516ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 71, 0xdbaf7ae5e2429516ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_y ) );
         }
     }
@@ -4111,7 +4119,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->aim_z == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 70, 0xdbaf79e5e2429363ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 70, 0xdbaf79e5e2429363ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_z ) );
         }
     }
@@ -4119,7 +4127,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->recoil == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 50, 0x9cef31fff7e2e457ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 50, 0x9cef31fff7e2e457ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->recoil ) );
         }
     }
@@ -4127,7 +4135,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->drift == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 27, 0x5ab3f9c9341f6c04ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 27, 0x5ab3f9c9341f6c04ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->drift ) );
         }
     }
@@ -4135,7 +4143,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->wide_key == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 55, 0xa3348580461faf16ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 55, 0xa3348580461faf16ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->wide_key ) );
         }
     }
@@ -4143,7 +4151,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->flux == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 68, 0xd61bdd7908af2642ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 68, 0xd61bdd7908af2642ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->flux ) );
         }
     }
@@ -4151,7 +4159,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->ping == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 62, 0xbf30e00dc53307a9ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 62, 0xbf30e00dc53307a9ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->ping ) );
         }
     }
@@ -4159,7 +4167,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->crc_hint == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 25, 0x560d6527ccd8515full ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 25, 0x560d6527ccd8515full, 8 );
             table_writer_put32( w, (uint32_t) ( value->crc_hint ) );
         }
     }
@@ -4167,7 +4175,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->has_extra == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 63, 0xc08292176cfd8672ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 63, 0xc08292176cfd8672ull, 1 );
             table_writer_put8( w, value->has_extra ? 1 : 0 );
         }
     }
@@ -4177,7 +4185,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->extra == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 76, 0xfd29ee12a979cb69ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 76, 0xfd29ee12a979cb69ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->extra ) );
         }
     }
@@ -4188,7 +4196,7 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( !( value->idle_ticks == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0x78101ac0aa8cbcfeull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 37, 0x78101ac0aa8cbcfeull, 4 );
             table_writer_put32( w, (uint32_t) ( value->idle_ticks ) );
         }
     }
@@ -6724,7 +6732,7 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
         if ( !( value->target_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 60, 0xb7bc9ac015a25050ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 60, 0xb7bc9ac015a25050ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->target_id ) );
         }
     }
@@ -6732,7 +6740,7 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
         if ( !( value->damage == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 40, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 40, 0x7f6308be8ab37fc0ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->damage ) );
         }
     }
@@ -6740,7 +6748,7 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
         if ( !( value->hit_kind == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x01fbc365b059b925ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 1, 0x01fbc365b059b925ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hit_kind ) );
         }
     }
@@ -6748,7 +6756,7 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
         if ( !( value->crit == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x126167908c9aa52dull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 6, 0x126167908c9aa52dull, 1 );
             table_writer_put8( w, value->crit ? 1 : 0 );
         }
     }
@@ -7260,7 +7268,7 @@ static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const Tabl
         if ( !( value->channel == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xa5013e9ad5caeda4ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 56, 0xa5013e9ad5caeda4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->channel ) );
         }
     }
@@ -7268,7 +7276,7 @@ static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const Tabl
         if ( !( value->speaker == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 75, 0xfbf1ac4d96ebd022ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 75, 0xfbf1ac4d96ebd022ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->speaker ) );
         }
     }
@@ -7629,7 +7637,7 @@ static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const Ta
         if ( !( value->item_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 51, 0x9e7fd06d864fbd56ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 51, 0x9e7fd06d864fbd56ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->item_id ) );
         }
     }
@@ -7637,7 +7645,7 @@ static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const Ta
         if ( !( value->amount == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 43, 0x8113fe7ea2b16969ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 43, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
     }

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -43,6 +43,13 @@ func (g *tableGen) wireIdCall(id uint64) string {
 	return fmt.Sprintf("table_writer_id_at( w, %d, 0x%016xull );", g.knownOrdinal(id), id)
 }
 
+func (g *tableGen) wireHeaderCall(id uint64, kind int) string {
+	if g.retain {
+		return fmt.Sprintf("%s table_writer_put8( w, %d );", g.wireIdCall(id), kind)
+	}
+	return fmt.Sprintf("table_writer_header_at( w, %d, 0x%016xull, %d );", g.knownOrdinal(id), id, kind)
+}
+
 func (g *tableGen) wirePrimitives() string {
 	runtime := ""
 	if g.fileWire() {
@@ -188,6 +195,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     if(r==0) { return; }
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(@ID_ORD@)ordinal;
+}
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED @INLINE@ void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
 }
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
@@ -670,7 +685,7 @@ func (g *tableGen) emitWireWrite(st *ir.Struct) {
 		}
 		g.pf("        if ( %s )\n        {\n", condition)
 		g.pf("            if ( w->check_default ) { w->offset = 2; return 1; }\n")
-		g.pf("            %s table_writer_put8( w, %d );\n", g.wireIdCall(ir.TableFieldWireId(f)), wireKind)
+		g.pf("            %s\n", g.wireHeaderCall(ir.TableFieldWireId(f), wireKind))
 		switch {
 		case framed:
 			if slots := g.wireElementCacheSlots(st, f); slots > 0 {

--- a/internal/tablenames/c.go
+++ b/internal/tablenames/c.go
@@ -271,6 +271,7 @@ func init() {
 		Name{Name: "table_writer_finish", What: "the form-1 file wire runtime"},
 		Name{Name: "table_writer_id", What: "the form-1 file wire runtime"},
 		Name{Name: "table_writer_id_at", What: "the form-1 file wire runtime's ordinal slot cache"},
+		Name{Name: "table_writer_header_at", What: "the form-1 file wire runtime's paired field header"},
 		Name{Name: "table_writer_leb", What: "the form-1 file wire runtime"},
 		Name{Name: "table_writer_probe", What: "the form-1 file wire runtime"},
 		Name{Name: "TableReport", What: "the read report — the permissive contract's ledger"},

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -361,6 +361,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1573,7 +1581,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( !( value->tag == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 25, 0x56d7ab194448a4f3ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 25, 0x56d7ab194448a4f3ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->tag ) );
         }
     }
@@ -1581,7 +1589,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( !( value->value == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0x7ce4fd9430e80ceaull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 36, 0x7ce4fd9430e80ceaull, 11 );
             table_writer_put64( w, table_double_to_bits( value->value ) );
         }
     }
@@ -1589,7 +1597,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( !( value->flag == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 73, 0xd5f2d079088c0b17ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 73, 0xd5f2d079088c0b17ull, 1 );
             table_writer_put8( w, value->flag ? 1 : 0 );
         }
     }
@@ -1597,7 +1605,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( !( value->id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x08b72e07b55c3ac0ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 0, 0x08b72e07b55c3ac0ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->id ) );
         }
     }
@@ -1606,7 +1614,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( value->label_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 16, 0x39f7fcec8fcb623dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 16, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1628,7 +1636,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 79, 0xe68c2e6bb1ee5646ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 79, 0xe68c2e6bb1ee5646ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1654,7 +1662,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 58, 0xbaaeb048a5a8fa6dull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 58, 0xbaaeb048a5a8fa6dull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1674,7 +1682,7 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( value->counter_present )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 35, 0x77976c7416517c63ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 35, 0x77976c7416517c63ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->counter ) );
         }
     }
@@ -2523,7 +2531,7 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( !( value->marker == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 81, 0xeddcb72b15486e77ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 81, 0xeddcb72b15486e77ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->marker ) );
         }
     }
@@ -2531,7 +2539,7 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( !( value->stamp == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 83, 0xee7ba9ad45c64144ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 83, 0xee7ba9ad45c64144ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->stamp ) );
         }
     }
@@ -2540,7 +2548,7 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( value->rows_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 48, 0xa3a7061ff10a8138ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 48, 0xa3a7061ff10a8138ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -2562,7 +2570,7 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( value->blob_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 64, 0xc573b39bc29148caull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 64, 0xc573b39bc29148caull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_BLOCKDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1878,7 +1886,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1901,7 +1909,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1921,7 +1929,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( !( value->camera_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 45, 0x9f61700f084ab92eull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 45, 0x9f61700f084ab92eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->camera_id ) );
         }
     }
@@ -1929,7 +1937,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( !( value->camera_type == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 15, 0x336d3dc7fffd0c9bull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 15, 0x336d3dc7fffd0c9bull, 8 );
             table_writer_put32( w, (uint32_t) ( value->camera_type ) );
         }
     }
@@ -1937,7 +1945,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( !( value->target_object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x6a0c6a156952b9c2ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
     }
@@ -1945,7 +1953,7 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         if ( !( value->fov == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 76, 0xdcb27c18fed9e15cull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 76, 0xdcb27c18fed9e15cull, 10 );
             table_writer_put32( w, table_float_to_bits( value->fov ) );
         }
     }
@@ -2505,7 +2513,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2528,7 +2536,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2548,7 +2556,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -2556,7 +2564,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x0bdab42c07f19812ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
     }
@@ -2564,7 +2572,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->target_object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x6a0c6a156952b9c2ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
     }
@@ -2572,7 +2580,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->thrust == 0.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 70, 0xcfd587cb3100cd73ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 70, 0xcfd587cb3100cd73ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->thrust ) );
         }
     }
@@ -2580,7 +2588,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->object_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x5de0015285763c46ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
     }
@@ -2588,7 +2596,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->ship_type == SHIP_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 11, 0x1f7d2e86a2e77268ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 11, 0x1f7d2e86a2e77268ull, 30 );
             switch ( value->ship_type )
             {
                 case SHIP_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -2603,7 +2611,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -2619,7 +2627,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->has_target_lock == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x1554fa45a1220171ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 7, 0x1554fa45a1220171ull, 1 );
             table_writer_put8( w, value->has_target_lock ? 1 : 0 );
         }
     }
@@ -2627,7 +2635,7 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         if ( !( value->predicted_explode == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 22, 0x4d5be97ba1b9cb81ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 22, 0x4d5be97ba1b9cb81ull, 1 );
             table_writer_put8( w, value->predicted_explode ? 1 : 0 );
         }
     }
@@ -3466,7 +3474,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3486,7 +3494,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -3494,7 +3502,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x0bdab42c07f19812ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
     }
@@ -3502,7 +3510,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->parent_object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 2, 0x0bee7b3cb4046c93ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 2, 0x0bee7b3cb4046c93ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->parent_object_id ) );
         }
     }
@@ -3510,7 +3518,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->turret_index == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 40, 0x88a11a6aed541f54ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 40, 0x88a11a6aed541f54ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->turret_index ) );
         }
     }
@@ -3518,7 +3526,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->target_object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x6a0c6a156952b9c2ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
     }
@@ -3526,7 +3534,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->object_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x5de0015285763c46ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
     }
@@ -3534,7 +3542,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -3550,7 +3558,7 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         if ( !( value->has_target_lock == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x1554fa45a1220171ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 7, 0x1554fa45a1220171ull, 1 );
             table_writer_put8( w, value->has_target_lock ? 1 : 0 );
         }
     }
@@ -4387,7 +4395,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4410,7 +4418,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4430,7 +4438,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -4438,7 +4446,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( !( value->object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x0bdab42c07f19812ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
     }
@@ -4446,7 +4454,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( !( value->object_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x5de0015285763c46ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
     }
@@ -4454,7 +4462,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( !( value->missile_type == MISSILE_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x151b2a0e2c07b4bcull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 6, 0x151b2a0e2c07b4bcull, 30 );
             switch ( value->missile_type )
             {
                 case MISSILE_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -4468,7 +4476,7 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -5086,7 +5094,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5109,7 +5117,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5129,7 +5137,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -5137,7 +5145,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( !( value->object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x0bdab42c07f19812ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
     }
@@ -5145,7 +5153,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( !( value->object_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x5de0015285763c46ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
     }
@@ -5153,7 +5161,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 78, 0xe5626f155e4c5dadull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
                 case PROP_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -5168,7 +5176,7 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -5791,7 +5799,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5814,7 +5822,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5834,7 +5842,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( !( value->scale == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 32, 0x6aacb9fbb71a1d91ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 32, 0x6aacb9fbb71a1d91ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->scale ) );
         }
     }
@@ -5842,7 +5850,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -5850,7 +5858,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( !( value->static_prop_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 72, 0xd23da7ab574b95c3ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 72, 0xd23da7ab574b95c3ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->static_prop_id ) );
         }
     }
@@ -5858,7 +5866,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 78, 0xe5626f155e4c5dadull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
                 case PROP_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -5873,7 +5881,7 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -6523,7 +6531,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6546,7 +6554,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6566,7 +6574,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->scale == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 32, 0x6aacb9fbb71a1d91ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 32, 0x6aacb9fbb71a1d91ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->scale ) );
         }
     }
@@ -6574,7 +6582,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->flags == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x17a3a1a985f75aecull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
     }
@@ -6582,7 +6590,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->cosmetic_prop_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 57, 0xb66e4449e56b2e26ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 57, 0xb66e4449e56b2e26ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->cosmetic_prop_id ) );
         }
     }
@@ -6590,7 +6598,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->prop_sequence == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 23, 0x4d7bf73bcbddc228ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 23, 0x4d7bf73bcbddc228ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->prop_sequence ) );
         }
     }
@@ -6598,7 +6606,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 78, 0xe5626f155e4c5dadull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
                 case PROP_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -6613,7 +6621,7 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -7312,7 +7320,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 82, 0xee5d97ad45ad251full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 82, 0xee5d97ad45ad251full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -7335,7 +7343,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 30, 0x6917a5bab91540f2ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 30, 0x6917a5bab91540f2ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -7355,7 +7363,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( !( value->t == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 50, 0xaf63e94c860202a3ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 50, 0xaf63e94c860202a3ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->t ) );
         }
     }
@@ -7363,7 +7371,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( !( value->laser_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 68, 0xcd29c05f390294ecull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 68, 0xcd29c05f390294ecull, 8 );
             table_writer_put32( w, (uint32_t) ( value->laser_id ) );
         }
     }
@@ -7371,7 +7379,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( !( value->laser_type == LASER_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 43, 0x96b593c242133841ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 43, 0x96b593c242133841ull, 30 );
             switch ( value->laser_type )
             {
                 case LASER_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -7385,7 +7393,7 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -7924,7 +7932,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x4cbf3a26fca1d74aull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -7947,7 +7955,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 56, 0xb51afb05cd34709full ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -7967,7 +7975,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( !( value->t == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 50, 0xaf63e94c860202a3ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 50, 0xaf63e94c860202a3ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->t ) );
         }
     }
@@ -7975,7 +7983,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( !( value->explosion_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 86, 0xfd7f3fa0b16ed778ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 86, 0xfd7f3fa0b16ed778ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->explosion_id ) );
         }
     }
@@ -7983,7 +7991,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( !( value->parent_object_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 2, 0x0bee7b3cb4046c93ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 2, 0x0bee7b3cb4046c93ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->parent_object_id ) );
         }
     }
@@ -7991,7 +7999,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( !( value->explosion_type == EXPLOSION_TYPE_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 75, 0xdc89eb9cd3393be5ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 75, 0xdc89eb9cd3393be5ull, 30 );
             switch ( value->explosion_type )
             {
                 case EXPLOSION_TYPE_NONE: table_writer_leb( w, 0 ); break;
@@ -8005,7 +8013,7 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         if ( !( value->team == TEAM_NONE ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xfa23d9ef19afc32cull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
                 case TEAM_NONE: table_writer_leb( w, 0 ); break;
@@ -9014,7 +9022,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( !( value->version == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 59, 0xbb62c62c9808ea37ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 59, 0xbb62c62c9808ea37ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->version ) );
         }
     }
@@ -9023,7 +9031,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->cameras_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 4, 0x0f9222d2ba7aa2a7ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 4, 0x0f9222d2ba7aa2a7ull, 14 );
             int64_t element_sizes[1]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9045,7 +9053,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->ships_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 12, 0x294a5c4913e1ad44ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 12, 0x294a5c4913e1ad44ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9067,7 +9075,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->turrets_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 38, 0x84f8260bc283608cull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 38, 0x84f8260bc283608cull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9089,7 +9097,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->missiles_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 9, 0x1c3027194b1ba4d0ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 9, 0x1c3027194b1ba4d0ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9111,7 +9119,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->dynamic_props_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 19, 0x43125398a9903d27ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 19, 0x43125398a9903d27ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9133,7 +9141,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->static_props_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 62, 0xc1f8d7edff7fcfd2ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 62, 0xc1f8d7edff7fcfd2ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9155,7 +9163,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->cosmetic_props_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 14, 0x33408e39f5f480ffull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 14, 0x33408e39f5f480ffull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9177,7 +9185,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->lasers_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 74, 0xd982b77b3e92d16dull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 74, 0xd982b77b3e92d16dull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -9199,7 +9207,7 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->explosions_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 39, 0x876a8c1a85806a69ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 39, 0x876a8c1a85806a69ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -10182,7 +10190,7 @@ static SCHEMA_UNUSED int render_vector3_save_body( TableWriter * w, const Render
         if ( !( value->x == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 53, 0xaf63f54c86021707ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 53, 0xaf63f54c86021707ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->x ) );
         }
     }
@@ -10190,7 +10198,7 @@ static SCHEMA_UNUSED int render_vector3_save_body( TableWriter * w, const Render
         if ( !( value->y == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 52, 0xaf63f44c86021554ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 52, 0xaf63f44c86021554ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->y ) );
         }
     }
@@ -10198,7 +10206,7 @@ static SCHEMA_UNUSED int render_vector3_save_body( TableWriter * w, const Render
         if ( !( value->z == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 54, 0xaf63f74c86021a6dull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 54, 0xaf63f74c86021a6dull, 11 );
             table_writer_put64( w, table_double_to_bits( value->z ) );
         }
     }
@@ -10602,7 +10610,7 @@ static SCHEMA_UNUSED int render_quaternion_save_body( TableWriter * w, const Ren
         if ( !( value->x == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 53, 0xaf63f54c86021707ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 53, 0xaf63f54c86021707ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->x ) );
         }
     }
@@ -10610,7 +10618,7 @@ static SCHEMA_UNUSED int render_quaternion_save_body( TableWriter * w, const Ren
         if ( !( value->y == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 52, 0xaf63f44c86021554ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 52, 0xaf63f44c86021554ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->y ) );
         }
     }
@@ -10618,7 +10626,7 @@ static SCHEMA_UNUSED int render_quaternion_save_body( TableWriter * w, const Ren
         if ( !( value->z == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 54, 0xaf63f74c86021a6dull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 54, 0xaf63f74c86021a6dull, 11 );
             table_writer_put64( w, table_double_to_bits( value->z ) );
         }
     }
@@ -10626,7 +10634,7 @@ static SCHEMA_UNUSED int render_quaternion_save_body( TableWriter * w, const Ren
         if ( !( value->w == 1.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 51, 0xaf63ea4c86020456ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 51, 0xaf63ea4c86020456ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->w ) );
         }
     }

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1499,7 +1507,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( !( value->active == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 57, 0x6580790b036f0c6full ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 57, 0x6580790b036f0c6full, 1 );
             table_writer_put8( w, value->active ? 1 : 0 );
         }
     }
@@ -1509,7 +1517,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( !( value->speed == 1.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 22, 0x2281498aa0200e40ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 22, 0x2281498aa0200e40ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->speed ) );
         }
     }
@@ -1520,7 +1528,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( !( value->has_target == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 23, 0x247f0e7f55aacfbdull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 23, 0x247f0e7f55aacfbdull, 1 );
             table_writer_put8( w, value->has_target ? 1 : 0 );
         }
     }
@@ -1531,7 +1539,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( !( value->target_id == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 103, 0xb7bc9ac015a25050ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 103, 0xb7bc9ac015a25050ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->target_id ) );
         }
     }
@@ -1542,7 +1550,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( !( value->wander == 0.5f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 104, 0xb8c758d8bd1845d4ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 104, 0xb8c758d8bd1845d4ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->wander ) );
         }
     }
@@ -1554,7 +1562,7 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( value->note_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0x3bf8fbbad1587cddull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 37, 0x3bf8fbbad1587cddull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1606,7 +1614,7 @@ static SCHEMA_UNUSED int team_config_save_body( TableWriter * w, const TeamConfi
         if ( !( value->spawn_count == 4 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 120, 0xceec99e2d65db674ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 120, 0xceec99e2d65db674ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->spawn_count ) );
         }
     }
@@ -1615,7 +1623,7 @@ static SCHEMA_UNUSED int team_config_save_body( TableWriter * w, const TeamConfi
         if ( value->banner_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 108, 0xbca0dab1c7a00ccfull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 108, 0xbca0dab1c7a00ccfull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1957,7 +1965,7 @@ static SCHEMA_UNUSED int gunner_config_save_body( TableWriter * w, const GunnerC
         if ( !( value->reaction == 0.2f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 101, 0xb75aa3662201646aull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 101, 0xb75aa3662201646aull, 10 );
             table_writer_put32( w, table_float_to_bits( value->reaction ) );
         }
     }
@@ -1965,7 +1973,7 @@ static SCHEMA_UNUSED int gunner_config_save_body( TableWriter * w, const GunnerC
         if ( !( value->tracking == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 90, 0xa6bf719a4602b0bcull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 90, 0xa6bf719a4602b0bcull, 1 );
             table_writer_put8( w, value->tracking ? 1 : 0 );
         }
     }
@@ -2202,7 +2210,7 @@ static SCHEMA_UNUSED int turret_config_save_body( TableWriter * w, const TurretC
         if ( !( value->damage == 10.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 66, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 66, 0x7f6308be8ab37fc0ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->damage ) );
         }
     }
@@ -2210,7 +2218,7 @@ static SCHEMA_UNUSED int turret_config_save_body( TableWriter * w, const TurretC
         if ( !( value->cooldown == 0.5f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 133, 0xdc2cbe6953343d48ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 133, 0xdc2cbe6953343d48ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->cooldown ) );
         }
     }
@@ -2218,7 +2226,7 @@ static SCHEMA_UNUSED int turret_config_save_body( TableWriter * w, const TurretC
         if ( value->gunner_present )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 38, 0x40dbb648c0cd44aaull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 38, 0x40dbb648c0cd44aaull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2551,7 +2559,7 @@ static SCHEMA_UNUSED int hull_config_save_body( TableWriter * w, const HullConfi
         if ( !( value->health == 100.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 67, 0x7f69d4b5288ba9cfull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 67, 0x7f69d4b5288ba9cfull, 10 );
             table_writer_put32( w, table_float_to_bits( value->health ) );
         }
     }
@@ -2559,7 +2567,7 @@ static SCHEMA_UNUSED int hull_config_save_body( TableWriter * w, const HullConfi
         if ( !( value->mass == 1.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 20, 0x1f3757a2ce7b0ab1ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 20, 0x1f3757a2ce7b0ab1ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->mass ) );
         }
     }
@@ -2576,7 +2584,7 @@ static SCHEMA_UNUSED int hull_config_save_body( TableWriter * w, const HullConfi
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 71, 0x84f8260bc283608cull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 71, 0x84f8260bc283608cull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3049,7 +3057,7 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 106, 0xbaaeb048a5a8fa6dull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 106, 0xbaaeb048a5a8fa6dull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3078,7 +3086,7 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 119, 0xce0ac3c25694d8ffull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 119, 0xce0ac3c25694d8ffull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3101,7 +3109,7 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x01986b0b27400fb2ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 1, 0x01986b0b27400fb2ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3581,7 +3589,7 @@ static SCHEMA_UNUSED int score_board_save_body( TableWriter * w, const ScoreBoar
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 142, 0xf10fad739a0e1660ull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 142, 0xf10fad739a0e1660ull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -361,6 +361,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1474,7 +1482,7 @@ static SCHEMA_UNUSED int archive_config_save_body( TableWriter * w, const Archiv
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 85, 0xa354fd1ff0c467c5ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 85, 0xa354fd1ff0c467c5ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1494,7 +1502,7 @@ static SCHEMA_UNUSED int archive_config_save_body( TableWriter * w, const Archiv
         if ( !( value->count == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 97, 0xb1e5e28e4479a274ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 97, 0xb1e5e28e4479a274ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->count ) );
         }
     }

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1584,7 +1592,7 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
         if ( !( value->reaction == 0.2f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 101, 0xb75aa3662201646aull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 101, 0xb75aa3662201646aull, 10 );
             table_writer_put32( w, table_float_to_bits( value->reaction ) );
         }
     }
@@ -1592,7 +1600,7 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
         if ( !( value->tracking == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 90, 0xa6bf719a4602b0bcull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 90, 0xa6bf719a4602b0bcull, 1 );
             table_writer_put8( w, value->tracking ? 1 : 0 );
         }
     }
@@ -1601,7 +1609,7 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
         if ( value->callsign_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 53, 0x5bc44627b9848818ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 53, 0x5bc44627b9848818ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1924,7 +1932,7 @@ static SCHEMA_UNUSED int ship_entry_save_body( TableWriter * w, const ShipEntry 
         if ( value->display_name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 27, 0x2d21d7cd66bd5a5dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 27, 0x2d21d7cd66bd5a5dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1944,7 +1952,7 @@ static SCHEMA_UNUSED int ship_entry_save_body( TableWriter * w, const ShipEntry 
         if ( !( value->health == 100.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 67, 0x7f69d4b5288ba9cfull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 67, 0x7f69d4b5288ba9cfull, 10 );
             table_writer_put32( w, table_float_to_bits( value->health ) );
         }
     }
@@ -1952,7 +1960,7 @@ static SCHEMA_UNUSED int ship_entry_save_body( TableWriter * w, const ShipEntry 
         if ( !( value->mass == 1.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 20, 0x1f3757a2ce7b0ab1ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 20, 0x1f3757a2ce7b0ab1ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->mass ) );
         }
     }
@@ -1961,7 +1969,7 @@ static SCHEMA_UNUSED int ship_entry_save_body( TableWriter * w, const ShipEntry 
         if ( value->hardpoints_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 77, 0x95d0cce09ca82b73ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 77, 0x95d0cce09ca82b73ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1981,7 +1989,7 @@ static SCHEMA_UNUSED int ship_entry_save_body( TableWriter * w, const ShipEntry 
         if ( value->gunner_present )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 38, 0x40dbb648c0cd44aaull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 38, 0x40dbb648c0cd44aaull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2459,7 +2467,7 @@ static SCHEMA_UNUSED int global_settings_save_body( TableWriter * w, const Globa
         if ( !( value->tick_rate == 60 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 88, 0xa65f859b617deaf3ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 88, 0xa65f859b617deaf3ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->tick_rate ) );
         }
     }
@@ -2467,7 +2475,7 @@ static SCHEMA_UNUSED int global_settings_save_body( TableWriter * w, const Globa
         if ( !( value->difficulty == DIFFICULTY_NORMAL ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 41, 0x467f35a74c6e4a70ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 41, 0x467f35a74c6e4a70ull, 30 );
             switch ( value->difficulty )
             {
                 case DIFFICULTY_NONE: table_writer_leb( w, 0 ); break;
@@ -2483,7 +2491,7 @@ static SCHEMA_UNUSED int global_settings_save_body( TableWriter * w, const Globa
         if ( value->build_note_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 11, 0x14ec921cc2549d60ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 11, 0x14ec921cc2549d60ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2505,7 +2513,7 @@ static SCHEMA_UNUSED int global_settings_save_body( TableWriter * w, const Globa
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x09ae5613b0051271ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 7, 0x09ae5613b0051271ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3104,7 +3112,7 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( !( value->version == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 107, 0xbb62c62c9808ea37ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 107, 0xbb62c62c9808ea37ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->version ) );
         }
     }
@@ -3115,7 +3123,7 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 68, 0x7fb43557b54149ceull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 68, 0x7fb43557b54149ceull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3144,7 +3152,7 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 25, 0x294a5c4913e1ad44ull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 25, 0x294a5c4913e1ad44ull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3170,7 +3178,7 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 80, 0x9cda940a344e1571ull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 80, 0x9cda940a344e1571ull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3191,7 +3199,7 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( value->reserves_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 64, 0x77707fccd201c228ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 64, 0x77707fccd201c228ull, 14 );
             int64_t element_sizes[3]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1604,7 +1612,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i8_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 43, 0x48121511bf702eb5ull ); table_writer_put8( w, 2 );
+            table_writer_header_at( w, 43, 0x48121511bf702eb5ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_span ) );
         }
     }
@@ -1612,7 +1620,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i8_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 76, 0x942bfe3168090f7dull ); table_writer_put8( w, 2 );
+            table_writer_header_at( w, 76, 0x942bfe3168090f7dull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_low ) );
         }
     }
@@ -1620,7 +1628,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i8_high == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 126, 0xd182acd105b55dd1ull ); table_writer_put8( w, 2 );
+            table_writer_header_at( w, 126, 0xd182acd105b55dd1ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_high ) );
         }
     }
@@ -1628,7 +1636,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i8_inside == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 141, 0xef9ded23c8912a81ull ); table_writer_put8( w, 2 );
+            table_writer_header_at( w, 141, 0xef9ded23c8912a81ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_inside ) );
         }
     }
@@ -1636,7 +1644,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i16_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 100, 0xb655574ea23760b4ull ); table_writer_put8( w, 3 );
+            table_writer_header_at( w, 100, 0xb655574ea23760b4ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_span ) );
         }
     }
@@ -1644,7 +1652,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i16_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 127, 0xd217b3af8d7a2bdeull ); table_writer_put8( w, 3 );
+            table_writer_header_at( w, 127, 0xd217b3af8d7a2bdeull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_low ) );
         }
     }
@@ -1652,7 +1660,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i16_high == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 75, 0x90652f70c9127900ull ); table_writer_put8( w, 3 );
+            table_writer_header_at( w, 75, 0x90652f70c9127900ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_high ) );
         }
     }
@@ -1660,7 +1668,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i16_inside == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 58, 0x6a659d7c354db158ull ); table_writer_put8( w, 3 );
+            table_writer_header_at( w, 58, 0x6a659d7c354db158ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_inside ) );
         }
     }
@@ -1668,7 +1676,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i32_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 137, 0xe693bd88532c91d6ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 137, 0xe693bd88532c91d6ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_span ) );
         }
     }
@@ -1676,7 +1684,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i32_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 5, 0x065ee827cf99fbb4ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 5, 0x065ee827cf99fbb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_low ) );
         }
     }
@@ -1684,7 +1692,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i32_high == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 118, 0xc9b121c4c2a186eeull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 118, 0xc9b121c4c2a186eeull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_high ) );
         }
     }
@@ -1692,7 +1700,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i32_inside == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 129, 0xd363dfa465acf27aull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 129, 0xd363dfa465acf27aull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_inside ) );
         }
     }
@@ -1700,7 +1708,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i64_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 63, 0x7549c70700c49d6full ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 63, 0x7549c70700c49d6full, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_span ) );
         }
     }
@@ -1708,7 +1716,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i64_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 16, 0x1cce6617419771dbull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 16, 0x1cce6617419771dbull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_low ) );
         }
     }
@@ -1716,7 +1724,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i64_high == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0x3b54fa60620b5597ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 36, 0x3b54fa60620b5597ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_high ) );
         }
     }
@@ -1724,7 +1732,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( !( value->i64_inside == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 128, 0xd308fcb98ece5d23ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 128, 0xd308fcb98ece5d23ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_inside ) );
         }
     }
@@ -1733,7 +1741,7 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( value->edges_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 117, 0xc70cde6b85b6197dull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 117, 0xc70cde6b85b6197dull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3484,7 +3492,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u8_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x0f8897557f37c021ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 8, 0x0f8897557f37c021ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_span ) );
         }
     }
@@ -3492,7 +3500,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u8_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 28, 0x2e17553f8200a2a1ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 28, 0x2e17553f8200a2a1ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_low ) );
         }
     }
@@ -3500,7 +3508,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u8_high == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 84, 0xa0e5c60df9301b7dull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 84, 0xa0e5c60df9301b7dull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_high ) );
         }
     }
@@ -3508,7 +3516,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u8_inside == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 15, 0x1cb2c073a6f5844dull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 15, 0x1cb2c073a6f5844dull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_inside ) );
         }
     }
@@ -3516,7 +3524,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u16_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 46, 0x4ca0c150b1790960ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 46, 0x4ca0c150b1790960ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_span ) );
         }
     }
@@ -3524,7 +3532,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u16_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 143, 0xf252136836b04cb2ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 143, 0xf252136836b04cb2ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_low ) );
         }
     }
@@ -3532,7 +3540,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u16_high == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 48, 0x4f37e1f216e7610cull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 48, 0x4f37e1f216e7610cull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_high ) );
         }
     }
@@ -3540,7 +3548,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u16_inside == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 125, 0xd176b605978f3304ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 125, 0xd176b605978f3304ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_inside ) );
         }
     }
@@ -3548,7 +3556,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u32_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x200b924de7479cdaull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 21, 0x200b924de7479cdaull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_span ) );
         }
     }
@@ -3556,7 +3564,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u32_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 87, 0xa53d2f2a31b5acb0ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 87, 0xa53d2f2a31b5acb0ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_low ) );
         }
     }
@@ -3564,7 +3572,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u32_high == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 78, 0x9759be8ea1a4e3d2ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 78, 0x9759be8ea1a4e3d2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_high ) );
         }
     }
@@ -3572,7 +3580,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u32_inside == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 74, 0x8dc515fc082e3c0eull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 74, 0x8dc515fc082e3c0eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_inside ) );
         }
     }
@@ -3580,7 +3588,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u64_span == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 109, 0xbeecef11dbdf8973ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 109, 0xbeecef11dbdf8973ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_span ) );
         }
     }
@@ -3588,7 +3596,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u64_low == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x0117ad66e0fff227ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 0, 0x0117ad66e0fff227ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_low ) );
         }
     }
@@ -3596,7 +3604,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u64_high == 1ull ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 144, 0xf2b45af3b50689dbull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 144, 0xf2b45af3b50689dbull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_high ) );
         }
     }
@@ -3604,7 +3612,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( !( value->u64_inside == 1ull ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 62, 0x713e12017eebcaf7ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 62, 0x713e12017eebcaf7ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_inside ) );
         }
     }
@@ -3613,7 +3621,7 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( value->counts_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 112, 0xc341febe5aae51e5ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 112, 0xc341febe5aae51e5ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5365,7 +5373,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b8 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x08a60c07b54d8dc7ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 6, 0x08a60c07b54d8dc7ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->b8 ) );
         }
     }
@@ -5373,7 +5381,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b16 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 149, 0xff95701912ad97beull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 149, 0xff95701912ad97beull, 7 );
             table_writer_put16( w, (uint16_t) ( value->b16 ) );
         }
     }
@@ -5381,7 +5389,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b32 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 151, 0xff9c5c1912b39470ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 151, 0xff9c5c1912b39470ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->b32 ) );
         }
     }
@@ -5389,7 +5397,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b64 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 148, 0xff92701912ab61e7ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 148, 0xff92701912ab61e7ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->b64 ) );
         }
     }
@@ -5397,7 +5405,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b12 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 150, 0xff95741912ad9e8aull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 150, 0xff95741912ad9e8aull, 7 );
             table_writer_put16( w, (uint16_t) ( value->b12 ) );
         }
     }
@@ -5405,7 +5413,7 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
         if ( !( value->b48 == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 147, 0xff8b681912a535a1ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 147, 0xff8b681912a535a1ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->b48 ) );
         }
     }

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1822,7 +1830,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( !( value->damage == 21.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 66, 0x7f6308be8ab37fc0ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 66, 0x7f6308be8ab37fc0ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->damage ) );
         }
     }
@@ -1830,7 +1838,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( !( value->speed == 500.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 12, 0x1733055702acb1d2ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 12, 0x1733055702acb1d2ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->speed ) );
         }
     }
@@ -1838,7 +1846,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( !( value->penetration == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 47, 0x4f31c5309e13e932ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 47, 0x4f31c5309e13e932ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->penetration ) );
         }
     }
@@ -1846,7 +1854,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( !( value->channel == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 86, 0xa5013e9ad5caeda4ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 86, 0xa5013e9ad5caeda4ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->channel ) );
         }
     }
@@ -1854,7 +1862,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( !( value->homing == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 94, 0xad6587bc602e3f59ull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 94, 0xad6587bc602e3f59ull, 1 );
             table_writer_put8( w, value->homing ? 1 : 0 );
         }
     }
@@ -1862,7 +1870,7 @@ static SCHEMA_UNUSED int weapon_config_save_body( TableWriter * w, const WeaponC
         if ( value->effect.type != EFFECT_TYPE_NONE )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 33, 0x36c1c83b51f24394ull ); table_writer_put8( w, 15 );
+            table_writer_header_at( w, 33, 0x36c1c83b51f24394ull, 15 );
             if ( !schema_tabledemo_effect_wire_save_( w, &value->effect ) ) { return 0; }
         }
     }
@@ -2455,7 +2463,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( !( value->grade == GRADE_SILVER ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 31, 0x32a89b2977c48ad4ull ); table_writer_put8( w, 30 );
+            table_writer_header_at( w, 31, 0x32a89b2977c48ad4ull, 30 );
             switch ( value->grade )
             {
                 case GRADE_NONE: table_writer_leb( w, 0 ); break;
@@ -2471,7 +2479,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( value->grades_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 131, 0xd90a4e7682f799c5ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 131, 0xd90a4e7682f799c5ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2493,7 +2501,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 98, 0xb46ff45a23d72549ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 98, 0xb46ff45a23d72549ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2513,7 +2521,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( !( value->perks == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 45, 0x4b06f5847096e54aull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 45, 0x4b06f5847096e54aull, 9 );
             table_writer_put64( w, (uint64_t) ( value->perks ) );
         }
     }
@@ -2524,7 +2532,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 110, 0xbf31137ff783e939ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 110, 0xbf31137ff783e939ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -2544,7 +2552,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 135, 0xde28f0f5118acc24ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 135, 0xde28f0f5118acc24ull, 14 );
             int64_t element_sizes[2]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -2566,7 +2574,7 @@ static SCHEMA_UNUSED int loadout_config_save_body( TableWriter * w, const Loadou
         if ( value->attachments_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 145, 0xf901aa0340249a41ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 145, 0xf901aa0340249a41ull, 14 );
             int64_t element_sizes[8]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -3330,7 +3338,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( value->name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 116, 0xc4bcadba8e631b86ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 116, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3351,7 +3359,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( value->icon_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 132, 0xdbff4cc56c2092f0ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 132, 0xdbff4cc56c2092f0ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3371,7 +3379,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->experience == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 93, 0xab8b6d521f80b969ull ); table_writer_put8( w, 8 );
+            table_writer_header_at( w, 93, 0xab8b6d521f80b969ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->experience ) );
         }
     }
@@ -3379,7 +3387,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->tilt == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 19, 0x1e5088ef2e9bafc6ull ); table_writer_put8( w, 2 );
+            table_writer_header_at( w, 19, 0x1e5088ef2e9bafc6ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->tilt ) );
         }
     }
@@ -3387,7 +3395,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->heading == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 96, 0xb128829190ca0f75ull ); table_writer_put8( w, 3 );
+            table_writer_header_at( w, 96, 0xb128829190ca0f75ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->heading ) );
         }
     }
@@ -3395,7 +3403,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->timestamp == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 54, 0x5ddc92338ef53403ull ); table_writer_put8( w, 5 );
+            table_writer_header_at( w, 54, 0x5ddc92338ef53403ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->timestamp ) );
         }
     }
@@ -3403,7 +3411,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->badge == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 9, 0x10bda981fe095518ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 9, 0x10bda981fe095518ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->badge ) );
         }
     }
@@ -3411,7 +3419,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->port == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 73, 0x8c2cdb0da8933fa6ull ); table_writer_put8( w, 7 );
+            table_writer_header_at( w, 73, 0x8c2cdb0da8933fa6ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->port ) );
         }
     }
@@ -3419,7 +3427,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->epoch == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 146, 0xfc9697d1196e6ba6ull ); table_writer_put8( w, 9 );
+            table_writer_header_at( w, 146, 0xfc9697d1196e6ba6ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->epoch ) );
         }
     }
@@ -3427,7 +3435,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->precision == 0.0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 24, 0x288427f5babd05f7ull ); table_writer_put8( w, 11 );
+            table_writer_header_at( w, 24, 0x288427f5babd05f7ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->precision ) );
         }
     }
@@ -3437,7 +3445,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 105, 0xb921eb8a3d0cb0f9ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 105, 0xb921eb8a3d0cb0f9ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3457,7 +3465,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( !( value->has_loadout == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 83, 0xa06f5e0a148e253cull ); table_writer_put8( w, 1 );
+            table_writer_header_at( w, 83, 0xa06f5e0a148e253cull, 1 );
             table_writer_put8( w, value->has_loadout ? 1 : 0 );
         }
     }
@@ -3470,7 +3478,7 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 50, 0x5759ce7586bbb5a3ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 50, 0x5759ce7586bbb5a3ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4672,7 +4680,7 @@ static SCHEMA_UNUSED int root_config_save_body( TableWriter * w, const RootConfi
         if ( value->version_note_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 72, 0x8a67c9728746d394ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 72, 0x8a67c9728746d394ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4693,7 +4701,7 @@ static SCHEMA_UNUSED int root_config_save_body( TableWriter * w, const RootConfi
         if ( value->weapons_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 40, 0x41cbd901b87fabb6ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 40, 0x41cbd901b87fabb6ull, 14 );
             int64_t element_sizes[8]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -4715,7 +4723,7 @@ static SCHEMA_UNUSED int root_config_save_body( TableWriter * w, const RootConfi
         if ( value->profiles_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 70, 0x8181e61fc0436767ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 70, 0x8181e61fc0436767ull, 14 );
             int64_t element_sizes[4]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
             {
@@ -5102,7 +5110,7 @@ static SCHEMA_UNUSED int attachment_save_body( TableWriter * w, const Attachment
         if ( !( value->slot == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 59, 0x6a771618f6fe31d1ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 59, 0x6a771618f6fe31d1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->slot ) );
         }
     }
@@ -5110,7 +5118,7 @@ static SCHEMA_UNUSED int attachment_save_body( TableWriter * w, const Attachment
         if ( !( value->power == 1.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 140, 0xeef9d1358ae7b4e6ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 140, 0xeef9d1358ae7b4e6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->power ) );
         }
     }
@@ -5428,7 +5436,7 @@ static SCHEMA_UNUSED int buff_save_body( TableWriter * w, const Buff * value )
         if ( !( value->multiplier == 1.0f ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 79, 0x9adc623a805c87c6ull ); table_writer_put8( w, 10 );
+            table_writer_header_at( w, 79, 0x9adc623a805c87c6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->multiplier ) );
         }
     }
@@ -5636,7 +5644,7 @@ static SCHEMA_UNUSED int debuff_save_body( TableWriter * w, const Debuff * value
         if ( !( value->amount == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 69, 0x8113fe7ea2b16969ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 69, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
     }

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -360,6 +360,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_TABLEDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -1506,7 +1514,7 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->label_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 35, 0x39f7fcec8fcb623dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 35, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1527,7 +1535,7 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->payload_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 122, 0xcfb8a9d063b5e9e5ull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 122, 0xcfb8a9d063b5e9e5ull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1548,7 +1556,7 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->samples_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 136, 0xe3b1ca6a3b48dddcull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 136, 0xe3b1ca6a3b48dddcull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -368,6 +368,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -3479,7 +3487,7 @@ static SCHEMA_UNUSED int meta_save_body( TableWriter * w, const Meta * value )
         if ( !( value->build == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 26, 0x802517e298c70b03ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 26, 0x802517e298c70b03ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->build ) );
         }
     }
@@ -3488,7 +3496,7 @@ static SCHEMA_UNUSED int meta_save_body( TableWriter * w, const Meta * value )
         if ( value->tag_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 13, 0x56d7ab194448a4f3ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 13, 0x56d7ab194448a4f3ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3824,7 +3832,7 @@ static SCHEMA_UNUSED int settings_save_body( TableWriter * w, const Settings * v
         if ( !( value->quality == 2 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 23, 0x7a8060916400fe66ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 23, 0x7a8060916400fe66ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->quality ) );
         }
     }
@@ -3833,7 +3841,7 @@ static SCHEMA_UNUSED int settings_save_body( TableWriter * w, const Settings * v
         if ( value->label_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x39f7fcec8fcb623dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 6, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4169,7 +4177,7 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
         if ( !( value->value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 24, 0x7ce4fd9430e80ceaull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 24, 0x7ce4fd9430e80ceaull, 4 );
             table_writer_put32( w, (uint32_t) ( value->value ) );
         }
     }
@@ -4178,7 +4186,7 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
         if ( value->name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0xc4bcadba8e631b86ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4198,7 +4206,7 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
         if ( !( value->next.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 41, 0xe5316cbaa025f028ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 41, 0xe5316cbaa025f028ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->next); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -4468,7 +4476,7 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
         if ( value->label_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x39f7fcec8fcb623dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 6, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4488,7 +4496,7 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
         if ( !( value->left.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 2, 0x24b070ada2041cb0ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 2, 0x24b070ada2041cb0ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->left); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -4497,7 +4505,7 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
         if ( !( value->right.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 21, 0x76aaaa535714d805ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 21, 0x76aaaa535714d805ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->right); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -4698,7 +4706,7 @@ static SCHEMA_UNUSED int layer_save_body( TableWriter * w, const Layer * value )
         if ( !( value->depth == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 20, 0x75d8e97600b296eaull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 20, 0x75d8e97600b296eaull, 4 );
             table_writer_put32( w, (uint32_t) ( value->depth ) );
         }
     }
@@ -4706,7 +4714,7 @@ static SCHEMA_UNUSED int layer_save_body( TableWriter * w, const Layer * value )
         if ( !( value->head.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x0a8f12cc5f9a0c03ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -4958,7 +4966,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( value->name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0xc4bcadba8e631b86ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -4978,7 +4986,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( !( value->version == 1 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 36, 0xbb62c62c9808ea37ull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 36, 0xbb62c62c9808ea37ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->version ) );
         }
     }
@@ -4986,7 +4994,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( !( value->head.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x0a8f12cc5f9a0c03ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -4995,7 +5003,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( !( value->tree.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 14, 0x5b25b8ef511eb395ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 14, 0x5b25b8ef511eb395ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->tree); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -5004,7 +5012,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( !( value->settings.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 43, 0xee5f6d7b48b44de8ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 43, 0xee5f6d7b48b44de8ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->settings); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -5013,7 +5021,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( !( value->alias.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 12, 0x509220bb65a646b7ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 12, 0x509220bb65a646b7ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->alias); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -5025,7 +5033,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 15, 0x60839e2395be697eull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 15, 0x60839e2395be697eull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5046,7 +5054,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( value->layers_count > 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 10, 0x4554e34a747022dfull ); table_writer_put8( w, 14 );
+            table_writer_header_at( w, 10, 0x4554e34a747022dfull, 14 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5069,7 +5077,7 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 8, 0x4320e9a2e32eac38ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 8, 0x4320e9a2e32eac38ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5669,7 +5677,7 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         if ( value->name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0xc4bcadba8e631b86ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5698,7 +5706,7 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         if ( rides )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 40, 0xdd9eb981e152e90cull ); table_writer_put8( w, 16 );
+            table_writer_header_at( w, 40, 0xdd9eb981e152e90cull, 16 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5718,7 +5726,7 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         if ( value->spare_present )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 9, 0x4339ee8ab21c8380ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 9, 0x4339ee8ab21c8380ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -5738,7 +5746,7 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         if ( !( value->head.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x0a8f12cc5f9a0c03ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -6060,7 +6068,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( value->name_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 37, 0xc4bcadba8e631b86ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6083,7 +6091,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 1, 0x1e4984ef2e958a4cull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 1, 0x1e4984ef2e958a4cull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6106,7 +6114,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 44, 0xee7ba9ad45c64144ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 44, 0xee7ba9ad45c64144ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6129,7 +6137,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( default_probe.offset > 1 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 42, 0xeddcb72b15486e77ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 42, 0xeddcb72b15486e77ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -6149,7 +6157,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( !( value->pin.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 22, 0x77af761956600b54ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 22, 0x77af761956600b54ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->pin); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }
@@ -6158,7 +6166,7 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( !( value->head.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 0, 0x0a8f12cc5f9a0c03ull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -366,6 +366,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -3215,7 +3223,7 @@ static SCHEMA_UNUSED int tally_save_body( TableWriter * w, const Tally * value )
         if ( !( value->hits == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 19, 0x732dfbcc9b0cf0bbull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 19, 0x732dfbcc9b0cf0bbull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hits ) );
         }
     }
@@ -3486,7 +3494,7 @@ static SCHEMA_UNUSED int marker_save_body( TableWriter * w, const Marker * value
         if ( value->label_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 6, 0x39f7fcec8fcb623dull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 6, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3506,7 +3514,7 @@ static SCHEMA_UNUSED int marker_save_body( TableWriter * w, const Marker * value
         if ( !( value->note.value == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 7, 0x3bf8fbbad1587cddull ); table_writer_put8( w, 17 );
+            table_writer_header_at( w, 7, 0x3bf8fbbad1587cddull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->note); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
         }

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -366,6 +366,14 @@ static SCHEMA_UNUSED void table_writer_id_at( TableWriter * w, int32_t ordinal, 
     v->slot[ordinal]=(int32_t)r-1;
     v->ordinal_of[r-1]=(int16_t)ordinal;
 }
+/* A repeated one-byte reference and its kind share one checked little-endian
+   store, as in the C++ Header writer. Misses keep the existing ID append path. */
+static SCHEMA_UNUSED SCHEMA_GRAPHDEMO_TABLE_INLINE void table_writer_header_at( TableWriter * w, int32_t ordinal, uint64_t id, uint8_t kind )
+{
+    const int32_t at=w->vocabulary->slot[ordinal];
+    if(at>=0 && at<127) { table_writer_put16(w,(uint16_t)((uint16_t)(at+1)|((uint16_t)kind<<8))); return; }
+    table_writer_id_at(w,ordinal,id); table_writer_put8(w,kind);
+}
 static SCHEMA_UNUSED TableWriter table_writer_probe( const TableWriter * w )
 {
     TableWriter probe = *w;
@@ -3105,7 +3113,7 @@ static SCHEMA_UNUSED int stamp_save_body( TableWriter * w, const Stamp * value )
         if ( value->tag_length != 0 )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 13, 0x56d7ab194448a4f3ull ); table_writer_put8( w, 12 );
+            table_writer_header_at( w, 13, 0x56d7ab194448a4f3ull, 12 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -3125,7 +3133,7 @@ static SCHEMA_UNUSED int stamp_save_body( TableWriter * w, const Stamp * value )
         if ( !( value->seq == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 27, 0x823b8a195ce2133cull ); table_writer_put8( w, 4 );
+            table_writer_header_at( w, 27, 0x823b8a195ce2133cull, 4 );
             table_writer_put32( w, (uint32_t) ( value->seq ) );
         }
     }
@@ -3464,7 +3472,7 @@ static SCHEMA_UNUSED int colour_save_body( TableWriter * w, const Colour * value
         if ( !( value->r == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 34, 0xaf63ef4c86020cd5ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 34, 0xaf63ef4c86020cd5ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->r ) );
         }
     }
@@ -3472,7 +3480,7 @@ static SCHEMA_UNUSED int colour_save_body( TableWriter * w, const Colour * value
         if ( !( value->g == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 32, 0xaf63da4c8601e926ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 32, 0xaf63da4c8601e926ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->g ) );
         }
     }
@@ -3480,7 +3488,7 @@ static SCHEMA_UNUSED int colour_save_body( TableWriter * w, const Colour * value
         if ( !( value->b == 0 ) )
         {
             if ( w->check_default ) { w->offset = 2; return 1; }
-            table_writer_id_at( w, 33, 0xaf63df4c8601f1a5ull ); table_writer_put8( w, 6 );
+            table_writer_header_at( w, 33, 0xaf63df4c8601f1a5ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->b ) );
         }
     }


### PR DESCRIPTION
C Fixed Table fields currently emit a cached reference and kind through separate byte-writing paths. Reuse the C++/Go header technique for ordinary C field headers: when an ordinal cache hit yields a one-byte reference, write the reference and kind through the existing checked little-endian 16-bit primitive. Cache misses and larger references keep the existing ID path; retained and union header emission stays unchanged.

Successful bytes, ID order, capacity checks and failed-Save return values are preserved. As with the existing C++ Header optimization, a failed Save can leave a different partial output prefix because the pair is checked together. Reserve the new internal helper name and update the two existing source-shape assertions while retaining their runtime values and pinned byte checks.

Validation on ARM: C generator/full source goldens, 11 existing C compiler checks including ordinal shared-ID/reference/default/graph/retained/message behavior, and a clean matched C Packet/Table gate. Generated output was checked mechanically: one runtime helper and the intended field-header substitutions across 15 mirrors.

Three alternating matched ARM pairs against 98809df03ec98836b025614ac6f847ebe70a7878 show median C write cost down23.55% and round-trip down14.72%, with consistent paired signs and under0.9% spreads. Background builds were recorded; this is a diagnostic, not a controlled performance seal. Native text grows7,204 bytes (67,928 to75,132); allocated segment/file size is unchanged. Final controlled ARM and batched x64 remain pending.
