### PR TITLE
Batch C table headers, Rust scaffolding cleanup and Linux benchmark fix

### DIFF
--- a/bench/tables/c/table_main.c
+++ b/bench/tables/c/table_main.c
@@ -19,6 +19,10 @@
  * Output: a human table on stderr; with --csv, CSV v2 rows on stdout.
  */
 
+#if defined( __linux__ ) && !defined( _POSIX_C_SOURCE )
+#define _POSIX_C_SOURCE 199309L
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -1690,7 +1690,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_event_wire_save_( TableWriter * w, c
     {
         case MIXED_EVENT_TYPE_NONE: table_writer_leb( w, 0 ); break;
         case MIXED_EVENT_TYPE_HIT:
-            table_writer_id_at( w, 16, 0x33732819300680aaull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 16, 0x33732819300680aaull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1706,7 +1706,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_event_wire_save_( TableWriter * w, c
             }
             break;
         case MIXED_EVENT_TYPE_CHAT:
-            table_writer_id_at( w, 75, 0xf2a38d910b5b348bull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 75, 0xf2a38d910b5b348bull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1722,7 +1722,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_event_wire_save_( TableWriter * w, c
             }
             break;
         case MIXED_EVENT_TYPE_PICKUP:
-            table_writer_id_at( w, 50, 0x9fa3a41c86ecb765ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 50, 0x9fa3a41c86ecb765ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -1750,7 +1750,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_event_wire_save_( TableWriter *
     {
         case TABLE_EVENT_TYPE_NONE: table_writer_leb( w, 0 ); break;
         case TABLE_EVENT_TYPE_HIT:
-            table_writer_id_at( w, 18, 0x33732819300680aaull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 18, 0x33732819300680aaull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1766,7 +1766,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_event_wire_save_( TableWriter *
             }
             break;
         case TABLE_EVENT_TYPE_CHAT:
-            table_writer_id_at( w, 74, 0xf2a38d910b5b348bull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 74, 0xf2a38d910b5b348bull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1782,7 +1782,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_event_wire_save_( TableWriter *
             }
             break;
         case TABLE_EVENT_TYPE_PICKUP:
-            table_writer_id_at( w, 52, 0x9fa3a41c86ecb765ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 52, 0x9fa3a41c86ecb765ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;

--- a/internal/codegen/ctable/unions.go
+++ b/internal/codegen/ctable/unions.go
@@ -145,7 +145,7 @@ func (g *tableGen) emitUnionWire(un *ir.Union) {
 	g.pf("        case %s: table_writer_leb( w, 0 ); break;\n", enumNoneConst(un.Name+"Type"))
 	for _, v := range un.Variants {
 		g.pf("        case %s:\n", enumConst(un.Name+"Type", v.Name))
-		g.pf("            %s table_writer_put8( w, %d );\n", g.wireIdCall(ir.TableWireId(v.WireName())), armWireKind(v))
+		g.pf("            %s\n", g.wireHeaderCall(ir.TableWireId(v.WireName()), armWireKind(v)))
 		if v.Void() {
 			g.pf("            table_writer_leb( w, 0 );\n")
 		} else {

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -61,7 +61,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	}
 
 	for _, f := range u.Files {
-		g := &gen{unit: u, file: f, home: home}
+		g := &gen{unit: u, file: f}
 		g.emitFile(f.Base == home)
 		g.needsCrate = g.needsCrate || len(deps[f.Base]) > 0 || (g.needsStreams && f.Base != home)
 		out[strings.ToLower(f.Base)+".rs"] = g.assemble()
@@ -161,7 +161,6 @@ func assembleLib(u *ir.Unit, modules map[string]string, extra []string) []byte {
 type gen struct {
 	unit *ir.Unit
 	file *ir.File
-	home string // the file that carries PROTOCOL_ID and Error/Result
 
 	body             strings.Builder
 	bulkBytes        map[*ir.Field]bool // fixed [N]u8 arrays at statically byte-aligned positions (ir.AlignedFixedByteArrays)

--- a/internal/codegen/rusttable/block.go
+++ b/internal/codegen/rusttable/block.go
@@ -37,7 +37,7 @@ func generateBlocks(u *ir.Unit, blocks *ir.BlockUnit, banner string) (map[string
 	}
 	for base, tables := range byFile {
 		sort.Slice(tables, func(i, j int) bool { return tables[i].Table.Name < tables[j].Table.Name })
-		b := &blockGen{unit: u, blocks: blocks}
+		b := &blockGen{unit: u}
 		for _, bl := range tables {
 			b.emitBlock(bl)
 		}
@@ -174,7 +174,6 @@ pub struct TableBlockInfo {
 
 type blockGen struct {
 	unit           *ir.Unit
-	blocks         *ir.BlockUnit
 	body           strings.Builder
 	emittedRecords map[string]bool // one descriptor per record per module
 }

--- a/internal/codegen/rusttable/cook.go
+++ b/internal/codegen/rusttable/cook.go
@@ -37,7 +37,6 @@ func (g *gen) cookModule() []byte {
 		return nil
 	}
 	var b strings.Builder
-	b.WriteString(g.banner)
 	b.WriteString(header(g.file.Base, g.unit.Package, "the COOKED FORM (docs/SPEC-TABLES.md §7): the READ half"))
 	b.WriteString(cookModuleBanner)
 	b.WriteString("use crate::*;\n\n")
@@ -73,7 +72,6 @@ func (g *gen) recordsModule() []byte {
 	}
 
 	var b strings.Builder
-	b.WriteString(g.banner)
 	b.WriteString(header(g.file.Base, g.unit.Package,
 		"the BLITTABLE RECORDS both accelerators are built from (docs/SPEC-TABLES.md §7.2, §19.3)"))
 	b.WriteString(recordsModuleBanner)

--- a/internal/codegen/rusttable/rusttable.go
+++ b/internal/codegen/rusttable/rusttable.go
@@ -51,7 +51,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	out[BuildVersionModule+".rs"] = buildVersionModule(u)
 
 	for _, f := range u.Files {
-		g := &gen{unit: u, file: f, closure: closure, blocks: blocks}
+		g := &gen{unit: u, file: f, closure: closure}
 		if body := g.recordsModule(); body != nil {
 			out[strings.ToLower(f.Base)+"_records.rs"] = body
 		}
@@ -105,26 +105,12 @@ type gen struct {
 	unit    *ir.Unit
 	file    *ir.File
 	closure map[string]bool
-	blocks  *ir.BlockUnit
-	banner  string
 
-	body   strings.Builder
-	indent string
+	body strings.Builder
 }
 
 func (g *gen) pf(format string, args ...any) {
-	s := fmt.Sprintf(format, args...)
-	if g.indent != "" && s != "" {
-		trailing := strings.HasSuffix(s, "\n")
-		if trailing {
-			s = s[:len(s)-1]
-		}
-		s = g.indent + strings.ReplaceAll(s, "\n", "\n"+g.indent)
-		if trailing {
-			s += "\n"
-		}
-	}
-	g.body.WriteString(s)
+	fmt.Fprintf(&g.body, format, args...)
 }
 
 // header is the generated-file banner every module carries.

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -1752,7 +1752,7 @@ static SCHEMA_UNUSED int schema_tabledemo_effect_wire_save_( TableWriter * w, co
     {
         case EFFECT_TYPE_NONE: table_writer_leb( w, 0 ); break;
         case EFFECT_TYPE_BUFF:
-            table_writer_id_at( w, 153, 0xffb5be9be2e469ccull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 153, 0xffb5be9be2e469ccull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;
@@ -1768,7 +1768,7 @@ static SCHEMA_UNUSED int schema_tabledemo_effect_wire_save_( TableWriter * w, co
             }
             break;
         case EFFECT_TYPE_DEBUFF:
-            table_writer_id_at( w, 10, 0x13cdc5ede73d2fd7ull ); table_writer_put8( w, 13 );
+            table_writer_header_at( w, 10, 0x13cdc5ede73d2fd7ull, 13 );
             if ( w->buffer == NULL )
             {
                 int64_t frame_begin = w->offset;


### PR DESCRIPTION
C Table union arms now use the same cached header write as ordinary fields, preserving successful wire output and the existing fallback. The batch also removes unread private Rust generator fields and empty formatting branches, and exposes the monotonic clock declarations for the Linux C Table benchmark under strict C99.

The three separately reviewed commits retain their original authors and cherry-pick provenance. Rust generated output is unchanged; public module exports are outside this cleanup. The Linux feature definition preserves caller-supplied settings and leaves macOS/Windows preprocessing unchanged. As with the existing C header helper, partial output after a failed Save may differ while the public failure result remains unchanged.

Validation: ordinary generator and source-golden checks, 15 existing C/Rust compiler checks, clean regeneration, strict-C99 C compilation, and one complete eight-runner ARM correctness gate passed on the final head. Packet and Table each match their own canonical 64-record corpus. The 130 Rust generated files match the accepted source-review hashes, allowing the previous 40 feature-build results to be reused. Linux clock visibility was also verified during the separate frozen Space build using the same feature definition as a recorded compiler flag. No performance claim is made before the next matched measurement batch.
