### PR TITLE
go tables: matched scalar reads use Has(N)+GetN

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -2089,47 +2089,75 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 		switch fieldID {
 		case 0x23fcfd6678e36712: // entity_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.EntityId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.EntityId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0xcb4b37357667310e: // pos_x
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosX = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2139,26 +2167,40 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.PosX = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xcb4b3835766732c1: // pos_y
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosY = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2168,26 +2210,40 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.PosY = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xcb4b353576672da8: // pos_z
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosZ = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2197,78 +2253,114 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.PosZ = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xb54d8e19798e16e8: // yaw
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Yaw = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 511 {
 					v = 511
 					r.Report.Clamped++
 				}
 				value.Yaw = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x53a9f665a90cc1b1: // pitch
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Pitch = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 511 {
 					v = 511
 					r.Report.Clamped++
 				}
 				value.Pitch = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x6cede6b6eb60ee67: // vel_x
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelX = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2278,26 +2370,40 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.VelX = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x6cede5b6eb60ecb4: // vel_y
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelY = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2307,26 +2413,40 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.VelY = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x6cede8b6eb60f1cd: // vel_z
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelZ = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2336,26 +2456,40 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				value.VelZ = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x7f69d4b5288ba9cf: // health
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 1000 {
+							v = 1000
+							r.Report.Clamped++
+						}
+						value.Health = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -2364,9 +2498,6 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 					r.Report.Clamped++
 				}
 				value.Health = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		case 0xa0b610205f2c6e01: // weapon
 			if kind != 30 {
@@ -2398,25 +2529,32 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 			}
 		case 0x7f6308be8ab37fc0: // damage
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.Damage = MixedDamage(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				value.Damage = MixedDamage(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x11a44fc1d1243da7: // moving
 			if kind != 1 {
@@ -2427,7 +2565,7 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -2441,7 +2579,7 @@ func MixedEntityLoadBody(r *TableReader, value *MixedEntity) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -3362,12 +3500,12 @@ func MixedStatLoadBody(r *TableReader, value *MixedStat) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get8()
 				if v > 255 {
 					v = 255
 					r.Report.Clamped++
@@ -3376,21 +3514,38 @@ func MixedStatLoadBody(r *TableReader, value *MixedStat) bool {
 			}
 		case 0x52076675ec13a0c1: // delta
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -512 {
+							v = -512
+							r.Report.Clamped++
+						} else if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Delta = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -512 {
 					v = -512
 					r.Report.Clamped++
@@ -3399,9 +3554,6 @@ func MixedStatLoadBody(r *TableReader, value *MixedStat) bool {
 					r.Report.Clamped++
 				}
 				value.Delta = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -3775,47 +3927,75 @@ func MixedHitEventLoadBody(r *TableReader, value *MixedHitEvent) bool {
 		switch fieldID {
 		case 0xb7bc9ac015a25050: // target_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.TargetId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.TargetId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x7f6308be8ab37fc0: // damage
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.Damage = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -3825,26 +4005,40 @@ func MixedHitEventLoadBody(r *TableReader, value *MixedHitEvent) bool {
 				}
 				value.Damage = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x01fbc365b059b925: // hit_kind
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 7 {
+							v = 7
+							r.Report.Clamped++
+						}
+						value.HitKind = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -3853,9 +4047,6 @@ func MixedHitEventLoadBody(r *TableReader, value *MixedHitEvent) bool {
 					r.Report.Clamped++
 				}
 				value.HitKind = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		case 0x126167908c9aa52d: // crit
 			if kind != 1 {
@@ -3866,7 +4057,7 @@ func MixedHitEventLoadBody(r *TableReader, value *MixedHitEvent) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4311,21 +4502,38 @@ func MixedChatEventLoadBody(r *TableReader, value *MixedChatEvent) bool {
 		switch fieldID {
 		case 0xa5013e9ad5caeda4: // channel
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 3 {
+							v = 3
+							r.Report.Clamped++
+						}
+						value.Channel = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -4335,34 +4543,42 @@ func MixedChatEventLoadBody(r *TableReader, value *MixedChatEvent) bool {
 				}
 				value.Channel = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xfbf1ac4d96ebd022: // speaker
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.Speaker = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.Speaker = uint32(v)
-			}
-			if kind != 7 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -4714,47 +4930,75 @@ func MixedPickupEventLoadBody(r *TableReader, value *MixedPickupEvent) bool {
 		switch fieldID {
 		case 0x9e7fd06d864fbd56: // item_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 1023 {
+							v = 1023
+							r.Report.Clamped++
+						}
+						value.ItemId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 1023 {
 					v = 1023
 					r.Report.Clamped++
 				}
 				value.ItemId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x8113fe7ea2b16969: // amount
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 255 {
+							v = 255
+							r.Report.Clamped++
+						}
+						value.Amount = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -4763,9 +5007,6 @@ func MixedPickupEventLoadBody(r *TableReader, value *MixedPickupEvent) bool {
 					r.Report.Clamped++
 				}
 				value.Amount = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -5609,47 +5850,75 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 		switch fieldID {
 		case 0xaa38aca481f528a8: // sequence
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 65535 {
+							v = 65535
+							r.Report.Clamped++
+						}
+						value.Sequence = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 65535 {
 					v = 65535
 					r.Report.Clamped++
 				}
 				value.Sequence = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x0dbe005c56697c3e: // ack_sequence
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 65535 {
+							v = 65535
+							r.Report.Clamped++
+						}
+						value.AckSequence = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -5659,96 +5928,135 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				value.AckSequence = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x9bae0da8b829ee03: // ack_bits
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4294967295 {
+							v = 4294967295
+							r.Report.Clamped++
+						}
+						value.AckBits = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				if v > 4294967295 {
 					v = 4294967295
 					r.Report.Clamped++
 				}
 				value.AckBits = uint32(v)
 			}
-			if kind != 8 {
-				r.Report.Widened++
-			}
 		case 0xb7d7b5650a590b05: // session_id
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.SessionId = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				value.SessionId = uint64(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x6d7b98e2d095967e: // client_id
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.ClientId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				value.ClientId = uint32(v)
-			}
-			if kind != 8 {
-				r.Report.Widened++
 			}
 		case 0x73a94c71d60dc0d8: // nonce
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 18446744073709551615 {
+							v = 18446744073709551615
+							r.Report.Clamped++
+						}
+						value.Nonce = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -5758,26 +6066,40 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				value.Nonce = uint64(v)
 			}
-			if kind != 9 {
-				r.Report.Widened++
-			}
 		case 0x3eee6b51be54fc85: // world_time
 			if kind != 5 {
-				if !tableKindWidens(kind, 5) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 5) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -1000000000000 {
+							v = -1000000000000
+							r.Report.Clamped++
+						} else if v > 1000000000000 {
+							v = 1000000000000
+							r.Report.Clamped++
+						}
+						value.WorldTime = int64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int64(r.Get64())
 				if v < -1000000000000 {
 					v = -1000000000000
 					r.Report.Clamped++
@@ -5787,34 +6109,42 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				value.WorldTime = int64(v)
 			}
-			if kind != 5 {
-				r.Report.Widened++
-			}
 		case 0x7bbc035f7b6d0112: // frame_tick
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 281474976710655 {
+							v = 281474976710655
+							r.Report.Clamped++
+						}
+						value.FrameTick = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				if v > 281474976710655 {
 					v = 281474976710655
 					r.Report.Clamped++
 				}
 				value.FrameTick = uint64(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x3c460475f9be69c6: // server_time
 			if kind != 22 {
@@ -5825,12 +6155,12 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -6151,7 +6481,7 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -6175,7 +6505,7 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -6199,7 +6529,7 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -6223,7 +6553,7 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -6233,82 +6563,117 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 			}
 		case 0x5ab3f9c9341f6c04: // drift
 			if kind != 11 {
-				if !tableKindWidens(kind, 11) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 11) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						var v float64
+						if kind == 10 {
+							v = math.Float64frombits(tableWidenFloat(r.Get32()))
+						} else {
+							v = math.Float64frombits(r.Get64())
+						}
+						value.Drift = v
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				var v float64
-				if kind == 10 {
-					v = math.Float64frombits(tableWidenFloat(r.Get32()))
-				} else {
-					v = math.Float64frombits(r.Get64())
-				}
+				v := math.Float64frombits(r.Get64())
 				value.Drift = v
-			}
-			if kind != 11 {
-				r.Report.Widened++
 			}
 		case 0xa3348580461faf16: // wide_key
 			if kind != 19 {
-				if !tableKindWidens(kind, 19) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 19) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						var v serialize.Uint128
+						if tableKindBytes(kind) == 16 {
+							v.Lo = r.Get64()
+							v.Hi = r.Get64()
+						} else {
+							v.Lo = r.Unsigned(kind)
+						}
+						value.WideKey = v
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(16) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
 				var v serialize.Uint128
-				if tableKindBytes(kind) == 16 {
-					v.Lo = r.Get64()
-					v.Hi = r.Get64()
-				} else {
-					v.Lo = r.Unsigned(kind)
-				}
+				v.Lo = r.Get64()
+				v.Hi = r.Get64()
 				value.WideKey = v
-			}
-			if kind != 19 {
-				r.Report.Widened++
 			}
 		case 0xd61bdd7908af2642: // flux
 			if kind != 18 {
-				if !tableKindWidens(kind, 18) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 18) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						var v serialize.Int128
+						if tableKindBytes(kind) == 16 {
+							v.Lo = r.Get64()
+							v.Hi = r.Get64()
+						} else {
+							v = serialize.Int128From64(r.Signed(kind))
+						}
+						if v.Cmp((serialize.Int128{Lo: 0, Hi: 18446744004990074880})) < 0 {
+							v = (serialize.Int128{Lo: 0, Hi: 18446744004990074880})
+							r.Report.Clamped++
+						} else if v.Cmp((serialize.Int128{Lo: 0, Hi: 68719476736})) > 0 {
+							v = (serialize.Int128{Lo: 0, Hi: 68719476736})
+							r.Report.Clamped++
+						}
+						value.Flux = v
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(16) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
 				var v serialize.Int128
-				if tableKindBytes(kind) == 16 {
-					v.Lo = r.Get64()
-					v.Hi = r.Get64()
-				} else {
-					v = serialize.Int128From64(r.Signed(kind))
-				}
+				v.Lo = r.Get64()
+				v.Hi = r.Get64()
 				if v.Cmp((serialize.Int128{Lo: 0, Hi: 18446744004990074880})) < 0 {
 					v = (serialize.Int128{Lo: 0, Hi: 18446744004990074880})
 					r.Report.Clamped++
@@ -6317,9 +6682,6 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 					r.Report.Clamped++
 				}
 				value.Flux = v
-			}
-			if kind != 18 {
-				r.Report.Widened++
 			}
 		case 0xbf30e00dc53307a9: // ping
 			if kind != 26 {
@@ -6330,12 +6692,12 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -6347,29 +6709,40 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 			}
 		case 0x560d6527ccd8515f: // crc_hint
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 16777215 {
+							v = 16777215
+							r.Report.Clamped++
+						}
+						value.CrcHint = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				if v > 16777215 {
 					v = 16777215
 					r.Report.Clamped++
 				}
 				value.CrcHint = uint32(v)
-			}
-			if kind != 8 {
-				r.Report.Widened++
 			}
 		case 0xc08292176cfd8672: // has_extra
 			if kind != 1 {
@@ -6380,28 +6753,45 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
 			value.HasExtra = r.Get8() != 0
 		case 0xfd29ee12a979cb69: // extra
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 255 {
+							v = 255
+							r.Report.Clamped++
+						}
+						value.Extra = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -6411,26 +6801,40 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				}
 				value.Extra = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x78101ac0aa8cbcfe: // idle_ticks
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 15 {
+							v = 15
+							r.Report.Clamped++
+						}
+						value.IdleTicks = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -6439,9 +6843,6 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 					r.Report.Clamped++
 				}
 				value.IdleTicks = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -2159,47 +2159,75 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 		switch fieldID {
 		case 0x23fcfd6678e36712: // entity_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.EntityId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.EntityId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0xcb4b37357667310e: // pos_x
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosX = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2209,26 +2237,40 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.PosX = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xcb4b3835766732c1: // pos_y
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosY = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2238,26 +2280,40 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.PosY = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xcb4b353576672da8: // pos_z
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -16383 {
+							v = -16383
+							r.Report.Clamped++
+						} else if v > 16383 {
+							v = 16383
+							r.Report.Clamped++
+						}
+						value.PosZ = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -16383 {
 					v = -16383
 					r.Report.Clamped++
@@ -2267,78 +2323,114 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.PosZ = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xb54d8e19798e16e8: // yaw
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Yaw = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 511 {
 					v = 511
 					r.Report.Clamped++
 				}
 				value.Yaw = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x53a9f665a90cc1b1: // pitch
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Pitch = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 511 {
 					v = 511
 					r.Report.Clamped++
 				}
 				value.Pitch = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x6cede6b6eb60ee67: // vel_x
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelX = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2348,26 +2440,40 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.VelX = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x6cede5b6eb60ecb4: // vel_y
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelY = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2377,26 +2483,40 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.VelY = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x6cede8b6eb60f1cd: // vel_z
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -2048 {
+							v = -2048
+							r.Report.Clamped++
+						} else if v > 2047 {
+							v = 2047
+							r.Report.Clamped++
+						}
+						value.VelZ = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -2048 {
 					v = -2048
 					r.Report.Clamped++
@@ -2406,26 +2526,40 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				value.VelZ = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x7f69d4b5288ba9cf: // health
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 1000 {
+							v = 1000
+							r.Report.Clamped++
+						}
+						value.Health = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -2434,9 +2568,6 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 					r.Report.Clamped++
 				}
 				value.Health = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		case 0xa0b610205f2c6e01: // weapon
 			if kind != 30 {
@@ -2468,25 +2599,32 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 			}
 		case 0x7f6308be8ab37fc0: // damage
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.Damage = TableDamage(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				value.Damage = TableDamage(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x11a44fc1d1243da7: // moving
 			if kind != 1 {
@@ -2497,7 +2635,7 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -2511,7 +2649,7 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -3445,12 +3583,12 @@ func TableStatLoadBody(r *TableReader, value *TableStat) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get8()
 				if v > 255 {
 					v = 255
 					r.Report.Clamped++
@@ -3459,21 +3597,38 @@ func TableStatLoadBody(r *TableReader, value *TableStat) bool {
 			}
 		case 0x52076675ec13a0c1: // delta
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -512 {
+							v = -512
+							r.Report.Clamped++
+						} else if v > 511 {
+							v = 511
+							r.Report.Clamped++
+						}
+						value.Delta = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < -512 {
 					v = -512
 					r.Report.Clamped++
@@ -3482,9 +3637,6 @@ func TableStatLoadBody(r *TableReader, value *TableStat) bool {
 					r.Report.Clamped++
 				}
 				value.Delta = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -4350,69 +4502,104 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 		switch fieldID {
 		case 0x6a5a70d91aa115fd: // protocol_magic
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.ProtocolMagic = uint16(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				value.ProtocolMagic = uint16(v)
-			}
-			if kind != 7 {
-				r.Report.Widened++
 			}
 		case 0xaa38aca481f528a8: // sequence
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 65535 {
+							v = 65535
+							r.Report.Clamped++
+						}
+						value.Sequence = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 65535 {
 					v = 65535
 					r.Report.Clamped++
 				}
 				value.Sequence = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x0dbe005c56697c3e: // ack_sequence
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 65535 {
+							v = 65535
+							r.Report.Clamped++
+						}
+						value.AckSequence = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -4422,96 +4609,135 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				value.AckSequence = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x9bae0da8b829ee03: // ack_bits
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4294967295 {
+							v = 4294967295
+							r.Report.Clamped++
+						}
+						value.AckBits = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				if v > 4294967295 {
 					v = 4294967295
 					r.Report.Clamped++
 				}
 				value.AckBits = uint32(v)
 			}
-			if kind != 8 {
-				r.Report.Widened++
-			}
 		case 0xb7d7b5650a590b05: // session_id
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.SessionId = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				value.SessionId = uint64(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x6d7b98e2d095967e: // client_id
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.ClientId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				value.ClientId = uint32(v)
-			}
-			if kind != 8 {
-				r.Report.Widened++
 			}
 		case 0x73a94c71d60dc0d8: // nonce
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v < 1 {
+							v = 1
+							r.Report.Clamped++
+						} else if v > 9223372036854775807 {
+							v = 9223372036854775807
+							r.Report.Clamped++
+						}
+						value.Nonce = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				if v < 1 {
 					v = 1
 					r.Report.Clamped++
@@ -4521,26 +4747,40 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				value.Nonce = uint64(v)
 			}
-			if kind != 9 {
-				r.Report.Widened++
-			}
 		case 0x3eee6b51be54fc85: // world_time
 			if kind != 5 {
-				if !tableKindWidens(kind, 5) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 5) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -1000000000000 {
+							v = -1000000000000
+							r.Report.Clamped++
+						} else if v > 1000000000000 {
+							v = 1000000000000
+							r.Report.Clamped++
+						}
+						value.WorldTime = int64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int64(r.Get64())
 				if v < -1000000000000 {
 					v = -1000000000000
 					r.Report.Clamped++
@@ -4550,34 +4790,42 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				value.WorldTime = int64(v)
 			}
-			if kind != 5 {
-				r.Report.Widened++
-			}
 		case 0x7bbc035f7b6d0112: // frame_tick
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 281474976710655 {
+							v = 281474976710655
+							r.Report.Clamped++
+						}
+						value.FrameTick = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				if v > 281474976710655 {
 					v = 281474976710655
 					r.Report.Clamped++
 				}
 				value.FrameTick = uint64(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0x3c460475f9be69c6: // server_time
 			if kind != 10 {
@@ -4588,7 +4836,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4914,7 +5162,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4938,7 +5186,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4962,7 +5210,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4986,7 +5234,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -4996,70 +5244,101 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 			}
 		case 0x5ab3f9c9341f6c04: // drift
 			if kind != 11 {
-				if !tableKindWidens(kind, 11) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 11) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						var v float64
+						if kind == 10 {
+							v = math.Float64frombits(tableWidenFloat(r.Get32()))
+						} else {
+							v = math.Float64frombits(r.Get64())
+						}
+						value.Drift = v
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				var v float64
-				if kind == 10 {
-					v = math.Float64frombits(tableWidenFloat(r.Get32()))
-				} else {
-					v = math.Float64frombits(r.Get64())
-				}
+				v := math.Float64frombits(r.Get64())
 				value.Drift = v
-			}
-			if kind != 11 {
-				r.Report.Widened++
 			}
 		case 0xa3348580461faf16: // wide_key
 			if kind != 9 {
-				if !tableKindWidens(kind, 9) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 9) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						value.WideKey = uint64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get64()
 				value.WideKey = uint64(v)
-			}
-			if kind != 9 {
-				r.Report.Widened++
 			}
 		case 0xd61bdd7908af2642: // flux
 			if kind != 5 {
-				if !tableKindWidens(kind, 5) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 5) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < -1000000000000000000 {
+							v = -1000000000000000000
+							r.Report.Clamped++
+						} else if v > 1000000000000000000 {
+							v = 1000000000000000000
+							r.Report.Clamped++
+						}
+						value.Flux = int64(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(8) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int64(r.Get64())
 				if v < -1000000000000000000 {
 					v = -1000000000000000000
 					r.Report.Clamped++
@@ -5068,9 +5347,6 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 					r.Report.Clamped++
 				}
 				value.Flux = int64(v)
-			}
-			if kind != 5 {
-				r.Report.Widened++
 			}
 		case 0xbf30e00dc53307a9: // ping
 			if kind != 10 {
@@ -5081,7 +5357,7 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -5098,29 +5374,40 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 			}
 		case 0x560d6527ccd8515f: // crc_hint
 			if kind != 8 {
-				if !tableKindWidens(kind, 8) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 8) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 16777215 {
+							v = 16777215
+							r.Report.Clamped++
+						}
+						value.CrcHint = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get32()
 				if v > 16777215 {
 					v = 16777215
 					r.Report.Clamped++
 				}
 				value.CrcHint = uint32(v)
-			}
-			if kind != 8 {
-				r.Report.Widened++
 			}
 		case 0xc08292176cfd8672: // has_extra
 			if kind != 1 {
@@ -5131,28 +5418,45 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
 			value.HasExtra = r.Get8() != 0
 		case 0xfd29ee12a979cb69: // extra
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 255 {
+							v = 255
+							r.Report.Clamped++
+						}
+						value.Extra = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -5162,26 +5466,40 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				}
 				value.Extra = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x78101ac0aa8cbcfe: // idle_ticks
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 15 {
+							v = 15
+							r.Report.Clamped++
+						}
+						value.IdleTicks = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -5190,9 +5508,6 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 					r.Report.Clamped++
 				}
 				value.IdleTicks = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -6995,47 +7310,75 @@ func TableHitEventLoadBody(r *TableReader, value *TableHitEvent) bool {
 		switch fieldID {
 		case 0xb7bc9ac015a25050: // target_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.TargetId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.TargetId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x7f6308be8ab37fc0: // damage
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.Damage = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -7045,26 +7388,40 @@ func TableHitEventLoadBody(r *TableReader, value *TableHitEvent) bool {
 				}
 				value.Damage = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0x01fbc365b059b925: // hit_kind
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 7 {
+							v = 7
+							r.Report.Clamped++
+						}
+						value.HitKind = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -7073,9 +7430,6 @@ func TableHitEventLoadBody(r *TableReader, value *TableHitEvent) bool {
 					r.Report.Clamped++
 				}
 				value.HitKind = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		case 0x126167908c9aa52d: // crit
 			if kind != 1 {
@@ -7086,7 +7440,7 @@ func TableHitEventLoadBody(r *TableReader, value *TableHitEvent) bool {
 				}
 				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(1) {
 				r.Report.Malformed = true
 				return false
 			}
@@ -7531,21 +7885,38 @@ func TableChatEventLoadBody(r *TableReader, value *TableChatEvent) bool {
 		switch fieldID {
 		case 0xa5013e9ad5caeda4: // channel
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 3 {
+							v = 3
+							r.Report.Clamped++
+						}
+						value.Channel = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -7555,34 +7926,42 @@ func TableChatEventLoadBody(r *TableReader, value *TableChatEvent) bool {
 				}
 				value.Channel = int32(v)
 			}
-			if kind != 4 {
-				r.Report.Widened++
-			}
 		case 0xfbf1ac4d96ebd022: // speaker
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 4095 {
+							v = 4095
+							r.Report.Clamped++
+						}
+						value.Speaker = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 4095 {
 					v = 4095
 					r.Report.Clamped++
 				}
 				value.Speaker = uint32(v)
-			}
-			if kind != 7 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++
@@ -7934,47 +8313,75 @@ func TablePickupEventLoadBody(r *TableReader, value *TablePickupEvent) bool {
 		switch fieldID {
 		case 0x9e7fd06d864fbd56: // item_id
 			if kind != 7 {
-				if !tableKindWidens(kind, 7) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 7) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Unsigned(kind)
+						if v > 1023 {
+							v = 1023
+							r.Report.Clamped++
+						}
+						value.ItemId = uint32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(2) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Unsigned(kind)
+				v := r.Get16()
 				if v > 1023 {
 					v = 1023
 					r.Report.Clamped++
 				}
 				value.ItemId = uint32(v)
 			}
-			if kind != 7 {
-				r.Report.Widened++
-			}
 		case 0x8113fe7ea2b16969: // amount
 			if kind != 4 {
-				if !tableKindWidens(kind, 4) {
-					r.Report.KindMismatch++
-					if !r.Skip(kind) {
+				if tableKindWidens(kind, 4) {
+					if !r.Has(tableKindBytes(kind)) {
 						r.Report.Malformed = true
 						return false
 					}
+					{
+						v := r.Signed(kind)
+						if v < 0 {
+							v = 0
+							r.Report.Clamped++
+						} else if v > 255 {
+							v = 255
+							r.Report.Clamped++
+						}
+						value.Amount = int32(v)
+					}
+					r.Report.Widened++
 					break
 				}
+				r.Report.KindMismatch++
+				if !r.Skip(kind) {
+					r.Report.Malformed = true
+					return false
+				}
+				break
 			}
-			if !r.Has(tableKindBytes(kind)) {
+			if !r.Has(4) {
 				r.Report.Malformed = true
 				return false
 			}
 			{
-				v := r.Signed(kind)
+				v := int32(r.Get32())
 				if v < 0 {
 					v = 0
 					r.Report.Clamped++
@@ -7983,9 +8390,6 @@ func TablePickupEventLoadBody(r *TableReader, value *TablePickupEvent) bool {
 					r.Report.Clamped++
 				}
 				value.Amount = int32(v)
-			}
-			if kind != 4 {
-				r.Report.Widened++
 			}
 		default:
 			r.Report.Unknown++

--- a/internal/codegen/gotable/matched_width_test.go
+++ b/internal/codegen/gotable/matched_width_test.go
@@ -1,0 +1,178 @@
+package gotable
+
+import (
+	"strings"
+	"testing"
+)
+
+const matchedWidthSchema = `package probe
+table Root {
+ a uint16
+ b int32
+}
+`
+
+func TestMatchedScalarWidthShape(t *testing.T) {
+	files := generate(t, matchedWidthSchema)
+	body := ""
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.go") {
+			body += string(data)
+		}
+	}
+	load := funcSource(body, "func RootLoadBody")
+	if load == "" {
+		t.Fatal("RootLoadBody was not emitted")
+	}
+	for _, want := range []string{
+		"r.Get16()",
+		"r.Get32()",
+		"r.Has(2)",
+		"r.Has(4)",
+		"tableKindWidens(kind, 7)",
+		"tableKindWidens(kind, 4)",
+		"r.Unsigned(kind)",
+		"r.Signed(kind)",
+	} {
+		if !strings.Contains(load, want) {
+			t.Fatalf("matched-width LoadBody is missing %q", want)
+		}
+	}
+	rest := stripWidenArms(load)
+	if strings.Contains(rest, "Unsigned(kind)") {
+		t.Fatal("Unsigned(kind) escaped the widen arm")
+	}
+	if strings.Contains(rest, "Signed(kind)") {
+		t.Fatal("Signed(kind) escaped the widen arm")
+	}
+	if strings.Contains(rest, "tableKindBytes(kind)") {
+		t.Fatal("matched arm still sizes the payload through tableKindBytes(kind)")
+	}
+	runGenerated(t, matchedWidthSchema, matchedWidthWireTest)
+}
+
+func funcSource(src, sig string) string {
+	start := strings.Index(src, sig)
+	if start < 0 {
+		return ""
+	}
+	brace := strings.Index(src[start:], "{")
+	if brace < 0 {
+		return ""
+	}
+	i := start + brace
+	depth := 0
+	for j := i; j < len(src); j++ {
+		switch src[j] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : j+1]
+			}
+		}
+	}
+	return src[start:]
+}
+
+func stripWidenArms(src string) string {
+	const needle = "tableKindWidens("
+	var b strings.Builder
+	for {
+		i := strings.Index(src, needle)
+		if i < 0 {
+			b.WriteString(src)
+			return b.String()
+		}
+		b.WriteString(src[:i])
+		j := strings.Index(src[i:], "{")
+		if j < 0 {
+			return b.String()
+		}
+		j += i
+		depth := 0
+		closed := false
+		for k := j; k < len(src); k++ {
+			switch src[k] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					src = src[k+1:]
+					closed = true
+				}
+			}
+			if closed {
+				break
+			}
+		}
+		if !closed {
+			return b.String()
+		}
+	}
+}
+
+const matchedWidthWireTest = `package probe
+import "testing"
+
+func finish(w *TableWriter) []byte {
+	w.Put8(0)
+	w.Trailer()
+	return w.Buffer[:w.Offset]
+}
+
+func TestMatchedWidthRoundTrip(t *testing.T) {
+	var value, loaded Root
+	value.A = 0x1234
+	value.B = -400
+	n := RootMeasure(&value)
+	if n < 0 {
+		t.Fatal("measure")
+	}
+	wire := make([]byte, n)
+	if RootSave(&value, wire) != n {
+		t.Fatal("save")
+	}
+	var report TableReport
+	if !RootLoad(&loaded, wire, &report) || report != (TableReport{}) || loaded.A != 0x1234 || loaded.B != -400 {
+		t.Fatalf("round trip %+v loaded=%+v", report, loaded)
+	}
+}
+
+func TestWidenArmReadsWireWidth(t *testing.T) {
+	var ids TableIds
+	buf := make([]byte, 256)
+	w := TableWriter{Buffer: buf, Ids: &ids}
+	w.Put8(1)
+	w.Id(RootTableFields[0].Id)
+	w.Put8(6)
+	w.Put8(9)
+	w.Id(RootTableFields[1].Id)
+	w.Put8(2)
+	w.Put8(7)
+	got := finish(&w)
+	var loaded Root
+	var report TableReport
+	if !RootLoad(&loaded, got, &report) || report.Widened != 2 || report.KindMismatch != 0 || report.Malformed || loaded.A != 9 || loaded.B != 7 {
+		t.Fatalf("widen: a=%d b=%d report=%+v", loaded.A, loaded.B, report)
+	}
+}
+
+func TestMatchedWidthMismatchSkips(t *testing.T) {
+	var ids TableIds
+	buf := make([]byte, 256)
+	w := TableWriter{Buffer: buf, Ids: &ids}
+	w.Put8(1)
+	w.Id(RootTableFields[1].Id)
+	w.Put8(1)
+	w.Put8(1)
+	got := finish(&w)
+	var loaded Root
+	var report TableReport
+	if !RootLoad(&loaded, got, &report) || report.KindMismatch != 1 || report.Widened != 0 || loaded.B != 0 {
+		t.Fatalf("mismatch: b=%d report=%+v", loaded.B, report)
+	}
+}
+`

--- a/internal/codegen/gotable/read.go
+++ b/internal/codegen/gotable/read.go
@@ -423,11 +423,12 @@ func (g *tableGen) emitReadScalar(f *ir.Field, expr, rdr, wireKind, ind, onBad s
 		g.pf("%s%s = %s.Get8() != 0\n", ind, expr, rdr)
 	case tkF32, tkF64:
 		g.needsMath = true
-		if kind == tkF32 {
+		switch {
+		case kind == tkF32:
 			g.pf("%s{\n%s\tv := math.Float32frombits(%s.Get32())\n", ind, ind, rdr)
-		} else if knownKindWidth(wireKind) > 0 {
+		case knownKindWidth(wireKind) > 0:
 			g.pf("%s{\n%s\tv := math.Float64frombits(%s.Get64())\n", ind, ind, rdr)
-		} else {
+		default:
 			g.pf("%s{\n%s\tvar v float64\n%s\tif %s == 10 { v = math.Float64frombits(tableWidenFloat(%s.Get32())) } else { v = math.Float64frombits(%s.Get64()) }\n", ind, ind, ind, wireKind, rdr, rdr)
 		}
 		if f.HasFloatRange {

--- a/internal/codegen/gotable/read.go
+++ b/internal/codegen/gotable/read.go
@@ -23,19 +23,21 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 		g.pf("\t\tcase 0x%016x: // %s\n", ir.TableFieldWireId(f), f.Name)
 		g.pf("\t\t\tif kind != %d {\n", kind)
 		if wireWidenable(kind) {
-			g.pf("\t\t\t\tif !tableKindWidens(kind, %d) {\n", kind)
-		}
-		g.pf("\t\t\t\tr.Report.KindMismatch++; if !r.Skip(kind) { r.Report.Malformed = true; return false }; break\n")
-		if wireWidenable(kind) {
+			// Widening lives in the mismatch arm so a matching kind reads a constant width (SPEC-TABLES §4).
+			g.pf("\t\t\t\tif tableKindWidens(kind, %d) {\n", kind)
+			g.emitReadScalar(f, "value."+member(f), "r", "kind", "\t\t\t\t\t", "r.Report.Malformed = true; return false")
+			if !st.IsMapEntry() || f.Name != ir.MapKeyFieldName {
+				g.pf("\t\t\t\t\tr.Report.Widened++\n")
+			}
+			if f.Type.Optional {
+				g.pf("\t\t\t\t\tvalue.%sPresent = true\n", member(f))
+			}
+			g.pf("\t\t\t\t\tbreak\n")
 			g.pf("\t\t\t\t}\n")
 		}
+		g.pf("\t\t\t\tr.Report.KindMismatch++; if !r.Skip(kind) { r.Report.Malformed = true; return false }; break\n")
 		g.pf("\t\t\t}\n")
 		g.emitReadField(f, "\t\t\t")
-		// A scalar widening counts only once its payload lands. Arrays and
-		// maps count at their own framing boundary instead (SPEC-TABLES §4).
-		if wireWidenable(kind) && (!st.IsMapEntry() || f.Name != ir.MapKeyFieldName) {
-			g.pf("\t\t\tif kind != %d { r.Report.Widened++ }\n", kind)
-		}
 		if f.Type.Optional {
 			g.pf("\t\t\tvalue.%sPresent = true\n", member(f))
 		}
@@ -100,6 +102,7 @@ func wireWidenable(kind int) bool {
 func (g *tableGen) emitReadField(f *ir.Field, ind string) {
 	expr := "value." + member(f)
 	kind := ir.TableWireScalarKind(f)
+	matched := fmt.Sprintf("%d", kind)
 	switch {
 	case f.IsMap():
 		g.emitMapRead(f, ind)
@@ -110,7 +113,7 @@ func (g *tableGen) emitReadField(f *ir.Field, ind string) {
 	case f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes && !f.Type.Pointer:
 		g.emitReadArray(f, ind, false)
 	case f.Type.Pointer:
-		g.emitReadScalar(f, expr, "r", "kind", ind, "r.Report.Malformed=true;return false")
+		g.emitReadScalar(f, expr, "r", matched, ind, "r.Report.Malformed=true;return false")
 	case f.Type.Kind == ir.TWString:
 		g.pf("%ssub,ok:=r.Body();if !ok {r.Report.Malformed=true;return false}\n", ind)
 		g.emitReadWString(f, expr, "sub", ind, "r.Report.Malformed=true;break")
@@ -128,7 +131,7 @@ func (g *tableGen) emitReadField(f *ir.Field, ind string) {
 		g.retainDiscard("r")
 		g.emitReadUnion(f.Type.Ref.(*ir.Union), expr, "r", ind, "return false")
 	default:
-		g.emitReadScalar(f, expr, "r", "kind", ind, "r.Report.Malformed = true; return false")
+		g.emitReadScalar(f, expr, "r", matched, ind, "r.Report.Malformed = true; return false")
 	}
 }
 
@@ -409,7 +412,12 @@ func (g *tableGen) emitReadScalar(f *ir.Field, expr, rdr, wireKind, ind, onBad s
 		g.emitReadWide(f, expr, rdr, wireKind, ind, onBad)
 		return
 	}
-	g.pf("%sif !%s.Has(tableKindBytes(%s)) { %s }\n", ind, rdr, wireKind, onBad)
+	// A compile-time kind is Has(N)+GetN; a runtime kind keeps Unsigned/Signed.
+	if n := knownKindWidth(wireKind); n > 0 {
+		g.pf("%sif !%s.Has(%d) { %s }\n", ind, rdr, n, onBad)
+	} else {
+		g.pf("%sif !%s.Has(tableKindBytes(%s)) { %s }\n", ind, rdr, wireKind, onBad)
+	}
 	switch kind {
 	case tkBool:
 		g.pf("%s%s = %s.Get8() != 0\n", ind, expr, rdr)
@@ -417,6 +425,8 @@ func (g *tableGen) emitReadScalar(f *ir.Field, expr, rdr, wireKind, ind, onBad s
 		g.needsMath = true
 		if kind == tkF32 {
 			g.pf("%s{\n%s\tv := math.Float32frombits(%s.Get32())\n", ind, ind, rdr)
+		} else if knownKindWidth(wireKind) > 0 {
+			g.pf("%s{\n%s\tv := math.Float64frombits(%s.Get64())\n", ind, ind, rdr)
 		} else {
 			g.pf("%s{\n%s\tvar v float64\n%s\tif %s == 10 { v = math.Float64frombits(tableWidenFloat(%s.Get32())) } else { v = math.Float64frombits(%s.Get64()) }\n", ind, ind, ind, wireKind, rdr, rdr)
 		}
@@ -430,11 +440,7 @@ func (g *tableGen) emitReadScalar(f *ir.Field, expr, rdr, wireKind, ind, onBad s
 		g.pf("%s\t%s = v\n%s}\n", ind, expr, ind)
 	default:
 		signed := (f.Type.Kind == ir.TInt || f.Type.Kind == ir.TFixed) && f.Type.Signed
-		method := "Unsigned"
-		if signed {
-			method = "Signed"
-		}
-		g.pf("%s{\n%s\tv := %s.%s(%s)\n", ind, ind, rdr, method, wireKind)
+		g.pf("%s{\n%s\tv := %s\n", ind, ind, scalarGetExpr(rdr, wireKind, signed))
 		if f.HasIntRange {
 			rlo, rhi, _ := ir.TableRawRange(f)
 			lo, hi := goIntLit(rlo, signed, 8), goIntLit(rhi, signed, 8)
@@ -449,6 +455,46 @@ func (g *tableGen) emitReadScalar(f *ir.Field, expr, rdr, wireKind, ind, onBad s
 			typ = "byte"
 		}
 		g.pf("%s\t%s = %s(v)\n%s}\n", ind, expr, typ, ind)
+	}
+}
+
+func knownKindWidth(wireKind string) int {
+	if wireKind == "" {
+		return 0
+	}
+	n := 0
+	for i := 0; i < len(wireKind); i++ {
+		c := wireKind[i]
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return ir.TableKindWidth(n)
+}
+
+func scalarGetExpr(rdr, wireKind string, signed bool) string {
+	n := knownKindWidth(wireKind)
+	if n != 1 && n != 2 && n != 4 && n != 8 {
+		method := "Unsigned"
+		if signed {
+			method = "Signed"
+		}
+		return fmt.Sprintf("%s.%s(%s)", rdr, method, wireKind)
+	}
+	get := fmt.Sprintf("%s.Get%d()", rdr, n*8)
+	if !signed {
+		return get
+	}
+	switch n {
+	case 1:
+		return "int8(" + get + ")"
+	case 2:
+		return "int16(" + get + ")"
+	case 4:
+		return "int32(" + get + ")"
+	default:
+		return "int64(" + get + ")"
 	}
 }
 

--- a/internal/codegen/gotable/wide.go
+++ b/internal/codegen/gotable/wide.go
@@ -26,15 +26,21 @@ func wideLiteral(v *big.Int, signed bool) string {
 }
 
 func (g *tableGen) emitReadWide(f *ir.Field, expr, rdr, kind, ind, onBad string) {
-	g.pf("%sif !%s.Has(tableKindBytes(%s)) { %s }\n", ind, rdr, kind, onBad)
-	g.pf("%s{\n%s var v %s\n", ind, ind, goFieldType(f.Type))
-	g.pf("%s if tableKindBytes(%s) == 16 { v.Lo = %s.Get64(); v.Hi = %s.Get64() } else {\n", ind, kind, rdr, rdr)
-	if f.Type.Signed {
-		g.pf("%s  v = serialize.Int128From64(%s.Signed(%s))\n", ind, rdr, kind)
+	if knownKindWidth(kind) == 16 {
+		g.pf("%sif !%s.Has(16) { %s }\n", ind, rdr, onBad)
+		g.pf("%s{\n%s var v %s\n", ind, ind, goFieldType(f.Type))
+		g.pf("%s v.Lo = %s.Get64(); v.Hi = %s.Get64()\n", ind, rdr, rdr)
 	} else {
-		g.pf("%s  v.Lo = %s.Unsigned(%s)\n", ind, rdr, kind)
+		g.pf("%sif !%s.Has(tableKindBytes(%s)) { %s }\n", ind, rdr, kind, onBad)
+		g.pf("%s{\n%s var v %s\n", ind, ind, goFieldType(f.Type))
+		g.pf("%s if tableKindBytes(%s) == 16 { v.Lo = %s.Get64(); v.Hi = %s.Get64() } else {\n", ind, kind, rdr, rdr)
+		if f.Type.Signed {
+			g.pf("%s  v = serialize.Int128From64(%s.Signed(%s))\n", ind, rdr, kind)
+		} else {
+			g.pf("%s  v.Lo = %s.Unsigned(%s)\n", ind, rdr, kind)
+		}
+		g.pf("%s }\n", ind)
 	}
-	g.pf("%s }\n", ind)
 	if f.HasIntRange {
 		rlo, rhi, _ := ir.TableRawRange(f)
 		lo, hi := wideLiteral(rlo, f.Type.Signed), wideLiteral(rhi, f.Type.Signed)


### PR DESCRIPTION
Rowan R-GO item 3.

C++ `codecs.go` puts widening inside the mismatch arm so a matching kind reads a constant width. Go's matched path called `Unsigned(kind)` / `Signed(kind)` even when the kind byte equalled the declaration.

This change makes matched `LoadBody` emit `Has(N)+Get8/16/32/64` at the declared width, like C++. `Unsigned` / `Signed` stay on the widen (mismatch) arm only. Array `elemKind`, union `armKind`, and map keys stay runtime.

Shape: MixedStatLoadBody matched delta is `Has(4)+Get32`; `Signed(kind)` only in the widen arm.

`GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable/` green.

I do not merge.

Johnny Grok.