### PR TITLE
Bound C# fixed-table element scratch by schema capacity

### DIFF
--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -223,6 +223,7 @@ namespace Bench
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4308,7 +4309,7 @@ namespace Bench
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);
@@ -5143,6 +5144,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.MixedEntity(); };
                 info.StorageSize = 64; info.StorageAlign = 8; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5190,6 +5192,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.MixedStat(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5225,6 +5228,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.MixedHitEvent(); };
                 info.StorageSize = 16; info.StorageAlign = 4; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5262,6 +5266,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.MixedChatEvent(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5297,6 +5302,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.MixedPickupEvent(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5332,6 +5338,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.BenchMixed(); };
                 info.StorageSize = 1376; info.StorageAlign = 16; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 88;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/generated/bench/paired/cs/BenchView.cs
+++ b/generated/bench/paired/cs/BenchView.cs
@@ -109,6 +109,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.BenchBits(); };
                 info.StorageSize = 40; info.StorageAlign = 8; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -166,6 +167,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.BenchInts(); };
                 info.StorageSize = 40; info.StorageAlign = 4; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -227,6 +229,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.BenchPacket(); };
                 info.StorageSize = 72; info.StorageAlign = 8; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/generated/bench/paired/cs/FixedTableTable.cs
+++ b/generated/bench/paired/cs/FixedTableTable.cs
@@ -74,6 +74,7 @@ namespace Bench
                 info.Create = delegate { return new global::Bench.FixedTable(); };
                 info.StorageSize = 1376; info.StorageAlign = 16; info.RegionAlign = 16;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -223,6 +223,7 @@ namespace Benchtable
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4392,7 +4393,7 @@ namespace Benchtable
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);
@@ -5228,6 +5229,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TableEntity(); };
                 info.StorageSize = 64; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5275,6 +5277,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TableStat(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5310,6 +5313,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TableMixed(); };
                 info.StorageSize = 1352; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 88;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5371,6 +5375,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TableHitEvent(); };
                 info.StorageSize = 16; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5408,6 +5413,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TableChatEvent(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -5443,6 +5449,7 @@ namespace Benchtable
                 info.Create = delegate { return new global::Benchtable.TablePickupEvent(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/internal/codegen/cstable/codecs.go
+++ b/internal/codegen/cstable/codecs.go
@@ -614,6 +614,7 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 	}
 	g.pf("    info.StorageSize = %d; info.StorageAlign = %d; info.RegionAlign = %d;\n", layout.Size, layout.Align, align)
 	g.pf("    info.Variable = %t;\n", ir.VariableTables(g.unit)[st.Name])
+	g.pf("    info.RootElemSlots = %d;\n", rootElemSlots(st))
 	var pt strings.Builder
 	pt.WriteString("info.PointerType = delegate(ulong id) { switch(id) { ")
 	for _, target := range ir.PointerReachable(st) {
@@ -978,4 +979,21 @@ func (g *tableGen) emitTableFieldDescriptor(f *ir.Field, guard string) {
 		f.Name, jsonName, tableFieldTypeName(f), id, kind, isArray, counted, f.Type.Optional, bound,
 		csElemWidth(f.Type), hasRange, rangeMin, rangeMax, enumMax, enumName, variantId,
 		keyTypeName, keyName, keyId, guard, tableRef, arms, doc, numTags, tags, g.tableStorageColumns(f)+g.wireColumns(f))
+}
+
+func rootElemSlots(st *ir.Struct) int {
+	slots := 0
+	for _, f := range st.Fields {
+		if f.KeyEnum == "" && tableScalarKind(f) == ir.TableKindTable {
+			if f.IsList() {
+				slots += 256
+			} else if f.Array != ir.ArrayNone && f.ArrayBound > 0 {
+				slots += int(f.ArrayBound)
+			}
+			if slots >= 256 {
+				return 256
+			}
+		}
+	}
+	return slots
 }

--- a/internal/codegen/cstable/codecs.go
+++ b/internal/codegen/cstable/codecs.go
@@ -982,18 +982,19 @@ func (g *tableGen) emitTableFieldDescriptor(f *ir.Field, guard string) {
 }
 
 func rootElemSlots(st *ir.Struct) int {
-	slots := 0
+	slots := int64(0)
 	for _, f := range st.Fields {
 		if f.KeyEnum == "" && tableScalarKind(f) == ir.TableKindTable {
-			if f.IsList() {
-				slots += 256
-			} else if f.Array != ir.ArrayNone && f.ArrayBound > 0 {
-				slots += int(f.ArrayBound)
-			}
-			if slots >= 256 {
+			if f.IsList() || f.ArrayBound >= 256 {
 				return 256
+			}
+			if f.Array != ir.ArrayNone && f.ArrayBound > 0 {
+				slots += f.ArrayBound
+				if slots >= 256 {
+					return 256
+				}
 			}
 		}
 	}
-	return slots
+	return int(slots)
 }

--- a/internal/codegen/cstable/cstable.go
+++ b/internal/codegen/cstable/cstable.go
@@ -837,6 +837,7 @@ public sealed class TableTypeInfo
     public Func<object> Create;
     public int StorageSize, StorageAlign, RegionAlign;
     public bool Variable;
+    internal int RootElemSlots;
     public Func<TableTypeInfo[]> PointerTypes;
     public Func<ulong,TableTypeInfo> PointerType;
     public bool BytesEdge, StringEdge;

--- a/internal/codegen/cstable/elem_cache_test.go
+++ b/internal/codegen/cstable/elem_cache_test.go
@@ -3,11 +3,13 @@ package cstable
 import (
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func TestCsharpRootArrayElemCacheShape(t *testing.T) {
 	requiredPatterns := []string{
-		"int cachedElemSlots = !measure && !type.Variable ? 256 : 0;",
+		"int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;",
 		"Span<long> rootElemSizes = stackalloc long[cachedElemSlots];",
 		"long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;",
 		"w.Byte(1); WriteBody(ref w, value, type, ref ids, true, rootPayloadSizes, rootElemSizes);",
@@ -27,5 +29,100 @@ func TestCsharpRootArrayElemCacheShape(t *testing.T) {
 		if !strings.Contains(tableWireSource, pattern) {
 			t.Fatalf("tableWireSource missing expected root array element cache pattern: %q", pattern)
 		}
+	}
+}
+
+func TestRootElemSlots(t *testing.T) {
+	cases := []struct {
+		name string
+		st   *ir.Struct
+		want int
+	}{
+		{
+			name: "empty",
+			st:   &ir.Struct{},
+			want: 0,
+		},
+		{
+			name: "scalar arrays only",
+			st: &ir.Struct{
+				Fields: []*ir.Field{
+					{Name: "data", Array: ir.ArrayFixed, ArrayBound: 16, Type: ir.FieldType{Kind: ir.TBytes}},
+					{Name: "nums", Array: ir.ArrayCounted, ArrayBound: 32, Type: ir.FieldType{Kind: ir.TInt}},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "keyed table array",
+			st: &ir.Struct{
+				Fields: []*ir.Field{
+					{
+						Name:       "keyed",
+						KeyEnum:    "Status",
+						Array:      ir.ArrayFixed,
+						ArrayBound: 8,
+						Type:       ir.FieldType{Kind: ir.TNamed, Ref: &ir.Struct{IsTable: true}},
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "unkeyed table arrays",
+			st: &ir.Struct{
+				Fields: []*ir.Field{
+					{
+						Name:       "entities",
+						Array:      ir.ArrayCounted,
+						ArrayBound: 8,
+						Type:       ir.FieldType{Kind: ir.TNamed, Ref: &ir.Struct{IsTable: true}},
+					},
+					{
+						Name:       "stats",
+						Array:      ir.ArrayCounted,
+						ArrayBound: 80,
+						Type:       ir.FieldType{Kind: ir.TNamed, Ref: &ir.Struct{IsTable: true}},
+					},
+				},
+			},
+			want: 88,
+		},
+		{
+			name: "unkeyed table list saturates at 256",
+			st: &ir.Struct{
+				Fields: []*ir.Field{
+					{
+						Name:  "items",
+						Array: ir.ArrayList,
+						Type:  ir.FieldType{Kind: ir.TNamed, Ref: &ir.Struct{IsTable: true}},
+					},
+				},
+			},
+			want: 256,
+		},
+		{
+			name: "unkeyed table array exceeding 256 saturates at 256",
+			st: &ir.Struct{
+				Fields: []*ir.Field{
+					{
+						Name:       "lots",
+						Array:      ir.ArrayCounted,
+						ArrayBound: 300,
+						Type:       ir.FieldType{Kind: ir.TNamed, Ref: &ir.Struct{IsTable: true}},
+					},
+				},
+			},
+			want: 256,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rootElemSlots(tc.st)
+			if got != tc.want {
+				t.Fatalf("rootElemSlots(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -587,7 +587,7 @@ public static partial class TableWire
         // validation still precedes the first output byte.
         int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
         Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-        int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+        int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
         Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
         long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
         long nodes = NodesSize(ref ids);

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -339,6 +339,7 @@ namespace Blockdemo
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4424,7 +4425,7 @@ namespace Blockdemo
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);

--- a/testdata/golden/tables/block-cs/PaddedTable.cs
+++ b/testdata/golden/tables/block-cs/PaddedTable.cs
@@ -156,6 +156,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.PaddedRow(); };
                 info.StorageSize = 64; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -197,6 +198,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.PaddedFrame(); };
                 info.StorageSize = 4136; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 64;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/block-cs/RenderTable.cs
+++ b/testdata/golden/tables/block-cs/RenderTable.cs
@@ -911,6 +911,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderFrame(); };
                 info.StorageSize = 7879320; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 256;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -954,6 +955,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderCamera(); };
                 info.StorageSize = 72; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -993,6 +995,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderShip(); };
                 info.StorageSize = 88; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1037,6 +1040,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderTurret(); };
                 info.StorageSize = 64; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1079,6 +1083,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderMissile(); };
                 info.StorageSize = 72; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1119,6 +1124,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderDynamicProp(); };
                 info.StorageSize = 72; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1159,6 +1165,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderStaticProp(); };
                 info.StorageSize = 80; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1199,6 +1206,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderCosmeticProp(); };
                 info.StorageSize = 80; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1240,6 +1248,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderLaser(); };
                 info.StorageSize = 64; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1279,6 +1288,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderExplosion(); };
                 info.StorageSize = 80; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1319,6 +1329,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderVector3(); };
                 info.StorageSize = 24; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -1355,6 +1366,7 @@ namespace Blockdemo
                 info.Create = delegate { return new global::Blockdemo.RenderQuaternion(); };
                 info.StorageSize = 32; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -223,6 +223,7 @@ namespace Blockhome
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4308,7 +4309,7 @@ namespace Blockhome
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -192,6 +192,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.ArmorPlate(); };
                 info.StorageSize = 16; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -228,6 +229,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.ArmorConfig(); };
                 info.StorageSize = 40; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -265,6 +267,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.FiringGroup(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -300,6 +303,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.GunnerSettings(); };
                 info.StorageSize = 304; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 36;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -138,6 +138,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.PartRow(); };
                 info.StorageSize = 352; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -175,6 +176,7 @@ namespace Blockhome
                 info.Create = delegate { return new global::Blockhome.PartFrame(); };
                 info.StorageSize = 11280; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 32;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/GuardedTable.cs
+++ b/testdata/golden/tables/examples-cs/GuardedTable.cs
@@ -98,6 +98,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.Patrol(); };
                 info.StorageSize = 36; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/KeyedTable.cs
+++ b/testdata/golden/tables/examples-cs/KeyedTable.cs
@@ -409,6 +409,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.TeamConfig(); };
                 info.StorageSize = 28; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -444,6 +445,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.GunnerConfig(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -479,6 +481,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.TurretConfig(); };
                 info.StorageSize = 20; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -515,6 +518,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.HullConfig(); };
                 info.StorageSize = 68; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -551,6 +555,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.KeyedConfig(); };
                 info.StorageSize = 300; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -587,6 +592,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.ScoreBoard(); };
                 info.StorageSize = 12; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/NestedTable.cs
+++ b/testdata/golden/tables/examples-cs/NestedTable.cs
@@ -76,6 +76,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.ArchiveConfig(); };
                 info.StorageSize = 1488; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/PackTable.cs
+++ b/testdata/golden/tables/examples-cs/PackTable.cs
@@ -311,6 +311,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.GunnerSettings(); };
                 info.StorageSize = 36; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -347,6 +348,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.ShipEntry(); };
                 info.StorageSize = 108; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -385,6 +387,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.GlobalSettings(); };
                 info.StorageSize = 72; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -422,6 +425,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.PackConfig(); };
                 info.StorageSize = 740; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 3;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/RangesTable.cs
+++ b/testdata/golden/tables/examples-cs/RangesTable.cs
@@ -238,6 +238,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.RangedSigned(); };
                 info.StorageSize = 80; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -288,6 +289,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.RangedUnsigned(); };
                 info.StorageSize = 104; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -338,6 +340,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.RangedWidths(); };
                 info.StorageSize = 40; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -339,6 +339,7 @@ namespace Tabledemo
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4424,7 +4425,7 @@ namespace Tabledemo
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -446,6 +446,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.RootConfig(); };
                 info.StorageSize = 1480; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 12;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -485,6 +486,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.WeaponConfig(); };
                 info.StorageSize = 28; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -524,6 +526,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.LoadoutConfig(); };
                 info.StorageSize = 176; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 10;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -564,6 +567,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.ProfileConfig(); };
                 info.StorageSize = 304; info.StorageAlign = 8; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -610,6 +614,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.Attachment(); };
                 info.StorageSize = 8; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -645,6 +650,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.Buff(); };
                 info.StorageSize = 4; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -679,6 +685,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.Debuff(); };
                 info.StorageSize = 4; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/tables/examples-cs/WideTable.cs
+++ b/testdata/golden/tables/examples-cs/WideTable.cs
@@ -84,6 +84,7 @@ namespace Tabledemo
                 info.Create = delegate { return new global::Tabledemo.WideBlob(); };
                 info.StorageSize = 280016; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/wide/cs/CaptionTable.cs
+++ b/testdata/golden/wide/cs/CaptionTable.cs
@@ -213,6 +213,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.Caption(); };
                 info.StorageSize = 108; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 3;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -250,6 +251,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.Stamp(); };
                 info.StorageSize = 20; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -285,6 +287,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.Line(); };
                 info.StorageSize = 16; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -223,6 +223,7 @@ namespace Wide
         public Func<object> Create;
         public int StorageSize, StorageAlign, RegionAlign;
         public bool Variable;
+        internal int RootElemSlots;
         public Func<TableTypeInfo[]> PointerTypes;
         public Func<ulong,TableTypeInfo> PointerType;
         public bool BytesEdge, StringEdge;
@@ -4308,7 +4309,7 @@ namespace Wide
                 // validation still precedes the first output byte.
                 int cachedFields = !measure && !type.Variable && type.Fields.Length <= 256 ? type.Fields.Length : 0;
                 Span<long> rootPayloadSizes = stackalloc long[cachedFields];
-                int cachedElemSlots = !measure && !type.Variable ? 256 : 0;
+                int cachedElemSlots = !measure && !type.Variable ? type.RootElemSlots : 0;
                 Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
                 long n = 1 + BodySize(value, type, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
                 long nodes = NodesSize(ref ids);

--- a/testdata/golden/wide/cs/WideView.cs
+++ b/testdata/golden/wide/cs/WideView.cs
@@ -103,6 +103,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.NarrowFifteen(); };
                 info.StorageSize = 20; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -145,6 +146,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.WideFour(); };
                 info.StorageSize = 16; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -187,6 +189,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.WideInterop(); };
                 info.StorageSize = 20; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;
@@ -229,6 +232,7 @@ namespace Wide
                 info.Create = delegate { return new global::Wide.WideSeven(); };
                 info.StorageSize = 20; info.StorageAlign = 4; info.RegionAlign = 8;
                 info.Variable = false;
+                info.RootElemSlots = 0;
                 info.PointerType = delegate(ulong id) { switch(id) { default: return null; } };
                 info.PointerTypes = delegate { return new TableTypeInfo[] { }; };
                 info.BytesEdge = false; info.StringEdge = false;


### PR DESCRIPTION
C# Fixed Table Save reserved 256 child-size slots for every ordinary fixed root, even when the schema needed fewer or none. The generator now computes an internal per-root bound for eligible unkeyed child arrays, saturating safely at 256, and Save requests that many slots.

The matched BenchMixed root requests 88 slots (704 bytes) instead of256 (2048 bytes). Roots without eligible child arrays request zero. Vocabulary and field-payload scratch remain separate; measurement, variable-table bypass, nested behavior and the existing cache fallback are preserved. No throughput claim is made.

The branch includes the legacy benchmark mirror and an overflow-safe accumulator. Independent reviews checked the exact revised head, all67 C# generated/golden files, IR eligibility and saturation. Existing C# generator/golden/compiler/namespace checks, Debug/Release table programs, benchmark builds and matched gates passed; unchanged-output validation supports carrying the earlier runtime results to the final source-only saturation fix.
