### PR TITLE
ctable: count warm scalar reference bytes during sizing

### DIFF
--- a/compiler/ctablewarmid_test.go
+++ b/compiler/ctablewarmid_test.go
@@ -1,0 +1,279 @@
+// THE WARM SCALAR-LEAF MEASURE IN C, COUNTED AT BOTH BRANCHES
+// (docs/SPEC-TABLES.md §3).
+//
+// A plain scalar leaf's measure has two ways to count the same body. The COLD
+// loop walks the riding fields, interning each field id through
+// table_writer_id_at and adding the kind and payload bytes. The WARM branch
+// counts the riding references — one byte each — with their payloads and
+// advances the measuring writer once, and it may only run when EVERY field id
+// of the leaf is already interned in this writer's vocabulary, the unit's
+// vocabulary is small enough that a reference is one byte, and the whole body
+// fits the remaining capacity.
+//
+// THE TWO BRANCHES MUST PRODUCE THE SAME NUMBER, and no byte the emitter
+// writes says which one ran — that is the point of the change and also the
+// reason a byte pin cannot hold it. So this fixture COUNTS THE ENTRIES. The
+// generated header is compiled with a counter bumped at the head of each
+// branch, and each case names which branch every leaf body must take:
+//
+//   - ALL FIELDS INTERNED takes the warm branch. Root's `second` Leaf is
+//     measured after `first` has interned a, b and c, and rows[1..] after
+//     rows[0] has interned p and q;
+//   - A FIELD NOT YET INTERNED takes the cold loop, whatever else is warm.
+//     The same file with Leaf's c and Row's q left at their defaults in every
+//     body — an elided field interns nothing — leaves slot[c] and slot[q]
+//     empty, and all five bodies must fall through to the cold walk.
+//
+// Both shapes ride here on purpose: Leaf is a scalar TABLE FIELD, so it is a
+// default-probe target and its measure opens on `!w->check_default`; Row is
+// only ever an ARRAY ELEMENT, which no probe reaches, so after #810 its
+// measure opens on the buffer alone. The warm branch hangs off both.
+//
+// The instrumentation is injected into the generated text inside this test and
+// never touches a tracked file; the injection is checked to have applied, so a
+// counter that stopped matching the emitter fails loudly instead of reporting
+// zero.
+package compiler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const cWarmIdSchema = `package warmid
+
+// a scalar leaf reached as a scalar table field: a default probe target
+table Leaf
+{
+    a int32
+    b float32
+    c uint8
+}
+
+// a scalar leaf reached only as an array element: no probe can set check_default
+table Row
+{
+    p int32
+    q int32
+}
+
+table Root
+{
+    first  Leaf
+    second Leaf
+    rows   [..8]Row
+    n      int32
+}
+`
+
+// The head of each branch of emitWireScalarLeafMeasure, in
+// internal/codegen/ctable/wire.go.
+const (
+	cWarmIdWarmHead = "            int64_t body_bytes = 1;\n"
+	cWarmIdColdHead = "        int64_t payload_bytes = 1; /* the zero reference ending this body */\n"
+)
+
+// cWarmIdInstrument bumps a counter at the head of each measure branch. It
+// answers the patched files and the number of leaf bodies the emitter wrote a
+// warm branch for, so a header that grew no warm branch at all cannot be read
+// as a leaf that declined to take one.
+func cWarmIdInstrument(t *testing.T, files map[string][]byte) (map[string][]byte, int) {
+	t.Helper()
+	out := map[string][]byte{}
+	warmSites, coldSites := 0, 0
+	for name, data := range files {
+		text := string(data)
+		if strings.HasSuffix(name, ".h") {
+			warmSites += strings.Count(text, cWarmIdWarmHead)
+			coldSites += strings.Count(text, cWarmIdColdHead)
+			text = strings.ReplaceAll(text, cWarmIdWarmHead, cWarmIdWarmHead+"            schema_warm_entries++;\n")
+			text = strings.ReplaceAll(text, cWarmIdColdHead, cWarmIdColdHead+"        schema_cold_entries++;\n")
+			text = "extern long schema_warm_entries;\nextern long schema_cold_entries;\n" + text
+		}
+		out[name] = []byte(text)
+	}
+	if warmSites == 0 {
+		t.Fatal("the generated C carries no warm scalar-leaf branch: this fixture would count nothing")
+	}
+	if coldSites == 0 {
+		t.Fatal("the generated C carries no cold scalar-leaf walk: this fixture would count nothing")
+	}
+	return out, warmSites
+}
+
+func cWarmIdDriver() string {
+	return `#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+long schema_warm_entries = 0;
+long schema_cold_entries = 0;
+
+#include "ProbeTable.h"
+
+static uint8_t buffer[ 8192 ];
+static uint8_t twin[ 8192 ];
+static Root value;
+static Root back;
+
+/* interned = 1: every leaf field rides, so the first body of each shape
+   interns every id that shape names and the bodies after it find them all.
+   interned = 0: ONE field of each shape -- Leaf's c, Row's q -- stays at its
+   default in every body. An elided field interns nothing, so slot[c] and
+   slot[q] are never filled and no body of either shape can go warm, however
+   many bodies the file carries. */
+static void build( Root * v, int interned )
+{
+    int32_t i;
+
+    root_reset( v );
+
+    v->first.a = 1;
+    v->first.b = 2.5f;
+    v->first.c = interned ? 3 : 0;   /* 0 is c's default: the field elides */
+
+    v->second.a = 4;
+    v->second.b = 5.5f;
+    v->second.c = interned ? 6 : 0;
+
+    v->rows_count = 3;
+    for ( i = 0; i < v->rows_count; i++ )
+    {
+        v->rows[ i ].p = 7 + i;
+        v->rows[ i ].q = interned ? 20 + i : 0;  /* 0 is q's default */
+    }
+
+    v->n = 13;
+}
+
+/* one measure, with the counters zeroed around it */
+static int64_t counted_measure( const Root * v, long * warm, long * cold )
+{
+    int64_t measured;
+    schema_warm_entries = 0;
+    schema_cold_entries = 0;
+    measured = root_measure( v );
+    *warm = schema_warm_entries;
+    *cold = schema_cold_entries;
+    return measured;
+}
+
+static int run( int interned )
+{
+    long warm = 0, cold = 0;
+    int64_t measured, wrote, again;
+    TableReport report;
+
+    build( &value, interned );
+    measured = counted_measure( &value, &warm, &cold );
+    printf( "interned=%d measure=%lld warm=%ld cold=%ld\n",
+            interned, (long long) measured, warm, cold );
+
+    /* whichever branch counted the body, the file has to agree with it */
+    wrote = root_save( &value, buffer, (int64_t) sizeof( buffer ) );
+    if ( wrote < 0 || wrote != measured )
+    {
+        printf( "MEASURE/SAVE DISAGREE save %lld measure %lld\n",
+                (long long) wrote, (long long) measured );
+        return 1;
+    }
+    memset( &report, 0, sizeof( report ) );
+    if ( !root_load( &back, buffer, wrote, &report ) )
+    {
+        printf( "LOAD FAILED\n" );
+        return 1;
+    }
+    if ( back.second.a != 4 || back.second.b != 5.5f || back.rows_count != 3 ||
+         back.rows[ 2 ].p != 9 || back.n != 13 ||
+         back.first.c != value.first.c || back.rows[ 2 ].q != value.rows[ 2 ].q )
+    {
+        printf( "VALUES MOVED\n" );
+        return 1;
+    }
+    again = root_save( &back, twin, (int64_t) sizeof( twin ) );
+    if ( again != wrote || memcmp( twin, buffer, (size_t) wrote ) != 0 )
+    {
+        printf( "ROUND TRIP MOVED\n" );
+        return 1;
+    }
+
+    /* AND THE SHORT BUFFER: the warm branch's room guard must hand a body one
+       byte short of its own maximum back to the cold walk, which is the path
+       that raises overflow. A save into a buffer that cannot hold the file
+       must answer -1, not a short file. */
+    if ( root_save( &value, buffer, wrote - 1 ) != -1 )
+    {
+        printf( "SHORT BUFFER ACCEPTED\n" );
+        return 1;
+    }
+    return 0;
+}
+
+int main( void )
+{
+    if ( run( 1 ) != 0 ) { return 1; }
+    if ( run( 0 ) != 0 ) { return 1; }
+    printf( "OK\n" );
+    return 0;
+}
+`
+}
+
+// TestCTableWarmIdBranches holds the warm scalar-leaf measure to the two
+// conditions it claims: every field id interned takes it, and one id missing
+// sends the same body back to the cold walk.
+func TestCTableWarmIdBranches(t *testing.T) {
+	files, err := New().Generate(unitFromSource(t, cWarmIdSchema), "c", Options{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	header := string(files["ProbeTable.h"])
+	// the two openings this fixture rides on, one per probe reachability
+	for _, want := range []string{
+		"    if ( w->buffer == NULL && !w->check_default )\n",
+		"    if ( w->buffer == NULL )\n",
+	} {
+		if !strings.Contains(header, want) {
+			t.Fatalf("the generated C no longer opens a scalar leaf measure with %q: this fixture would not cover both shapes", strings.TrimSpace(want))
+		}
+	}
+	patched, warmSites := cWarmIdInstrument(t, files)
+	out := runCRefOrdinal(t, patched, cWarmIdDriver(), "cwarmid",
+		"the counted measure refused its own value")
+
+	want := []string{
+		// Leaf: `first` interns a, b, c cold, `second` finds all three warm.
+		// Row: rows[0] interns p and q cold, rows[1] and rows[2] go warm.
+		"interned=1 measure=" + cWarmIdMeasure(out, 1) + " warm=3 cold=2",
+		// Leaf's c and Row's q elide in every body, so slot[c] and slot[q]
+		// are never filled and all five bodies fall through to the cold walk.
+		"interned=0 measure=" + cWarmIdMeasure(out, 0) + " warm=0 cold=5",
+	}
+	for _, line := range want {
+		if !strings.Contains(out, line+"\n") {
+			t.Fatalf("THE MEASURE TOOK THE WRONG BRANCH\n  want: %s\n   got:\n%s", line, out)
+		}
+	}
+	if !strings.Contains(out, "OK\n") {
+		t.Fatalf("the driver did not finish:\n%s", out)
+	}
+	t.Logf("%d warm branches emitted; counts: %s", warmSites, strings.TrimSpace(out))
+}
+
+// cWarmIdMeasure lifts the measured length the driver printed for one case.
+// The LENGTH is not what this test pins — compiler/ctablerefordinal_test.go
+// and the goldens hold the bytes — the BRANCH COUNTS beside it are.
+func cWarmIdMeasure(out string, interned int) string {
+	prefix := fmt.Sprintf("interned=%d measure=", interned)
+	for line := range strings.SplitSeq(out, "\n") {
+		rest, ok := strings.CutPrefix(line, prefix)
+		if !ok {
+			continue
+		}
+		if measure, _, found := strings.Cut(rest, " "); found {
+			return measure
+		}
+	}
+	return "?"
+}

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -3402,6 +3402,14 @@ static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat 
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[38] >= 0 && w->vocabulary->slot[21] >= 0 && 10 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->stat_id == 0 ) ) { body_bytes += 3; }
+            if ( !( value->delta == 0 ) ) { body_bytes += 6; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->stat_id == 0 ) )
         {
@@ -3735,6 +3743,16 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[59] >= 0 && w->vocabulary->slot[36] >= 0 && w->vocabulary->slot[1] >= 0 && w->vocabulary->slot[6] >= 0 && 20 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->target_id == 0 ) ) { body_bytes += 4; }
+            if ( !( value->damage == 0 ) ) { body_bytes += 6; }
+            if ( !( value->hit_kind == 0 ) ) { body_bytes += 6; }
+            if ( !( value->crit == 0 ) ) { body_bytes += 3; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->target_id == 0 ) )
         {
@@ -4281,6 +4299,14 @@ static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const Mixe
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[54] >= 0 && w->vocabulary->slot[76] >= 0 && 11 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->channel == 0 ) ) { body_bytes += 6; }
+            if ( !( value->speaker == 0 ) ) { body_bytes += 4; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->channel == 0 ) )
         {
@@ -4650,6 +4676,14 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const Mi
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[48] >= 0 && w->vocabulary->slot[39] >= 0 && 11 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->item_id == 0 ) ) { body_bytes += 4; }
+            if ( !( value->amount == 0 ) ) { body_bytes += 6; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->item_id == 0 ) )
         {

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -3462,6 +3462,14 @@ static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat 
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[42] >= 0 && w->vocabulary->slot[23] >= 0 && 10 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->stat_id == 0 ) ) { body_bytes += 3; }
+            if ( !( value->delta == 0 ) ) { body_bytes += 6; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->stat_id == 0 ) )
         {
@@ -6703,6 +6711,16 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[60] >= 0 && w->vocabulary->slot[40] >= 0 && w->vocabulary->slot[1] >= 0 && w->vocabulary->slot[6] >= 0 && 20 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->target_id == 0 ) ) { body_bytes += 4; }
+            if ( !( value->damage == 0 ) ) { body_bytes += 6; }
+            if ( !( value->hit_kind == 0 ) ) { body_bytes += 6; }
+            if ( !( value->crit == 0 ) ) { body_bytes += 3; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->target_id == 0 ) )
         {
@@ -7249,6 +7267,14 @@ static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const Tabl
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[56] >= 0 && w->vocabulary->slot[75] >= 0 && 11 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->channel == 0 ) ) { body_bytes += 6; }
+            if ( !( value->speaker == 0 ) ) { body_bytes += 4; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->channel == 0 ) )
         {
@@ -7618,6 +7644,14 @@ static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const Ta
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[51] >= 0 && w->vocabulary->slot[43] >= 0 && 11 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->item_id == 0 ) ) { body_bytes += 4; }
+            if ( !( value->amount == 0 ) ) { body_bytes += 6; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->item_id == 0 ) )
         {

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -609,8 +609,31 @@ func (g *tableGen) emitWireScalarLeafMeasure(st *ir.Struct) {
 		}
 	}
 	g.pf("    if ( w->buffer == NULL && !w->check_default )\n    {\n")
-	g.pf("        int64_t payload_bytes = 1; /* the zero reference ending this body */\n")
 	guards := tableGuardExprs(st)
+	// With every field id already interned, a small vocabulary needs one byte
+	// per riding reference. Count those bytes with the scalar payload instead
+	// of advancing the measuring writer for each id. The full-body room guard
+	// keeps the existing path's cursor and overflow behavior for short capacity.
+	if len(ir.TableWireIds(g.unit))+1 <= 127 {
+		maxBytes := int64(1)
+		warm := []string{"!w->overflow", "w->offset >= 0", "w->offset <= w->capacity"}
+		for _, f := range st.Fields {
+			maxBytes += int64(2 + tableKindWidth(ir.TableWireScalarKind(f)))
+			warm = append(warm, fmt.Sprintf("w->vocabulary->slot[%d] >= 0", g.knownOrdinal(ir.TableFieldWireId(f))))
+		}
+		warm = append(warm, fmt.Sprintf("%d <= w->capacity - w->offset", maxBytes))
+		g.pf("        if ( %s )\n        {\n", strings.Join(warm, " && "))
+		g.pf("            int64_t body_bytes = 1;\n")
+		for _, f := range st.Fields {
+			condition := "!( " + g.wireDefaultEquals(f, "value->"+f.Name) + " )"
+			if guard := guards[f.Name]; guard != "" {
+				condition = "( " + guard + " ) && " + condition
+			}
+			g.pf("            if ( %s ) { body_bytes += %d; }\n", condition, 2+tableKindWidth(ir.TableWireScalarKind(f)))
+		}
+		g.pf("            w->offset += body_bytes;\n            return 1;\n        }\n")
+	}
+	g.pf("        int64_t payload_bytes = 1; /* the zero reference ending this body */\n")
 	for _, f := range st.Fields {
 		condition := "!( " + g.wireDefaultEquals(f, "value->"+f.Name) + " )"
 		if guard := guards[f.Name]; guard != "" {

--- a/make/c.mk
+++ b/make/c.mk
@@ -318,6 +318,10 @@ tables-c: tables-c-wire-fuzz build/conformance-c build/conformance-c-asan tables
 	# compiler/ctablerefordinal_test.go, and the ONE rule a green pin cannot be
 	# read for is the rewind taking the slot back — so its control is here.
 	$(MAKE) tables-c-ref-ordinal-negative-control
+	# THE WARM SCALAR-LEAF MEASURE (docs/SPEC-TABLES.md §3): the reference byte
+	# a warm body counts is a constant in the emitter, and nothing green reads
+	# a constant — so its control is here too.
+	$(MAKE) tables-c-warm-id-negative-control
 
 # THE NEGATIVE CONTROL FOR THE C LEG, and it is the C# control's twin over the
 # C emitter: a green matrix row proves nothing until the row is shown capable
@@ -718,6 +722,84 @@ tables-c-ref-ordinal-negative-control:
 # ordinal_of points back — rather than correct by an argument about probe/redo
 # pairing that a change to the measure path could quietly retire.
 
+# THE WARM SCALAR-LEAF MEASURE'S OWN CONTROL (docs/SPEC-TABLES.md §3). A plain
+# scalar leaf whose field ids are ALL already interned is measured by the warm
+# branch in internal/codegen/ctable/wire.go's emitWireScalarLeafMeasure: it
+# counts each riding field as ONE REFERENCE BYTE plus its kind and fixed-width
+# payload and advances the measuring writer once, instead of interning the ids
+# again down the cold walk. The reference byte is the whole claim — a warm body
+# still WRITES that byte on the save pass — and it is a CONSTANT in the
+# emitter, so a wrong constant is silent in the emitter's own tests: the number
+# it produces is arithmetic nobody reads.
+#
+# WHAT READS IT IS THE FILE. Drop the reference byte from the warm count and
+# every measure of a warm leaf comes back one byte per riding field short of
+# what the save writes, so a save into a measured buffer runs off its end and
+# the conformance driver's `wire` surface — the one that holds save against
+# measure and against the compiler's independent engine — must go RED.
+#
+# AND ONLY THE SURFACES THAT MEASURE A SAVE. `wire` and `json-read` are the two
+# rows that build a file from a value, and both go red; `json-write`,
+# `cook-write`, `report`, `message` and the block rows read files somebody else
+# measured and must stay GREEN. A control that reddened the whole column would
+# be saying "the C leg broke" rather than "the warm count is short". Through
+# `go build -overlay`, so no tracked file moves.
+C_WARM_ID_NC := build/c-warm-id-nc
+
+# out-dir:schema, the corpus the C conformance driver is compiled over. The
+# sabotaged emitter has to generate all of it: the driver links every unit.
+C_WARM_ID_UNITS := maps:tables/maps lists:tables/lists arms:tables/arms \
+	w1:test/tables/W1.schema w2:test/tables/W2.schema g1:test/tables/G1.schema \
+	stream:tables/stream blobs:tables/blobs vocab9:tables/vocab9 vocab:tables/vocab \
+	backend:tables/backend r2:test/tables/R2.schema r1:test/tables/R1.schema \
+	rt1:test/tables/RT1.schema k2:test/tables/K2.schema k1:test/tables/K1.schema \
+	a2:test/tables/A2.schema a1:test/tables/A1.schema m2:test/tables/M2.schema \
+	m1:test/tables/M1.schema messages:tables/messages examples:tables/examples \
+	pointers:tables/pointers block:tables/block blockhome:tables/blockhome \
+	v1:test/tables/V1.schema v2:test/tables/V2.schema p1:test/tables/P1.schema \
+	p2:test/tables/P2.schema p3:test/tables/P3.schema wide:examples-wide \
+	scalars:tables/scalars scalars2:test/tables/Scalars2.schema \
+	jsonkeys:test/tables/JsonKeys.schema
+
+.PHONY: tables-c-warm-id-negative-control
+tables-c-warm-id-negative-control: build/conformance-harness
+	@rm -rf $(C_WARM_ID_NC) && mkdir -p $(C_WARM_ID_NC)
+	@sed -e 's|{ body_bytes += %d; }|{ body_bytes += %d; } /* SABOTAGED: the reference byte is not counted */|' \
+		-e 's|condition, 2+tableKindWidth|condition, 1+tableKindWidth|' \
+		internal/codegen/ctable/wire.go > $(C_WARM_ID_NC)/emitter.go.txt
+	@cmp -s internal/codegen/ctable/wire.go $(C_WARM_ID_NC)/emitter.go.txt && \
+		{ echo "NEGATIVE CONTROL: the warm reference-byte sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/ctable/wire.go":"%s/$(C_WARM_ID_NC)/emitter.go.txt"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > $(C_WARM_ID_NC)/overlay.json
+	go build -overlay $(C_WARM_ID_NC)/overlay.json -o $(C_WARM_ID_NC)/schema ./cmd/schema
+	@set -e; for entry in $(C_WARM_ID_UNITS); do \
+		out=$${entry%%:*}; src=$${entry##*:}; \
+		$(C_WARM_ID_NC)/schema generate --lang c --out $(C_WARM_ID_NC)/generated/$$out $$src; \
+	done
+	@grep -lq SABOTAGED $(C_WARM_ID_NC)/generated/*/*Table.h || \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotaged emitter emitted no warm branch at all"; exit 1; }
+	$(CC) $(TABLES_CFLAGS_CONTROL) $(subst build/tables-generated-c,$(C_WARM_ID_NC)/generated,$(C_CONFORMANCE_INCLUDES)) \
+		$(subst build/tables-generated-c,$(C_WARM_ID_NC)/generated,$(C_CONFORMANCE_SOURCES)) -o $(C_WARM_ID_NC)/driver-bin -lm
+	@printf '#!/bin/sh\nexec "%s/driver-bin" "$$@"\n' "$(CURDIR)/$(C_WARM_ID_NC)" > $(C_WARM_ID_NC)/driver
+	@chmod +x $(C_WARM_ID_NC)/driver
+	@printf 'c %s/driver\n' "$(C_WARM_ID_NC)" > $(C_WARM_ID_NC)/drivers.txt
+	@if ./build/conformance-harness run --drivers $(C_WARM_ID_NC)/drivers.txt \
+			--work $(C_WARM_ID_NC)/work > $(C_WARM_ID_NC)/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a warm count one byte short per riding field left the harness green"; \
+		cat $(C_WARM_ID_NC)/log; exit 1; \
+	fi
+	@grep -q "c / wire" $(C_WARM_ID_NC)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the harness went red, but not on the wire surface"; \
+		  cat $(C_WARM_ID_NC)/log; exit 1; }
+	@grep -q "json-write    pass" $(C_WARM_ID_NC)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: json-write went red too, so the control does not localise the SAVE MEASURE"; \
+		  cat $(C_WARM_ID_NC)/log; exit 1; }
+	@grep -q "report        pass" $(C_WARM_ID_NC)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the read side went red, so the control localises nothing"; \
+		  cat $(C_WARM_ID_NC)/log; exit 1; }
+	@grep -m1 "c / wire" $(C_WARM_ID_NC)/log
+	@echo "negative control: a warm scalar-leaf count without the reference byte turns the C conformance wire surface RED"
+
 # The C half of `make update-goldens`: the committed generated table sources
 # (testdata/golden/tables/*-c).
 .PHONY: update-goldens-c
@@ -774,6 +856,7 @@ test-c: build/schema_test_c build/schema_test_c_ludicrous build/schema_test_benc
 	$(MAKE) tables-c-soak SOAK_SECONDS=2
 	$(MAKE) tables-c-soak-negative-control
 	$(MAKE) tables-c-ref-ordinal-negative-control
+	$(MAKE) tables-c-warm-id-negative-control
 	# and the whole matrix again under ASan + UBSan: the sanitized run is the
 	# strongest gate this leg has, and a gate that only fires under a target
 	# nobody types is not in the chain.

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -87,6 +87,14 @@
       ]
     },
     {
+      "name": "base-c-warm-id",
+      "when": "pull-request",
+      "why": "the warm scalar-leaf measure's reference byte, held by the C conformance driver's wire surface. A complete C driver rebuild off a sabotaged emitter, so it rides its own job the way the wire and foreign rebuilds do. Measured 13 s.",
+      "targets": [
+        "tables-c-warm-id-negative-control"
+      ]
+    },
+    {
       "name": "base-c-wire",
       "when": "pull-request",
       "why": "The complete C wire roster rebuilt with a permissive LEB reader took about 99 seconds on run 34186742566. Keep that compile in its own job within the control-time budget.",

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -10166,6 +10166,15 @@ static SCHEMA_UNUSED int render_vector3_save_body( TableWriter * w, const Render
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[53] >= 0 && w->vocabulary->slot[52] >= 0 && w->vocabulary->slot[54] >= 0 && 31 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->x == 0.0 ) ) { body_bytes += 10; }
+            if ( !( value->y == 0.0 ) ) { body_bytes += 10; }
+            if ( !( value->z == 0.0 ) ) { body_bytes += 10; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->x == 0.0 ) )
         {
@@ -10581,6 +10590,16 @@ static SCHEMA_UNUSED int render_quaternion_save_body( TableWriter * w, const Ren
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[53] >= 0 && w->vocabulary->slot[52] >= 0 && w->vocabulary->slot[54] >= 0 && w->vocabulary->slot[51] >= 0 && 41 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->x == 0.0 ) ) { body_bytes += 10; }
+            if ( !( value->y == 0.0 ) ) { body_bytes += 10; }
+            if ( !( value->z == 0.0 ) ) { body_bytes += 10; }
+            if ( !( value->w == 1.0 ) ) { body_bytes += 10; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->x == 0.0 ) )
         {

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -3209,6 +3209,13 @@ static SCHEMA_UNUSED int tally_save_body( TableWriter * w, const Tally * value )
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[19] >= 0 && 7 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->hits == 0 ) ) { body_bytes += 6; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->hits == 0 ) )
         {

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -3448,6 +3448,15 @@ static SCHEMA_UNUSED int colour_save_body( TableWriter * w, const Colour * value
     (void) value;
     if ( w->buffer == NULL && !w->check_default )
     {
+        if ( !w->overflow && w->offset >= 0 && w->offset <= w->capacity && w->vocabulary->slot[34] >= 0 && w->vocabulary->slot[32] >= 0 && w->vocabulary->slot[33] >= 0 && 10 <= w->capacity - w->offset )
+        {
+            int64_t body_bytes = 1;
+            if ( !( value->r == 0 ) ) { body_bytes += 3; }
+            if ( !( value->g == 0 ) ) { body_bytes += 3; }
+            if ( !( value->b == 0 ) ) { body_bytes += 3; }
+            w->offset += body_bytes;
+            return 1;
+        }
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->r == 0 ) )
         {


### PR DESCRIPTION
Scalar-leaf NULL-buffer sizing still serialized each field reference byte in C, while C++ counted its width. For existing eligible leaves in one-byte-reference units, count the body locally when every ID is already cached and the entire maximum body fits, then advance once. Cold IDs, overflow, limited capacity and other states retain the original measurement path; actual writes and their partial-write behavior are unchanged.

Existing ctable tests, full source goldens,12 ordinary C compiler roots, strict-C99 legacy compile/gate and matched C/C++ gates passed on ARM. Only12 warm-count blocks appear in5 generated headers; removing those blocks restores every parent byte. Independent review requested from Emma; Space A/B pending, so no performance gain is claimed.
