### PR TITLE
CI: restore the Go build cache in every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,28 @@ jobs:
       # TOOLCHAIN REPORTS IT rather than a version restated here (a literal
       # '1.26' in fourteen places would be a second home for a pin the
       # setup-go step above owns), and a hash of every Go source and go.mod.
-      # The fallbacks go up one rung at a time: the same toolchain over an
-      # older tree first, then the same OS over any toolchain. The path comes
-      # from `go env GOCACHE` for the same reason — it is a different
-      # directory on the Windows runners, and reading it beats knowing it.
+      # The path comes from `go env GOCACHE` for the same reason — it is a
+      # different directory on the Windows runners, and reading it beats
+      # knowing it.
+      #
+      # THERE IS EXACTLY ONE FALLBACK RUNG, and the missing one is the point.
+      # `go-build-<os>-<toolchain>-` is the rung that matters: it is the same
+      # toolchain over an older tree, which is what a pull request restores
+      # from main and what makes its first run warm. A rung below that —
+      # `go-build-<os>-` — can only ever match a DIFFERENT toolchain, and a
+      # cache written by another toolchain hits nothing, because every entry
+      # in it is keyed on that compiler's build ID. So it would download
+      # 120 MB to find zero usable entries, every time, and it is not here.
+      #
+      # WHICH IS ALSO A FINDING ABOUT THIS FILE, and this branch measured it:
+      # `go-version: '1.26'` is a RANGE, and setup-go resolves it to whatever
+      # 1.26.x the runner image already carries. One warm run of this file put
+      # 1.26.7 on thirty-one of the forty-six negative-control rows and 1.26.8
+      # on the other fifteen, so only the fifteen could use a cache the
+      # go-test row wrote under 1.26.8. Pinning the patch would make the whole
+      # leg warm and would make what CI proves the same fact twice running;
+      # that is a decision about the toolchain pin rather than about caching,
+      # so it is named here and left for its own change.
       #
       # ONE WRITER PER OS, AND IT IS THIS JOB. `actions/cache` saves whenever
       # the exact key missed, so fifty-five jobs sharing one key would be
@@ -185,9 +203,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: go vet
         run: go vet ./...
@@ -339,9 +355,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: rewrite every pin under testdata/ from the reference
         run: make -j"$(nproc)" conformance-pin update-goldens
@@ -405,9 +419,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - id: discover
         name: the registry, as a matrix
@@ -459,9 +471,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       # One step per toolchain, each keyed on the row's field for it. The
       # version is the leg's to name, and it is the same pin the leg's
@@ -566,9 +576,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
@@ -633,9 +641,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: the pinned cross toolchain and emulator
         run: |
@@ -718,9 +724,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: gofmt
         run: |
@@ -797,9 +801,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       # PINNED to a govulncheck release, bumped by hand. What has to change
       # on its own is the VULNERABILITY DATABASE, which the tool fetches at run
@@ -835,9 +837,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - run: go vet ./...
       - run: go build ./...
@@ -916,9 +916,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       # The one sibling this leg needs, at the same pin every other job uses.
       # Header-only, and only the PACKET headers (<Base>.h / <Base>Wire.h)
@@ -1064,9 +1062,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: refuse hand-coded shape measurement
         run: go run ./bench/tools/shapegate
@@ -1206,9 +1202,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       # The enumeration gate, first and on its own, so a control that nothing
       # runs is named here rather than discovered by its absence from a log.
@@ -1269,9 +1263,7 @@ jobs:
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
-            go-build-${{ runner.os }}-
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       # One step per toolchain, each keyed on the row's field for it, exactly as
       # the conformance matrix above does. A base row names none of them and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,71 @@ jobs:
           go-version: '1.26'
           cache: false
 
+      # THE GO BUILD CACHE (the two-minute rule, issue #368). Every job in this
+      # file that touches Go begins by compiling the same compiler from the
+      # same sources on a runner that has never seen them. `go build
+      # ./cmd/schema` is about 15 s cold, and this file pays it forty-seven
+      # times over in the negative-control rows alone, again in each
+      # conformance leg, and again in every gate that shells out to `go run`.
+      #
+      # THE THING WORTH CARRYING IS THE BUILD CACHE, NOT THE MODULE CACHE.
+      # This module has no external dependency and no go.sum, so there is
+      # nothing to download and a module cache would cache the empty set.
+      # ~/.cache/go-build — about 100 MB of compiled package archives — is
+      # where the fifteen seconds actually are.
+      #
+      # A STALE ENTRY CANNOT MAKE A WRONG BUILD, and that is the load-bearing
+      # fact about this whole block. Go's build cache is content-addressed:
+      # every entry is keyed by a hash of the source, the compiler's own
+      # identity and the build flags, so a cache carried across a toolchain
+      # bump or a source change serves the parts that still match and is
+      # simply ignored for the parts that do not. The key below is therefore
+      # only ever about the HIT RATE, never about correctness — which is what
+      # lets the last fallback rung be as coarse as it is.
+      #
+      # THE KEY: the runner's OS, the toolchain's identity AS THE INSTALLED
+      # TOOLCHAIN REPORTS IT rather than a version restated here (a literal
+      # '1.26' in fourteen places would be a second home for a pin the
+      # setup-go step above owns), and a hash of every Go source and go.mod.
+      # The fallbacks go up one rung at a time: the same toolchain over an
+      # older tree first, then the same OS over any toolchain. The path comes
+      # from `go env GOCACHE` for the same reason — it is a different
+      # directory on the Windows runners, and reading it beats knowing it.
+      #
+      # ONE WRITER PER OS, AND IT IS THIS JOB. `actions/cache` saves whenever
+      # the exact key missed, so fifty-five jobs sharing one key would be
+      # fifty-five jobs racing to upload the same 100 MB: GitHub reserves a
+      # key to exactly one of them and the rest warn and drop it. So every job
+      # takes the RESTORE half and exactly one job per OS takes the SAVE half
+      # — `go-test` for Linux, at the bottom of this job, because vet and
+      # `go test ./...` between them compile every package in the module and
+      # its cache is the widest one this tree can produce; and `windows`
+      # below for Windows, which vets and builds the whole module too.
+      #
+      # THE FIRST RUN OF A BRANCH IS ALREADY WARM. A cache written on main is
+      # readable from every branch, so a branch's first run restores main's
+      # entry through the fallback key, recompiles only what its own diff
+      # moved, and writes its own entry for its second run. A pull request
+      # pays for its diff and nothing else.
+      #
+      # THE `generated` GATE TAKES NO CACHE, deliberately. It is the job that
+      # decides whether the committed tree matches what the current compiler
+      # emits, and it is the one place in this file where "the build did no
+      # work" must not be an available explanation for a green.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - name: go vet
         run: go vet ./...
 
@@ -152,6 +217,16 @@ jobs:
       # a second.
       - name: the toolchain gate goes red without the toolchains it pins
         run: make toolchain-negative-control
+
+      # THE ONE LINUX WRITER, per the block at the top of this job. It is last
+      # so that what it uploads is the cache AFTER vet and the whole test
+      # suite have filled it, which is the widest cache this tree produces.
+      # `actions/cache/save` cannot redden a job: a key another run reserved
+      # first is a logged warning and this step's success.
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
 
   # THE GENERATED TREE IS CURRENT (issue #30). The committed generated/ tree is
   # what this repo treats as ground truth — findings are receipted against its
@@ -252,6 +327,22 @@ jobs:
           go-version: '1.26'
           cache: false
 
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - name: rewrite every pin under testdata/ from the reference
         run: make -j"$(nproc)" conformance-pin update-goldens
 
@@ -301,6 +392,23 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - id: discover
         name: the registry, as a matrix
         run: |
@@ -338,6 +446,22 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
 
       # One step per toolchain, each keyed on the row's field for it. The
       # version is the leg's to name, and it is the same pin the leg's
@@ -430,6 +554,22 @@ jobs:
           go-version: '1.26'
           cache: false
 
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
@@ -480,6 +620,22 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
 
       - name: the pinned cross toolchain and emulator
         run: |
@@ -549,6 +705,23 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - name: gofmt
         run: |
           out=$(gofmt -l .)
@@ -611,6 +784,23 @@ jobs:
         with:
           go-version: stable
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       # PINNED to a govulncheck release, bumped by hand. What has to change
       # on its own is the VULNERABILITY DATABASE, which the tool fetches at run
       # time — so the pin costs this gate nothing, and a red run can no longer
@@ -630,8 +820,35 @@ jobs:
         with:
           go-version: stable
           cache: false
+
+      # The Go build cache. This job is the Windows half of the pair — it
+      # restores here and saves at the bottom. The block on `go-test` carries
+      # the reasoning. GOCACHE is read rather than written down because on
+      # this runner it is not ~/.cache/go-build at all.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - run: go vet ./...
       - run: go build ./...
+
+      # THE ONE WINDOWS WRITER. Vet and build above cover the whole module, so
+      # this is the widest Windows cache available, and `msvc` — which builds
+      # bin/schema.exe and nothing else in Go — restores it.
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
 
   # MSVC over the generated corpus (issue #286). The estate's standing rule is
   # that Visual C++ is a hard requirement — emulate extensions, never require
@@ -686,6 +903,22 @@ jobs:
         with:
           go-version: stable
           cache: false
+
+      # The Go build cache, restore only — `windows` is the one Windows
+      # writer. The block on `go-test` carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
 
       # The one sibling this leg needs, at the same pin every other job uses.
       # Header-only, and only the PACKET headers (<Base>.h / <Base>Wire.h)
@@ -818,6 +1051,23 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       - name: refuse hand-coded shape measurement
         run: go run ./bench/tools/shapegate
 
@@ -944,6 +1194,22 @@ jobs:
           go-version: '1.26'
           cache: false
 
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
+
       # The enumeration gate, first and on its own, so a control that nothing
       # runs is named here rather than discovered by its absence from a log.
       - name: every negative control the makefiles define is in the plan
@@ -990,6 +1256,22 @@ jobs:
         with:
           go-version: '1.26'
           cache: false
+
+      # The Go build cache, restore only — `go-test` is the one Linux writer.
+      # The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+            go-build-${{ runner.os }}-
 
       # One step per toolchain, each keyed on the row's field for it, exactly as
       # the conformance matrix above does. A base row names none of them and


### PR DESCRIPTION
Independent of #790. That branch shards the tests and parallelises the corpus builds; this one attacks the other half of the cold cost — every job in `ci.yml` compiles the same compiler, from the same sources, on a runner that has never seen them.

## What it does

Every job that runs Go takes `actions/cache/restore` immediately after `setup-go`, preceded by a one-line probe that reads `go env GOCACHE` and `go env GOVERSION`. Two jobs — one per OS — also take `actions/cache/save`.

**The module cache is moot here.** This module has no external dependency and no `go.sum`, so a module cache would cache the empty set. The one worth carrying is `~/.cache/go-build`: about 100 MB of compiled package archives, measured.

**The key**

```
key:          go-build-<runner.os>-<GOVERSION>-<GOARCH>-<hash of **/*.go and go.mod>
restore-keys: go-build-<runner.os>-<GOVERSION>-<GOARCH>-
              go-build-<runner.os>-
```

The toolchain identity is read from the toolchain that `setup-go` just installed rather than restated in the workflow — a literal `'1.26'` in fourteen places would be a second home for a pin the `setup-go` step already owns, and it would be wrong anyway in the three jobs that ask for `stable`. The path comes from `go env GOCACHE` for the same reason: on the Windows runners it is not `~/.cache/go-build` at all.

The fallbacks go up one rung at a time: the same toolchain over an older tree, then the same OS over any toolchain. The coarse last rung is safe because **a stale entry cannot make a wrong build** — Go's build cache is content-addressed on the source, the compiler's own identity and the build flags, so an entry carried across a toolchain bump or a source change serves the parts that still match and is simply ignored for the parts that do not. The key is therefore only ever about the hit rate, never about correctness.

## The save strategy, and why

**Restore in every job; save in exactly one job per OS.** `actions/cache` saves whenever the exact key missed, so if all ~55 jobs used the composite action they would all race to upload the same 100 MB — GitHub reserves a key to exactly one of them and the rest warn and drop the upload. That is wasted runner minutes on every row, and the log noise makes a real cache failure invisible.

The writers are the two jobs whose caches are the widest:

- **`go-test` (Linux)** — `go vet ./...` and `go test ./...` between them compile every package in the module. The save step is last in the job, so what it uploads is the cache after the whole suite has filled it.
- **`windows` (Windows)** — `go vet ./...` and `go build ./...` cover the whole module there too, and `msvc` (which builds `bin/schema.exe` and nothing else in Go) restores it.

`actions/cache/save` cannot redden a job: a key another run reserved first is a logged warning and the step's success.

**A branch's first run is already warm.** A cache written on `main` is readable from every branch, so a pull request's first run restores main's entry through the fallback rung, recompiles only what its own diff moved, and writes its own entry for its second run. A pull request pays for its diff and nothing else.

## Measured, on this branch's own runs

**Cold run** ([34356940244](https://github.com/mas-bandwidth/schema/actions/runs/34356940244), attempt 1) — 8m02s wall, 69 jobs, green. Every restore missed (1 s each); the two save steps wrote 119.76 MiB for Linux (go1.26.8) and 27.00 MiB for Windows (go1.27.1), 4 s each. Nothing regressed: `build bin/schema and the generated tree once` averaged 15.0 s over 46 rows, against 15.7 s on main's run of the same hour.

**Warm run** (attempt 2, same commit re-run) — 8m19s wall, green.

| step | cold | warm |
| --- | --- | --- |
| `windows`: `go vet ./...` | 25 s | **1 s** |
| `go-test`: `go vet` | 16 s | **3 s** |
| `build bin/schema and the generated tree once`, 46 rows | 15.0 s mean, 690 s total | 10.5 s mean, 484 s total |
| `actions/cache/restore` | 1 s (miss) | 3.4 s mean |

The `go test` step is unchanged, as expected — it is test EXECUTION, not compilation, and no cache touches that.

**Why only 484 s and not less.** The 46 build steps came back bimodal: 15 rows at 1–8 s, 31 still at 12–20 s. The restore succeeded in all 46. The cause is in the logs: `go-version: '1.26'` is a RANGE, and setup-go resolves it to whatever 1.26.x the runner image already carries — that run put **1.26.7 on 31 rows and 1.26.8 on 15**, and only the fifteen could use a cache `go-test` wrote under 1.26.8. A cache from another patch release hits nothing, because Go keys every entry on the compiler's own build ID.

That is a finding about the toolchain pin rather than about caching, and the second commit here does two things with it: it names it in the comment, and it **drops the `go-build-<os>-` fallback rung**, which can only ever match a different toolchain and so downloaded 120 MB to hit zero. Restores now average 1.5 s instead of 3.4 s when the toolchain does not match. Pinning `go-version` to the patch would make the whole leg warm; that is its own change, and it would have to touch the `generated` gate.

**The run's wall time does not move, and was never going to.** The critical path is `pins` (8m) and `big-endian` (7–8m), neither of which is Go-compile-bound. This gives back per-job seconds against the 120 s per-job rule and about 200 s of runner time per run today — more once the toolchain resolves to one version. The wall is #790's and #684's ground.

One unrelated flake on the way: `pins` went red once on `error obtaining VCS status: signal: bus error (core dumped)` — git crashing on the runner. It passed on re-run.

## No check changes

No job added, removed, renamed or moved between tiers. No `run:` step changed. The `generated` gate is untouched, and takes no cache on purpose: it is the job that decides whether the committed tree matches what the current compiler emits, and the one place in this file where "the build did no work" must not be an available explanation for a green.

`go test ./internal/ci/` passes (action pins: `actions/cache/restore` and `actions/cache/save` are pinned to `55cc834` with the `v6.1.0` tag in a trailing comment, like every other action here). `actionlint` v1.7.12 is clean over all three workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
