### PR TITLE
gotable: arithmetic MeasureBody for fixed scalar leaves

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -1858,25 +1858,96 @@ func MixedEntityReset(value *MixedEntity) {
 }
 
 func MixedEntityMeasureBody(value *MixedEntity, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !MixedEntitySaveBody(&w, value) {
-		return -1
+	bytes := int64(1)
+	if value.EntityId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(11, 0x23fcfd6678e36712)) + 1 + 2
+	} // entity_id
+	if value.PosX != 0 {
+		bytes += tableLebBytes(ids.refAtHit(65, 0xcb4b37357667310e)) + 1 + 4
+	} // pos_x
+	if value.PosY != 0 {
+		bytes += tableLebBytes(ids.refAtHit(66, 0xcb4b3835766732c1)) + 1 + 4
+	} // pos_y
+	if value.PosZ != 0 {
+		bytes += tableLebBytes(ids.refAtHit(64, 0xcb4b353576672da8)) + 1 + 4
+	} // pos_z
+	if value.Yaw != 0 {
+		bytes += tableLebBytes(ids.refAtHit(58, 0xb54d8e19798e16e8)) + 1 + 2
+	} // yaw
+	if value.Pitch != 0 {
+		bytes += tableLebBytes(ids.refAtHit(22, 0x53a9f665a90cc1b1)) + 1 + 2
+	} // pitch
+	if value.VelX != 0 {
+		bytes += tableLebBytes(ids.refAtHit(27, 0x6cede6b6eb60ee67)) + 1 + 4
+	} // vel_x
+	if value.VelY != 0 {
+		bytes += tableLebBytes(ids.refAtHit(26, 0x6cede5b6eb60ecb4)) + 1 + 4
+	} // vel_y
+	if value.VelZ != 0 {
+		bytes += tableLebBytes(ids.refAtHit(28, 0x6cede8b6eb60f1cd)) + 1 + 4
+	} // vel_z
+	if value.Health != 0 {
+		bytes += tableLebBytes(ids.refAtHit(37, 0x7f69d4b5288ba9cf)) + 1 + 4
+	} // health
+	if value.Weapon != MixedWeaponNone {
+		ref := ids.refAtHit(52, 0xa0b610205f2c6e01)
+		var vref uint64
+		switch value.Weapon {
+		case MixedWeaponNone:
+		case MixedWeaponFists:
+			vref = ids.refAtHit(55, 0xa790eee12766cf0c)
+		case MixedWeaponPistol:
+			vref = ids.refAtHit(51, 0x9fbfefa835da8476)
+		case MixedWeaponShotgun:
+			vref = ids.refAtHit(8, 0x188bbb1783928a95)
+		case MixedWeaponRifle:
+			vref = ids.refAtHit(12, 0x2c3667b9c2f272f1)
+		case MixedWeaponSniper:
+			vref = ids.refAtHit(3, 0x0ca8b41b00d755f6)
+		case MixedWeaponSmg:
+			vref = ids.refAtHit(45, 0x985fc819fab21a4e)
+		case MixedWeaponRocket:
+			vref = ids.refAtHit(10, 0x229d0447c3086a55)
+		case MixedWeaponGrenade:
+			vref = ids.refAtHit(0, 0x011c7b49a7228f9d)
+		case MixedWeaponPlasma:
+			vref = ids.refAtHit(41, 0x89f7566e1123e15f)
+		case MixedWeaponRailgun:
+			vref = ids.refAtHit(42, 0x8d7f25318b3b4469)
+		case MixedWeaponFlamer:
+			vref = ids.refAtHit(69, 0xd9cd0dcc285b7816)
+		case MixedWeaponMine:
+			vref = ids.refAtHit(2, 0x04dc16aea8ff5276)
+		case MixedWeaponTurret:
+			vref = ids.refAtHit(17, 0x35e53bc341129217)
+		case MixedWeaponDrone:
+			vref = ids.refAtHit(13, 0x2cc8282fb0de8831)
+		case MixedWeaponRepair:
+			vref = ids.refAtHit(9, 0x20bada21bc8cb334)
+		default:
+			return -1
+		}
+		bytes += tableLebBytes(ref) + 1 + tableLebBytes(vref)
 	}
-	return w.Offset
+	if value.Damage != 0 {
+		bytes += tableLebBytes(ids.refAtHit(36, 0x7f6308be8ab37fc0)) + 1 + 8
+	} // damage
+	if value.Moving != false {
+		bytes += tableLebBytes(ids.refAtHit(5, 0x11a44fc1d1243da7)) + 1 + 1
+	} // moving
+	if value.Firing != false {
+		bytes += tableLebBytes(ids.refAtHit(32, 0x7674cfd19b9031ca)) + 1 + 1
+	} // firing
+	return bytes
 }
 
 func MixedEntityMeasure(value *MixedEntity) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !MixedEntitySaveBody(&w, value) {
+	body := MixedEntityMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func MixedEntityMeasureReason(value *MixedEntity) (int64, error) {
@@ -3265,25 +3336,23 @@ func MixedStatReset(value *MixedStat) {
 }
 
 func MixedStatMeasureBody(value *MixedStat, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !MixedStatSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.StatId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(38, 0x80ab75f0866dbf65)) + 1 + 1
+	} // stat_id
+	if value.Delta != 0 {
+		bytes += tableLebBytes(ids.refAtHit(21, 0x52076675ec13a0c1)) + 1 + 4
+	} // delta
+	return bytes
 }
 
 func MixedStatMeasure(value *MixedStat) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !MixedStatSaveBody(&w, value) {
+	body := MixedStatMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func MixedStatMeasureReason(value *MixedStat) (int64, error) {
@@ -3665,25 +3734,29 @@ func MixedHitEventReset(value *MixedHitEvent) {
 }
 
 func MixedHitEventMeasureBody(value *MixedHitEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !MixedHitEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.TargetId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(59, 0xb7bc9ac015a25050)) + 1 + 2
+	} // target_id
+	if value.Damage != 0 {
+		bytes += tableLebBytes(ids.refAtHit(36, 0x7f6308be8ab37fc0)) + 1 + 4
+	} // damage
+	if value.HitKind != 0 {
+		bytes += tableLebBytes(ids.refAtHit(1, 0x01fbc365b059b925)) + 1 + 4
+	} // hit_kind
+	if value.Crit != false {
+		bytes += tableLebBytes(ids.refAtHit(6, 0x126167908c9aa52d)) + 1 + 1
+	} // crit
+	return bytes
 }
 
 func MixedHitEventMeasure(value *MixedHitEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !MixedHitEventSaveBody(&w, value) {
+	body := MixedHitEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func MixedHitEventMeasureReason(value *MixedHitEvent) (int64, error) {
@@ -4221,25 +4294,23 @@ func MixedChatEventReset(value *MixedChatEvent) {
 }
 
 func MixedChatEventMeasureBody(value *MixedChatEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !MixedChatEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.Channel != 0 {
+		bytes += tableLebBytes(ids.refAtHit(54, 0xa5013e9ad5caeda4)) + 1 + 4
+	} // channel
+	if value.Speaker != 0 {
+		bytes += tableLebBytes(ids.refAtHit(76, 0xfbf1ac4d96ebd022)) + 1 + 2
+	} // speaker
+	return bytes
 }
 
 func MixedChatEventMeasure(value *MixedChatEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !MixedChatEventSaveBody(&w, value) {
+	body := MixedChatEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func MixedChatEventMeasureReason(value *MixedChatEvent) (int64, error) {
@@ -4624,25 +4695,23 @@ func MixedPickupEventReset(value *MixedPickupEvent) {
 }
 
 func MixedPickupEventMeasureBody(value *MixedPickupEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !MixedPickupEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.ItemId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(48, 0x9e7fd06d864fbd56)) + 1 + 2
+	} // item_id
+	if value.Amount != 0 {
+		bytes += tableLebBytes(ids.refAtHit(39, 0x8113fe7ea2b16969)) + 1 + 4
+	} // amount
+	return bytes
 }
 
 func MixedPickupEventMeasure(value *MixedPickupEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !MixedPickupEventSaveBody(&w, value) {
+	body := MixedPickupEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func MixedPickupEventMeasureReason(value *MixedPickupEvent) (int64, error) {

--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -1938,6 +1938,9 @@ func MixedEntityMeasureBody(value *MixedEntity, ids *TableIds) int64 {
 	if value.Firing != false {
 		bytes += tableLebBytes(ids.refAtHit(32, 0x7674cfd19b9031ca)) + 1 + 1
 	} // firing
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -3343,6 +3346,9 @@ func MixedStatMeasureBody(value *MixedStat, ids *TableIds) int64 {
 	if value.Delta != 0 {
 		bytes += tableLebBytes(ids.refAtHit(21, 0x52076675ec13a0c1)) + 1 + 4
 	} // delta
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -3747,6 +3753,9 @@ func MixedHitEventMeasureBody(value *MixedHitEvent, ids *TableIds) int64 {
 	if value.Crit != false {
 		bytes += tableLebBytes(ids.refAtHit(6, 0x126167908c9aa52d)) + 1 + 1
 	} // crit
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -4301,6 +4310,9 @@ func MixedChatEventMeasureBody(value *MixedChatEvent, ids *TableIds) int64 {
 	if value.Speaker != 0 {
 		bytes += tableLebBytes(ids.refAtHit(76, 0xfbf1ac4d96ebd022)) + 1 + 2
 	} // speaker
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -4702,6 +4714,9 @@ func MixedPickupEventMeasureBody(value *MixedPickupEvent, ids *TableIds) int64 {
 	if value.Amount != 0 {
 		bytes += tableLebBytes(ids.refAtHit(39, 0x8113fe7ea2b16969)) + 1 + 4
 	} // amount
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -1928,25 +1928,96 @@ func TableEntityReset(value *TableEntity) {
 }
 
 func TableEntityMeasureBody(value *TableEntity, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !TableEntitySaveBody(&w, value) {
-		return -1
+	bytes := int64(1)
+	if value.EntityId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(11, 0x23fcfd6678e36712)) + 1 + 2
+	} // entity_id
+	if value.PosX != 0 {
+		bytes += tableLebBytes(ids.refAtHit(65, 0xcb4b37357667310e)) + 1 + 4
+	} // pos_x
+	if value.PosY != 0 {
+		bytes += tableLebBytes(ids.refAtHit(66, 0xcb4b3835766732c1)) + 1 + 4
+	} // pos_y
+	if value.PosZ != 0 {
+		bytes += tableLebBytes(ids.refAtHit(64, 0xcb4b353576672da8)) + 1 + 4
+	} // pos_z
+	if value.Yaw != 0 {
+		bytes += tableLebBytes(ids.refAtHit(59, 0xb54d8e19798e16e8)) + 1 + 2
+	} // yaw
+	if value.Pitch != 0 {
+		bytes += tableLebBytes(ids.refAtHit(24, 0x53a9f665a90cc1b1)) + 1 + 2
+	} // pitch
+	if value.VelX != 0 {
+		bytes += tableLebBytes(ids.refAtHit(30, 0x6cede6b6eb60ee67)) + 1 + 4
+	} // vel_x
+	if value.VelY != 0 {
+		bytes += tableLebBytes(ids.refAtHit(29, 0x6cede5b6eb60ecb4)) + 1 + 4
+	} // vel_y
+	if value.VelZ != 0 {
+		bytes += tableLebBytes(ids.refAtHit(31, 0x6cede8b6eb60f1cd)) + 1 + 4
+	} // vel_z
+	if value.Health != 0 {
+		bytes += tableLebBytes(ids.refAtHit(41, 0x7f69d4b5288ba9cf)) + 1 + 4
+	} // health
+	if value.Weapon != TableWeaponNone {
+		ref := ids.refAtHit(54, 0xa0b610205f2c6e01)
+		var vref uint64
+		switch value.Weapon {
+		case TableWeaponNone:
+		case TableWeaponFists:
+			vref = ids.refAtHit(57, 0xa790eee12766cf0c)
+		case TableWeaponPistol:
+			vref = ids.refAtHit(53, 0x9fbfefa835da8476)
+		case TableWeaponShotgun:
+			vref = ids.refAtHit(8, 0x188bbb1783928a95)
+		case TableWeaponRifle:
+			vref = ids.refAtHit(13, 0x2c3667b9c2f272f1)
+		case TableWeaponSniper:
+			vref = ids.refAtHit(3, 0x0ca8b41b00d755f6)
+		case TableWeaponSmg:
+			vref = ids.refAtHit(48, 0x985fc819fab21a4e)
+		case TableWeaponRocket:
+			vref = ids.refAtHit(10, 0x229d0447c3086a55)
+		case TableWeaponGrenade:
+			vref = ids.refAtHit(0, 0x011c7b49a7228f9d)
+		case TableWeaponPlasma:
+			vref = ids.refAtHit(44, 0x89f7566e1123e15f)
+		case TableWeaponRailgun:
+			vref = ids.refAtHit(45, 0x8d7f25318b3b4469)
+		case TableWeaponFlamer:
+			vref = ids.refAtHit(69, 0xd9cd0dcc285b7816)
+		case TableWeaponMine:
+			vref = ids.refAtHit(2, 0x04dc16aea8ff5276)
+		case TableWeaponTurret:
+			vref = ids.refAtHit(19, 0x35e53bc341129217)
+		case TableWeaponDrone:
+			vref = ids.refAtHit(14, 0x2cc8282fb0de8831)
+		case TableWeaponRepair:
+			vref = ids.refAtHit(9, 0x20bada21bc8cb334)
+		default:
+			return -1
+		}
+		bytes += tableLebBytes(ref) + 1 + tableLebBytes(vref)
 	}
-	return w.Offset
+	if value.Damage != 0 {
+		bytes += tableLebBytes(ids.refAtHit(40, 0x7f6308be8ab37fc0)) + 1 + 8
+	} // damage
+	if value.Moving != false {
+		bytes += tableLebBytes(ids.refAtHit(5, 0x11a44fc1d1243da7)) + 1 + 1
+	} // moving
+	if value.Firing != false {
+		bytes += tableLebBytes(ids.refAtHit(36, 0x7674cfd19b9031ca)) + 1 + 1
+	} // firing
+	return bytes
 }
 
 func TableEntityMeasure(value *TableEntity) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !TableEntitySaveBody(&w, value) {
+	body := TableEntityMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func TableEntityMeasureReason(value *TableEntity) (int64, error) {
@@ -3348,25 +3419,23 @@ func TableStatReset(value *TableStat) {
 }
 
 func TableStatMeasureBody(value *TableStat, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !TableStatSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.StatId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(42, 0x80ab75f0866dbf65)) + 1 + 1
+	} // stat_id
+	if value.Delta != 0 {
+		bytes += tableLebBytes(ids.refAtHit(23, 0x52076675ec13a0c1)) + 1 + 4
+	} // delta
+	return bytes
 }
 
 func TableStatMeasure(value *TableStat) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !TableStatSaveBody(&w, value) {
+	body := TableStatMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func TableStatMeasureReason(value *TableStat) (int64, error) {
@@ -6885,25 +6954,29 @@ func TableHitEventReset(value *TableHitEvent) {
 }
 
 func TableHitEventMeasureBody(value *TableHitEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !TableHitEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.TargetId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(60, 0xb7bc9ac015a25050)) + 1 + 2
+	} // target_id
+	if value.Damage != 0 {
+		bytes += tableLebBytes(ids.refAtHit(40, 0x7f6308be8ab37fc0)) + 1 + 4
+	} // damage
+	if value.HitKind != 0 {
+		bytes += tableLebBytes(ids.refAtHit(1, 0x01fbc365b059b925)) + 1 + 4
+	} // hit_kind
+	if value.Crit != false {
+		bytes += tableLebBytes(ids.refAtHit(6, 0x126167908c9aa52d)) + 1 + 1
+	} // crit
+	return bytes
 }
 
 func TableHitEventMeasure(value *TableHitEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !TableHitEventSaveBody(&w, value) {
+	body := TableHitEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func TableHitEventMeasureReason(value *TableHitEvent) (int64, error) {
@@ -7441,25 +7514,23 @@ func TableChatEventReset(value *TableChatEvent) {
 }
 
 func TableChatEventMeasureBody(value *TableChatEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !TableChatEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.Channel != 0 {
+		bytes += tableLebBytes(ids.refAtHit(56, 0xa5013e9ad5caeda4)) + 1 + 4
+	} // channel
+	if value.Speaker != 0 {
+		bytes += tableLebBytes(ids.refAtHit(75, 0xfbf1ac4d96ebd022)) + 1 + 2
+	} // speaker
+	return bytes
 }
 
 func TableChatEventMeasure(value *TableChatEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !TableChatEventSaveBody(&w, value) {
+	body := TableChatEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func TableChatEventMeasureReason(value *TableChatEvent) (int64, error) {
@@ -7844,25 +7915,23 @@ func TablePickupEventReset(value *TablePickupEvent) {
 }
 
 func TablePickupEventMeasureBody(value *TablePickupEvent, ids *TableIds) int64 {
-	w := TableWriter{Measuring: true, Ids: ids}
-	if !TablePickupEventSaveBody(&w, value) {
-		return -1
-	}
-	return w.Offset
+	bytes := int64(1)
+	if value.ItemId != 0 {
+		bytes += tableLebBytes(ids.refAtHit(51, 0x9e7fd06d864fbd56)) + 1 + 2
+	} // item_id
+	if value.Amount != 0 {
+		bytes += tableLebBytes(ids.refAtHit(43, 0x8113fe7ea2b16969)) + 1 + 4
+	} // amount
+	return bytes
 }
 
 func TablePickupEventMeasure(value *TablePickupEvent) int64 {
 	var ids TableIds
-	w := TableWriter{Measuring: true, Ids: &ids}
-	w.Put8(1)
-	if !TablePickupEventSaveBody(&w, value) {
+	body := TablePickupEventMeasureBody(value, &ids)
+	if body < 0 || ids.Overflow {
 		return -1
 	}
-	w.Trailer()
-	if w.Overflow || ids.Overflow {
-		return -1
-	}
-	return w.Offset
+	return 1 + body + int64(ids.Count)*8 + 8
 }
 
 func TablePickupEventMeasureReason(value *TablePickupEvent) (int64, error) {

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -2008,6 +2008,9 @@ func TableEntityMeasureBody(value *TableEntity, ids *TableIds) int64 {
 	if value.Firing != false {
 		bytes += tableLebBytes(ids.refAtHit(36, 0x7674cfd19b9031ca)) + 1 + 1
 	} // firing
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -3426,6 +3429,9 @@ func TableStatMeasureBody(value *TableStat, ids *TableIds) int64 {
 	if value.Delta != 0 {
 		bytes += tableLebBytes(ids.refAtHit(23, 0x52076675ec13a0c1)) + 1 + 4
 	} // delta
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -6967,6 +6973,9 @@ func TableHitEventMeasureBody(value *TableHitEvent, ids *TableIds) int64 {
 	if value.Crit != false {
 		bytes += tableLebBytes(ids.refAtHit(6, 0x126167908c9aa52d)) + 1 + 1
 	} // crit
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -7521,6 +7530,9 @@ func TableChatEventMeasureBody(value *TableChatEvent, ids *TableIds) int64 {
 	if value.Speaker != 0 {
 		bytes += tableLebBytes(ids.refAtHit(75, 0xfbf1ac4d96ebd022)) + 1 + 2
 	} // speaker
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 
@@ -7922,6 +7934,9 @@ func TablePickupEventMeasureBody(value *TablePickupEvent, ids *TableIds) int64 {
 	if value.Amount != 0 {
 		bytes += tableLebBytes(ids.refAtHit(43, 0x8113fe7ea2b16969)) + 1 + 4
 	} // amount
+	if ids.Overflow {
+		return -1
+	}
 	return bytes
 }
 

--- a/internal/codegen/gotable/measurebody_test.go
+++ b/internal/codegen/gotable/measurebody_test.go
@@ -1,0 +1,224 @@
+package gotable
+
+import (
+	"strings"
+	"testing"
+)
+
+const arithMeasureSchema = `package probe
+flags Caps { Jump, Fly }
+enum Grade { Gold, Silver }
+table Leaf {
+ n int32
+ u uint8
+ flag Caps
+ grade Grade
+ ok bool
+ x float32
+ wide uint128
+ bitsy bits(8)
+ maybe ?int32
+}
+table Child {
+ n uint32
+}
+table Root {
+ a uint32
+ child Child
+ note string(8)
+}
+table Arr {
+ xs [..3]int32
+}
+table Fixedish {
+ q fixed(4,4) | min = -8, max = 7
+}
+`
+
+func tableGoSource(t *testing.T, src string) string {
+	t.Helper()
+	files := generate(t, src)
+	var body string
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.go") {
+			body += string(data)
+		}
+	}
+	if body == "" {
+		t.Fatal("no Table.go")
+	}
+	return body
+}
+
+func generatedFunc(src, name string) string {
+	marker := "func " + name
+	i := strings.Index(src, marker)
+	if i < 0 {
+		return ""
+	}
+	src = src[i:]
+	if j := strings.Index(src[1:], "\nfunc "); j >= 0 {
+		src = src[:j+1]
+	}
+	return src
+}
+
+func TestArithMeasureBodyShape(t *testing.T) {
+	body := tableGoSource(t, arithMeasureSchema)
+	leaf := generatedFunc(body, "LeafMeasureBody")
+	if leaf == "" {
+		t.Fatal("LeafMeasureBody missing")
+	}
+	for _, want := range []string{
+		"bytes := int64(1)",
+		"tableLebBytes(ids.refAtHit(",
+		"+ 1 + 4",
+		"+ 1 + 1",
+		"+ 1 + 8",
+		"+ 1 + 16",
+		"vref = ids.refAtHit(",
+		"tableLebBytes(ref) + 1 + tableLebBytes(vref)",
+	} {
+		if !strings.Contains(leaf, want) {
+			t.Fatalf("LeafMeasureBody missing %q\n%s", want, leaf)
+		}
+	}
+	for _, old := range []string{"Measuring", "LeafSaveBody", "TableWriter{", "w.Header(", "w.Ids.RefAt("} {
+		if strings.Contains(leaf, old) {
+			t.Fatalf("LeafMeasureBody still dry-runs via %q\n%s", old, leaf)
+		}
+	}
+	child := generatedFunc(body, "ChildMeasureBody")
+	if !strings.Contains(child, "tableLebBytes(ids.refAtHit(") || strings.Contains(child, "ChildSaveBody") {
+		t.Fatalf("ChildMeasureBody is not arithmetic\n%s", child)
+	}
+	for _, name := range []string{"RootMeasureBody", "ArrMeasureBody", "FixedishMeasureBody"} {
+		fn := generatedFunc(body, name)
+		if !strings.Contains(fn, "Measuring") || !strings.Contains(fn, "SaveBody") {
+			t.Fatalf("%s dropped the dry-run walk\n%s", name, fn)
+		}
+	}
+	save := generatedFunc(body, "LeafSaveBody")
+	if !strings.Contains(save, "w.Ids.refAtHit(") || !strings.Contains(save, "headerPair") {
+		t.Fatal("LeafSaveBody lost the 795 write path")
+	}
+	rootSave := generatedFunc(body, "RootSaveBody")
+	if !strings.Contains(rootSave, "ChildMeasureBody") || !strings.Contains(rootSave, "n > 1") {
+		t.Fatal("RootSaveBody lost the 793 child-table reuse")
+	}
+	runGenerated(t, arithMeasureSchema, arithMeasureWireTest)
+}
+
+const arithMeasureWireTest = `package probe
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func trailerIds(t *testing.T, wire []byte) []uint64 {
+	t.Helper()
+	if len(wire) < 8 {
+		t.Fatalf("short wire %d", len(wire))
+	}
+	count := int(binary.LittleEndian.Uint64(wire[len(wire)-8:]))
+	if count < 0 || 8+count*8 > len(wire) {
+		t.Fatalf("trailer count %d in %d bytes", count, len(wire))
+	}
+	ids := make([]uint64, count)
+	off := len(wire) - 8 - count*8
+	for i := range ids {
+		ids[i] = binary.LittleEndian.Uint64(wire[off+i*8:])
+	}
+	return ids
+}
+
+func TestLeafMeasureEqualsSave(t *testing.T) {
+	var empty Leaf
+	if n := LeafMeasure(&empty); n != 10 {
+		t.Fatalf("elided file %d", n)
+	}
+	buf := make([]byte, 10)
+	if LeafSave(&empty, buf) != 10 {
+		t.Fatal("elided save")
+	}
+	if got := trailerIds(t, buf); len(got) != 0 {
+		t.Fatalf("elided ids %v", got)
+	}
+
+	empty.MaybePresent = true
+	if n := LeafMeasure(&empty); n <= 10 {
+		t.Fatalf("optional default elided: %d", n)
+	}
+
+	var v Leaf
+	v.N = 7
+	v.U = 3
+	v.Flag = CapsJump | CapsFly
+	v.Grade = GradeGold
+	v.Ok = true
+	v.X = 1.5
+	v.Wide.Lo = 9
+	v.Bitsy = 4
+	v.Maybe = 0
+	v.MaybePresent = true
+
+	var ids TableIds
+	body := LeafMeasureBody(&v, &ids)
+	if body < 0 || ids.Overflow {
+		t.Fatal("measure body")
+	}
+	size := LeafMeasure(&v)
+	if size != 1+body+int64(ids.Count)*8+8 {
+		t.Fatalf("file size %d body %d ids %d", size, body, ids.Count)
+	}
+	wire := make([]byte, size)
+	if LeafSave(&v, wire) != size {
+		t.Fatal("save")
+	}
+	got := trailerIds(t, wire)
+	if len(got) != ids.Count {
+		t.Fatalf("id count measure %d save %d", ids.Count, len(got))
+	}
+	for i, id := range got {
+		if id != ids.Values[i] {
+			t.Fatalf("first-use id %d: measure 0x%x save 0x%x", i, ids.Values[i], id)
+		}
+	}
+	if LeafSave(&v, make([]byte, size-1)) != -1 {
+		t.Fatal("short buffer accepted")
+	}
+	v.Grade = Grade(99)
+	if LeafMeasure(&v) != -1 || LeafSave(&v, make([]byte, 256)) != -1 {
+		t.Fatal("invalid enum measured or saved")
+	}
+}
+
+func TestChildMeasureOnParentWalk(t *testing.T) {
+	var v Root
+	v.A = 1
+	v.Child.N = 5
+	copy(v.Note[:], []byte("hi"))
+	v.NoteLength = 2
+	n := RootMeasure(&v)
+	if n < 0 {
+		t.Fatal("measure")
+	}
+	wire := make([]byte, n)
+	if RootSave(&v, wire) != n {
+		t.Fatal("save")
+	}
+	if RootSave(&v, make([]byte, n-1)) != -1 {
+		t.Fatal("short buffer accepted")
+	}
+	var loaded Root
+	var report TableReport
+	if !RootLoad(&loaded, wire, &report) || report != (TableReport{}) || loaded.A != 1 || loaded.Child.N != 5 || loaded.NoteLength != 2 {
+		t.Fatalf("round trip %+v %+v", loaded, report)
+	}
+
+	var z Root
+	if n := RootMeasure(&z); n != 10 {
+		t.Fatalf("elided root %d", n)
+	}
+}
+`

--- a/internal/codegen/gotable/measurebody_test.go
+++ b/internal/codegen/gotable/measurebody_test.go
@@ -78,6 +78,7 @@ func TestArithMeasureBodyShape(t *testing.T) {
 		"+ 1 + 16",
 		"vref = ids.refAtHit(",
 		"tableLebBytes(ref) + 1 + tableLebBytes(vref)",
+		"if ids.Overflow",
 	} {
 		if !strings.Contains(leaf, want) {
 			t.Fatalf("LeafMeasureBody missing %q\n%s", want, leaf)
@@ -190,6 +191,17 @@ func TestLeafMeasureEqualsSave(t *testing.T) {
 	v.Grade = Grade(99)
 	if LeafMeasure(&v) != -1 || LeafSave(&v, make([]byte, 256)) != -1 {
 		t.Fatal("invalid enum measured or saved")
+	}
+
+	var full TableIds
+	full.Count = len(full.Values)
+	v.Grade = GradeGold
+	body = LeafMeasureBody(&v, &full)
+	if body != -1 {
+		t.Fatalf("MeasureBody on overflow returned %d, want -1", body)
+	}
+	if !full.Overflow {
+		t.Fatal("Overflow unset")
 	}
 }
 

--- a/internal/codegen/gotable/write.go
+++ b/internal/codegen/gotable/write.go
@@ -14,14 +14,124 @@ func (g *tableGen) emitHeader(ind, writer, ref, kind string) {
 	g.pf("%sif !%s.headerPair(%s, %s) { %s.headerRest(%s, %s) }\n", ind, writer, ref, kind, writer, ref, kind)
 }
 
+// arithMeasureEligible is a table whose body is only fixed scalar leaves:
+// TInt/TBits/TFloat/TBool/enum/flags, including optional and guarded forms.
+// Arrays, strings, bytes, nested tables, unions, keyed fields, pointers,
+// retain tails and variable tables keep the dry-run SaveBody walk (and the
+// 793 child-table / array-length cache on that path).
+func (g *tableGen) arithMeasureEligible(st *ir.Struct) bool {
+	if g.retain || ir.VariableTables(g.unit)[st.Name] {
+		return false
+	}
+	for _, f := range st.Fields {
+		if !arithMeasureFieldEligible(f) {
+			return false
+		}
+	}
+	return true
+}
+
+func arithMeasureFieldEligible(f *ir.Field) bool {
+	if f.IsMap() || f.IsList() || f.KeyEnum != "" || f.Array != ir.ArrayNone || f.Type.Pointer || f.Type.Blob() {
+		return false
+	}
+	switch f.Type.Kind {
+	case ir.TInt, ir.TBits, ir.TBool, ir.TFloat32, ir.TFloat64:
+		return true
+	case ir.TNamed:
+		switch f.Type.Ref.(type) {
+		case *ir.Enum, *ir.Flags:
+			return true
+		}
+	}
+	return false
+}
+
 func (g *tableGen) emitTableMeasure(st *ir.Struct) {
 	n := st.Name
-	g.pf("func %sMeasureBody(value *%s, ids *TableIds) int64 {\n w := TableWriter{Measuring:true, Ids:ids}\n if !%sSaveBody(&w,value) { return -1 }; return w.Offset\n}\n\n", n, g.storageName(n), n)
+	if g.arithMeasureEligible(st) {
+		g.emitArithMeasureBody(st)
+	} else {
+		g.pf("func %sMeasureBody(value *%s, ids *TableIds) int64 {\n w := TableWriter{Measuring:true, Ids:ids}\n if !%sSaveBody(&w,value) { return -1 }; return w.Offset\n}\n\n", n, g.storageName(n), n)
+	}
 	if g.retain || st.IsMapEntry() || g.regional && ir.VariableTables(g.unit)[st.Name] {
 		return
 	}
-	g.pf("func %sMeasure(value *%s) int64 {\n var ids TableIds\n w := TableWriter{Measuring:true, Ids:&ids}\n w.Put8(1)\n if !%sSaveBody(&w,value) { return -1 }; w.Trailer()\n if w.Overflow || ids.Overflow { return -1 }; return w.Offset\n}\n\n", n, g.storageName(n), n)
+	if g.arithMeasureEligible(st) {
+		g.pf("func %sMeasure(value *%s) int64 {\n var ids TableIds\n body := %sMeasureBody(value, &ids)\n if body < 0 || ids.Overflow { return -1 }\n return 1 + body + int64(ids.Count)*8 + 8\n}\n\n", n, g.storageName(n), n)
+	} else {
+		g.pf("func %sMeasure(value *%s) int64 {\n var ids TableIds\n w := TableWriter{Measuring:true, Ids:&ids}\n w.Put8(1)\n if !%sSaveBody(&w,value) { return -1 }; w.Trailer()\n if w.Overflow || ids.Overflow { return -1 }; return w.Offset\n}\n\n", n, g.storageName(n), n)
+	}
 	g.pf("func %sMeasureReason(value *%s)(int64,error){size:=%sMeasure(value);if size<0{return size,TableRefuseInvalidValue};return size,nil}\n", n, g.storageName(n), n)
+}
+
+// emitArithMeasureBody is C++ MixedStatMeasureBody: terminator 1, then
+// tableLebBytes(ids.refAtHit(...))+1+width per riding leaf. Enums intern the
+// field then the variant and add leb(variant) instead of a fixed width.
+func (g *tableGen) emitArithMeasureBody(st *ir.Struct) {
+	n := st.Name
+	g.pf("func %sMeasureBody(value *%s, ids *TableIds) int64 {\n", n, g.storageName(n))
+	if len(st.Fields) == 0 {
+		g.pf("\t_ = value\n\t_ = ids\n\treturn 1\n}\n\n")
+		return
+	}
+	g.pf("\tbytes := int64(1)\n")
+	guards := tableGuardExprs(st)
+	for _, f := range st.Fields {
+		cond := guards[f.Name]
+		if f.Type.Optional {
+			present := "value." + member(f) + "Present"
+			if cond != "" {
+				cond = "(" + cond + ") && " + present
+			} else {
+				cond = present
+			}
+		}
+		g.emitArithMeasureField(f, cond, "\t")
+	}
+	g.pf("\treturn bytes\n}\n\n")
+}
+
+func (g *tableGen) emitArithMeasureField(f *ir.Field, cond, ind string) {
+	expr := "value." + member(f)
+	id := ir.TableFieldWireId(f)
+	ride := cond
+	if !f.Type.Optional {
+		elide := expr + " != " + fieldDefaultExpr(f)
+		if ride != "" {
+			ride += " && " + elide
+		} else {
+			ride = elide
+		}
+	}
+	if e := enumRef(f); e != nil {
+		inner := ind
+		if ride != "" {
+			g.pf("%sif %s {\n", ind, ride)
+			inner = ind + "\t"
+		}
+		g.pf("%sref := ids.refAtHit(%d, 0x%016x)\n", inner, g.knownOrdinal(id), id)
+		g.pf("%svar vref uint64\n", inner)
+		g.pf("%sswitch %s {\n", inner, expr)
+		g.pf("%scase %sNone:\n", inner, e.Name)
+		for i, v := range e.Variants {
+			vid := ir.TableWireId(e.VariantWireName(i))
+			g.pf("%scase %s%s:\n%s\tvref = ids.refAtHit(%d, 0x%016x)\n", inner, e.Name, v, inner, g.knownOrdinal(vid), vid)
+		}
+		g.pf("%sdefault:\n%s\treturn -1\n%s}\n", inner, inner, inner)
+		g.pf("%sbytes += tableLebBytes(ref) + 1 + tableLebBytes(vref)\n", inner)
+		if ride != "" {
+			g.pf("%s}\n", ind)
+		}
+		return
+	}
+	width := ir.TableKindWidth(ir.TableWireScalarKind(f))
+	add := fmt.Sprintf("bytes += tableLebBytes(ids.refAtHit(%d, 0x%016x)) + 1 + %d", g.knownOrdinal(id), id, width)
+	if ride != "" {
+		g.pf("%sif %s { %s } // %s\n", ind, ride, add, f.Name)
+	} else {
+		g.pf("%s%s // %s\n", ind, add, f.Name)
+	}
 }
 
 func (g *tableGen) emitTableSave(st *ir.Struct) {

--- a/internal/codegen/gotable/write.go
+++ b/internal/codegen/gotable/write.go
@@ -72,7 +72,7 @@ func (g *tableGen) emitArithMeasureBody(st *ir.Struct) {
 	n := st.Name
 	g.pf("func %sMeasureBody(value *%s, ids *TableIds) int64 {\n", n, g.storageName(n))
 	if len(st.Fields) == 0 {
-		g.pf("\t_ = value\n\t_ = ids\n\treturn 1\n}\n\n")
+		g.pf("\t_ = value\n\tif ids.Overflow { return -1 }\n\treturn 1\n}\n\n")
 		return
 	}
 	g.pf("\tbytes := int64(1)\n")
@@ -89,7 +89,7 @@ func (g *tableGen) emitArithMeasureBody(st *ir.Struct) {
 		}
 		g.emitArithMeasureField(f, cond, "\t")
 	}
-	g.pf("\treturn bytes\n}\n\n")
+	g.pf("\tif ids.Overflow { return -1 }\n\treturn bytes\n}\n\n")
 }
 
 func (g *tableGen) emitArithMeasureField(f *ir.Field, cond, ind string) {


### PR DESCRIPTION
C++ MixedStatMeasureBody shape for eligible fixed scalar tables (TInt/TBits/TFloat/TBool/enum/flags, including optional and guarded): terminator 1, then tableLebBytes(ids.refAtHit(...))+1+width per riding leaf. Enums intern the field then the variant. Interning stays on measure; no truncate on generated fixed scalar codecs.

Ineligible tables keep the dry-run SaveBody walk, including 793 child-table n>1 and array-length cache. 795 headerPair/putLebPair/refAtHit stay on the write path. Public RefAt is unchanged.

Measure==Save, elision, first-use ids, and short-buffer -1 are covered in gotable tests.

GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable/ -count=1 -timeout 180s green.

No timing claim.

I do not merge.

Johnny Grok.