### PR TITLE
packet C++/C#: one range-check predicate across the three ranged-int emitters

### DIFF
--- a/bench/results/2026-09-09-arm64-studio-lock-pass.csv
+++ b/bench/results/2026-09-09-arm64-studio-lock-pass.csv
@@ -1,0 +1,45 @@
+# schema bench results
+# date: 2026-09-09T13:52:49Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.8.1 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: d697492e-dirty (packet-range-check-elision-cpp-cs)
+# serialize commit: 56a1b59 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/75ee244e-e95f-4bcd-9e3b-ae04de39d592/scratchpad/serialize]
+# serialize.c commit: e67dc6a (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/75ee244e-e95f-4bcd-9e3b-ae04de39d592/scratchpad/serialize.c]
+# serialize.go commit: c3a34b1 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/75ee244e-e95f-4bcd-9e3b-ae04de39d592/scratchpad/serialize.go]
+# serialize.rs commit: unknown (unknown) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.cs commit: 0305cf8 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/75ee244e-e95f-4bcd-9e3b-ae04de39d592/scratchpad/serialize.cs]
+# serialize.js commit: unknown (unknown) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c
+# load_start: 16.15 14.62 13.03
+# load_end: 15.78 15.88 13.97
+# load_max: 19.74
+# core_busy_pct: n/a
+# foreign_procs: 34
+# control_start_median: 6218309   control_end_median: 6334162
+# control_delta_pct: 1.9   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8157876,8018764,8525113,3407.62,6.21,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4437462,4390471,4562856,1853.57,3.88,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,90064,88715,92131,5627.42,3.79,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,120455,102275,123357,7526.37,17.50,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8162620,7928548,8512598,3409.60,7.16,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4230692,4184846,4348862,1767.20,3.88,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,89572,88127,91556,5596.68,3.83,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,121915,118462,122955,7617.59,3.69,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -249,10 +249,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->b = (int32_t) offset_value;
     }
     {
@@ -419,10 +415,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->f1 = (int32_t) offset_value;
     }
     {
@@ -447,10 +439,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 3ULL )
-        {
-            return 0;
-        }
         value->f3 = (int32_t) offset_value;
     }
     {
@@ -489,10 +477,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->f6 = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -503,10 +487,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 255ULL )
-        {
-            return 0;
-        }
         value->f7 = (int32_t) offset_value;
     }
     {
@@ -820,10 +800,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_x = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -834,10 +810,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_y = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -848,10 +820,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_z = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -947,10 +915,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_stat( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 1023ULL )
-        {
-            return 0;
-        }
         value->delta = (int32_t) ( offset_value + (-512) );
     }
     return 1;
@@ -1005,10 +969,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->damage = (int32_t) offset_value;
     }
     {
@@ -1019,10 +979,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 7ULL )
-        {
-            return 0;
-        }
         value->hit_kind = (int32_t) offset_value;
     }
     {
@@ -1068,10 +1024,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_chat_event( serialize_r
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 3ULL )
-        {
-            return 0;
-        }
         value->channel = (int32_t) offset_value;
     }
     {
@@ -1125,10 +1077,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_pickup_event( serialize
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 255ULL )
-        {
-            return 0;
-        }
         value->amount = (int32_t) offset_value;
     }
     return 1;
@@ -1422,10 +1370,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->ack_sequence = (int32_t) offset_value;
     }
     {
@@ -1656,10 +1600,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
                 return 0;
             }
             offset_value = raw;
-            if ( offset_value > 255ULL )
-            {
-                return 0;
-            }
             value->extra = (int32_t) offset_value;
         }
         value->idle_ticks = 0;
@@ -1674,10 +1614,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
                 return 0;
             }
             offset_value = raw;
-            if ( offset_value > 15ULL )
-            {
-                return 0;
-            }
             value->idle_ticks = (int32_t) offset_value;
         }
         value->extra = 0;

--- a/generated/bench/paired/c/BenchWire.h
+++ b/generated/bench/paired/c/BenchWire.h
@@ -249,10 +249,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->b = (int32_t) offset_value;
     }
     {
@@ -419,10 +415,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->f1 = (int32_t) offset_value;
     }
     {
@@ -447,10 +439,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 3ULL )
-        {
-            return 0;
-        }
         value->f3 = (int32_t) offset_value;
     }
     {
@@ -489,10 +477,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->f6 = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -503,10 +487,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 255ULL )
-        {
-            return 0;
-        }
         value->f7 = (int32_t) offset_value;
     }
     {
@@ -820,10 +800,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_x = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -834,10 +810,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_y = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -848,10 +820,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_entity( serialize_read_
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->vel_z = (int32_t) ( offset_value + (-2048) );
     }
     {
@@ -947,10 +915,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_stat( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 1023ULL )
-        {
-            return 0;
-        }
         value->delta = (int32_t) ( offset_value + (-512) );
     }
     return 1;
@@ -1005,10 +969,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->damage = (int32_t) offset_value;
     }
     {
@@ -1019,10 +979,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 7ULL )
-        {
-            return 0;
-        }
         value->hit_kind = (int32_t) offset_value;
     }
     {
@@ -1068,10 +1024,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_chat_event( serialize_r
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 3ULL )
-        {
-            return 0;
-        }
         value->channel = (int32_t) offset_value;
     }
     {
@@ -1125,10 +1077,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_pickup_event( serialize
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 255ULL )
-        {
-            return 0;
-        }
         value->amount = (int32_t) offset_value;
     }
     return 1;
@@ -1422,10 +1370,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 65535ULL )
-        {
-            return 0;
-        }
         value->ack_sequence = (int32_t) offset_value;
     }
     {
@@ -1656,10 +1600,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
                 return 0;
             }
             offset_value = raw;
-            if ( offset_value > 255ULL )
-            {
-                return 0;
-            }
             value->extra = (int32_t) offset_value;
         }
         value->idle_ticks = 0;
@@ -1674,10 +1614,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_s
                 return 0;
             }
             offset_value = raw;
-            if ( offset_value > 15ULL )
-            {
-                return 0;
-            }
             value->idle_ticks = (int32_t) offset_value;
         }
         value->extra = 0;

--- a/generated/bench/tables/c/BenchTableWire.h
+++ b/generated/bench/tables/c/BenchTableWire.h
@@ -101,10 +101,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4095ULL )
-        {
-            return 0;
-        }
         value->damage = (int32_t) offset_value;
     }
     {
@@ -115,10 +111,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_hit_event( serialize_re
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 7ULL )
-        {
-            return 0;
-        }
         value->hit_kind = (int32_t) offset_value;
     }
     {
@@ -164,10 +156,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_chat_event( serialize_r
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 3ULL )
-        {
-            return 0;
-        }
         value->channel = (int32_t) offset_value;
     }
     {
@@ -221,10 +209,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_pickup_event( serialize
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 255ULL )
-        {
-            return 0;
-        }
         value->amount = (int32_t) offset_value;
     }
     return 1;

--- a/generated/c/ArmDefaultsWire.h
+++ b/generated/c/ArmDefaultsWire.h
@@ -103,10 +103,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_arm( serialize_read_s
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 7ULL )
-        {
-            return 0;
-        }
         value->marker = (uint8_t) offset_value;
     }
     return 1;

--- a/generated/c/ClausesWire.h
+++ b/generated/c/ClausesWire.h
@@ -204,10 +204,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w13( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }
@@ -256,10 +252,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w17( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 131071ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint32_t) offset_value;
             }
         }
@@ -308,10 +300,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w26( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 67108863ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint32_t) offset_value;
             }
         }
@@ -360,10 +348,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w1( serialize_read_stream_t *
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 1ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint8_t) offset_value;
             }
         }
@@ -424,10 +408,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w52( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = (serialize_uint64_t) lo | ( ( (serialize_uint64_t) hi ) << 32 );
-                if ( offset_value > 4503599627370495ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint64_t) offset_value;
             }
         }
@@ -488,10 +468,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w50( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = (serialize_uint64_t) lo | ( ( (serialize_uint64_t) hi ) << 32 );
-                if ( offset_value > 1125899906842623ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint64_t) offset_value;
             }
         }
@@ -537,10 +513,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_f13( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }

--- a/generated/c/JoinsWire.h
+++ b/generated/c/JoinsWire.h
@@ -719,10 +719,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_arm_array( serialize_read_str
                         return 0;
                     }
                     offset_value = raw;
-                    if ( offset_value > 8191ULL )
-                    {
-                        return 0;
-                    }
                     value->items[i] = (uint16_t) offset_value;
                 }
             }
@@ -1065,10 +1061,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_regain_after_align( serialize
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -915,10 +915,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 31ULL )
-        {
-            return 0;
-        }
         value->hardpoint_index = (int32_t) offset_value;
     }
     {

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -336,10 +336,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4294967295ULL )
-        {
-            return 0;
-        }
         value->sensor = (uint32_t) offset_value;
     }
     {
@@ -1247,10 +1243,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 255ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (int32_t) offset_value;
             }
         }

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -68,7 +68,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		out[f.Base+".h"] = g.assembleHeader()
 		errs = append(errs, g.errs...)
 
-		w := &gen{unit: u, file: f, deps: sortedDeps(deps[f.Base]), wire: true}
+		w := &gen{unit: u, file: f, deps: sortedDeps(deps[f.Base])}
 		w.emitWireHeader()
 		out[f.Base+"Wire.h"] = w.assembleWireHeader()
 		errs = append(errs, w.errs...)
@@ -99,7 +99,6 @@ type gen struct {
 	saidFlagAppend bool // the flag_names_* append helpers are emitted once per file
 	file           *ir.File
 	deps           []string
-	wire           bool
 	body           strings.Builder
 
 	// fixed [N]uint8 arrays of the struct being emitted whose element bytes

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -396,12 +396,10 @@ func (g *gen) emitReadRangedInt(f *ir.Field, expr, ind string) {
 		g.call(ind+"    ", fmt.Sprintf("serialize_read_bits( stream, &hi, %d )", bits-32))
 		g.pf("%s    offset_value = (serialize_uint64_t) lo | ( ( (serialize_uint64_t) hi ) << 32 );\n", ind)
 	}
-	// Reject, never clamp -- a value smuggled into the range's bit headroom.
-	// Elided when the span fills the full 64-bit domain: there is no headroom
-	// to smuggle into, and the comparison would be vacuous (which -Wtype-limits
-	// rejects, and this family builds with -Werror).
-	maxU64 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(1))
-	if span.Cmp(maxU64) < 0 {
+	// A successful read bounds the offset to its encoded width. Reject encodings
+	// only when the declared span leaves headroom in that encoded width.
+	maxOffset := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+	if span.Cmp(maxOffset) < 0 {
 		g.pf("%s    if ( offset_value > %sULL )\n%s    {\n%s        return 0;\n%s    }\n", ind, span.String(), ind, ind, ind)
 	}
 	if f.IntMin.Sign() == 0 {

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -673,10 +673,15 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 				g.pf("%sread_int64( stream, %s, %s, %s );\n", ind, name, lo, hi)
 			default:
 				diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+				bits := bitsRequired(f.IntMin, f.IntMax)
 				g.pf("%s{\n%s    uint64_t offset_value = 0;\n", ind, ind)
-				g.pf("%s    read_bits( stream, offset_value, %d );\n", ind, bitsRequired(f.IntMin, f.IntMax))
-				if diff.Cmp(maxUint64) != 0 {
-					// a full-width diff cannot overflow its own read — elided
+				g.pf("%s    read_bits( stream, offset_value, %d );\n", ind, bits)
+				// A successful read bounds the offset to its encoded width:
+				// serialize.h:1520 masks every decoded chunk with (1<<bits)-1
+				// unconditionally. Reject encodings only when the declared span
+				// leaves headroom in that encoded width.
+				maxOffset := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+				if diff.Cmp(maxOffset) < 0 {
 					g.pf("%s    if ( offset_value > %sull )\n%s    {\n%s        return false;\n%s    }\n", ind, diff.String(), ind, ind, ind)
 				}
 				if f.IntMin.Sign() == 0 {

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -652,8 +652,11 @@ func (g *gen) flatReadRangedPiece(item *ir.FieldItem, name string) (flatPiece, b
 		// out-of-range WITHOUT latching, so the fold changes nothing
 		lo, _ := g.rangeArgs(f, "ulong")
 		diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+		// The unpacked source is masked to the piece's own width (flatMaskLit,
+		// and a 64-bit piece is a whole chunk), so a refusal whose span fills
+		// that width can never fire — the same predicate flatVacuousRange uses.
 		return flatPiece{item: item, bits: bits, read: func(ind, src string) {
-			if diff.Cmp(maxUint64) != 0 {
+			if !flatVacuousRange(f.IntMin, f.IntMax) {
 				g.sf("%sif (%s > %s) // a read rejects out-of-range (SPEC §5) — not latched\n", ind, src, diff.String())
 				g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
 			}

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -1110,10 +1110,16 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 			default:
 				lo, _ := g.rangeArgs(f, "ulong")
 				diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+				bits := ir.BitsRequired(f.IntMin, f.IntMax)
 				g.sf("%s{\n%s    ulong offsetValue = 0;\n", ind, ind)
-				g.call(ind+"    ", fmt.Sprintf("%s.SerializeBits64(ref offsetValue, %d)", g.rv(), ir.BitsRequired(f.IntMin, f.IntMax)), "")
-				if diff.Cmp(maxUint64) != 0 {
-					// a full-width diff cannot overflow its own read — elided
+				g.call(ind+"    ", fmt.Sprintf("%s.SerializeBits64(ref offsetValue, %d)", g.rv(), bits), "")
+				// A successful read bounds the offset to its encoded width:
+				// Serialize.cs ReadBitsUnchecked masks every decoded chunk with
+				// (1<<bits)-1 unconditionally — that mask is the decode, not a
+				// check, so it stays in every build mode. Reject encodings only
+				// when the declared span leaves headroom in that encoded width.
+				maxOffset := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+				if diff.Cmp(maxOffset) < 0 {
 					g.sf("%s    if (offsetValue > %s) // a read rejects out-of-range (SPEC §5) — not latched\n", ind, diff.String())
 					g.sf("%s    {\n%s        return false;\n%s    }\n", ind, ind, ind)
 				}

--- a/internal/codegen/ctable/ctable.go
+++ b/internal/codegen/ctable/ctable.go
@@ -236,11 +236,6 @@ static SCHEMA_UNUSED int32_t table_keyed_slot( int32_t key, uint32_t count )
 // per-package guard — one definition per TU whatever the include order, and a
 // lone Table.h works standalone.
 func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool, wireRuntime string) string {
-	idType := "uint64_t"
-	if wireRuntime == "" {
-		idType = "uint16_t"
-		wireRuntime = legacyTableWireRuntime(tableInlineMacro(pkg))
-	}
 	keyed := ""
 	if anyKeyed {
 		keyed = tableKeyedAccessor
@@ -391,7 +386,7 @@ typedef struct TableUnionInfo
 typedef struct TableVariantInfo
 {
     const char * name;
-    ` + idType + ` id;
+    uint64_t id;
 } TableVariantInfo;
 
 /* THE SHARED EMPTY DOC (docs/SPEC-TABLES.md §8.1): a declaration with no ///
@@ -408,7 +403,7 @@ typedef struct TableFieldInfo
     const char * name;      /* schema field name, e.g. "health" */
     const char * json;      /* the TEXT form's key: the json = "key" attribute, else name (§16.3) */
     const char * type_name; /* schema type name, e.g. "float32", "Grade" */
-    ` + idType + ` id;            /* table-wire field id (name hash; the was alias's hash after a rename) */
+    uint64_t id;            /* table-wire field id (name hash; the was alias's hash after a rename) */
     uint8_t kind;           /* table-wire kind; for arrays/strings/bytes, the ELEMENT kind */
     int is_array;           /* fixed or counted array (bytes included) */` + pointerFieldMember + `
     int counted;            /* a _count/_length int32 companion exists (counted arrays, strings, bytes) */
@@ -481,144 +476,6 @@ static SCHEMA_UNUSED double table_bits_to_double( uint64_t bits ) { double d; me
 static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8 ); return b; }
 
 #endif /* ` + guard + ` */
-`
-}
-
-// legacyTableWireRuntime remains with the variable carrier until its node-table
-// codec is ported. Fixed units select the form-1 runtime in wire.go.
-func legacyTableWireRuntime(forceInline string) string {
-	return `typedef struct TableWriter
-{
-    uint8_t * buffer;
-    int64_t capacity;
-    int64_t offset;
-    int overflow;
-} TableWriter;
-
-static SCHEMA_UNUSED TableWriter table_writer_make( uint8_t * buffer, int64_t capacity )
-{
-    TableWriter w;
-    w.buffer = buffer;
-    w.capacity = capacity;
-    w.offset = 0;
-    w.overflow = 0;
-    return w;
-}
-
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_raw( TableWriter * w, const void * data, int64_t bytes )
-{
-    if ( w->offset + bytes > w->capacity ) { w->overflow = 1; return; }
-    memcpy( w->buffer + w->offset, data, (size_t) bytes );
-    w->offset += bytes;
-}
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_put8( TableWriter * w, uint8_t v ) { table_writer_raw( w, &v, 1 ); }
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_put16( TableWriter * w, uint16_t v )
-{
-    uint8_t b[2];
-    b[0] = (uint8_t) v; b[1] = (uint8_t) ( v >> 8 );
-    table_writer_raw( w, b, 2 );
-}
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_put32( TableWriter * w, uint32_t v )
-{
-    uint8_t b[4];
-    b[0] = (uint8_t) v; b[1] = (uint8_t) ( v >> 8 ); b[2] = (uint8_t) ( v >> 16 ); b[3] = (uint8_t) ( v >> 24 );
-    table_writer_raw( w, b, 4 );
-}
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_put64( TableWriter * w, uint64_t v )
-{
-    table_writer_put32( w, (uint32_t) v );
-    table_writer_put32( w, (uint32_t) ( v >> 32 ) );
-}
-static SCHEMA_UNUSED ` + forceInline + ` void table_writer_patch32( TableWriter * w, int64_t at, uint32_t v )
-{
-    if ( at + 4 > w->capacity ) { w->overflow = 1; return; }
-    w->buffer[at] = (uint8_t) v; w->buffer[at+1] = (uint8_t) ( v >> 8 );
-    w->buffer[at+2] = (uint8_t) ( v >> 16 ); w->buffer[at+3] = (uint8_t) ( v >> 24 );
-}
-
-typedef struct TableReader
-{
-    const uint8_t * buffer;
-    int64_t size;
-    int64_t offset;
-    TableReport * report;
-} TableReader;
-
-static SCHEMA_UNUSED TableReader table_reader_make( const uint8_t * buffer, int64_t size, TableReport * report )
-{
-    TableReader r;
-    r.buffer = buffer;
-    r.size = size;
-    r.offset = 0;
-    r.report = report;
-    return r;
-}
-
-static SCHEMA_UNUSED ` + forceInline + ` int table_reader_has( const TableReader * r, int64_t bytes ) { return bytes >= 0 && r->offset >= 0 && r->offset <= r->size && bytes <= r->size - r->offset; }
-static SCHEMA_UNUSED ` + forceInline + ` uint8_t table_reader_get8( TableReader * r ) { return r->buffer[r->offset++]; }
-static SCHEMA_UNUSED ` + forceInline + ` uint16_t table_reader_get16( TableReader * r )
-{
-    uint16_t v = (uint16_t) ( (uint16_t) r->buffer[r->offset] | ( (uint16_t) r->buffer[r->offset+1] << 8 ) );
-    r->offset += 2;
-    return v;
-}
-static SCHEMA_UNUSED ` + forceInline + ` uint32_t table_reader_get32( TableReader * r )
-{
-    uint32_t v = (uint32_t) r->buffer[r->offset] | ( (uint32_t) r->buffer[r->offset+1] << 8 )
-               | ( (uint32_t) r->buffer[r->offset+2] << 16 ) | ( (uint32_t) r->buffer[r->offset+3] << 24 );
-    r->offset += 4;
-    return v;
-}
-static SCHEMA_UNUSED ` + forceInline + ` uint64_t table_reader_get64( TableReader * r )
-{
-    uint64_t lo = table_reader_get32( r );
-    uint64_t hi = table_reader_get32( r );
-    return lo | ( hi << 32 );
-}
-
-/* skip one payload by kind; 0 = framing damage */
-static SCHEMA_UNUSED int table_reader_skip( TableReader * r, uint8_t kind )
-{
-    switch ( kind )
-    {
-        case 1: case 2: case 6:
-            if ( !table_reader_has( r, 1 ) ) { return 0; }
-            r->offset += 1; return 1;
-        case 3: case 7:
-            if ( !table_reader_has( r, 2 ) ) { return 0; }
-            r->offset += 2; return 1;
-        /* 17 is a NODE INDEX (docs/SPEC-TABLES.md 3.1): four bytes, so it costs
-           one row here and a reader without the kind still skips a pointer field */
-        case 4: case 8: case 10: case 17:
-            if ( !table_reader_has( r, 4 ) ) { return 0; }
-            r->offset += 4; return 1;
-        case 5: case 9: case 11:
-            if ( !table_reader_has( r, 8 ) ) { return 0; }
-            r->offset += 8; return 1;
-        case 12: case 13: case 14: case 16:
-        {
-            uint32_t n;
-            if ( !table_reader_has( r, 4 ) ) { return 0; }
-            n = table_reader_get32( r );
-            if ( !table_reader_has( r, n ) ) { return 0; }
-            r->offset += n;
-            return 1;
-        }
-        case 15: /* union: u16 arm id, then the arm length-prefixed (id 0 = empty, no body) */
-        {
-            uint32_t n;
-            if ( !table_reader_has( r, 2 ) ) { return 0; }
-            if ( table_reader_get16( r ) == 0 ) { return 1; }
-            if ( !table_reader_has( r, 4 ) ) { return 0; }
-            n = table_reader_get32( r );
-            if ( !table_reader_has( r, n ) ) { return 0; }
-            r->offset += n;
-            return 1;
-        }
-        default: break;
-    }
-    return 0;
-}
 `
 }
 

--- a/testdata/golden/c/ArmDefaultsWire.h
+++ b/testdata/golden/c/ArmDefaultsWire.h
@@ -103,10 +103,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_default_arm( serialize_read_s
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 7ULL )
-        {
-            return 0;
-        }
         value->marker = (uint8_t) offset_value;
     }
     return 1;

--- a/testdata/golden/c/ClausesWire.h
+++ b/testdata/golden/c/ClausesWire.h
@@ -204,10 +204,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w13( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }
@@ -256,10 +252,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w17( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 131071ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint32_t) offset_value;
             }
         }
@@ -308,10 +300,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w26( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 67108863ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint32_t) offset_value;
             }
         }
@@ -360,10 +348,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w1( serialize_read_stream_t *
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 1ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint8_t) offset_value;
             }
         }
@@ -424,10 +408,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w52( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = (serialize_uint64_t) lo | ( ( (serialize_uint64_t) hi ) << 32 );
-                if ( offset_value > 4503599627370495ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint64_t) offset_value;
             }
         }
@@ -488,10 +468,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_w50( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = (serialize_uint64_t) lo | ( ( (serialize_uint64_t) hi ) << 32 );
-                if ( offset_value > 1125899906842623ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint64_t) offset_value;
             }
         }
@@ -537,10 +513,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_f13( serialize_read_stream_t 
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }

--- a/testdata/golden/c/JoinsWire.h
+++ b/testdata/golden/c/JoinsWire.h
@@ -719,10 +719,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_arm_array( serialize_read_str
                         return 0;
                     }
                     offset_value = raw;
-                    if ( offset_value > 8191ULL )
-                    {
-                        return 0;
-                    }
                     value->items[i] = (uint16_t) offset_value;
                 }
             }
@@ -1065,10 +1061,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_regain_after_align( serialize
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 8191ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (uint16_t) offset_value;
             }
         }

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -915,10 +915,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 31ULL )
-        {
-            return 0;
-        }
         value->hardpoint_index = (int32_t) offset_value;
     }
     {

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -336,10 +336,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_st
             return 0;
         }
         offset_value = raw;
-        if ( offset_value > 4294967295ULL )
-        {
-            return 0;
-        }
         value->sensor = (uint32_t) offset_value;
     }
     {
@@ -1247,10 +1243,6 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
                     return 0;
                 }
                 offset_value = raw;
-                if ( offset_value > 255ULL )
-                {
-                    return 0;
-                }
                 value->items[i] = (int32_t) offset_value;
             }
         }


### PR DESCRIPTION
The cross-language follow-up from #796. C elides the offset range check when the declared span exactly fills its encoded width, because a successful read is already bounded by the mask. C++ and C# tested a different predicate (`diff != MaxUint64`). This commit makes all three emitters use the same one: elide when `span == 2^bits - 1`, keep when the span leaves headroom.

**Runtime proof, both backends, read under my hand:** serialize.h:1520 masks every decoded chunk with `(1<<bits)-1` unconditionally (not inside an assert, not under SERIALIZE_RELEASE); ReadStream::SerializeBits writes the caller's value only after the past-end check. Serialize.cs:1123 `ReadBitsUnchecked` masks the same way; `unchecked` there is the overflow-check suppression on the cast, not a conditional compile; the Debug.Assert at :1844 compiles out but the mask is the decode and stays.

**Generated output: byte-identical.** Every committed C++ and C# tree and golden regenerated with `git status` clean, and the pre-change compiler's output diffed tree-by-tree against the committed trees: zero content differences. The reason is structural: C++ and C# route anything that fits int64 through `read_int`/`SerializeInt`, so the raw-bits path this predicate guards is reached only for ranges above MaxInt64, and no schema in the tree declares one whose span fills a sub-64-bit width. The 4 + 4 emitter-level checks that remain (Types.schema `ceiling_range` and `clamped_ceiling`, headroom 1 and 2) are exactly the real-headroom set. A synthetic probe (`uint64` at min 2^63, span 2^8-1 versus one less) shows the change is live: all three backends now elide the full-span check and keep the headroom check.

**Gates:** build/vet/test; C++ and C# packet legs and conformance on all 18 surfaces; packet-utf8-cs and packet-wide-cs bit-flip differentials against the C++ oracle; defaults goldens; negative controls red on demand; C# wire and region fuzz 252,842 mutants each, 0 divergences; shape gate; bench-table-check, bench-paired-check; matched runner gate on cpp and cs packet `6b213fbfa1a03a99` and table `07c57b4fa34b2700`; golangci-lint v2.12.2 and modernize v0.23.0 clean; PORTING register. Not run in the child's clone: the dart and rust conformance legs (toolchains absent; unreachable by a cpp/cs emitter change); no timed sitting.

Plainly: this makes the C++ packet leg do no less work; the baseline the tables compare against is unchanged instruction for instruction. It buys one predicate instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)