### PR TITLE
bench: add cached matched fast profiling mode

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -985,6 +985,41 @@ blended statistic) are working values pending the owner's ruling, marked
 here so a table produced by quick mode can name its contract. Certification
 and every published ratio remain governed by §2.1–§2.7.
 
+**The paired FAST instrument — `bench/paired -mode fast`.** Admitted here by
+name so its artifacts can cite a clause instead of an opinion. It is the
+paired pass's iteration instrument, never its certification instrument, and
+it is narrower than `--quick`:
+
+- **Non-certified diagnostic, and it says so.** A completed directory is
+  stamped `COMPLETED_NON_CERTIFIED_FAST_DIAGNOSTIC` and every artifact
+  repeats the same qualification sentence.
+- **One round by default** (`-fast-rounds`, 1..3); the confirmation protocol
+  stays the separate seven-round `-mode run`.
+- **Reduced iteration counts, stated in every artifact, and uniform.** The
+  defaults are half the confirmation counts — 2,000,000 packet and 200,000
+  table operations against 4,000,000 and 400,000. §2.1 holds inside the
+  diagnostic — one count per benchmark, identical across every language: when
+  any leg of a wire's group falls below the 200 ms floor, the count rises for
+  the WHOLE group and every language is measured again at it, so no table
+  mixes counts. The final count per wire is recorded once in `fast.json` and
+  once in the generated `README.md`.
+- **The warmup runs at the requested count**, not at the confirmation count:
+  one discarded run of the same reduced size precedes each measured path. That
+  covers first touch and cold cache; it is NOT a claim about a managed
+  runtime's steady state, and the qualification sentence says so.
+- **Median only, and at one round the spread is structurally zero.** The
+  generated table prints the median of the adequate rounds; at one round its
+  Range column is a single value that is its own minimum and maximum, so it
+  reads as zero variance BY CONSTRUCTION and cannot be read against §2.3.
+  §2.2's best-of-seven headline is not produced at all.
+- **No seal, and render refuses it.** No control legs (§2.6), no quiet-window
+  verdict and no `completion.json`. `-mode render` verifies that seal before
+  deriving any number and refuses an unsealed directory, and it refuses
+  metadata declaring fewer than seven rounds — a fast directory fails both.
+- **Never mixed into a certified table.** A fast number publishes nothing: it
+  does not enter a results CSV, a headline ratio or the ledger, and a fast
+  directory is not a sitting.
+
 ### §2.9 The write / round-trip contract — NORMATIVE for the gen family's `bench_mixed` rows
 
 Ratified 2026-08-31 (issue #191, PR #197): proposed by the C++ tracer, and

--- a/bench/c/bench_datadriven.inc
+++ b/bench/c/bench_datadriven.inc
@@ -27,7 +27,7 @@ static BM_TYPE BM_CAT( g_instances_, BM_SUFFIX )[NumVariants];
 
 static void BM_FUNC( const char * name, const char * golden, long base_iters )
 {
-    const long iters = base_iters / IterScale;
+    const long iters = g_iterations ? g_iterations : base_iters / IterScale;
     BM_TYPE * instances = BM_CAT( g_instances_, BM_SUFFIX );
     BM_TYPE out;
     int bytes_per_op;

--- a/bench/c/bench_main.c
+++ b/bench/c/bench_main.c
@@ -60,6 +60,7 @@ static uint64_t bench_rng( uint64_t rng )
 static int g_gate = 0;
 static int g_quick = 0;             /* --quick: bench_mixed only, 3 measured runs —
                                        the iteration instrument, never certification */
+static long g_iterations = 0; /* explicit diagnostic count; defaults stay standard */
 static int g_num_runs = MaxNumRuns; /* --round K drops this to 1 (§2.4: one warmup +
                                        one measured run per round; the driver
                                        aggregates across rounds) */
@@ -560,6 +561,17 @@ int main( int argc, char ** argv )
             g_wire_dir = argv[++i];
         else if ( strcmp( argv[i], "--variant-dir" ) == 0 && i + 1 < argc )
             g_variant_dir = argv[++i];
+        else if ( strcmp( argv[i], "--iterations" ) == 0 && i + 1 < argc )
+        {
+            char * end = NULL;
+            long n = strtol( argv[++i], &end, 10 );
+            if ( end == argv[i] || *end != '\0' || n <= 0 || n > 2147483584L || n % NumVariants != 0 )
+            {
+                fprintf( stderr, "--iterations requires a positive multiple of 64 up to 2147483584\n" );
+                return 1;
+            }
+            g_iterations = n;
+        }
         else if ( strcmp( argv[i], "--round" ) == 0 && i + 1 < argc )
         {
             /* §2.4: one warmup + one measured run of every benchmark, then
@@ -578,7 +590,7 @@ int main( int argc, char ** argv )
             g_quick = 1;
         else
         {
-            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--iterations N] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/cpp/bench_main.cpp
+++ b/bench/cpp/bench_main.cpp
@@ -66,6 +66,7 @@ inline uint64_t bench_rng( uint64_t rng )
 }
 
 const int MaxNumRuns = 7;       // median of 7 (N >= 5), after 1 warmup run
+static long g_iterations = 0; /* explicit diagnostic count; defaults stay standard */
 static int g_num_runs = MaxNumRuns; // --round K drops this to 1 (§2.4: one warmup + one measured run per round; the driver aggregates across rounds)
 static bool g_gate = false;
 static bool g_quick = false;    // --quick: bench_mixed only, 3 measured runs — the iteration instrument, never the certification instrument
@@ -294,7 +295,7 @@ template <typename T, typename WriteFn, typename ReadFn>
 static void bench_datadriven( const char * name, const char * golden, long base_iters,
                               WriteFn write_fn, ReadFn read_fn )
 {
-    const long iters = base_iters / IterScale;
+    const long iters = g_iterations ? g_iterations : base_iters / IterScale;
 
     const int64_t bytes_per_op = load_variants( name );
     if ( bytes_per_op < 0 )
@@ -640,6 +641,17 @@ int main( int argc, char ** argv )
             g_wire_dir = argv[++i];
         else if ( strcmp( argv[i], "--variant-dir" ) == 0 && i + 1 < argc )
             g_variant_dir = argv[++i];
+        else if ( strcmp( argv[i], "--iterations" ) == 0 && i + 1 < argc )
+        {
+            char * end = NULL;
+            long n = strtol( argv[++i], &end, 10 );
+            if ( end == argv[i] || *end != '\0' || n <= 0 || n > 2147483584L || n % NumVariants != 0 )
+            {
+                fprintf( stderr, "--iterations requires a positive multiple of 64 up to 2147483584\n" );
+                return 1;
+            }
+            g_iterations = n;
+        }
         else if ( strcmp( argv[i], "--round" ) == 0 && i + 1 < argc )
         {
             // §2.4: one warmup + one measured run of every benchmark, then
@@ -658,7 +670,7 @@ int main( int argc, char ** argv )
             g_quick = true;
         else
         {
-            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--gate] [--csv] [--round K] [--iterations N] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/cs/src/Program.cs
+++ b/bench/cs/src/Program.cs
@@ -32,6 +32,7 @@ static partial class Program
     const int MaxNumRuns = 7;   // median of 7 (N >= 5), after 1 warmup run
     static bool gGate = false;
     static bool gQuick = false; // --quick: bench_mixed only, 3 measured runs
+    static long gIterations = 0; // explicit diagnostic count; defaults stay standard
     static int gNumRuns = MaxNumRuns; // --round K drops this to 1 (§2.4: one warmup +
                                       // one measured run per round; the driver
                                       // aggregates across rounds)
@@ -281,6 +282,7 @@ static partial class Program
         Func<WriteStream, T, bool> writeFn, Func<ReadStream, T, bool> readFn)
         where T : class, new()
     {
+        if (gIterations > 0) iters = gIterations;
         long bytesPerOp = LoadVariants(name);
         if (bytesPerOp < 0)
         {
@@ -476,6 +478,15 @@ static partial class Program
             {
                 gWireDir = args[++i];
             }
+            else if (args[i] == "--iterations" && i + 1 < args.Length)
+            {
+                if (!long.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out long n) || n <= 0 || n > 2147483584L || n % NumVariants != 0)
+                {
+                    Console.Error.WriteLine("--iterations requires a positive multiple of 64 up to 2147483584");
+                    return 1;
+                }
+                gIterations = n;
+            }
             else if (args[i] == "--round" && i + 1 < args.Length)
             {
                 // §2.4: one warmup + one measured run of every benchmark,
@@ -494,7 +505,7 @@ static partial class Program
             }
             else
             {
-                Console.Error.WriteLine("usage: schemabench [--gate] [--csv] [--round K] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]");
+                Console.Error.WriteLine("usage: schemabench [--gate] [--csv] [--round K] [--iterations N] [--quick] [--wire-dir <dir>] [--variant-dir <dir>]");
                 return 1;
             }
         }

--- a/bench/go/main.go
+++ b/bench/go/main.go
@@ -38,6 +38,7 @@ import (
 
 const MaxNumRuns = 7 // median of 7 (N >= 5), after 1 warmup run
 var gGate bool
+var gIterations int64     // explicit diagnostic count; zero keeps the standard count
 var gQuick = false        // --quick: bench_mixed only, 3 measured runs
 var gNumRuns = MaxNumRuns // --round K drops this to 1 (§2.4: one warmup + one
 // measured run per round; the driver aggregates across rounds)
@@ -234,6 +235,9 @@ func loadVariants(name string) int64 {
 func benchDataDriven[T any](name, golden string, iters int64,
 	writeFn func(*serialize.WriteStream, *T) error,
 	readFn func(*serialize.ReadStream, *T) error) {
+	if gIterations > 0 {
+		iters = gIterations
+	}
 
 	bytesPerOp := loadVariants(name)
 	if bytesPerOp < 0 {
@@ -404,6 +408,14 @@ func main() {
 		case args[i] == "--variant-dir" && i+1 < len(args):
 			i++
 			gVariantDir = args[i]
+		case args[i] == "--iterations" && i+1 < len(args):
+			i++
+			n, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil || n <= 0 || n > 2147483584 || n%64 != 0 {
+				fmt.Fprintln(os.Stderr, "--iterations requires a positive multiple of 64 up to 2147483584")
+				os.Exit(1)
+			}
+			gIterations = n
 		case args[i] == "--round" && i+1 < len(args):
 			// §2.4: one warmup + one measured run of every benchmark, then
 			// exit. K only identifies the round to the interleaved driver,
@@ -434,7 +446,7 @@ func main() {
 			}
 			defer pprof.StopCPUProfile()
 		default:
-			fmt.Fprintf(os.Stderr, "usage: %s [--gate] [--csv] [--round K] [--quick] [--wire-dir <dir>] [--variant-dir <dir>] [--cpuprofile <file>]\n", os.Args[0])
+			fmt.Fprintf(os.Stderr, "usage: %s [--gate] [--csv] [--round K] [--iterations N] [--quick] [--wire-dir <dir>] [--variant-dir <dir>] [--cpuprofile <file>]\n", os.Args[0])
 			os.Exit(1)
 		}
 	}

--- a/bench/paired/README.md
+++ b/bench/paired/README.md
@@ -35,14 +35,18 @@ then one complete round across all four languages and both wires. Each path
 retains one discarded warmup at its requested sample count. Packet `--quick`
 skips the unrelated bitpacker workload.
 
-The initial counts are 2,000,000 Packet operations and 200,000 Table operations,
-both whole rotations of the unchanged 64 records. `-packet-iters` and
-`-table-iters` override these defaults. Every accepted write and round-trip
-sample still needs at least 200 ms, derived from its recorded iterations and
-measured rate. A short sample causes a larger whole-rotation count and another
-complete warmup/sample invocation for that leg, at most three attempts. All
-attempts remain in the evidence; only the first adequate one supplies that
-round. `-fast-rounds 2` or `3` requests additional complete rounds, rotating
+The initial counts are 2,000,000 Packet operations and 200,000 Table
+operations, both whole rotations of the unchanged 64 records. `-packet-iters`
+and `-table-iters` override these defaults. Every accepted write and
+round-trip sample still needs at least 200 ms, derived from its recorded
+iterations and measured rate. A short sample raises the count for that wire's
+whole group, never for the short leg alone: BENCH-STANDARD §2.1 fixes one
+count per benchmark, identical across every language, so all four languages
+are measured again at the largest whole-rotation count any of them needed, at
+most three uniform attempts. All attempts remain in the evidence; only those
+at the final count supply a row, so one table cannot mix counts. `fast.json`
+records that final count per wire and the generated `README.md` states it
+once. `-fast-rounds 2` or `3` requests additional complete rounds, rotating
 language order and alternating each language's wire order.
 
 The target is about one minute, with a five-minute deadline including gates.
@@ -55,15 +59,17 @@ evidence in the printed temporary directory. Final file bookkeeping may follow
 the deadline. A slow or noisy machine can fail to complete an adequate pass.
 
 `fast.json` records the build, actual commands and counts, measured sample
-durations, attempts, noise warnings and artifact hashes. Process/load snapshots
-use the same bounded calls as confirmation, but foreign work qualifies this
-diagnostic instead of refusing it. `README.md` reports median costs and the
-matched ratios. One round does not establish stability; shortened warmup does
-not prove managed-runtime steady state. Fast results are explicitly
-**not certified**: no bracketing drift controls, quiet-window verdict or
-confirmation seal is produced. Use the separate seven-round confirmation mode
-for accepted performance claims. Its counts, controls and validation are
-unchanged.
+durations, attempts, noise warnings and artifact hashes. Process/load
+snapshots use the same bounded calls as confirmation, but foreign work
+qualifies this diagnostic instead of refusing it. `README.md` reports median
+costs and the matched ratios. At one round its Range column is degenerate —
+the single measured value is its own minimum and maximum — so it reads as zero
+variance by construction, not as measured stability. One round does not
+establish stability; a warmup at the requested count does not prove
+managed-runtime steady state. Fast results are explicitly **not certified**:
+no bracketing drift controls, quiet-window verdict or confirmation seal is
+produced. Use the separate seven-round confirmation mode for accepted
+performance claims. Its counts, controls and validation are unchanged.
 
 Run from the repository root. The tool needs the C, C++, Go and .NET toolchains
 and the same sibling serialize runtimes as the standard packet pass. `CC`,

--- a/bench/paired/README.md
+++ b/bench/paired/README.md
@@ -14,14 +14,56 @@ The driver refuses any different checks axes. Full semantics, raw timings and
 methodology live in the result directory's `DETAILS.md`.
 
 ```sh
-# Build every leg and verify both wires; no timing.
-go run ./bench/paired -mode gate
+# Prepare once per source checkpoint: driver, all legs, and correctness gates.
+go build -o bin/schema-paired ./bench/paired
+bin/schema-paired -mode gate
 
-# During an exclusive measurement window, use those hashed binaries.
-go run ./bench/paired -mode run -reuse-build \
+# Fast iteration on the designated profiling host, reusing the cached build.
+bin/schema-paired -mode fast -out build/paired-fast/<iteration> \
+  -noise-note 'profiling reservation and current background-work context'
+
+# Slower confirmation, during an exclusive measurement window.
+bin/schema-paired -mode run -reuse-build \
   -quiet-window 'operator READY/START coordination reference' \
   -out bench/paired/results/<sitting>
 ```
+
+Fast mode never builds or generates. It requires a clean checkpoint with an
+existing all-language build whose source, host, runtime settings, binaries and
+corpora still match. It runs the existing correctness gates before any clocks,
+then one complete round across all four languages and both wires. Each path
+retains one discarded warmup at its requested sample count. Packet `--quick`
+skips the unrelated bitpacker workload.
+
+The initial counts are 2,000,000 Packet operations and 200,000 Table operations,
+both whole rotations of the unchanged 64 records. `-packet-iters` and
+`-table-iters` override these defaults. Every accepted write and round-trip
+sample still needs at least 200 ms, derived from its recorded iterations and
+measured rate. A short sample causes a larger whole-rotation count and another
+complete warmup/sample invocation for that leg, at most three attempts. All
+attempts remain in the evidence; only the first adequate one supplies that
+round. `-fast-rounds 2` or `3` requests additional complete rounds, rotating
+language order and alternating each language's wire order.
+
+The target is about one minute, with a five-minute deadline including gates.
+The initial duration model halves a previously observed approximately 104-second
+all-eight Space round, then removes Packet bitpacker work; fixed startup/JIT and
+gate costs do not halve. This is an estimate, not a measured guarantee for a new
+machine or revision. `-fast-timeout` can shorten the deadline but cannot exceed
+five minutes. Timeout kills only the current owned runner and retains incomplete
+evidence in the printed temporary directory. Final file bookkeeping may follow
+the deadline. A slow or noisy machine can fail to complete an adequate pass.
+
+`fast.json` records the build, actual commands and counts, measured sample
+durations, attempts, noise warnings and artifact hashes. Process/load snapshots
+use the same bounded calls as confirmation, but foreign work qualifies this
+diagnostic instead of refusing it. `README.md` reports median costs and the
+matched ratios. One round does not establish stability; shortened warmup does
+not prove managed-runtime steady state. Fast results are explicitly
+**not certified**: no bracketing drift controls, quiet-window verdict or
+confirmation seal is produced. Use the separate seven-round confirmation mode
+for accepted performance claims. Its counts, controls and validation are
+unchanged.
 
 Run from the repository root. The tool needs the C, C++, Go and .NET toolchains
 and the same sibling serialize runtimes as the standard packet pass. `CC`,

--- a/bench/paired/fast.go
+++ b/bench/paired/fast.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maximumFastIterations int64 = 2147483584 // whole 64-record rotations, also fits 32-bit long
+const fastMinimumSeconds = 0.2
+
+type fastConfig struct {
+	Rounds           int           `json:"rounds"`
+	PacketIterations int64         `json:"initial_packet_iterations"`
+	TableIterations  int64         `json:"initial_table_iterations"`
+	Timeout          time.Duration `json:"timeout_ns"`
+	Noise            string        `json:"noise_note"`
+}
+
+func (c fastConfig) validate() error {
+	if c.Rounds < 1 || c.Rounds > 3 {
+		return errors.New("fast-rounds must be 1..3; use run for confirmation")
+	}
+	for _, n := range []int64{c.PacketIterations, c.TableIterations} {
+		if n <= 0 || n > maximumFastIterations || n%64 != 0 {
+			return errors.New("fast iterations must be positive multiples of 64 up to 2147483584")
+		}
+	}
+	if c.Timeout <= 0 || c.Timeout > 5*time.Minute {
+		return errors.New("fast-timeout must be positive and at most 5m")
+	}
+	if strings.TrimSpace(c.Noise) == "" {
+		return errors.New("noise-note must describe the diagnostic context")
+	}
+	return nil
+}
+
+func fastCommand(wire, lang string, round int, iterations int64) command {
+	args := []string{"--csv", "--round", strconv.Itoa(round), "--iterations", strconv.FormatInt(iterations, 10)}
+	if wire == "packet" {
+		args = append(args, "--quick") // retain BenchMixed; skip the unrelated bitpacker
+	}
+	return runner(wire, lang, args...)
+}
+
+func fastWires(round, languageIndex int) []string {
+	if (round+languageIndex)%2 == 1 {
+		return []string{"table", "packet"}
+	}
+	return []string{"packet", "table"}
+}
+
+// Adapt only a short sample. CSV rates encode the runner's actual measured
+// duration as iterations/rate, exactly as the confirmation parser checks it.
+// The 25% margin avoids aiming precisely at the 200ms acceptance boundary.
+func fastNextIterations(rows []sample, current int64) (int64, bool, error) {
+	adequate, fastest := true, float64(0)
+	for _, row := range rows {
+		adequate = adequate && float64(row.iters)/row.rate >= fastMinimumSeconds
+		fastest = math.Max(fastest, row.rate)
+	}
+	if adequate {
+		return current, true, nil
+	}
+	next := math.Ceil(fastest*fastMinimumSeconds*1.25/64) * 64
+	if next > float64(maximumFastIterations) {
+		return 0, false, errors.New("timer adequacy needs more than the supported iteration count")
+	}
+	return max(current+64, int64(next)), false, nil
+}
+
+type fastMetric struct {
+	Path       string  `json:"path"`
+	Iterations int64   `json:"iterations"`
+	Rate       float64 `json:"messages_per_second"`
+	Seconds    float64 `json:"measured_seconds_from_csv"`
+	Bytes      float64 `json:"bytes_per_op"`
+}
+
+type fastAttempt struct {
+	Round    int          `json:"round"`
+	Language string       `json:"language"`
+	Wire     string       `json:"wire"`
+	Attempt  int          `json:"attempt"`
+	Adequate bool         `json:"adequate"`
+	Raw      string       `json:"raw"`
+	Metrics  []fastMetric `json:"metrics"`
+}
+
+type fastCommandReceipt struct {
+	Arguments []string `json:"arguments"`
+	Phase     string   `json:"phase"`
+	Started   string   `json:"started"`
+	Ended     string   `json:"ended"`
+	Error     string   `json:"error,omitempty"`
+}
+
+type fastEvidence struct {
+	Status        string               `json:"status"`
+	Reason        string               `json:"reason,omitempty"`
+	Started       string               `json:"started"`
+	Ended         string               `json:"ended,omitempty"`
+	Elapsed       float64              `json:"elapsed_seconds"`
+	Qualification string               `json:"qualification"`
+	Config        fastConfig           `json:"config"`
+	Build         buildInfo            `json:"build"`
+	Noise         []string             `json:"observed_noise"`
+	Commands      []fastCommandReceipt `json:"commands"`
+	Attempts      []fastAttempt        `json:"attempts"`
+	Artifacts     map[string]string    `json:"artifact_sha256,omitempty"`
+}
+
+type fastCollector struct {
+	dir      string
+	journal  *os.File
+	evidence fastEvidence
+}
+
+func (f *fastCollector) save() error {
+	b, err := json.MarshalIndent(f.evidence, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(f.dir, "fast.json"), append(b, '\n'), 0644)
+}
+
+func (f *fastCollector) snapshot(ctx context.Context, phase string) error {
+	s, err := windowSnapshotContext(ctx, phase)
+	if err != nil {
+		return err
+	}
+	owned := ownedProcesses(s.Processes, os.Getpid())
+	for i := range s.Processes {
+		s.Processes[i].Owned = owned[s.Processes[i].PID]
+	}
+	// Foreign work qualifies a diagnostic; it still refuses confirmation.
+	if err := inspectSample(s, os.Getpid()); err != nil {
+		f.evidence.Noise = append(f.evidence.Noise, err.Error())
+	}
+	return json.NewEncoder(f.journal).Encode(s)
+}
+
+func (f *fastCollector) capture(ctx context.Context, c command, phase string) (output []byte, resultErr error) {
+	entry := fastCommandReceipt{Arguments: c.args, Phase: phase, Started: time.Now().UTC().Format(time.RFC3339Nano)}
+	defer func() {
+		entry.Ended = time.Now().UTC().Format(time.RFC3339Nano)
+		if resultErr != nil {
+			entry.Error = resultErr.Error()
+		}
+		f.evidence.Commands = append(f.evidence.Commands, entry)
+		resultErr = errors.Join(resultErr, f.save())
+	}()
+	if err := f.snapshot(ctx, "before/"+phase); err != nil {
+		return nil, err
+	}
+	log, err := os.Create(filepath.Join(f.dir, phase+".log"))
+	if err != nil {
+		return nil, err
+	}
+	defer log.Close()
+	cmd := exec.CommandContext(ctx, c.args[0], c.args[1:]...)
+	cmd.Dir = c.dir
+	cmd.WaitDelay = time.Second
+	var stdout bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, log
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	ticker := time.NewTicker(windowInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				return stdout.Bytes(), errors.Join(err, ctx.Err())
+			}
+			return stdout.Bytes(), f.snapshot(ctx, "after/"+phase)
+		case <-ticker.C:
+			if err := f.snapshot(ctx, "during/"+phase); err != nil {
+				_ = cmd.Process.Kill() // only this owned invocation
+				<-done
+				return stdout.Bytes(), err
+			}
+		}
+	}
+}
+
+func fastMeasure(langs []string, out string, info buildInfo, config fastConfig) (resultErr error) {
+	if err := config.validate(); err != nil {
+		return err
+	}
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return errors.New("fast process monitoring requires Linux or macOS")
+	}
+	if info.Dirty || gitValue(".", "status", "--porcelain") != "" {
+		return errors.New("fast mode requires a clean source/build checkpoint")
+	}
+	if out == "" {
+		return errors.New("fast requires -out (a new diagnostic directory)")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		return errors.New("refusing to overwrite diagnostic directory")
+	}
+	for _, lang := range languages {
+		for _, wire := range []string{"packet", "table"} {
+			if info.Binaries[binary(wire, lang)] == "" {
+				return fmt.Errorf("cached build lacks %s/%s; run the all-language gate first", lang, wire)
+			}
+		}
+	}
+	started := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
+	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
+		return err
+	}
+	tmp, err := os.MkdirTemp(filepath.Dir(out), ".paired-fast-")
+	if err != nil {
+		return err
+	}
+	f := fastCollector{dir: tmp, evidence: fastEvidence{Status: "INCOMPLETE_FAST_DIAGNOSTIC", Started: started.UTC().Format(time.RFC3339Nano), Config: config, Build: info, Qualification: "Non-certified diagnostic: reduced iterations and 1..3 rounds; no bracketing drift controls or quiet-window seal. Process samples can miss short or unusually named work. One full-count warmup per path is retained, but managed-runtime steady state still needs confirmation."}}
+	f.journal, err = os.Create(filepath.Join(tmp, "process-samples.jsonl"))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "fast diagnostic evidence:", tmp)
+	defer func() {
+		resultErr = errors.Join(resultErr, f.journal.Close())
+		resultErr = errors.Join(resultErr, ctx.Err())
+		f.evidence.Ended, f.evidence.Elapsed = time.Now().UTC().Format(time.RFC3339Nano), time.Since(started).Seconds()
+		if resultErr != nil {
+			f.evidence.Status = "INCOMPLETE_FAST_DIAGNOSTIC"
+			f.evidence.Reason = resultErr.Error()
+		}
+		resultErr = errors.Join(resultErr, f.save())
+		if resultErr == nil {
+			resultErr = os.Rename(tmp, out)
+			if resultErr == nil {
+				fmt.Fprintln(os.Stderr, "completed non-certified fast diagnostic:", out)
+			}
+		}
+	}()
+	if err := f.save(); err != nil {
+		return err
+	}
+	// These are the same no-clock correctness gates as the confirmation pass.
+	if _, err := f.capture(ctx, command{args: []string{"build/paired/corpus", "verify"}}, "corpus-gate"); err != nil {
+		return err
+	}
+	for _, lang := range langs {
+		for _, wire := range []string{"packet", "table"} {
+			data, err := f.capture(ctx, runner(wire, lang, "--gate"), "gate-"+lang+"-"+wire)
+			if err != nil {
+				return err
+			}
+			if len(bytes.TrimSpace(data)) != 0 {
+				return errors.New("correctness gate emitted timing rows")
+			}
+		}
+	}
+	counts := map[string]int64{}
+	for round := range config.Rounds {
+		for i := range langs {
+			languageIndex := (i + round) % len(langs)
+			lang := langs[languageIndex]
+			wires := fastWires(round, languageIndex)
+			for _, wire := range wires {
+				key := lang + "/" + wire
+				n := counts[key]
+				if n == 0 {
+					n = config.PacketIterations
+					if wire == "table" {
+						n = config.TableIterations
+					}
+				}
+				for attempt := 0; attempt < 3; attempt++ {
+					phase := fmt.Sprintf("round-%d-%s-%s-attempt-%d", round, lang, wire, attempt)
+					fmt.Fprintln(os.Stderr, phase, "iterations", n)
+					data, runErr := f.capture(ctx, fastCommand(wire, lang, round, n), phase)
+					if err := os.WriteFile(filepath.Join(tmp, phase+".csv"), data, 0644); err != nil {
+						return errors.Join(runErr, err)
+					}
+					if runErr != nil {
+						return runErr
+					}
+					rows, err := parseRowsForIterations(data, lang, wire, info.CorpusIDs[wire], n, 0)
+					if err != nil {
+						return err
+					}
+					next, adequate, err := fastNextIterations(rows, n)
+					if err != nil {
+						return err
+					}
+					a := fastAttempt{Round: round, Language: lang, Wire: wire, Attempt: attempt, Adequate: adequate, Raw: phase + ".csv"}
+					for _, row := range rows {
+						a.Metrics = append(a.Metrics, fastMetric{Path: row.cols[2], Iterations: row.iters, Rate: row.rate, Seconds: float64(row.iters) / row.rate, Bytes: row.bytes})
+					}
+					f.evidence.Attempts = append(f.evidence.Attempts, a)
+					if err := f.save(); err != nil {
+						return err
+					}
+					counts[key] = next
+					if adequate {
+						break
+					}
+					if attempt == 2 {
+						return fmt.Errorf("%s still has a sample below 200ms after three attempts", key)
+					}
+					n = next
+				}
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := checkBuildRevision(info.Revision, gitValue(".", "rev-parse", "HEAD")); err != nil {
+		return err
+	}
+	if err := verifyRecordedArtifacts(info); err != nil {
+		return err
+	}
+	// The owned diagnostic directory may live outside ignored build/. It is
+	// evidence, not a source change; every other tracked/untracked path counts.
+	statusArgs := []string{"status", "--porcelain", "--", "."}
+	if rel, err := filepath.Rel(abs("."), abs(tmp)); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		statusArgs = append(statusArgs, ":(exclude,top,literal)"+filepath.ToSlash(rel))
+	}
+	if gitValue(".", statusArgs...) != "" {
+		return errors.New("source changed during fast diagnostic")
+	}
+	if err := writeFastSummary(tmp, f.evidence); err != nil {
+		return err
+	}
+	f.evidence.Artifacts = map[string]string{}
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name() == "fast.json" {
+			continue
+		}
+		hash, err := hashFile(filepath.Join(tmp, entry.Name()))
+		if err != nil {
+			return err
+		}
+		f.evidence.Artifacts[entry.Name()] = hash
+	}
+	f.evidence.Status = "COMPLETED_NON_CERTIFIED_FAST_DIAGNOSTIC"
+	return nil
+}
+
+func writeFastSummary(dir string, e fastEvidence) error {
+	costs := map[string][]float64{}
+	for _, attempt := range e.Attempts {
+		if !attempt.Adequate {
+			continue
+		}
+		for _, m := range attempt.Metrics {
+			key := attempt.Language + "/" + attempt.Wire + "/" + m.Path
+			costs[key] = append(costs[key], 1e6/m.Rate)
+		}
+	}
+	median := map[string]float64{}
+	var text strings.Builder
+	fmt.Fprintf(&text, "# Fast iteration diagnostic — not certified\n\n%s\n\nOperator context: %s\n\n%d observed noise warnings; see fast.json and process-samples.jsonl. Every accepted sample is at least 200ms. Short attempts are retained but excluded below. Costs use the median of the adequate rounds; one round does not establish stability.\n\n| Language | Wire | Path | Median µs/op | Range µs/op |\n|---|---|---|---:|---:|\n", e.Qualification, e.Config.Noise, len(e.Noise))
+	for _, lang := range languages {
+		for _, wire := range []string{"packet", "table"} {
+			for _, path := range []string{"write", "round_trip"} {
+				key := lang + "/" + wire + "/" + path
+				values := costs[key]
+				if len(values) != e.Config.Rounds {
+					return fmt.Errorf("incomplete adequate fast pairs: %s", key)
+				}
+				sort.Float64s(values)
+				middle := len(values) / 2
+				v := values[middle]
+				if len(values)%2 == 0 {
+					v = (v + values[middle-1]) / 2
+				}
+				median[key] = v
+				fmt.Fprintf(&text, "| %s | %s | %s | %.3f | %.3f–%.3f |\n", names[lang], wire, path, v, values[0], values[len(values)-1])
+			}
+		}
+	}
+	fastest := math.Inf(1)
+	for _, lang := range languages {
+		fastest = math.Min(fastest, median[lang+"/table/round_trip"])
+	}
+	text.WriteString("\n| Language | Fixed Table % | vs Packet Wire % |\n|---|---:|---:|\n")
+	for _, lang := range languages {
+		table := median[lang+"/table/round_trip"]
+		fmt.Fprintf(&text, "| %s | %.1f%% | %.1f%% |\n", names[lang], 100*table/fastest, 100*table/median[lang+"/packet/round_trip"])
+	}
+	text.WriteString("\n" + checksDetails + "\n\nConfirmation remains the separate seven-round `-mode run` protocol. This directory has no confirmation seal.\n")
+	return os.WriteFile(filepath.Join(dir, "README.md"), []byte(text.String()), 0644)
+}

--- a/bench/paired/fast.go
+++ b/bench/paired/fast.go
@@ -20,6 +20,10 @@ import (
 const maximumFastIterations int64 = 2147483584 // whole 64-record rotations, also fits 32-bit long
 const fastMinimumSeconds = 0.2
 
+// Uniform escalation costs a whole group per attempt, so the bound is on
+// passes over the schedule, not on attempts by an individual leg.
+const fastPasses = 3
+
 type fastConfig struct {
 	Rounds           int           `json:"rounds"`
 	PacketIterations int64         `json:"initial_packet_iterations"`
@@ -49,7 +53,9 @@ func (c fastConfig) validate() error {
 func fastCommand(wire, lang string, round int, iterations int64) command {
 	args := []string{"--csv", "--round", strconv.Itoa(round), "--iterations", strconv.FormatInt(iterations, 10)}
 	if wire == "packet" {
-		args = append(args, "--quick") // retain BenchMixed; skip the unrelated bitpacker
+		// --quick keeps the one sanctioned mixed benchmark and drops only the
+		// separate bitpacker workload, which this pairing does not measure.
+		args = append(args, "--quick")
 	}
 	return runner(wire, lang, args...)
 }
@@ -80,6 +86,62 @@ func fastNextIterations(rows []sample, current int64) (int64, bool, error) {
 	return max(current+64, int64(next)), false, nil
 }
 
+// inadequateWires names the groups that never reached the floor, in the fixed
+// wire order rather than the map's.
+func inadequateWires(raised map[string]int64) string {
+	var named []string
+	for _, wire := range []string{"packet", "table"} {
+		if raised[wire] != 0 {
+			named = append(named, wire)
+		}
+	}
+	return strings.Join(named, " and ")
+}
+
+// fastSchedule measures every (round, language, wire) leg and settles on ONE
+// iteration count per wire. §2.1 fixes the count per benchmark, identical
+// across every language, and forbids auto-scaling in a cross-language row, so
+// escalation here is uniform and never per leg: when any leg of a wire's group
+// falls below the 200ms floor, the count for that whole group rises to the
+// largest count any of its legs needed and EVERY leg of the group is measured
+// again at it. Superseded attempts stay in the evidence and supply no row, so
+// a rendered table cannot mix counts. counts carries the final values out.
+func fastSchedule(langs []string, rounds int, counts map[string]int64, measure func(pass, round int, lang, wire string, n int64) (int64, bool, error)) error {
+	pending := map[string]bool{"packet": true, "table": true}
+	for pass := range fastPasses {
+		raised := map[string]int64{}
+		for round := range rounds {
+			for i := range langs {
+				languageIndex := (i + round) % len(langs)
+				lang := langs[languageIndex]
+				for _, wire := range fastWires(round, languageIndex) {
+					if !pending[wire] {
+						continue
+					}
+					next, adequate, err := measure(pass, round, lang, wire, counts[wire])
+					if err != nil {
+						return err
+					}
+					if !adequate {
+						raised[wire] = max(raised[wire], next)
+					}
+				}
+			}
+		}
+		if len(raised) == 0 {
+			return nil
+		}
+		if pass == fastPasses-1 {
+			return fmt.Errorf("%s still has a sample below 200ms after %d uniform attempts", inadequateWires(raised), fastPasses)
+		}
+		pending = map[string]bool{}
+		for wire, n := range raised {
+			counts[wire], pending[wire] = n, true
+		}
+	}
+	return nil
+}
+
 type fastMetric struct {
 	Path       string  `json:"path"`
 	Iterations int64   `json:"iterations"`
@@ -89,13 +151,14 @@ type fastMetric struct {
 }
 
 type fastAttempt struct {
-	Round    int          `json:"round"`
-	Language string       `json:"language"`
-	Wire     string       `json:"wire"`
-	Attempt  int          `json:"attempt"`
-	Adequate bool         `json:"adequate"`
-	Raw      string       `json:"raw"`
-	Metrics  []fastMetric `json:"metrics"`
+	Round      int          `json:"round"`
+	Language   string       `json:"language"`
+	Wire       string       `json:"wire"`
+	Attempt    int          `json:"attempt"`
+	Iterations int64        `json:"iterations"`
+	Adequate   bool         `json:"adequate"`
+	Raw        string       `json:"raw"`
+	Metrics    []fastMetric `json:"metrics"`
 }
 
 type fastCommandReceipt struct {
@@ -114,6 +177,7 @@ type fastEvidence struct {
 	Elapsed       float64              `json:"elapsed_seconds"`
 	Qualification string               `json:"qualification"`
 	Config        fastConfig           `json:"config"`
+	FinalCounts   map[string]int64     `json:"final_iterations_per_wire,omitempty"`
 	Build         buildInfo            `json:"build"`
 	Noise         []string             `json:"observed_noise"`
 	Commands      []fastCommandReceipt `json:"commands"`
@@ -168,7 +232,7 @@ func (f *fastCollector) capture(ctx context.Context, c command, phase string) (o
 	if err != nil {
 		return nil, err
 	}
-	defer log.Close()
+	defer func() { resultErr = errors.Join(resultErr, log.Close()) }()
 	cmd := exec.CommandContext(ctx, c.args[0], c.args[1:]...)
 	cmd.Dir = c.dir
 	cmd.WaitDelay = time.Second
@@ -231,7 +295,7 @@ func fastMeasure(langs []string, out string, info buildInfo, config fastConfig) 
 	if err != nil {
 		return err
 	}
-	f := fastCollector{dir: tmp, evidence: fastEvidence{Status: "INCOMPLETE_FAST_DIAGNOSTIC", Started: started.UTC().Format(time.RFC3339Nano), Config: config, Build: info, Qualification: "Non-certified diagnostic: reduced iterations and 1..3 rounds; no bracketing drift controls or quiet-window seal. Process samples can miss short or unusually named work. One full-count warmup per path is retained, but managed-runtime steady state still needs confirmation."}}
+	f := fastCollector{dir: tmp, evidence: fastEvidence{Status: "INCOMPLETE_FAST_DIAGNOSTIC", Started: started.UTC().Format(time.RFC3339Nano), Config: config, Build: info, Qualification: "Non-certified diagnostic: reduced iterations and 1..3 rounds; no bracketing drift controls or quiet-window seal. Process samples can miss short or unusually named work. One warmup per path is retained at the requested sample count, half the standard count at the defaults, so managed-runtime steady state still needs confirmation."}}
 	f.journal, err = os.Create(filepath.Join(tmp, "process-samples.jsonl"))
 	if err != nil {
 		return err
@@ -271,58 +335,38 @@ func fastMeasure(langs []string, out string, info buildInfo, config fastConfig) 
 			}
 		}
 	}
-	counts := map[string]int64{}
-	for round := range config.Rounds {
-		for i := range langs {
-			languageIndex := (i + round) % len(langs)
-			lang := langs[languageIndex]
-			wires := fastWires(round, languageIndex)
-			for _, wire := range wires {
-				key := lang + "/" + wire
-				n := counts[key]
-				if n == 0 {
-					n = config.PacketIterations
-					if wire == "table" {
-						n = config.TableIterations
-					}
-				}
-				for attempt := 0; attempt < 3; attempt++ {
-					phase := fmt.Sprintf("round-%d-%s-%s-attempt-%d", round, lang, wire, attempt)
-					fmt.Fprintln(os.Stderr, phase, "iterations", n)
-					data, runErr := f.capture(ctx, fastCommand(wire, lang, round, n), phase)
-					if err := os.WriteFile(filepath.Join(tmp, phase+".csv"), data, 0644); err != nil {
-						return errors.Join(runErr, err)
-					}
-					if runErr != nil {
-						return runErr
-					}
-					rows, err := parseRowsForIterations(data, lang, wire, info.CorpusIDs[wire], n, 0)
-					if err != nil {
-						return err
-					}
-					next, adequate, err := fastNextIterations(rows, n)
-					if err != nil {
-						return err
-					}
-					a := fastAttempt{Round: round, Language: lang, Wire: wire, Attempt: attempt, Adequate: adequate, Raw: phase + ".csv"}
-					for _, row := range rows {
-						a.Metrics = append(a.Metrics, fastMetric{Path: row.cols[2], Iterations: row.iters, Rate: row.rate, Seconds: float64(row.iters) / row.rate, Bytes: row.bytes})
-					}
-					f.evidence.Attempts = append(f.evidence.Attempts, a)
-					if err := f.save(); err != nil {
-						return err
-					}
-					counts[key] = next
-					if adequate {
-						break
-					}
-					if attempt == 2 {
-						return fmt.Errorf("%s still has a sample below 200ms after three attempts", key)
-					}
-					n = next
-				}
-			}
+	counts := map[string]int64{"packet": config.PacketIterations, "table": config.TableIterations}
+	err = fastSchedule(langs, config.Rounds, counts, func(pass, round int, lang, wire string, n int64) (int64, bool, error) {
+		phase := fmt.Sprintf("round-%d-%s-%s-attempt-%d", round, lang, wire, pass)
+		fmt.Fprintln(os.Stderr, phase, "iterations", n)
+		data, runErr := f.capture(ctx, fastCommand(wire, lang, round, n), phase)
+		if err := os.WriteFile(filepath.Join(tmp, phase+".csv"), data, 0644); err != nil {
+			return 0, false, errors.Join(runErr, err)
 		}
+		if runErr != nil {
+			return 0, false, runErr
+		}
+		rows, err := parseRowsForIterations(data, lang, wire, info.CorpusIDs[wire], n, 0)
+		if err != nil {
+			return 0, false, err
+		}
+		next, adequate, err := fastNextIterations(rows, n)
+		if err != nil {
+			return 0, false, err
+		}
+		a := fastAttempt{Round: round, Language: lang, Wire: wire, Attempt: pass, Iterations: n, Adequate: adequate, Raw: phase + ".csv"}
+		for _, row := range rows {
+			a.Metrics = append(a.Metrics, fastMetric{Path: row.cols[2], Iterations: row.iters, Rate: row.rate, Seconds: float64(row.iters) / row.rate, Bytes: row.bytes})
+		}
+		f.evidence.Attempts = append(f.evidence.Attempts, a)
+		return next, adequate, f.save()
+	})
+	if err != nil {
+		return err
+	}
+	f.evidence.FinalCounts = counts
+	if err := f.save(); err != nil {
+		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
@@ -364,10 +408,26 @@ func fastMeasure(langs []string, out string, info buildInfo, config fastConfig) 
 	return nil
 }
 
+// grouped writes an iteration count the way the prose does, 2,000,000 rather
+// than 2000000, so the stated count reads as the same number in both places.
+func grouped(n int64) string {
+	digits := strconv.FormatInt(n, 10)
+	var b strings.Builder
+	for i, r := range digits {
+		if i > 0 && (len(digits)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func writeFastSummary(dir string, e fastEvidence) error {
 	costs := map[string][]float64{}
 	for _, attempt := range e.Attempts {
-		if !attempt.Adequate {
+		// Only the final uniform count supplies rows; a superseded attempt is
+		// evidence of the escalation, not a measurement of this table.
+		if !attempt.Adequate || attempt.Iterations != e.FinalCounts[attempt.Wire] {
 			continue
 		}
 		for _, m := range attempt.Metrics {
@@ -377,7 +437,7 @@ func writeFastSummary(dir string, e fastEvidence) error {
 	}
 	median := map[string]float64{}
 	var text strings.Builder
-	fmt.Fprintf(&text, "# Fast iteration diagnostic — not certified\n\n%s\n\nOperator context: %s\n\n%d observed noise warnings; see fast.json and process-samples.jsonl. Every accepted sample is at least 200ms. Short attempts are retained but excluded below. Costs use the median of the adequate rounds; one round does not establish stability.\n\n| Language | Wire | Path | Median µs/op | Range µs/op |\n|---|---|---|---:|---:|\n", e.Qualification, e.Config.Noise, len(e.Noise))
+	fmt.Fprintf(&text, "# Fast iteration diagnostic — not certified\n\n%s\n\nOperator context: %s\n\n%d observed noise warnings; see fast.json and process-samples.jsonl. Every accepted sample is at least 200ms. Short attempts are retained but excluded below. Costs use the median of the adequate rounds; one round does not establish stability.\n\nOne iteration count per wire, identical across all four languages and every round (BENCH-STANDARD §2.1): %s Packet and %s Table operations per warmup and per measured sample. A short leg raised the count for its whole group, never for itself alone. At one round the Range column is degenerate — the single value is its own minimum and maximum — so it reads as zero variance by construction, not as measured stability.\n\n| Language | Wire | Path | Median µs/op | Range µs/op |\n|---|---|---|---:|---:|\n", e.Qualification, e.Config.Noise, len(e.Noise), grouped(e.FinalCounts["packet"]), grouped(e.FinalCounts["table"]))
 	for _, lang := range languages {
 		for _, wire := range []string{"packet", "table"} {
 			for _, path := range []string{"write", "round_trip"} {

--- a/bench/paired/fast_test.go
+++ b/bench/paired/fast_test.go
@@ -61,15 +61,18 @@ func TestFastCountPlanningRetainsAdequateSamples(t *testing.T) {
 }
 
 func TestFastSummaryUsesOnlyCompleteAdequatePairs(t *testing.T) {
-	e := fastEvidence{Config: fastConfig{Rounds: 1, Noise: "background recorded"}, Qualification: "Non-certified diagnostic"}
+	e := fastEvidence{Config: fastConfig{Rounds: 1, Noise: "background recorded"}, Qualification: "Non-certified diagnostic", FinalCounts: map[string]int64{"packet": 2000000, "table": 263168}}
 	for _, lang := range languages {
 		for _, wire := range []string{"packet", "table"} {
 			cost := float64(1)
 			if wire == "table" {
 				cost = 2
 			}
-			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Adequate: false, Metrics: []fastMetric{{Path: "write", Rate: 1e9}}})
-			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Adequate: true, Metrics: []fastMetric{{Path: "write", Rate: 1e6 / cost}, {Path: "round_trip", Rate: 1e6 / cost}}})
+			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Iterations: e.FinalCounts[wire], Adequate: false, Metrics: []fastMetric{{Path: "write", Rate: 1e9}}})
+			// An adequate attempt at a superseded count is evidence of the
+			// group's escalation and must not supply a row.
+			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Iterations: 100, Adequate: true, Metrics: []fastMetric{{Path: "write", Rate: 1e9}, {Path: "round_trip", Rate: 1e9}}})
+			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Iterations: e.FinalCounts[wire], Adequate: true, Metrics: []fastMetric{{Path: "write", Rate: 1e6 / cost}, {Path: "round_trip", Rate: 1e6 / cost}}})
 		}
 	}
 	dir := t.TempDir()
@@ -83,6 +86,11 @@ func TestFastSummaryUsesOnlyCompleteAdequatePairs(t *testing.T) {
 	if !strings.Contains(string(b), "| C++ | 100.0% | 200.0% |") || !strings.Contains(string(b), "not certified") {
 		t.Fatal(string(b))
 	}
+	// The one count per wire is stated once, and the one-round Range column
+	// names itself degenerate rather than passing as measured stability.
+	if !strings.Contains(string(b), "2,000,000 Packet and 263,168 Table operations") || !strings.Contains(string(b), "Range column is degenerate") {
+		t.Fatal(string(b))
+	}
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -93,5 +101,63 @@ func TestFastSummaryUsesOnlyCompleteAdequatePairs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(names, []string{"README.md"}) {
 		t.Fatal("fast summary created confirmation evidence", names)
+	}
+}
+
+// One slow leg must not give itself a private iteration count. §2.1 requires
+// the count to be identical across every language of a cross-language row, so
+// the whole group is re-measured and every leg of the finished table reports
+// the same number.
+func TestFastScheduleEscalatesEveryLegOfTheGroup(t *testing.T) {
+	counts := map[string]int64{"packet": 2000000, "table": 200000}
+	const adequateTable int64 = 263168
+	measured := map[string][]int64{}
+	final := map[string]int64{}
+	err := fastSchedule(languages, 1, counts, func(pass, round int, lang, wire string, n int64) (int64, bool, error) {
+		key := lang + "/" + wire
+		measured[key] = append(measured[key], n)
+		// C# on the table wire is the slow leg: below the floor until the
+		// count reaches adequateTable. Every other leg is already adequate.
+		if lang == "cs" && wire == "table" && n < adequateTable {
+			return adequateTable, false, nil
+		}
+		final[key] = n
+		return n, true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["table"] != adequateTable || counts["packet"] != 2000000 {
+		t.Fatalf("final counts: %v", counts)
+	}
+	for _, lang := range languages {
+		if got := final[lang+"/table"]; got != adequateTable {
+			t.Fatalf("%s finished the table group at %d, not the group's %d", lang, got, adequateTable)
+		}
+		if got := final[lang+"/packet"]; got != 2000000 {
+			t.Fatalf("%s finished the packet group at %d", lang, got)
+		}
+		// The adequate group is not disturbed by the other group's raise.
+		if got := measured[lang+"/packet"]; len(got) != 1 {
+			t.Fatalf("%s packet was measured %d times: %v", lang, len(got), got)
+		}
+		if got := measured[lang+"/table"]; len(got) != 2 || got[0] != 200000 || got[1] != adequateTable {
+			t.Fatalf("%s table attempts: %v", lang, got)
+		}
+	}
+}
+
+func TestFastScheduleRefusesAPermanentlyShortLeg(t *testing.T) {
+	counts := map[string]int64{"packet": 2000000, "table": 200000}
+	passes := 0
+	err := fastSchedule(languages, 1, counts, func(pass, round int, lang, wire string, n int64) (int64, bool, error) {
+		if lang == "go" && wire == "packet" {
+			passes = pass + 1
+			return n + 64, false, nil
+		}
+		return n, true, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "packet") || passes != fastPasses {
+		t.Fatalf("%v after %d passes", err, passes)
 	}
 }

--- a/bench/paired/fast_test.go
+++ b/bench/paired/fast_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFastCommandsKeepCompleteCorpusAndWarmup(t *testing.T) {
+	config := fastConfig{Rounds: 1, PacketIterations: 2000000, TableIterations: 200000, Timeout: time.Minute, Noise: "ordinary diagnostic"}
+	if err := config.validate(); err != nil {
+		t.Fatal(err)
+	}
+	for _, lang := range languages {
+		for _, wire := range []string{"packet", "table"} {
+			n := config.PacketIterations
+			if wire == "table" {
+				n = config.TableIterations
+			}
+			got := fastCommand(wire, lang, 0, n)
+			if !strings.Contains(strings.Join(got.args, " "), "--round 0 --iterations ") {
+				t.Fatal(got.args)
+			}
+			if contains(got.args, "--quick") != (wire == "packet") || contains(got.args, "--indexed") != (wire == "table") {
+				t.Fatal(got.args)
+			}
+			if n%64 != 0 {
+				t.Fatal("partial corpus rotation")
+			}
+		}
+	}
+	for index := range languages {
+		first, second := fastWires(0, index), fastWires(1, index)
+		if first[0] != second[1] || first[1] != second[0] {
+			t.Fatal("wire order did not alternate")
+		}
+	}
+}
+
+func TestFastCountPlanningRetainsAdequateSamples(t *testing.T) {
+	// Ordinary CSV accounting values: the fast path retains the same identity
+	// and checks parser while allowing an explicitly requested whole rotation.
+	data := fixtureRow("c", "packet", "write", 4000000) + fixtureRow("c", "packet", "round_trip", 2000000)
+	data = strings.ReplaceAll(data, ",4000000,320,", ",2000000,320,")
+	rows, err := parseRowsForIterations([]byte(data), "c", "packet", "packet", 2000000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, adequate, err := fastNextIterations(rows, 2000000)
+	if err != nil || !adequate || n != 2000000 {
+		t.Fatalf("adequate sample changed: %d %v %v", n, adequate, err)
+	}
+	rows[0].rate = 16000000 // 125ms at the same valid count; increase to250ms
+	n, adequate, err = fastNextIterations(rows, 2000000)
+	if err != nil || adequate || n != 4000000 || n%64 != 0 {
+		t.Fatalf("count plan: %d %v %v", n, adequate, err)
+	}
+}
+
+func TestFastSummaryUsesOnlyCompleteAdequatePairs(t *testing.T) {
+	e := fastEvidence{Config: fastConfig{Rounds: 1, Noise: "background recorded"}, Qualification: "Non-certified diagnostic"}
+	for _, lang := range languages {
+		for _, wire := range []string{"packet", "table"} {
+			cost := float64(1)
+			if wire == "table" {
+				cost = 2
+			}
+			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Adequate: false, Metrics: []fastMetric{{Path: "write", Rate: 1e9}}})
+			e.Attempts = append(e.Attempts, fastAttempt{Language: lang, Wire: wire, Adequate: true, Metrics: []fastMetric{{Path: "write", Rate: 1e6 / cost}, {Path: "round_trip", Rate: 1e6 / cost}}})
+		}
+	}
+	dir := t.TempDir()
+	if err := writeFastSummary(dir, e); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "| C++ | 100.0% | 200.0% |") || !strings.Contains(string(b), "not certified") {
+		t.Fatal(string(b))
+	}
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, f := range files {
+		names = append(names, f.Name())
+	}
+	if !reflect.DeepEqual(names, []string{"README.md"}) {
+		t.Fatal("fast summary created confirmation evidence", names)
+	}
+}

--- a/bench/paired/main.go
+++ b/bench/paired/main.go
@@ -431,6 +431,14 @@ type sample struct {
 }
 
 func parseRows(data []byte, lang, wire, id string) ([]sample, error) {
+	iterations := int64(4000000)
+	if wire == "table" {
+		iterations = 400000
+	}
+	return parseRowsForIterations(data, lang, wire, id, iterations, 0.2)
+}
+
+func parseRowsForIterations(data []byte, lang, wire, id string, wantIterations int64, minimumSeconds float64) ([]sample, error) {
 	r := csv.NewReader(bytes.NewReader(data))
 	r.FieldsPerRecord = -1
 	rows := []sample{}
@@ -472,14 +480,10 @@ func parseRows(data []byte, lang, wire, id string) ([]sample, error) {
 			return nil, errors.New("invalid bytes/op")
 		}
 		iters, e := strconv.ParseInt(cols[3], 10, 64)
-		wantIterations := int64(4000000)
-		if wire == "table" {
-			wantIterations = 400000
-		}
 		if e != nil || iters != wantIterations {
-			return nil, errors.New("iterations must be 4,000,000 packet or 400,000 table operations")
+			return nil, fmt.Errorf("iterations must match requested count %d", wantIterations)
 		}
-		if float64(iters)/rate < 0.2 {
+		if float64(iters)/rate < minimumSeconds {
 			return nil, fmt.Errorf("%s/%s/%s measured run below 200ms", lang, wire, cols[2])
 		}
 		if cols[6] != cols[8] || cols[7] != cols[8] {
@@ -789,12 +793,17 @@ func renderReport(dir string, writeOutputs bool) error {
 	return nil
 }
 func main() {
-	mode := flag.String("mode", "gate", "build, gate, run, or render")
+	mode := flag.String("mode", "gate", "build, gate, fast diagnostic, run confirmation, or render")
 	out := flag.String("out", "", "new results directory (or existing directory for render)")
 	langsFlag := flag.String("langs", "cpp,c,go,cs", "comma-separated required build/gate languages")
 	rounds := flag.Int("rounds", 7, "interleaved measured rounds")
 	reuse := flag.Bool("reuse-build", false, "use previously hashed binaries and corpus")
 	receipt := flag.String("quiet-window", "", "operator READY/START receipt or reference, required for run")
+	fastRounds := flag.Int("fast-rounds", 1, "complete diagnostic rounds (1..3), fast mode only")
+	packetIters := flag.Int64("packet-iters", 2000000, "initial Packet iterations per warmup/sample, fast mode only")
+	tableIters := flag.Int64("table-iters", 200000, "initial Table iterations per warmup/sample, fast mode only")
+	fastTimeout := flag.Duration("fast-timeout", 5*time.Minute, "whole fast-mode deadline, at most 5m including gates")
+	noise := flag.String("noise-note", "uncontrolled diagnostic; no quiet-window claim", "operator context recorded by fast mode")
 	flag.Parse()
 	fail := func(e error) { fmt.Fprintln(os.Stderr, "paired:", e); os.Exit(1) }
 	if _, e := os.Stat("bench/corpus/Bench.schema"); e != nil {
@@ -814,13 +823,22 @@ func main() {
 		}
 		return
 	}
-	if *mode != "build" && *mode != "gate" && *mode != "run" {
+	if *mode != "build" && *mode != "gate" && *mode != "run" && *mode != "fast" {
 		fail(errors.New("unknown mode"))
 	}
 	if *mode == "run" && strings.TrimSpace(*receipt) == "" {
 		fail(errors.New("run requires -quiet-window with the operator’s READY/START receipt or reference"))
 	}
-	if !*reuse {
+	fast := fastConfig{Rounds: *fastRounds, PacketIterations: *packetIters, TableIterations: *tableIters, Timeout: *fastTimeout, Noise: *noise}
+	if *mode == "fast" {
+		if len(langs) != 4 {
+			fail(errors.New("fast mode requires all four languages"))
+		}
+		if e := fast.validate(); e != nil {
+			fail(e)
+		}
+	}
+	if !*reuse && *mode != "fast" {
 		if e := generateAndBuild(langs); e != nil {
 			fail(e)
 		}
@@ -828,6 +846,12 @@ func main() {
 	info, e := readBuild()
 	if e != nil {
 		fail(e)
+	}
+	if *mode == "fast" {
+		if e := fastMeasure(langs, *out, info, fast); e != nil {
+			fail(e)
+		}
+		return
 	}
 	if *mode == "build" {
 		return

--- a/bench/paired/window.go
+++ b/bench/paired/window.go
@@ -240,8 +240,12 @@ type quietWindow struct {
 }
 
 func windowSnapshot(phase string) (windowSample, error) {
+	return windowSnapshotContext(context.Background(), phase)
+}
+
+func windowSnapshotContext(parent context.Context, phase string) (windowSample, error) {
 	sample := windowSample{Date: time.Now().UTC().Format(time.RFC3339Nano), Phase: phase}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "ps", "-A", "-o", "pid=,ppid=,pcpu=,stat=,comm=")
 	cmd.Env = append(os.Environ(), "LC_ALL=C")
@@ -254,7 +258,7 @@ func windowSnapshot(phase string) (windowSample, error) {
 		return sample, err
 	}
 	if runtime.GOOS == "darwin" {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 		defer cancel()
 		data, err = exec.CommandContext(ctx, "sysctl", "-n", "vm.loadavg").Output()
 	} else {

--- a/bench/tables/c/table_main.c
+++ b/bench/tables/c/table_main.c
@@ -60,6 +60,7 @@ static double time_now( void )
 
 #define MaxNumRuns 7      /* median of 7 (N >= 5), after 1 warmup run */
 #define NumVariants 64    /* read-path variant buffers */
+static long g_iterations = 0; /* explicit diagnostic count; defaults stay standard */
 static int g_num_runs = MaxNumRuns; /* --round K drops this to 1 (§2.4) */
 
 #if defined( NDEBUG )
@@ -349,7 +350,7 @@ static int bench_load( TableMixed * value, const uint8_t * bytes, int64_t size )
 
 static void bench_table( const char * name, const char * golden, long base_iters )
 {
-    const long iters = base_iters / IterScale;
+    const long iters = g_iterations ? g_iterations : base_iters / IterScale;
     const double bytes_per_op = load_variants( name );
     double write_rates[MaxNumRuns];
     double roundtrip_rates[MaxNumRuns];
@@ -468,6 +469,17 @@ int main( int argc, char ** argv )
         else if ( strcmp( argv[i], "--csv" ) == 0 ) { g_csv = 1; }
         else if ( strcmp( argv[i], "--wire-dir" ) == 0 && i + 1 < argc ) { g_wire_dir = argv[++i]; }
         else if ( strcmp( argv[i], "--variant-dir" ) == 0 && i + 1 < argc ) { g_variant_dir = argv[++i]; }
+        else if ( strcmp( argv[i], "--iterations" ) == 0 && i + 1 < argc )
+        {
+            char * end = NULL;
+            long n = strtol( argv[++i], &end, 10 );
+            if ( end == argv[i] || *end != '\0' || n <= 0 || n > 2147483584L || n % NumVariants != 0 )
+            {
+                fprintf( stderr, "--iterations requires a positive multiple of 64 up to 2147483584\n" );
+                return 1;
+            }
+            g_iterations = n;
+        }
         else if ( strcmp( argv[i], "--round" ) == 0 && i + 1 < argc )
         {
             char * end = NULL;
@@ -481,7 +493,7 @@ int main( int argc, char ** argv )
         }
         else
         {
-            fprintf( stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--iterations N] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/tables/cpp/table_main.cpp
+++ b/bench/tables/cpp/table_main.cpp
@@ -64,6 +64,7 @@ inline double time_now()
 }
 
 const int MaxNumRuns = 7;           // median of 7 (N >= 5), after 1 warmup run
+static long g_iterations = 0; /* explicit diagnostic count; defaults stay standard */
 static int g_num_runs = MaxNumRuns; // --round K drops this to 1 (§2.4)
 const int NumVariants = 64;         // read-path variant buffers
 
@@ -281,7 +282,7 @@ template <typename T, typename ResetFn, typename SaveFn, typename LoadFn>
 static void bench_table( const char * name, const char * golden, long base_iters,
                          ResetFn reset_fn, SaveFn save_fn, LoadFn load_fn )
 {
-    const long iters = base_iters / IterScale;
+    const long iters = g_iterations ? g_iterations : base_iters / IterScale;
 
     const double bytes_per_op = load_variants( name );
     if ( bytes_per_op < 0 )
@@ -419,6 +420,17 @@ int main( int argc, char ** argv )
             g_wire_dir = argv[++i];
         else if ( strcmp( argv[i], "--variant-dir" ) == 0 && i + 1 < argc )
             g_variant_dir = argv[++i];
+        else if ( strcmp( argv[i], "--iterations" ) == 0 && i + 1 < argc )
+        {
+            char * end = NULL;
+            long n = strtol( argv[++i], &end, 10 );
+            if ( end == argv[i] || *end != '\0' || n <= 0 || n > 2147483584L || n % NumVariants != 0 )
+            {
+                fprintf( stderr, "--iterations requires a positive multiple of 64 up to 2147483584\n" );
+                return 1;
+            }
+            g_iterations = n;
+        }
         else if ( strcmp( argv[i], "--round" ) == 0 && i + 1 < argc )
         {
             char * end = NULL;
@@ -432,7 +444,7 @@ int main( int argc, char ** argv )
         }
         else
         {
-            fprintf( stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
+            fprintf( stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--iterations N] [--wire-dir <dir>] [--variant-dir <dir>]\n", argv[0] );
             return 1;
         }
     }

--- a/bench/tables/cs/src/Program.cs
+++ b/bench/tables/cs/src/Program.cs
@@ -40,6 +40,7 @@ static class Program
     const int MaxNumRuns = 7;           // median of 7 (N >= 5), after 1 warmup run
     static bool gIndexed;
     static readonly int[] gLengths = new int[NumVariants];
+    static long gIterations = 0; // explicit diagnostic count; defaults stay standard
     static int gNumRuns = MaxNumRuns;   // --round K drops this to 1 (§2.4)
     const int NumVariants = 64;         // read-path variant buffers
 
@@ -238,7 +239,7 @@ static class Program
                               Func<T> make, ResetOf<T> reset, SaveOf<T> save, LoadOf<T> load)
         where T : class
     {
-        long iters = baseIters;
+        long iters = gIterations > 0 ? gIterations : baseIters;
 
         double bytesPerOp = LoadVariants(name);
         if (bytesPerOp < 0)
@@ -400,6 +401,15 @@ static class Program
             {
                 gVariantDir = args[++i];
             }
+            else if (args[i] == "--iterations" && i + 1 < args.Length)
+            {
+                if (!long.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out long n) || n <= 0 || n > 2147483584L || n % NumVariants != 0)
+                {
+                    Console.Error.WriteLine("--iterations requires a positive multiple of 64 up to 2147483584");
+                    return 1;
+                }
+                gIterations = n;
+            }
             else if (args[i] == "--round" && i + 1 < args.Length)
             {
                 if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out int k) || k < 0)
@@ -411,7 +421,7 @@ static class Program
             }
             else
             {
-                Console.Error.WriteLine("usage: schematablesbench [--indexed] [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]");
+                Console.Error.WriteLine("usage: schematablesbench [--indexed] [--gate] [--csv] [--round K] [--iterations N] [--wire-dir <dir>] [--variant-dir <dir>]");
                 return 1;
             }
         }

--- a/bench/tables/go/table_main.go
+++ b/bench/tables/go/table_main.go
@@ -44,6 +44,7 @@ import (
 
 // sink defeats dead-code elimination of the computed lengths. It is written
 // every iteration and read once at the end.
+var iterations int64 // explicit diagnostic count; zero keeps the standard count
 var sink uint64
 
 const (
@@ -219,6 +220,9 @@ func loadVariants(name string) float64 {
 func benchTable[T any](name, golden string, baseIters int64,
 	reset func(*T), save func(*T, []byte) int64, load func(*T, []byte) bool) {
 	iters := baseIters
+	if iterations > 0 {
+		iters = iterations
+	}
 
 	bytesPerOp := loadVariants(name)
 	if bytesPerOp < 0 {
@@ -352,6 +356,14 @@ func main() {
 		case args[i] == "--variant-dir" && i+1 < len(args):
 			i++
 			variantDir = args[i]
+		case args[i] == "--iterations" && i+1 < len(args):
+			i++
+			n, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil || n <= 0 || n > 2147483584 || n%64 != 0 {
+				fmt.Fprintln(os.Stderr, "--iterations requires a positive multiple of 64 up to 2147483584")
+				os.Exit(1)
+			}
+			iterations = n
 		case args[i] == "--round" && i+1 < len(args):
 			i++
 			if k, err := strconv.ParseInt(args[i], 10, 64); err != nil || k < 0 {
@@ -360,7 +372,7 @@ func main() {
 			}
 			numRuns = 1
 		default:
-			fmt.Fprintf(os.Stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--wire-dir <dir>] [--variant-dir <dir>]\n", os.Args[0])
+			fmt.Fprintf(os.Stderr, "usage: %s [--indexed] [--gate] [--csv] [--round K] [--iterations N] [--wire-dir <dir>] [--variant-dir <dir>]\n", os.Args[0])
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
Routine seven-round profiling delayed team feedback by over12minutes. Add a cached fast mode that runs the same64 logical records and correctness gates, retains one warmup per path, and reports one matched C/C++/Go/C# Packet/Table round as diagnostic data. Counts adapt only when a sample falls below200ms; preserve attempts and cap the gate/runner budget. Existing confirmation defaults and seal stay unchanged.

Paired tests/vet, all-eight ARM builds/gates and iteration-override gates passed; all-eight Linux x64 gates passed. First Space calibration completed in44.25seconds including hashing, gates, warmups and bookkeeping, with16 adequate samples and no retries. Independent source review requested from Johnny. This timing demonstrates workflow duration, not stable codec gains; the outer wall measurement covers bookkeeping outside the runner deadline.
