### PR TITLE
gotable: MeasureBody on table union arms

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -5609,74 +5609,71 @@ func BenchMixedSaveBody(w *TableWriter, value *BenchMixed) bool {
 					}
 				case MixedEventTypeHit:
 					ref := w.Ids.refAtHit(16, 0x33732819300680aa)
-					start := w.Ids.Count
-					payload31 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !MixedHitEventSaveBody(&payload31, &payload30.Hit) {
-						return false
-					}
-					if payload31.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload31.Offset)) {
-						w.putLebWide(uint64(payload31.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload31.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !MixedHitEventSaveBody(w, &payload30.Hit) {
+					{
+						mark := w.Ids.Count
+						n := MixedHitEventMeasureBody(&payload30.Hit, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !MixedHitEventSaveBody(w, &payload30.Hit) {
+								return false
+							}
 						}
 					}
 				case MixedEventTypeChat:
 					ref := w.Ids.refAtHit(75, 0xf2a38d910b5b348b)
-					start := w.Ids.Count
-					payload32 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !MixedChatEventSaveBody(&payload32, &payload30.Chat) {
-						return false
-					}
-					if payload32.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload32.Offset)) {
-						w.putLebWide(uint64(payload32.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload32.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !MixedChatEventSaveBody(w, &payload30.Chat) {
+					{
+						mark := w.Ids.Count
+						n := MixedChatEventMeasureBody(&payload30.Chat, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !MixedChatEventSaveBody(w, &payload30.Chat) {
+								return false
+							}
 						}
 					}
 				case MixedEventTypePickup:
 					ref := w.Ids.refAtHit(50, 0x9fa3a41c86ecb765)
-					start := w.Ids.Count
-					payload33 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !MixedPickupEventSaveBody(&payload33, &payload30.Pickup) {
-						return false
-					}
-					if payload33.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload33.Offset)) {
-						w.putLebWide(uint64(payload33.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload33.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !MixedPickupEventSaveBody(w, &payload30.Pickup) {
+					{
+						mark := w.Ids.Count
+						n := MixedPickupEventMeasureBody(&payload30.Pickup, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !MixedPickupEventSaveBody(w, &payload30.Pickup) {
+								return false
+							}
 						}
 					}
 				default:
@@ -5699,16 +5696,16 @@ func BenchMixedSaveBody(w *TableWriter, value *BenchMixed) bool {
 			}
 			{
 				mark := w.Ids.Count
-				payload34 := TableWriter{Measuring: true, Ids: w.Ids}
+				payload31 := TableWriter{Measuring: true, Ids: w.Ids}
 				pairs := uint64(0)
 				for i := 0; i < int(4); i++ {
-					payload34.Put8(uint8(value.Loadout[i]))
+					payload31.Put8(uint8(value.Loadout[i]))
 					pairs++
 				}
-				if payload34.Overflow {
+				if payload31.Overflow {
 					return false
 				}
-				n := int64(1) + tableLebBytes(pairs) + payload34.Offset
+				n := int64(1) + tableLebBytes(pairs) + payload31.Offset
 				if !w.putLebPair(uint64(n)) {
 					w.putLebWide(uint64(n))
 				}
@@ -5757,16 +5754,16 @@ func BenchMixedSaveBody(w *TableWriter, value *BenchMixed) bool {
 			}
 			{
 				mark := w.Ids.Count
-				payload37 := TableWriter{Measuring: true, Ids: w.Ids}
+				payload34 := TableWriter{Measuring: true, Ids: w.Ids}
 				pairs := uint64(0)
 				for i := 0; i < int(value.PayloadLength); i++ {
-					payload37.Put8(uint8(value.Payload[i]))
+					payload34.Put8(uint8(value.Payload[i]))
 					pairs++
 				}
-				if payload37.Overflow {
+				if payload34.Overflow {
 					return false
 				}
-				n := int64(1) + tableLebBytes(pairs) + payload37.Offset
+				n := int64(1) + tableLebBytes(pairs) + payload34.Offset
 				if !w.putLebPair(uint64(n)) {
 					w.putLebWide(uint64(n))
 				}
@@ -6370,14 +6367,14 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 				break
 			}
 			{
-				payload41 := &value.GameEvent
+				payload38 := &value.GameEvent
 				armRef, ok := r.Leb()
 				if !ok {
 					r.Report.Malformed = true
 					return false
 				}
 				if armRef == 0 {
-					payload41.Type = MixedEventTypeNone
+					payload38.Type = MixedEventTypeNone
 				} else {
 					armID, ok := r.Resolve(armRef)
 					if !ok || !r.Has(1) {
@@ -6385,22 +6382,22 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 						return false
 					}
 					armKind := r.Get8()
-					payload40, ok := r.Body()
+					payload37, ok := r.Body()
 					if !ok {
 						r.Report.Malformed = true
 						return false
 					}
-					payload41.Type = MixedEventTypeNone
+					payload38.Type = MixedEventTypeNone
 					switch armID {
 					case 0x33732819300680aa:
 						if armKind != 13 {
 							r.Report.KindMismatch++
 							break
 						}
-						payload41.Type = MixedEventTypeHit
-						MixedHitEventLoadBody(&payload40, &payload41.Hit)
-						if payload40.Offset != int64(len(payload40.Buffer)) {
-							payload41.Type = MixedEventTypeNone
+						payload38.Type = MixedEventTypeHit
+						MixedHitEventLoadBody(&payload37, &payload38.Hit)
+						if payload37.Offset != int64(len(payload37.Buffer)) {
+							payload38.Type = MixedEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -6409,10 +6406,10 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 							r.Report.KindMismatch++
 							break
 						}
-						payload41.Type = MixedEventTypeChat
-						MixedChatEventLoadBody(&payload40, &payload41.Chat)
-						if payload40.Offset != int64(len(payload40.Buffer)) {
-							payload41.Type = MixedEventTypeNone
+						payload38.Type = MixedEventTypeChat
+						MixedChatEventLoadBody(&payload37, &payload38.Chat)
+						if payload37.Offset != int64(len(payload37.Buffer)) {
+							payload38.Type = MixedEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -6421,10 +6418,10 @@ func BenchMixedLoadBody(r *TableReader, value *BenchMixed) bool {
 							r.Report.KindMismatch++
 							break
 						}
-						payload41.Type = MixedEventTypePickup
-						MixedPickupEventLoadBody(&payload40, &payload41.Pickup)
-						if payload40.Offset != int64(len(payload40.Buffer)) {
-							payload41.Type = MixedEventTypeNone
+						payload38.Type = MixedEventTypePickup
+						MixedPickupEventLoadBody(&payload37, &payload38.Pickup)
+						if payload37.Offset != int64(len(payload37.Buffer)) {
+							payload38.Type = MixedEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -7324,13 +7321,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload42 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload42.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload39 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload39.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload42.Unsigned(entry.Shape.Kind)
+						v := payload39.Unsigned(entry.Shape.Kind)
 						if v > 65535 {
 							v = 65535
 							r.Report.Clamped++
@@ -7363,13 +7360,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload43 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload43.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload40 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload40.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload43.Signed(entry.Shape.Kind)
+						v := payload40.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7405,13 +7402,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload44 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload44.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload41 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload41.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload44.Unsigned(entry.Shape.Kind)
+						v := payload41.Unsigned(entry.Shape.Kind)
 						if v > 4294967295 {
 							v = 4294967295
 							r.Report.Clamped++
@@ -7444,13 +7441,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload45 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload45.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload42 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload42.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload45.Unsigned(entry.Shape.Kind)
+						v := payload42.Unsigned(entry.Shape.Kind)
 						value.SessionId = uint64(v)
 					}
 				}
@@ -7479,13 +7476,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload46 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload46.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload43 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload43.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload46.Unsigned(entry.Shape.Kind)
+						v := payload43.Unsigned(entry.Shape.Kind)
 						value.ClientId = uint32(v)
 					}
 				}
@@ -7514,13 +7511,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload47 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload47.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload44 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload44.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload47.Unsigned(entry.Shape.Kind)
+						v := payload44.Unsigned(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7556,13 +7553,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload48 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload48.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload45 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload45.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload48.Signed(entry.Shape.Kind)
+						v := payload45.Signed(entry.Shape.Kind)
 						if v < -1000000000000 {
 							v = -1000000000000
 							r.Report.Clamped++
@@ -7598,13 +7595,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload49 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload49.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload46 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload46.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload49.Unsigned(entry.Shape.Kind)
+						v := payload46.Unsigned(entry.Shape.Kind)
 						if v > 281474976710655 {
 							v = 281474976710655
 							r.Report.Clamped++
@@ -7637,13 +7634,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload50 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload50.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload47 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload47.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload50.Signed(entry.Shape.Kind)
+						v := payload47.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7786,7 +7783,7 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 					}
 				}
 				{
-					payload51 := &value.GameEvent
+					payload48 := &value.GameEvent
 					{
 						ref, ok := r.Bits.Get(r.Vocabulary.RefBits)
 						if !ok {
@@ -7794,36 +7791,36 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 							return false
 						}
 						if ref == 0 {
-							(*payload51).Type = MixedEventTypeNone
+							(*payload48).Type = MixedEventTypeNone
 						} else {
-							payload52, ok := r.Vocabulary.Entry(ref)
-							if !ok || payload52.Id >= 0xfffffffffffffffd || payload52.Shape.Kind == 0 {
+							payload49, ok := r.Vocabulary.Entry(ref)
+							if !ok || payload49.Id >= 0xfffffffffffffffd || payload49.Shape.Kind == 0 {
 								r.Report.Malformed = true
 								return false
 							}
-							switch payload52.Id {
+							switch payload49.Id {
 							case 0x33732819300680aa:
 								{
 									widened := false
-									if payload52.Shape.Kind != 13 || payload52.Element.Kind != 0 {
+									if payload49.Shape.Kind != 13 || payload49.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload51).Type = MixedEventTypeNone
+											(*payload48).Type = MixedEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload52, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload49, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload51).Type = MixedEventTypeHit
+									(*payload48).Type = MixedEventTypeHit
 									{
-										value := &(*payload51)
+										value := &(*payload48)
 										MixedHitEventReset(&value.Hit)
 									}
-									if !MixedHitEventLoadMessageBody(r, &(*payload51).Hit) {
+									if !MixedHitEventLoadMessageBody(r, &(*payload48).Hit) {
 										return false
 									}
 									if widened {
@@ -7833,25 +7830,25 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 							case 0xf2a38d910b5b348b:
 								{
 									widened := false
-									if payload52.Shape.Kind != 13 || payload52.Element.Kind != 0 {
+									if payload49.Shape.Kind != 13 || payload49.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload51).Type = MixedEventTypeNone
+											(*payload48).Type = MixedEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload52, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload49, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload51).Type = MixedEventTypeChat
+									(*payload48).Type = MixedEventTypeChat
 									{
-										value := &(*payload51)
+										value := &(*payload48)
 										MixedChatEventReset(&value.Chat)
 									}
-									if !MixedChatEventLoadMessageBody(r, &(*payload51).Chat) {
+									if !MixedChatEventLoadMessageBody(r, &(*payload48).Chat) {
 										return false
 									}
 									if widened {
@@ -7861,25 +7858,25 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 							case 0x9fa3a41c86ecb765:
 								{
 									widened := false
-									if payload52.Shape.Kind != 13 || payload52.Element.Kind != 0 {
+									if payload49.Shape.Kind != 13 || payload49.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload51).Type = MixedEventTypeNone
+											(*payload48).Type = MixedEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload52, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload49, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload51).Type = MixedEventTypePickup
+									(*payload48).Type = MixedEventTypePickup
 									{
-										value := &(*payload51)
+										value := &(*payload48)
 										MixedPickupEventReset(&value.Pickup)
 									}
-									if !MixedPickupEventLoadMessageBody(r, &(*payload51).Pickup) {
+									if !MixedPickupEventLoadMessageBody(r, &(*payload48).Pickup) {
 										return false
 									}
 									if widened {
@@ -7887,9 +7884,9 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 									}
 								}
 							default:
-								(*payload51).Type = MixedEventTypeNone
+								(*payload48).Type = MixedEventTypeNone
 								r.Report.Unknown++
-								if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload52, 0) {
+								if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload49, 0) {
 									r.Report.Malformed = true
 									return false
 								}
@@ -7949,13 +7946,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 								r.Report.Malformed = true
 								return false
 							}
-							payload53 := TableReader{Buffer: raw[:], Report: &r.Report}
-							if !payload53.Has(tableKindBytes(element.Shape.Kind)) {
+							payload50 := TableReader{Buffer: raw[:], Report: &r.Report}
+							if !payload50.Has(tableKindBytes(element.Shape.Kind)) {
 								r.Report.Malformed = true
 								return false
 							}
 							{
-								v := payload53.Unsigned(element.Shape.Kind)
+								v := payload50.Unsigned(element.Shape.Kind)
 								(*p) = uint8(v)
 							}
 						}
@@ -8071,13 +8068,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload54 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload54.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload51 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload51.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload54.Get32())
+						v := math.Float32frombits(payload51.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -8113,13 +8110,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload55 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload55.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload52 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload52.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload55.Get32())
+						v := math.Float32frombits(payload52.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -8155,13 +8152,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload56 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload56.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload53 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload53.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload56.Get32())
+						v := math.Float32frombits(payload53.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -8197,13 +8194,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload57 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload57.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload54 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload54.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload57.Get32())
+						v := math.Float32frombits(payload54.Get32())
 						value.Recoil = v
 					}
 				}
@@ -8232,17 +8229,17 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload58 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload58.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload55 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload55.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
 						var v float64
 						if entry.Shape.Kind == 10 {
-							v = math.Float64frombits(tableWidenFloat(payload58.Get32()))
+							v = math.Float64frombits(tableWidenFloat(payload55.Get32()))
 						} else {
-							v = math.Float64frombits(payload58.Get64())
+							v = math.Float64frombits(payload55.Get64())
 						}
 						value.Drift = v
 					}
@@ -8272,18 +8269,18 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload59 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload59.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload56 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload56.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
 						var v serialize.Uint128
 						if tableKindBytes(entry.Shape.Kind) == 16 {
-							v.Lo = payload59.Get64()
-							v.Hi = payload59.Get64()
+							v.Lo = payload56.Get64()
+							v.Hi = payload56.Get64()
 						} else {
-							v.Lo = payload59.Unsigned(entry.Shape.Kind)
+							v.Lo = payload56.Unsigned(entry.Shape.Kind)
 						}
 						value.WideKey = v
 					}
@@ -8313,18 +8310,18 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload60 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload60.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload57 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload57.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
 						var v serialize.Int128
 						if tableKindBytes(entry.Shape.Kind) == 16 {
-							v.Lo = payload60.Get64()
-							v.Hi = payload60.Get64()
+							v.Lo = payload57.Get64()
+							v.Hi = payload57.Get64()
 						} else {
-							v = serialize.Int128From64(payload60.Signed(entry.Shape.Kind))
+							v = serialize.Int128From64(payload57.Signed(entry.Shape.Kind))
 						}
 						if v.Cmp((serialize.Int128{Lo: 0, Hi: 18446744004990074880})) < 0 {
 							v = (serialize.Int128{Lo: 0, Hi: 18446744004990074880})
@@ -8361,13 +8358,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload61 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload61.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload58 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload58.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload61.Unsigned(entry.Shape.Kind)
+						v := payload58.Unsigned(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -8403,13 +8400,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload62 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload62.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload59 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload59.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload62.Unsigned(entry.Shape.Kind)
+						v := payload59.Unsigned(entry.Shape.Kind)
 						if v > 16777215 {
 							v = 16777215
 							r.Report.Clamped++
@@ -8442,12 +8439,12 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload63 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload63.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload60 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload60.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
-					value.HasExtra = payload63.Get8() != 0
+					value.HasExtra = payload60.Get8() != 0
 				}
 				if widened {
 					r.Report.Widened++
@@ -8474,13 +8471,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload64 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload64.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload61 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload61.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload64.Signed(entry.Shape.Kind)
+						v := payload61.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -8516,13 +8513,13 @@ func BenchMixedLoadMessageBody(r *TableMessageReader, value *BenchMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload65 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload65.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload62 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload62.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload65.Signed(entry.Shape.Kind)
+						v := payload62.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -4252,74 +4252,71 @@ func TableMixedSaveBody(w *TableWriter, value *TableMixed) bool {
 					}
 				case TableEventTypeHit:
 					ref := w.Ids.refAtHit(18, 0x33732819300680aa)
-					start := w.Ids.Count
-					payload23 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !TableHitEventSaveBody(&payload23, &payload22.Hit) {
-						return false
-					}
-					if payload23.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload23.Offset)) {
-						w.putLebWide(uint64(payload23.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload23.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !TableHitEventSaveBody(w, &payload22.Hit) {
+					{
+						mark := w.Ids.Count
+						n := TableHitEventMeasureBody(&payload22.Hit, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !TableHitEventSaveBody(w, &payload22.Hit) {
+								return false
+							}
 						}
 					}
 				case TableEventTypeChat:
 					ref := w.Ids.refAtHit(74, 0xf2a38d910b5b348b)
-					start := w.Ids.Count
-					payload24 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !TableChatEventSaveBody(&payload24, &payload22.Chat) {
-						return false
-					}
-					if payload24.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload24.Offset)) {
-						w.putLebWide(uint64(payload24.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload24.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !TableChatEventSaveBody(w, &payload22.Chat) {
+					{
+						mark := w.Ids.Count
+						n := TableChatEventMeasureBody(&payload22.Chat, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !TableChatEventSaveBody(w, &payload22.Chat) {
+								return false
+							}
 						}
 					}
 				case TableEventTypePickup:
 					ref := w.Ids.refAtHit(52, 0x9fa3a41c86ecb765)
-					start := w.Ids.Count
-					payload25 := TableWriter{Measuring: true, Ids: w.Ids}
-					if !TablePickupEventSaveBody(&payload25, &payload22.Pickup) {
-						return false
-					}
-					if payload25.Overflow {
-						return false
-					}
-					if !w.headerPair(ref, 13) {
-						w.headerRest(ref, 13)
-					}
-					if !w.putLebPair(uint64(payload25.Offset)) {
-						w.putLebWide(uint64(payload25.Offset))
-					}
-					if w.Measuring {
-						w.Advance(payload25.Offset)
-					} else {
-						w.Ids.Truncate(start)
-						if !TablePickupEventSaveBody(w, &payload22.Pickup) {
+					{
+						mark := w.Ids.Count
+						n := TablePickupEventMeasureBody(&payload22.Pickup, w.Ids)
+						if n < 0 {
 							return false
+						}
+						if !w.headerPair(ref, 13) {
+							w.headerRest(ref, 13)
+						}
+						if !w.putLebPair(uint64(n)) {
+							w.putLebWide(uint64(n))
+						}
+						if w.Measuring {
+							w.Advance(n)
+						} else {
+							w.Ids.Truncate(mark)
+							if !TablePickupEventSaveBody(w, &payload22.Pickup) {
+								return false
+							}
 						}
 					}
 				default:
@@ -4342,16 +4339,16 @@ func TableMixedSaveBody(w *TableWriter, value *TableMixed) bool {
 			}
 			{
 				mark := w.Ids.Count
-				payload26 := TableWriter{Measuring: true, Ids: w.Ids}
+				payload23 := TableWriter{Measuring: true, Ids: w.Ids}
 				pairs := uint64(0)
 				for i := 0; i < int(4); i++ {
-					payload26.Put8(uint8(value.Loadout[i]))
+					payload23.Put8(uint8(value.Loadout[i]))
 					pairs++
 				}
-				if payload26.Overflow {
+				if payload23.Overflow {
 					return false
 				}
-				n := int64(1) + tableLebBytes(pairs) + payload26.Offset
+				n := int64(1) + tableLebBytes(pairs) + payload23.Offset
 				if !w.putLebPair(uint64(n)) {
 					w.putLebWide(uint64(n))
 				}
@@ -4400,16 +4397,16 @@ func TableMixedSaveBody(w *TableWriter, value *TableMixed) bool {
 			}
 			{
 				mark := w.Ids.Count
-				payload29 := TableWriter{Measuring: true, Ids: w.Ids}
+				payload26 := TableWriter{Measuring: true, Ids: w.Ids}
 				pairs := uint64(0)
 				for i := 0; i < int(value.PayloadLength); i++ {
-					payload29.Put8(uint8(value.Payload[i]))
+					payload26.Put8(uint8(value.Payload[i]))
 					pairs++
 				}
-				if payload29.Overflow {
+				if payload26.Overflow {
 					return false
 				}
-				n := int64(1) + tableLebBytes(pairs) + payload29.Offset
+				n := int64(1) + tableLebBytes(pairs) + payload26.Offset
 				if !w.putLebPair(uint64(n)) {
 					w.putLebWide(uint64(n))
 				}
@@ -5042,14 +5039,14 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 				break
 			}
 			{
-				payload33 := &value.GameEvent
+				payload30 := &value.GameEvent
 				armRef, ok := r.Leb()
 				if !ok {
 					r.Report.Malformed = true
 					return false
 				}
 				if armRef == 0 {
-					payload33.Type = TableEventTypeNone
+					payload30.Type = TableEventTypeNone
 				} else {
 					armID, ok := r.Resolve(armRef)
 					if !ok || !r.Has(1) {
@@ -5057,22 +5054,22 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 						return false
 					}
 					armKind := r.Get8()
-					payload32, ok := r.Body()
+					payload29, ok := r.Body()
 					if !ok {
 						r.Report.Malformed = true
 						return false
 					}
-					payload33.Type = TableEventTypeNone
+					payload30.Type = TableEventTypeNone
 					switch armID {
 					case 0x33732819300680aa:
 						if armKind != 13 {
 							r.Report.KindMismatch++
 							break
 						}
-						payload33.Type = TableEventTypeHit
-						TableHitEventLoadBody(&payload32, &payload33.Hit)
-						if payload32.Offset != int64(len(payload32.Buffer)) {
-							payload33.Type = TableEventTypeNone
+						payload30.Type = TableEventTypeHit
+						TableHitEventLoadBody(&payload29, &payload30.Hit)
+						if payload29.Offset != int64(len(payload29.Buffer)) {
+							payload30.Type = TableEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -5081,10 +5078,10 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 							r.Report.KindMismatch++
 							break
 						}
-						payload33.Type = TableEventTypeChat
-						TableChatEventLoadBody(&payload32, &payload33.Chat)
-						if payload32.Offset != int64(len(payload32.Buffer)) {
-							payload33.Type = TableEventTypeNone
+						payload30.Type = TableEventTypeChat
+						TableChatEventLoadBody(&payload29, &payload30.Chat)
+						if payload29.Offset != int64(len(payload29.Buffer)) {
+							payload30.Type = TableEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -5093,10 +5090,10 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 							r.Report.KindMismatch++
 							break
 						}
-						payload33.Type = TableEventTypePickup
-						TablePickupEventLoadBody(&payload32, &payload33.Pickup)
-						if payload32.Offset != int64(len(payload32.Buffer)) {
-							payload33.Type = TableEventTypeNone
+						payload30.Type = TableEventTypePickup
+						TablePickupEventLoadBody(&payload29, &payload30.Pickup)
+						if payload29.Offset != int64(len(payload29.Buffer)) {
+							payload30.Type = TableEventTypeNone
 							r.Report.Malformed = true
 							break
 						}
@@ -5999,13 +5996,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload34 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload34.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload31 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload31.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload34.Unsigned(entry.Shape.Kind)
+						v := payload31.Unsigned(entry.Shape.Kind)
 						value.ProtocolMagic = uint16(v)
 					}
 				}
@@ -6034,13 +6031,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload35 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload35.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload32 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload32.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload35.Unsigned(entry.Shape.Kind)
+						v := payload32.Unsigned(entry.Shape.Kind)
 						if v > 65535 {
 							v = 65535
 							r.Report.Clamped++
@@ -6073,13 +6070,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload36 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload36.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload33 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload33.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload36.Signed(entry.Shape.Kind)
+						v := payload33.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -6115,13 +6112,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload37 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload37.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload34 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload34.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload37.Unsigned(entry.Shape.Kind)
+						v := payload34.Unsigned(entry.Shape.Kind)
 						if v > 4294967295 {
 							v = 4294967295
 							r.Report.Clamped++
@@ -6154,13 +6151,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload38 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload38.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload35 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload35.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload38.Unsigned(entry.Shape.Kind)
+						v := payload35.Unsigned(entry.Shape.Kind)
 						value.SessionId = uint64(v)
 					}
 				}
@@ -6189,13 +6186,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload39 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload39.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload36 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload36.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload39.Unsigned(entry.Shape.Kind)
+						v := payload36.Unsigned(entry.Shape.Kind)
 						value.ClientId = uint32(v)
 					}
 				}
@@ -6224,13 +6221,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload40 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload40.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload37 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload37.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload40.Unsigned(entry.Shape.Kind)
+						v := payload37.Unsigned(entry.Shape.Kind)
 						if v < 1 {
 							v = 1
 							r.Report.Clamped++
@@ -6266,13 +6263,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload41 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload41.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload38 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload38.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload41.Signed(entry.Shape.Kind)
+						v := payload38.Signed(entry.Shape.Kind)
 						if v < -1000000000000 {
 							v = -1000000000000
 							r.Report.Clamped++
@@ -6308,13 +6305,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload42 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload42.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload39 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload39.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload42.Unsigned(entry.Shape.Kind)
+						v := payload39.Unsigned(entry.Shape.Kind)
 						if v > 281474976710655 {
 							v = 281474976710655
 							r.Report.Clamped++
@@ -6347,13 +6344,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload43 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload43.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload40 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload40.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload43.Get32())
+						v := math.Float32frombits(payload40.Get32())
 						if v < 0.0 {
 							v = 0.0
 							r.Report.Clamped++
@@ -6496,7 +6493,7 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 					}
 				}
 				{
-					payload44 := &value.GameEvent
+					payload41 := &value.GameEvent
 					{
 						ref, ok := r.Bits.Get(r.Vocabulary.RefBits)
 						if !ok {
@@ -6504,36 +6501,36 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 							return false
 						}
 						if ref == 0 {
-							(*payload44).Type = TableEventTypeNone
+							(*payload41).Type = TableEventTypeNone
 						} else {
-							payload45, ok := r.Vocabulary.Entry(ref)
-							if !ok || payload45.Id >= 0xfffffffffffffffd || payload45.Shape.Kind == 0 {
+							payload42, ok := r.Vocabulary.Entry(ref)
+							if !ok || payload42.Id >= 0xfffffffffffffffd || payload42.Shape.Kind == 0 {
 								r.Report.Malformed = true
 								return false
 							}
-							switch payload45.Id {
+							switch payload42.Id {
 							case 0x33732819300680aa:
 								{
 									widened := false
-									if payload45.Shape.Kind != 13 || payload45.Element.Kind != 0 {
+									if payload42.Shape.Kind != 13 || payload42.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload44).Type = TableEventTypeNone
+											(*payload41).Type = TableEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload45, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload42, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload44).Type = TableEventTypeHit
+									(*payload41).Type = TableEventTypeHit
 									{
-										value := &(*payload44)
+										value := &(*payload41)
 										TableHitEventReset(&value.Hit)
 									}
-									if !TableHitEventLoadMessageBody(r, &(*payload44).Hit) {
+									if !TableHitEventLoadMessageBody(r, &(*payload41).Hit) {
 										return false
 									}
 									if widened {
@@ -6543,25 +6540,25 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 							case 0xf2a38d910b5b348b:
 								{
 									widened := false
-									if payload45.Shape.Kind != 13 || payload45.Element.Kind != 0 {
+									if payload42.Shape.Kind != 13 || payload42.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload44).Type = TableEventTypeNone
+											(*payload41).Type = TableEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload45, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload42, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload44).Type = TableEventTypeChat
+									(*payload41).Type = TableEventTypeChat
 									{
-										value := &(*payload44)
+										value := &(*payload41)
 										TableChatEventReset(&value.Chat)
 									}
-									if !TableChatEventLoadMessageBody(r, &(*payload44).Chat) {
+									if !TableChatEventLoadMessageBody(r, &(*payload41).Chat) {
 										return false
 									}
 									if widened {
@@ -6571,25 +6568,25 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 							case 0x9fa3a41c86ecb765:
 								{
 									widened := false
-									if payload45.Shape.Kind != 13 || payload45.Element.Kind != 0 {
+									if payload42.Shape.Kind != 13 || payload42.Element.Kind != 0 {
 										if false {
 											widened = true
 										} else {
-											(*payload44).Type = TableEventTypeNone
+											(*payload41).Type = TableEventTypeNone
 											r.Report.KindMismatch++
-											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload45, 0) {
+											if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload42, 0) {
 												r.Report.Malformed = true
 												return false
 											}
 											break
 										}
 									}
-									(*payload44).Type = TableEventTypePickup
+									(*payload41).Type = TableEventTypePickup
 									{
-										value := &(*payload44)
+										value := &(*payload41)
 										TablePickupEventReset(&value.Pickup)
 									}
-									if !TablePickupEventLoadMessageBody(r, &(*payload44).Pickup) {
+									if !TablePickupEventLoadMessageBody(r, &(*payload41).Pickup) {
 										return false
 									}
 									if widened {
@@ -6597,9 +6594,9 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 									}
 								}
 							default:
-								(*payload44).Type = TableEventTypeNone
+								(*payload41).Type = TableEventTypeNone
 								r.Report.Unknown++
-								if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload45, 0) {
+								if !tableMessageSkip(&r.Bits, r.Vocabulary, r.IndexBits, payload42, 0) {
 									r.Report.Malformed = true
 									return false
 								}
@@ -6659,13 +6656,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 								r.Report.Malformed = true
 								return false
 							}
-							payload46 := TableReader{Buffer: raw[:], Report: &r.Report}
-							if !payload46.Has(tableKindBytes(element.Shape.Kind)) {
+							payload43 := TableReader{Buffer: raw[:], Report: &r.Report}
+							if !payload43.Has(tableKindBytes(element.Shape.Kind)) {
 								r.Report.Malformed = true
 								return false
 							}
 							{
-								v := payload46.Unsigned(element.Shape.Kind)
+								v := payload43.Unsigned(element.Shape.Kind)
 								(*p) = uint8(v)
 							}
 						}
@@ -6781,13 +6778,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload47 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload47.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload44 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload44.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload47.Get32())
+						v := math.Float32frombits(payload44.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -6823,13 +6820,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload48 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload48.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload45 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload45.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload48.Get32())
+						v := math.Float32frombits(payload45.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -6865,13 +6862,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload49 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload49.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload46 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload46.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload49.Get32())
+						v := math.Float32frombits(payload46.Get32())
 						if v < -1.0 {
 							v = -1.0
 							r.Report.Clamped++
@@ -6907,13 +6904,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload50 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload50.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload47 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload47.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload50.Get32())
+						v := math.Float32frombits(payload47.Get32())
 						value.Recoil = v
 					}
 				}
@@ -6942,17 +6939,17 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload51 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload51.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload48 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload48.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
 						var v float64
 						if entry.Shape.Kind == 10 {
-							v = math.Float64frombits(tableWidenFloat(payload51.Get32()))
+							v = math.Float64frombits(tableWidenFloat(payload48.Get32()))
 						} else {
-							v = math.Float64frombits(payload51.Get64())
+							v = math.Float64frombits(payload48.Get64())
 						}
 						value.Drift = v
 					}
@@ -6982,13 +6979,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload52 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload52.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload49 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload49.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload52.Unsigned(entry.Shape.Kind)
+						v := payload49.Unsigned(entry.Shape.Kind)
 						value.WideKey = uint64(v)
 					}
 				}
@@ -7017,13 +7014,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload53 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload53.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload50 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload50.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload53.Signed(entry.Shape.Kind)
+						v := payload50.Signed(entry.Shape.Kind)
 						if v < -1000000000000000000 {
 							v = -1000000000000000000
 							r.Report.Clamped++
@@ -7059,13 +7056,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload54 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload54.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload51 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload51.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := math.Float32frombits(payload54.Get32())
+						v := math.Float32frombits(payload51.Get32())
 						if v < 0.0 {
 							v = 0.0
 							r.Report.Clamped++
@@ -7101,13 +7098,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload55 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload55.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload52 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload52.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload55.Unsigned(entry.Shape.Kind)
+						v := payload52.Unsigned(entry.Shape.Kind)
 						if v > 16777215 {
 							v = 16777215
 							r.Report.Clamped++
@@ -7140,12 +7137,12 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload56 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload56.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload53 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload53.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
-					value.HasExtra = payload56.Get8() != 0
+					value.HasExtra = payload53.Get8() != 0
 				}
 				if widened {
 					r.Report.Widened++
@@ -7172,13 +7169,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload57 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload57.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload54 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload54.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload57.Signed(entry.Shape.Kind)
+						v := payload54.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7214,13 +7211,13 @@ func TableMixedLoadMessageBody(r *TableMessageReader, value *TableMixed) bool {
 						r.Report.Malformed = true
 						return false
 					}
-					payload58 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload58.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload55 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload55.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload58.Signed(entry.Shape.Kind)
+						v := payload55.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7705,13 +7702,13 @@ func TableHitEventLoadMessageBody(r *TableMessageReader, value *TableHitEvent) b
 						r.Report.Malformed = true
 						return false
 					}
-					payload59 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload59.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload56 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload56.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload59.Unsigned(entry.Shape.Kind)
+						v := payload56.Unsigned(entry.Shape.Kind)
 						if v > 4095 {
 							v = 4095
 							r.Report.Clamped++
@@ -7744,13 +7741,13 @@ func TableHitEventLoadMessageBody(r *TableMessageReader, value *TableHitEvent) b
 						r.Report.Malformed = true
 						return false
 					}
-					payload60 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload60.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload57 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload57.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload60.Signed(entry.Shape.Kind)
+						v := payload57.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7786,13 +7783,13 @@ func TableHitEventLoadMessageBody(r *TableMessageReader, value *TableHitEvent) b
 						r.Report.Malformed = true
 						return false
 					}
-					payload61 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload61.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload58 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload58.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload61.Signed(entry.Shape.Kind)
+						v := payload58.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -7828,12 +7825,12 @@ func TableHitEventLoadMessageBody(r *TableMessageReader, value *TableHitEvent) b
 						r.Report.Malformed = true
 						return false
 					}
-					payload62 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload62.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload59 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload59.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
-					value.Crit = payload62.Get8() != 0
+					value.Crit = payload59.Get8() != 0
 				}
 				if widened {
 					r.Report.Widened++
@@ -8208,13 +8205,13 @@ func TableChatEventLoadMessageBody(r *TableMessageReader, value *TableChatEvent)
 						r.Report.Malformed = true
 						return false
 					}
-					payload63 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload63.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload60 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload60.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload63.Signed(entry.Shape.Kind)
+						v := payload60.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++
@@ -8250,13 +8247,13 @@ func TableChatEventLoadMessageBody(r *TableMessageReader, value *TableChatEvent)
 						r.Report.Malformed = true
 						return false
 					}
-					payload64 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload64.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload61 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload61.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload64.Unsigned(entry.Shape.Kind)
+						v := payload61.Unsigned(entry.Shape.Kind)
 						if v > 4095 {
 							v = 4095
 							r.Report.Clamped++
@@ -8637,13 +8634,13 @@ func TablePickupEventLoadMessageBody(r *TableMessageReader, value *TablePickupEv
 						r.Report.Malformed = true
 						return false
 					}
-					payload65 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload65.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload62 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload62.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload65.Unsigned(entry.Shape.Kind)
+						v := payload62.Unsigned(entry.Shape.Kind)
 						if v > 1023 {
 							v = 1023
 							r.Report.Clamped++
@@ -8676,13 +8673,13 @@ func TablePickupEventLoadMessageBody(r *TableMessageReader, value *TablePickupEv
 						r.Report.Malformed = true
 						return false
 					}
-					payload66 := TableReader{Buffer: raw[:], Report: &r.Report}
-					if !payload66.Has(tableKindBytes(entry.Shape.Kind)) {
+					payload63 := TableReader{Buffer: raw[:], Report: &r.Report}
+					if !payload63.Has(tableKindBytes(entry.Shape.Kind)) {
 						r.Report.Malformed = true
 						return false
 					}
 					{
-						v := payload66.Signed(entry.Shape.Kind)
+						v := payload63.Signed(entry.Shape.Kind)
 						if v < 0 {
 							v = 0
 							r.Report.Clamped++

--- a/internal/codegen/gotable/measurebody_test.go
+++ b/internal/codegen/gotable/measurebody_test.go
@@ -234,3 +234,157 @@ func TestChildMeasureOnParentWalk(t *testing.T) {
 	}
 }
 `
+
+const unionArmMeasureSchema = `package probe
+table Hit {
+ n int32
+}
+table Chat {
+ note string(8)
+}
+union Event {
+ hit Hit
+ chat Chat
+ ping
+ note string(8)
+}
+table Root {
+ choice Event
+}
+`
+
+func TestUnionTableArmMeasureBodyShape(t *testing.T) {
+	body := tableGoSource(t, unionArmMeasureSchema)
+	save := generatedFunc(body, "RootSaveBody")
+	if save == "" {
+		t.Fatal("RootSaveBody missing")
+	}
+	for _, want := range []string{
+		"HitMeasureBody(&",
+		"ChatMeasureBody(&",
+		"HitSaveBody(",
+		"ChatSaveBody(",
+		"Ids.Truncate(mark)",
+	} {
+		if !strings.Contains(save, want) {
+			t.Fatalf("RootSaveBody missing %q\n%s", want, save)
+		}
+	}
+	if n := strings.Count(save, "TableWriter{Measuring: true"); n != 1 {
+		t.Fatalf("RootSaveBody nested measuring writers = %d, want 1 (string arm only)\n%s", n, save)
+	}
+	if strings.Contains(save, "HitSaveBody(&") {
+		t.Fatalf("Hit arm still dry-runs SaveBody into a measuring writer\n%s", save)
+	}
+	runGenerated(t, unionArmMeasureSchema, unionArmMeasureWireTest)
+}
+
+const unionArmMeasureWireTest = `package probe
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func trailerIds(t *testing.T, wire []byte) []uint64 {
+	t.Helper()
+	if len(wire) < 8 {
+		t.Fatalf("short wire %d", len(wire))
+	}
+	count := int(binary.LittleEndian.Uint64(wire[len(wire)-8:]))
+	if count < 0 || 8+count*8 > len(wire) {
+		t.Fatalf("trailer count %d in %d bytes", count, len(wire))
+	}
+	ids := make([]uint64, count)
+	off := len(wire) - 8 - count*8
+	for i := range ids {
+		ids[i] = binary.LittleEndian.Uint64(wire[off+i*8:])
+	}
+	return ids
+}
+
+func roundTrip(t *testing.T, v *Root) []byte {
+	t.Helper()
+	n := RootMeasure(v)
+	if n < 0 {
+		t.Fatal("measure")
+	}
+	wire := make([]byte, n)
+	if RootSave(v, wire) != n {
+		t.Fatal("save")
+	}
+	if RootSave(v, make([]byte, n-1)) != -1 {
+		t.Fatal("short buffer accepted")
+	}
+	var loaded Root
+	var report TableReport
+	if !RootLoad(&loaded, wire, &report) || report != (TableReport{}) {
+		t.Fatalf("load %+v", report)
+	}
+	if loaded.Choice.Type != v.Choice.Type || loaded.Choice.Hit.N != v.Choice.Hit.N ||
+		loaded.Choice.Chat.NoteLength != v.Choice.Chat.NoteLength ||
+		string(loaded.Choice.Chat.Note[:loaded.Choice.Chat.NoteLength]) != string(v.Choice.Chat.Note[:v.Choice.Chat.NoteLength]) ||
+		loaded.Choice.NoteLength != v.Choice.NoteLength ||
+		string(loaded.Choice.Note[:loaded.Choice.NoteLength]) != string(v.Choice.Note[:v.Choice.NoteLength]) {
+		t.Fatalf("round trip %+v want %+v", loaded, *v)
+	}
+	return wire
+}
+
+func TestUnionTableArmMeasureEqualsSave(t *testing.T) {
+	var empty Root
+	if n := RootMeasure(&empty); n != 10 {
+		t.Fatalf("elided file %d", n)
+	}
+
+	var hit Root
+	hit.Choice.Type = EventTypeHit
+	hit.Choice.Hit.N = 7
+	wire := roundTrip(t, &hit)
+	got := trailerIds(t, wire)
+	var ids TableIds
+	body := HitMeasureBody(&hit.Choice.Hit, &ids)
+	if body < 0 || ids.Overflow {
+		t.Fatal("hit measure body")
+	}
+	if len(got) < ids.Count {
+		t.Fatalf("trailer lost arm ids: measure %d save %d", ids.Count, len(got))
+	}
+	found := 0
+	for _, want := range ids.Values[:ids.Count] {
+		for _, id := range got {
+			if id == want {
+				found++
+				break
+			}
+		}
+	}
+	if found != ids.Count {
+		t.Fatalf("arm field ids %v not in trailer %v", ids.Values[:ids.Count], got)
+	}
+
+	var chat Root
+	chat.Choice.Type = EventTypeChat
+	copy(chat.Choice.Chat.Note[:], []byte("hi"))
+	chat.Choice.Chat.NoteLength = 2
+	roundTrip(t, &chat)
+
+	var ping Root
+	ping.Choice.Type = EventTypePing
+	roundTrip(t, &ping)
+
+	var note Root
+	note.Choice.Type = EventTypeNote
+	copy(note.Choice.Note[:], []byte("ab"))
+	note.Choice.NoteLength = 2
+	roundTrip(t, &note)
+
+	var full TableIds
+	full.Count = len(full.Values)
+	if HitMeasureBody(&hit.Choice.Hit, &full) != -1 {
+		t.Fatal("HitMeasureBody on overflow")
+	}
+	if RootMeasure(&hit) < 0 {
+		t.Fatal("fresh RootMeasure overflowed")
+	}
+}
+`

--- a/internal/codegen/gotable/write.go
+++ b/internal/codegen/gotable/write.go
@@ -490,16 +490,25 @@ func (g *tableGen) emitWireUnion(un *ir.Union, expr, writer, ind string) {
 		if g.retain {
 			restore = g.retainWritePush(writer, fmt.Sprint(ordinal+1))
 		}
-		payload := g.nextWireWriter()
 		arm := g.unionArmExpr(un, v, expr)
-		g.pf("%sstart := %s.Ids.Count; %s := TableWriter{Measuring:true, Ids:%s.Ids}\n", i, writer, payload, writer)
-		g.emitWireValue(v.F, arm, payload, i, false)
-		g.pf("%sif %s.Overflow { return false }\n", i, payload)
-		g.emitHeader(i, writer, "ref", fmt.Sprintf("%d", kind))
-		g.emitPutLeb(i, writer, "uint64("+payload+".Offset)")
-		g.pf("%sif %s.Measuring { %s.Advance(%s.Offset) } else {\n%s %s.Ids.Truncate(start)\n", i, writer, writer, payload, i, writer)
-		g.emitWireValue(v.F, arm, writer, i+"\t", false)
-		g.pf("%s}\n", i)
+		// A table-body arm is the framed nested-struct case. Retain keeps the
+		// nested measuring writer: its Path push sits on that writer.
+		if !g.retain && v.Body() {
+			g.pf("%s{\n%s mark := %s.Ids.Count\n%s n := %sMeasureBody(&%s,%s.Ids); if n < 0 { return false }\n", i, i, writer, i, v.F.Type.Name, arm, writer)
+			g.emitHeader(i+" ", writer, "ref", fmt.Sprintf("%d", kind))
+			g.emitPutLeb(i+" ", writer, "uint64(n)")
+			g.pf("%s if %s.Measuring { %s.Advance(n) } else {\n%s  %s.Ids.Truncate(mark)\n%s  if !%sSaveBody(%s,&%s) { return false }\n%s }\n%s}\n", i, writer, writer, i, writer, i, v.F.Type.Name, writerPointer(writer), arm, i, i)
+		} else {
+			payload := g.nextWireWriter()
+			g.pf("%sstart := %s.Ids.Count; %s := TableWriter{Measuring:true, Ids:%s.Ids}\n", i, writer, payload, writer)
+			g.emitWireValue(v.F, arm, payload, i, false)
+			g.pf("%sif %s.Overflow { return false }\n", i, payload)
+			g.emitHeader(i, writer, "ref", fmt.Sprintf("%d", kind))
+			g.emitPutLeb(i, writer, "uint64("+payload+".Offset)")
+			g.pf("%sif %s.Measuring { %s.Advance(%s.Offset) } else {\n%s %s.Ids.Truncate(start)\n", i, writer, writer, payload, i, writer)
+			g.emitWireValue(v.F, arm, writer, i+"\t", false)
+			g.pf("%s}\n", i)
+		}
 		if restore != "" {
 			g.retainWritePop(writer, restore)
 		}


### PR DESCRIPTION
Hit/Chat/Pickup union arms size with MeasureBody instead of a nested measuring SaveBody. Same framed-struct pattern as nested tables. Non-table arms and retain keep the dry-run writer.

Head: b269c5d9441fbea76fd9642c35c4e64d91f7b58b
Base: 0b42d653 (#803 merge)

Johnny Grok.