### PR TITLE
C++ tables: four widening helpers follow the kinds a unit declares

### DIFF
--- a/compiler/tablewidencpp_test.go
+++ b/compiler/tablewidencpp_test.go
@@ -1,0 +1,284 @@
+// THE FOUR WIDENING HELPERS AND THE SUPERSET THAT CARRIES THEM
+// (docs/SPEC-TABLES.md §2.2, §3, §4).
+//
+// The C++ Table header used to carry the whole widening runtime in EVERY unit.
+// Four of its five functions are reached only from a kind the unit DECLARES:
+//
+//   - TableWidenF32, the float rung: a declared kind 11.
+//   - TableReadSignedAt: a declared kind 3, 4, 5 or 18, the signed ladder's
+//     tops, which are the only kinds that have a rung below them.
+//   - TableReadUnsignedAt: a declared kind 7, 8, 9 or 19.
+//   - TableKindWidth, the one place a payload WIDTH is a run-time fact: an ARM
+//     on a ladder, whose L must be the wire kind's own width (§3), and the
+//     list runtime's extent term, which asks for that width on any list.
+//
+// The fifth, TableKindWidens, stays in every unit: a kind comparison is what
+// every reader does.
+//
+// THE CENSUS IS A SAFE SUPERSET AND THE TESTS BELOW ARE WRITTEN TO THAT.
+// Each helper's call sites are emitted from four to eight places, each behind
+// its own shape test — plainScalar at a field, widenableElement at an array, a
+// keyed body or a list, plainScalar again at an arm, widenable at a map key —
+// so the census asks instead the one question §4 says the rule is decided by:
+// does any field, arm, element or map key in the closure DECLARE a kind with a
+// rung below it? A unit can therefore keep a helper it never calls. What it can
+// never do is call one it does not carry, and that is the direction that
+// decides whether the header compiles.
+//
+// A GREEN GATE ON THE UNITS THAT KEEP THEM IS NOT THE PROOF WANTED, because a
+// census that is always true and one that is always false both leave those
+// units compiling. So each helper is asked for TWICE against a NEAREST
+// NEIGHBOUR: one schema with the declaration at the top of its ladder, which
+// must carry the helper, must CALL it, and must compile and run at -Werror
+// with the sanitizers on; and the same schema with that one declaration
+// respelled at the ladder's BOTTOM — int8, uint8, float32 — which must carry
+// not one symbol of it. TableKindWidens is named on the absent side on purpose:
+// it is every unit's, and a change that took it out with the rest is red here.
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// THE NEAREST-NEIGHBOUR BASE: every scalar at the BOTTOM of its own ladder, so
+// no kind in the unit has a rung below it and no call site can exist. `pick`
+// is a union with an int8 arm, so the unit HAS arms and the arm's own width is
+// still not a run-time fact — which is what separates TableKindWidth's census
+// from "the unit declares a union".
+const widenNoneSrc = `package probe
+
+union Pick
+{
+    small int8
+    tag
+}
+
+table Note
+{
+    tally int8
+    count uint8
+    ratio float32
+    label string(4)
+    pick  Pick
+}
+`
+
+// int64 for int8: the signed ladder's top, and nothing else moved.
+const widenSignedSrc = `package probe
+
+union Pick
+{
+    small int8
+    tag
+}
+
+table Note
+{
+    tally int64
+    count uint8
+    ratio float32
+    label string(4)
+    pick  Pick
+}
+`
+
+// uint32 for uint8: the unsigned ladder, and nothing else moved.
+const widenUnsignedSrc = `package probe
+
+union Pick
+{
+    small int8
+    tag
+}
+
+table Note
+{
+    tally int8
+    count uint32
+    ratio float32
+    label string(4)
+    pick  Pick
+}
+`
+
+// float64 for float32: the float rung's top, and nothing else moved.
+const widenF32Src = `package probe
+
+union Pick
+{
+    small int8
+    tag
+}
+
+table Note
+{
+    tally int8
+    count uint8
+    ratio float64
+    label string(4)
+    pick  Pick
+}
+`
+
+// THE ARM moved instead of a field: int64 for int8 inside the union, so the
+// arm's L is the wire kind's width and TableKindWidth has a call site. The
+// signed reader comes with it, because an arm that widens decodes through it.
+const widenArmSrc = `package probe
+
+union Pick
+{
+    small int64
+    tag
+}
+
+table Note
+{
+    tally int8
+    count uint8
+    ratio float32
+    label string(4)
+    pick  Pick
+}
+`
+
+// A LIST OF int8: nothing in the unit widens, and TableKindWidth is still
+// reached — the list runtime's extent term asks for a wire kind's width on any
+// list at all (lists.go's TableListWireExtent). This is the half of the width
+// census that is NOT about a declared kind, and it is asked for on its own so
+// that folding anyList in is a claim under test rather than an assumption.
+const widenListSrc = `package probe
+
+union Pick
+{
+    small int8
+    tag
+}
+
+table Note
+{
+    tally int8
+    count uint8
+    ratio float32
+    label string(4)
+    marks []int8
+    pick  Pick
+}
+`
+
+// widenHelper is one helper, its definition's spelling, and the CALL its own
+// positive fixture must contain: present is not the same as reached.
+type widenHelper struct {
+	symbol string
+	def    string
+	call   string
+}
+
+var (
+	widenSignedHelper = widenHelper{
+		"TableReadSignedAt",
+		"inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )",
+		"if ( !TableReadSignedAt( r, kind, widened_v ) )",
+	}
+	widenUnsignedHelper = widenHelper{
+		"TableReadUnsignedAt",
+		"inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )",
+		"if ( !TableReadUnsignedAt( r, kind, widened_v ) )",
+	}
+	widenF32Helper = widenHelper{
+		"TableWidenF32",
+		"inline double TableWidenF32( uint32_t bits )",
+		"TableWidenF32( r.get32() )",
+	}
+	widenWidthArm = widenHelper{
+		"TableKindWidth",
+		"inline int64_t TableKindWidth( uint8_t kind )",
+		"if ( sub.size != TableKindWidth( arm_kind ) )",
+	}
+	widenWidthList = widenHelper{
+		"TableKindWidth",
+		"inline int64_t TableKindWidth( uint8_t kind )",
+		"elem_floor = TableKindWidth( wire_kind );",
+	}
+)
+
+// widenBothWays is the shape every case below takes: the fixture that declares
+// the kind carries the helper, calls it, and compiles and runs; the nearest
+// neighbour carries not one symbol of it, and still carries the ladder
+// predicate every unit owns.
+func widenBothWays(t *testing.T, src string, want widenHelper, absent []string) {
+	t.Helper()
+	with, files := deadCppHeader(t, src)
+	if !strings.Contains(with, want.def) {
+		t.Errorf("a unit that declares the kind must define %s", want.symbol)
+	}
+	if !strings.Contains(with, want.call) {
+		t.Errorf("%s must be CALLED by the unit that carries it; no %q in the header", want.symbol, want.call)
+	}
+	for _, sym := range absent {
+		if strings.Contains(with, sym) {
+			t.Errorf("this unit declares no kind that reaches %s and must carry none of it", sym)
+		}
+	}
+	deadCppCompile(t, files)
+
+	without, base := deadCppHeader(t, widenNoneSrc)
+	if strings.Contains(without, want.symbol) {
+		t.Errorf("the nearest neighbour reaches no %s call site and must carry none of it", want.symbol)
+	}
+	// the ladder predicate is EVERY unit's: a kind comparison is what every
+	// reader does, and it is named by the walks
+	if !strings.Contains(without, "inline bool TableKindWidens") {
+		t.Error("TableKindWidens is every unit's and left one")
+	}
+	deadCppCompile(t, base)
+}
+
+func TestCppTableWidenSignedFollowsTheCensus(t *testing.T) {
+	widenBothWays(t, widenSignedSrc, widenSignedHelper,
+		[]string{"TableReadUnsignedAt", "TableWidenF32", "TableKindWidth"})
+}
+
+func TestCppTableWidenUnsignedFollowsTheCensus(t *testing.T) {
+	widenBothWays(t, widenUnsignedSrc, widenUnsignedHelper,
+		[]string{"TableReadSignedAt", "TableWidenF32", "TableKindWidth"})
+}
+
+func TestCppTableWidenF32FollowsTheCensus(t *testing.T) {
+	widenBothWays(t, widenF32Src, widenF32Helper,
+		[]string{"TableReadSignedAt", "TableReadUnsignedAt", "TableKindWidth"})
+}
+
+// AN ARM ON A LADDER is TableKindWidth's declared-kind half: the arm's L must
+// be the WIRE kind's width, which no constant can spell. The signed reader
+// rides with it, because that is what the arm's payload decodes through — so
+// it is not named absent here.
+func TestCppTableWidenArmWidthFollowsTheCensus(t *testing.T) {
+	widenBothWays(t, widenArmSrc, widenWidthArm,
+		[]string{"TableReadUnsignedAt", "TableWidenF32"})
+}
+
+// A LIST is the other half, and it is reached with nothing in the unit
+// widening at all.
+func TestCppTableWidenListWidthFollowsTheCensus(t *testing.T) {
+	widenBothWays(t, widenListSrc, widenWidthList,
+		[]string{"TableReadSignedAt", "TableReadUnsignedAt", "TableWidenF32"})
+}
+
+// THE ALL-ABSENT UNIT, asked for once on its own: a schema whose every scalar
+// sits at the bottom of its ladder carries none of the four, and still
+// compiles and runs. It is the claim the five cases above each lean on.
+func TestCppTableWidenRuntimeAbsentFromALadderlessUnit(t *testing.T) {
+	header, files := deadCppHeader(t, widenNoneSrc)
+	for _, sym := range []string{
+		"TableKindWidth", "TableReadSignedAt", "TableReadUnsignedAt", "TableWidenF32",
+	} {
+		if strings.Contains(header, sym) {
+			t.Errorf("a unit with no kind above a ladder's bottom must carry no %s", sym)
+		}
+	}
+	if !strings.Contains(header, "inline bool TableKindWidens") {
+		t.Error("TableKindWidens is every unit's and left one")
+	}
+	deadCppCompile(t, files)
+}

--- a/generated/bench/paired/cpp/BenchTable.h
+++ b/generated/bench/paired/cpp/BenchTable.h
@@ -675,22 +675,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/generated/bench/paired/cpp/FixedTableTable.h
+++ b/generated/bench/paired/cpp/FixedTableTable.h
@@ -676,22 +676,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -674,22 +674,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -524,7 +524,7 @@ struct TableKeyed
 // same way would be a redefinition.
 func tableInlineMacro(pkg string) string { return strings.ToUpper(pkg) + "_TABLE_INLINE" }
 
-func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool, anyExtent bool, anyWide bool, idCap int, u *ir.Unit) string {
+func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool, anyExtent bool, anyWide bool, widen widenCensus, idCap int, u *ir.Unit) string {
 	// THE ID TABLE'S CAPACITY IS A COMPILE-TIME FACT of the unit (§3): the
 	// distinct names its table closure can spell, so a save allocates nothing.
 	// The bucket count is the next power of two at twice the capacity, so the
@@ -562,6 +562,13 @@ func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool, anyExtent bool
 	if anyWide {
 		wideText = tableWideTextRuntime
 	}
+	// THE WIDENING RUNTIME, minus the helpers no kind in this unit's closure
+	// declares (docs/SPEC-TABLES.md §2.2, §4): the ladder predicate always,
+	// and TableKindWidth, TableReadSignedAt, TableReadUnsignedAt and
+	// TableWidenF32 each where the census could not rule its call sites out.
+	// The census is a SAFE SUPERSET of the emitter's own shape tests — see
+	// unitWidenCensus.
+	widenRuntime := widen.runtime()
 	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_PRIMITIVES"
 	forceInline := tableInlineMacro(pkg)
 	messageForm := tableMessageForm(u, anyVariable)
@@ -1220,7 +1227,7 @@ struct TableReader
     }
 };
 
-` + tableWidenRuntime + tableTextRuntime + wideText + `
+` + widenRuntime + tableTextRuntime + wideText + `
 // The RESERVED node-table id, the one id the language holds back
 // (docs/SPEC-TABLES.md §3.1, §5). It rides in every unit, pointered or not,
 // because every body has to know that a NESTED body claiming one is damaged.
@@ -1404,6 +1411,11 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// or out for the whole unit. ir.WideTextFields is the census every other
 	// target refuses on (compiler/widetext.go), taken over both wires.
 	anyWide := len(ir.WideTextFields(u)) > 0
+	// THE WIDENING HELPERS take their census the same way and for the same
+	// reason (docs/SPEC-TABLES.md §4): a unit carries the runtime for the
+	// kinds it DECLARES, and the list runtime's own extent term is one more
+	// call site for the width.
+	widen := unitWidenCensus(u, closure, anyList)
 	blocks := ir.Blocks(u)
 
 	// The BLOCK FORM (docs/SPEC-TABLES.md §19) is emitted ON THE SIDE, into
@@ -1596,7 +1608,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			fmt.Fprintf(&h, "#include \"%s\"\n", n)
 		}
 		h.WriteString("\n")
-		h.WriteString(tablePrimitives(u.Package, anyVariable, anyKeyed, anyExtent, anyWide, ir.TableWireIdCapacity(u), u))
+		h.WriteString(tablePrimitives(u.Package, anyVariable, anyKeyed, anyExtent, anyWide, widen, ir.TableWireIdCapacity(u), u))
 		if anyVariable {
 			h.WriteString("\n")
 			h.WriteString(tableArenaRuntime(u, anyExtent))

--- a/internal/codegen/cpptable/trailer_test.go
+++ b/internal/codegen/cpptable/trailer_test.go
@@ -29,7 +29,7 @@ func TestTableIdsWriteBulkProperties(t *testing.T) {
 	}
 
 	u := &ir.Unit{Package: "bench"}
-	src := tablePrimitives("bench", false, false, false, false, 64, u)
+	src := tablePrimitives("bench", false, false, false, false, widenCensus{}, 64, u)
 	for _, snip := range requiredSnippets {
 		if !strings.Contains(src, snip) {
 			t.Errorf("tablePrimitives missing required trailer snippet: %q", snip)

--- a/internal/codegen/cpptable/widen.go
+++ b/internal/codegen/cpptable/widen.go
@@ -17,10 +17,14 @@ import (
 // inside the kind-mismatch branch a reader already takes, which today skips
 // the payload. A payload under the declared kind never reaches it.
 
-// tableWidenRuntime is the runtime half, emitted after TableReader in every
-// unit: the ladder predicate and the two readers that fetch a payload at ITS
-// kind's width and extend it to sixty-four bits.
-const tableWidenRuntime = `
+// THE RUNTIME HALF IS FIVE FUNCTIONS AND FOUR CENSUSES (§2.2). The ladder
+// predicate below rides in every unit, because a kind comparison is what every
+// reader does and the walks name it. The other four are each reached from a
+// kind the unit DECLARES, so each is emitted only where a call site could
+// exist — see unitWidenCensus for the superset each is taken over.
+//
+// tableWidensRuntime is the predicate, emitted after TableReader in every unit.
+const tableWidensRuntime = `
 // WIDENING (docs/SPEC-TABLES.md §4): a payload under a kind BELOW the reader's
 // on the same ladder decodes exactly. The signed ladder is kinds 2, 3, 4, 5,
 // 18, the unsigned one 6, 7, 8, 9, 19, and 10 into 11 is the float rung. Every
@@ -39,7 +43,13 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     }
     return false;
 }
+`
 
+// tableKindWidthRuntime is emitted where a WIDTH can be a run-time fact: an
+// arm whose kind byte the reader widens (widen.go's emitArmWiden), and the
+// list runtime's own extent term (lists.go's TableListWireExtent). A unit that
+// declares neither an arm on a ladder nor a list has no call site for it.
+const tableKindWidthRuntime = `
 // a fixed-width kind's payload width, for the one place the width is a
 // runtime fact: an arm whose kind byte the reader widens, whose L must be the
 // wire kind's own width (§3)
@@ -55,7 +65,12 @@ inline int64_t TableKindWidth( uint8_t kind )
     }
     return 0;
 }
+`
 
+// tableReadSignedAtRuntime is emitted where a SIGNED ladder's top is declared
+// — a field, an arm, an element or a map key of kind 3, 4, 5 or 18. Nothing
+// below one of those reads a signed payload at a run-time width.
+const tableReadSignedAtRuntime = `
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
@@ -68,7 +83,12 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
         default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
     }
 }
+`
 
+// tableReadUnsignedAtRuntime is the unsigned half, and its census is the
+// unsigned ladder's tops: kind 7, 8, 9 or 19 — which a `flags` and a `bits(N)`
+// field reach under, because the kind pair alone decides widening (§4).
+const tableReadUnsignedAtRuntime = `
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {
@@ -80,7 +100,13 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
         default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
     }
 }
+`
 
+// tableWidenF32Runtime is the FLOAT RUNG, kind 10 into kind 11, and it is
+// emitted only where kind 11 is declared: the file wire's widened scalar and
+// the message form's f32-shaped entry into an f64 field (messageload.go) are
+// its two call sites, and both are behind a declared f64.
+const tableWidenF32Runtime = `
 // f32 into f64, exact: a NaN's payload is data and rides on the bits, since
 // the hardware conversion would set the quiet bit (§4)
 inline double TableWidenF32( uint32_t bits )
@@ -95,6 +121,120 @@ inline double TableWidenF32( uint32_t bits )
     float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 `
+
+// widenCensus is the unit-level census of the four widening helpers
+// (docs/SPEC-TABLES.md §2.2, §3, §4). It is UNIT-LEVEL and not per-file for
+// the reason §794's two are: the primitives block sits behind ONE
+// package-scoped guard, so whichever <Base>Table.h a translation unit includes
+// first defines the runtime for every other file of the package, and a helper
+// is therefore in or out for the whole unit.
+//
+// IT IS A SAFE SUPERSET AND NOT AN EXACT MATCH, deliberately. The call sites
+// are emitted from four to eight places apiece, each behind its own shape test
+// — plainScalar at a field, widenableElement at an array, a keyed body or a
+// list, plainScalar again at an arm, widenable at a map key — and no census
+// could match that union without spelling those tests a second time and
+// growing a second way to be wrong. So the census asks the ONE question the
+// widening rule is decided by (§4: "the rule is decided by the KIND PAIR and
+// by nothing else"): does any field, arm, element or map key in the unit's
+// closure DECLARE a kind whose ladder has a rung below it? A pointer field of
+// kind 11, a map of int64 values, a *bytes — none of them will ever reach a
+// call site, and each still answers yes. The cost of the superset is a unit
+// that keeps a helper it does not call; the cost of a subset would be a unit
+// that does not compile, which is why it is taken this way round.
+type widenCensus struct {
+	f32      bool // TableWidenF32: a declared kind 11, the float rung's top
+	signed   bool // TableReadSignedAt: a declared kind 3, 4, 5 or 18
+	unsigned bool // TableReadUnsignedAt: a declared kind 7, 8, 9 or 19
+	width    bool // TableKindWidth: an arm on any ladder, or a list
+}
+
+// unitWidenCensus walks the closure the emitter itself emits codecs for —
+// every table and struct it reaches, the generated map entries among them
+// (ir.TableClosure) — and every union an arm or a field of one of those
+// reaches, transitively. For each field it asks BOTH kinds a widening site can
+// be keyed on: the field's own scalar kind, which is what a plain field, an
+// arm and a map key are compared under, and its ELEMENT kind, which is what a
+// bounded array, a keyed body and a list are compared under.
+//
+// anyList is folded into `width` because the list runtime's extent term calls
+// TableKindWidth on a wire kind unconditionally (lists.go's
+// TableListWireExtent), whatever the element kind is: a unit with a list has
+// that call site whether or not any element could widen.
+func unitWidenCensus(u *ir.Unit, closure map[string]bool, anyList bool) widenCensus {
+	c := widenCensus{width: anyList}
+	seen := map[*ir.Union]bool{}
+	var note func(f *ir.Field, arm bool)
+	var walkUnion func(un *ir.Union)
+	note = func(f *ir.Field, arm bool) {
+		if f == nil {
+			return
+		}
+		for _, kind := range [2]int{tableScalarKind(f), ir.TableWireElemKind(f)} {
+			if !widenable(kind) {
+				continue
+			}
+			switch {
+			case kind == tkF64:
+				c.f32 = true
+			case ir.TableKindSigned(kind):
+				c.signed = true
+			default:
+				c.unsigned = true
+			}
+			// AN ARM IS THE ONE FIELD-LIKE POSITION whose payload width is a
+			// run-time fact (§3): the arm's L must be the WIRE kind's width,
+			// which is the width the reader has to ask for.
+			if arm {
+				c.width = true
+			}
+		}
+		if f.Type.Kind == ir.TNamed {
+			if un, ok := f.Type.Ref.(*ir.Union); ok {
+				walkUnion(un)
+			}
+		}
+	}
+	walkUnion = func(un *ir.Union) {
+		if seen[un] {
+			return
+		}
+		seen[un] = true
+		for _, v := range un.Variants {
+			note(v.F, true)
+		}
+	}
+	for name := range closure {
+		st := memberOf(u, name)
+		if st == nil {
+			continue
+		}
+		for _, f := range st.Fields {
+			note(f, false)
+		}
+	}
+	return c
+}
+
+// runtime composes the widening runtime this unit carries: the ladder
+// predicate always, and each of the four helpers where the census could not
+// rule its call sites out.
+func (c widenCensus) runtime() string {
+	out := tableWidensRuntime
+	if c.width {
+		out += tableKindWidthRuntime
+	}
+	if c.signed {
+		out += tableReadSignedAtRuntime
+	}
+	if c.unsigned {
+		out += tableReadUnsignedAtRuntime
+	}
+	if c.f32 {
+		out += tableWidenF32Runtime
+	}
+	return out
+}
 
 // widenable reports whether a declared kind sits ABOVE the bottom of a ladder,
 // so a reader of it has kinds to widen from and emits the branch.

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -761,32 +761,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
     }
 }
 
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -761,32 +761,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
     }
 }
 
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -762,32 +762,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
     }
 }
 
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -761,32 +761,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
     }
 }
 
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -707,35 +707,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
-// the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
-// sixty-four bits; false = the body cannot cover it, which is framing damage
-inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
-{
-    switch ( kind )
-    {
-        case 2: if ( !r.has( 1 ) ) { return false; } out = (int8_t) r.get8(); return true;
-        case 3: if ( !r.has( 2 ) ) { return false; } out = (int16_t) r.get16(); return true;
-        case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
-    }
-}
-
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {
@@ -746,20 +717,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
         case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
     }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -693,22 +693,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -674,35 +674,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
-// the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
-// sixty-four bits; false = the body cannot cover it, which is framing damage
-inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
-{
-    switch ( kind )
-    {
-        case 2: if ( !r.has( 1 ) ) { return false; } out = (int8_t) r.get8(); return true;
-        case 3: if ( !r.has( 2 ) ) { return false; } out = (int16_t) r.get16(); return true;
-        case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
-    }
-}
-
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -674,35 +674,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
-// the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
-// sixty-four bits; false = the body cannot cover it, which is framing damage
-inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
-{
-    switch ( kind )
-    {
-        case 2: if ( !r.has( 1 ) ) { return false; } out = (int8_t) r.get8(); return true;
-        case 3: if ( !r.has( 2 ) ) { return false; } out = (int16_t) r.get16(); return true;
-        case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
-    }
-}
-
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -675,35 +675,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
-// the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
-// sixty-four bits; false = the body cannot cover it, which is framing damage
-inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
-{
-    switch ( kind )
-    {
-        case 2: if ( !r.has( 1 ) ) { return false; } out = (int8_t) r.get8(); return true;
-        case 3: if ( !r.has( 2 ) ) { return false; } out = (int16_t) r.get16(); return true;
-        case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
-    }
-}
-
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -693,22 +693,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/RangesTable.h
+++ b/testdata/golden/tables/examples/RangesTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -692,22 +692,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )

--- a/testdata/golden/tables/lists/HoldersTable.h
+++ b/testdata/golden/tables/lists/HoldersTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/lists/MigrateTable.h
+++ b/testdata/golden/tables/lists/MigrateTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/lists/ReportTable.h
+++ b/testdata/golden/tables/lists/ReportTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/lists/SharedTable.h
+++ b/testdata/golden/tables/lists/SharedTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/CrewsTable.h
+++ b/testdata/golden/tables/maps/CrewsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/FleetTable.h
+++ b/testdata/golden/tables/maps/FleetTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/PairsTable.h
+++ b/testdata/golden/tables/maps/PairsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/RowsTable.h
+++ b/testdata/golden/tables/maps/RowsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/TextTable.h
+++ b/testdata/golden/tables/maps/TextTable.h
@@ -773,20 +773,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/maps/TrailsTable.h
+++ b/testdata/golden/tables/maps/TrailsTable.h
@@ -774,20 +774,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -715,20 +715,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -728,22 +728,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
@@ -755,32 +739,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
         case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
     }
-}
-
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -725,22 +725,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
@@ -752,32 +736,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
         case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
     }
-}
-
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -725,22 +725,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
@@ -752,32 +736,6 @@ inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
         case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
     }
-}
-
-// the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
-inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
-{
-    switch ( kind )
-    {
-        case 6: if ( !r.has( 1 ) ) { return false; } out = r.get8(); return true;
-        case 7: if ( !r.has( 2 ) ) { return false; } out = r.get16(); return true;
-        case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
-    }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -693,22 +693,6 @@ inline bool TableKindWidens( uint8_t kind, uint8_t declared )
     return false;
 }
 
-// a fixed-width kind's payload width, for the one place the width is a
-// runtime fact: an arm whose kind byte the reader widens, whose L must be the
-// wire kind's own width (§3)
-inline int64_t TableKindWidth( uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6: case 20: case 25: return 1;
-        case 3: case 7: case 21: case 26: return 2;
-        case 4: case 8: case 10: case 22: case 27: return 4;
-        case 5: case 9: case 11: case 23: case 28: return 8;
-        case 18: case 19: case 24: case 29: return 16;
-    }
-    return 0;
-}
-
 // the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
 // sixty-four bits; false = the body cannot cover it, which is framing damage
 inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
@@ -732,20 +716,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
         case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
     }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -723,19 +723,6 @@ inline int64_t TableKindWidth( uint8_t kind )
     return 0;
 }
 
-// the payload of a kind on the SIGNED ladder (2 to 5), sign-extended to
-// sixty-four bits; false = the body cannot cover it, which is framing damage
-inline bool TableReadSignedAt( TableReader & r, uint8_t kind, int64_t & out )
-{
-    switch ( kind )
-    {
-        case 2: if ( !r.has( 1 ) ) { return false; } out = (int8_t) r.get8(); return true;
-        case 3: if ( !r.has( 2 ) ) { return false; } out = (int16_t) r.get16(); return true;
-        case 4: if ( !r.has( 4 ) ) { return false; } out = (int32_t) r.get32(); return true;
-        default: if ( !r.has( 8 ) ) { return false; } out = (int64_t) r.get64(); return true;
-    }
-}
-
 // the payload of a kind on the UNSIGNED ladder (6 to 9), zero-extended
 inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
 {
@@ -746,20 +733,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
         case 8: if ( !r.has( 4 ) ) { return false; } out = r.get32(); return true;
         default: if ( !r.has( 8 ) ) { return false; } out = r.get64(); return true;
     }
-}
-
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
 }
 
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -715,20 +715,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/tables/wide/WideTextTable.h
+++ b/testdata/golden/tables/wide/WideTextTable.h
@@ -715,20 +715,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -715,20 +715,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not

--- a/testdata/golden/wide/cpp/WideTextTable.h
+++ b/testdata/golden/wide/cpp/WideTextTable.h
@@ -715,20 +715,6 @@ inline bool TableReadUnsignedAt( TableReader & r, uint8_t kind, uint64_t & out )
     }
 }
 
-// f32 into f64, exact: a NaN's payload is data and rides on the bits, since
-// the hardware conversion would set the quiet bit (§4)
-inline double TableWidenF32( uint32_t bits )
-{
-    if ( ( bits & 0x7F800000u ) == 0x7F800000u && ( bits & 0x007FFFFFu ) != 0 )
-    {
-        const uint64_t sign = (uint64_t) ( bits >> 31 ) << 63;
-        const uint64_t payload = (uint64_t) ( bits & 0x007FFFFFu ) << 29;
-        const uint64_t nan_bits = sign | 0x7FF0000000000000ull | payload;
-        double d; memcpy( &d, &nan_bits, 8 ); return d;
-    }
-    float f; memcpy( &f, &bits, 4 ); return (double) f;
-}
-
 // ILL-FORMED TEXT IS DAMAGE (docs/SPEC-TABLES.md §3, §4): a kind 12 payload is
 // well-formed UTF-8 with no zero byte among its bytes, checked AS IT ARRIVES
 // and before the reader's own bound, because a payload that is not text is not


### PR DESCRIPTION
Stacked on #794 (base is its branch; retarget to main once #794 merges). The follow-up #794 named: the widening runtime (`TableWidenF32`, `TableReadSignedAt`, `TableReadUnsignedAt`, `TableKindWidth`) is now emitted only in units whose census says a call site can exist. The census is a superset of emission: it asks which declared kinds the closure carries (f32 → WidenF32; signed kinds → ReadSignedAt; unsigned/flags/bits → ReadUnsignedAt; an arm on a ladder or any list → KindWidth) and never repeats the shape tests behind the eight `emitWidenedScalar` callers. `TableKindWidens` stays in every unit (generic walks and the message codec name it).

- 931 lines deleted from 48 committed C++ headers, 0 insertions; 16 lines from each of the three bench headers (all `TableKindWidth`); no unit references a helper it does not define, checked across all 40 generated units.
- `compiler/tablewidencpp_test.go`: six both-ways cases against a nearest neighbour; each positive fixture moves one declaration and must define, call, compile and run its helper at `-O1 -Wall -Wextra -Werror -fsanitize=address,undefined`; the neighbour carries none. Sabotaging the census turns all five positive cases red at the compile (undeclared identifier), reverted.
- Gates run in the child's clone: build/vet/test, tables + ASan, wire fuzz 171,387 mutants and retain fuzz 74,522 mutants with 0 divergences on both legs, negative controls all red, cpp conformance on every surface including forgery 12/12 and cook-forgery 113/113, maps/lists/arms/view/cook-open/cook-write, bench gate `b51387f36d9b59c4`, matched cpp/c/go legs `07c57b4fa34b2700`, PORTING register, shape gate, golangci-lint v2.12.2, modernize v0.23.0, regeneration byte-stable twice.
- Not run there: the eight non-cpp conformance legs (only C++ headers changed), `bench/paired -mode gate` end-to-end (no dotnet in the sandbox; the three matched binaries were run directly), full `make test`. CI here is the control.

No speed claim; this is dead generated output only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)