### PR TITLE
Reuse Go table child sizes and omit unused wide-text helpers

### DIFF
--- a/compiler/tablesgo_test.go
+++ b/compiler/tablesgo_test.go
@@ -134,7 +134,12 @@ table Effected
 // adds, which is how the hole reached a reviewer.
 func TestTableRuntimeNamesAreClaimedGo(t *testing.T) {
 	files := map[string][]byte{}
-	for i, source := range []string{goRuntimeSrc, goRuntimeSrc + "\ntable Graph {head *Graph\ndata *bytes\ncaption *string\n}\n", goRuntimeSrc + "\ntable Lists {rows []int32}\n"} {
+	for i, source := range []string{
+		goRuntimeSrc,
+		goRuntimeSrc + "\ntable Graph {head *Graph\ndata *bytes\ncaption *string\n}\n",
+		goRuntimeSrc + "\ntable Lists {rows []int32}\n",
+		goRuntimeSrc + "\ntable Wide {label wstring(16)\n}\n",
+	} {
 		generated, err := New().Generate(unitFromSource(t, source), "go", Options{})
 		if err != nil {
 			t.Fatal(err)

--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -759,38 +759,6 @@ func tableUtf8Clamp(data []byte, n int64) int64 {
 	return n
 }
 
-func tableUtf16Valid(data []byte) bool {
-	if len(data)&1 != 0 {
-		return false
-	}
-	for i := 0; i < len(data); i += 2 {
-		u := binary.LittleEndian.Uint16(data[i:])
-		if u == 0 || u >= 0xdc00 && u <= 0xdfff {
-			return false
-		}
-		if u >= 0xd800 && u <= 0xdbff {
-			i += 2
-			if i >= len(data) {
-				return false
-			}
-			v := binary.LittleEndian.Uint16(data[i:])
-			if v < 0xdc00 || v > 0xdfff {
-				return false
-			}
-		}
-	}
-	return true
-}
-func tableUtf16Clamp(data []byte, keep int) int {
-	if keep > 0 && keep < len(data)/2 {
-		u := binary.LittleEndian.Uint16(data[(keep-1)*2:])
-		if u >= 0xd800 && u <= 0xdbff {
-			keep--
-		}
-	}
-	return keep
-}
-
 const TableMessageBatchMax = 256
 const TableMessageRefBitsHere = 7
 const TableMessageEntriesHere = 75

--- a/generated/bench/paired/go/FixedTableTable.go
+++ b/generated/bench/paired/go/FixedTableTable.go
@@ -56,47 +56,19 @@ func FixedTableSaveBody(w *TableWriter, value *FixedTable) bool {
 		mark := w.Ids.Count
 		ref := w.Ids.RefAt(35, 0x7ce4fd9430e80cea)
 		start := w.Ids.Count
-		payload := TableWriter{Measuring: true, Ids: w.Ids}
-		{
-			mark := payload.Ids.Count
-			n := BenchMixedMeasureBody(&value.Value, payload.Ids)
-			if n < 0 {
-				return false
-			}
-			payload.PutLeb(uint64(n))
-			if payload.Measuring {
-				payload.Advance(n)
-			} else {
-				payload.Ids.Truncate(mark)
-				if !BenchMixedSaveBody(&payload, &value.Value) {
-					return false
-				}
-			}
-		}
-		if payload.Overflow || w.Ids.Overflow {
+		n := BenchMixedMeasureBody(&value.Value, w.Ids)
+		if n < 0 || w.Ids.Overflow {
 			return false
 		}
-		if payload.Offset > 2 {
+		if n > 1 {
 			if w.Measuring {
-				w.Advance(tableLebBytes(ref) + 1 + payload.Offset)
+				w.Advance(tableLebBytes(ref) + 1 + tableLebBytes(uint64(n)) + n)
 			} else {
 				w.Ids.Truncate(start)
 				w.Header(ref, 13)
-				{
-					mark := w.Ids.Count
-					n := BenchMixedMeasureBody(&value.Value, w.Ids)
-					if n < 0 {
-						return false
-					}
-					w.PutLeb(uint64(n))
-					if w.Measuring {
-						w.Advance(n)
-					} else {
-						w.Ids.Truncate(mark)
-						if !BenchMixedSaveBody(w, &value.Value) {
-							return false
-						}
-					}
+				w.PutLeb(uint64(n))
+				if !BenchMixedSaveBody(w, &value.Value) {
+					return false
 				}
 			}
 		} else {

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -827,38 +827,6 @@ func tableUtf8Clamp(data []byte, n int64) int64 {
 	return n
 }
 
-func tableUtf16Valid(data []byte) bool {
-	if len(data)&1 != 0 {
-		return false
-	}
-	for i := 0; i < len(data); i += 2 {
-		u := binary.LittleEndian.Uint16(data[i:])
-		if u == 0 || u >= 0xdc00 && u <= 0xdfff {
-			return false
-		}
-		if u >= 0xd800 && u <= 0xdbff {
-			i += 2
-			if i >= len(data) {
-				return false
-			}
-			v := binary.LittleEndian.Uint16(data[i:])
-			if v < 0xdc00 || v > 0xdfff {
-				return false
-			}
-		}
-	}
-	return true
-}
-func tableUtf16Clamp(data []byte, keep int) int {
-	if keep > 0 && keep < len(data)/2 {
-		u := binary.LittleEndian.Uint16(data[(keep-1)*2:])
-		if u >= 0xd800 && u <= 0xdbff {
-			keep--
-		}
-	}
-	return keep
-}
-
 const TableMessageBatchMax = 256
 const TableMessageRefBitsHere = 7
 const TableMessageEntriesHere = 77

--- a/internal/codegen/gotable/wire.go
+++ b/internal/codegen/gotable/wire.go
@@ -20,10 +20,14 @@ func tableWireRuntime(u *ir.Unit) string {
 		source = strings.Replace(source, "type TableReader struct {", "type TableReader struct {\nNodes TableNodeMap", 1)
 		source = strings.ReplaceAll(source, "Ids:r.Ids, Nested:true", "Ids:r.Ids, Nested:true, Nodes:r.Nodes")
 	}
-	return fmt.Sprintf(`
+	res := fmt.Sprintf(`
 const tableIdCapacity = %d
 const tableIdBuckets = %d
-`, n, buckets) + source + tableWStringSource
+`, n, buckets) + source
+	if len(ir.WideTextFields(u)) > 0 {
+		res += tableWStringSource
+	}
+	return res
 }
 
 const tableWireSource = `

--- a/internal/codegen/gotable/write.go
+++ b/internal/codegen/gotable/write.go
@@ -82,6 +82,19 @@ func (g *tableGen) emitWireField(f *ir.Field, expr, ind string) {
 		g.pf("%s}\n%s}\n", i, ind)
 		return
 	}
+	if !g.retain && f.KeyEnum == "" && kind == tkTable {
+		g.pf("%s{\n", ind)
+		i := ind + "\t"
+		g.pf("%smark := w.Ids.Count; ref := w.Ids.RefAt(%d, 0x%016x); start := w.Ids.Count\n", i, g.knownOrdinal(ir.TableFieldWireId(f)), ir.TableFieldWireId(f))
+		g.pf("%sn := %sMeasureBody(&%s, w.Ids)\n", i, f.Type.Name, expr)
+		g.pf("%sif n < 0 || w.Ids.Overflow { return false }\n", i)
+		cond := "n > 1"
+		if f.Type.Optional {
+			cond = "true"
+		}
+		g.pf("%sif %s {\n%s if w.Measuring { w.Advance(tableLebBytes(ref)+1+tableLebBytes(uint64(n))+n) } else {\n%s  w.Ids.Truncate(start); w.Header(ref, %d); w.PutLeb(uint64(n))\n%s  if !%sSaveBody(w, &%s) { return false }\n%s }\n%s} else { w.Ids.Truncate(mark) }\n%s}\n", i, cond, i, i, kind, i, f.Type.Name, expr, i, i, ind)
+		return
+	}
 	g.pf("%s{\n", ind)
 	i := ind + "\t"
 	g.pf("%smark := w.Ids.Count; ref := w.Ids.RefAt(%d, 0x%016x); start := w.Ids.Count\n", i, g.knownOrdinal(ir.TableFieldWireId(f)), ir.TableFieldWireId(f))


### PR DESCRIPTION
Go table Save measured a single by-value struct child again after already measuring it for default elision. It now reuses that body length for framing and preserves the existing field guards, optional presence, checked writes and vocabulary rewind/replay. Retained, pointer, array, map and keyed paths keep their existing handling.

The Go emitter also omits its two unexported UTF-16 wire helpers when the complete unit declares no wide text. Runtime name reservations stay unchanged. The existing namespace scan includes a wide-text unit, and paired plus legacy benchmark mirrors are refreshed.

Validation: existing Go table and source-golden suites, Go compiler and namespace checks, 32 regenerated fixture modules with gofmt/go vet, documented usage and zero-allocation Measure/Save checks, and matched Packet/Table correctness gates for C, C++, Go and C# on ARM.

These are a repeated-work removal and generated-source cleanup. No matched benchmark speedup is claimed.
