### PR TITLE
c tables: matched scalar reads use has(N)+getN

### DIFF
--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -1991,27 +1991,11 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->entity_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->entity_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->entity_id = decoded_v;
                 }
                 break;
             }
@@ -2061,38 +2045,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_x = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_x = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_x = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_x = decoded_v;
                 }
                 break;
             }
@@ -2142,38 +2100,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_y = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_y = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_y = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_y = decoded_v;
                 }
                 break;
             }
@@ -2223,38 +2155,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_z = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_z = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_z = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_z = decoded_v;
                 }
                 break;
             }
@@ -2293,27 +2199,11 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 511ull ) { decoded_wide = 511ull; r->report->clamped++; }
-                        value->yaw = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
-                            value->yaw = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
+                    value->yaw = decoded_v;
                 }
                 break;
             }
@@ -2352,27 +2242,11 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 511ull ) { decoded_wide = 511ull; r->report->clamped++; }
-                        value->pitch = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
-                            value->pitch = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
+                    value->pitch = decoded_v;
                 }
                 break;
             }
@@ -2422,38 +2296,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_x = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_x = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_x = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_x = decoded_v;
                 }
                 break;
             }
@@ -2503,38 +2351,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_y = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_y = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_y = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_y = decoded_v;
                 }
                 break;
             }
@@ -2584,38 +2406,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_z = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_z = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_z = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_z = decoded_v;
                 }
                 break;
             }
@@ -2665,38 +2461,12 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->health = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->health = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
-                            value->health = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
+                    value->health = decoded_v;
                 }
                 break;
             }
@@ -2784,39 +2554,10 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->damage = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->damage = decoded_v;
                 }
                 break;
             }
@@ -2828,16 +2569,8 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->moving = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->moving = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x7674cfd19b9031caull: /* firing */
@@ -2848,16 +2581,8 @@ static SCHEMA_UNUSED int mixed_entity_load_body( TableReader * r, MixedEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->firing = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->firing = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -3477,18 +3202,10 @@ static SCHEMA_UNUSED int mixed_stat_load_body( TableReader * r, MixedStat * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->stat_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->stat_id = decoded_v;
                 }
                 break;
             }
@@ -3538,38 +3255,12 @@ static SCHEMA_UNUSED int mixed_stat_load_body( TableReader * r, MixedStat * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -512ll ) { decoded_wide = -512ll; r->report->clamped++; }
-                        if ( decoded_wide > 511ll ) { decoded_wide = 511ll; r->report->clamped++; }
-                        value->delta = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -512ll ) { decoded_wide = -512ll; r->report->clamped++; }
-                        if ( decoded_wide > 511ll ) { decoded_wide = 511ll; r->report->clamped++; }
-                        value->delta = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -512 ) { decoded_v = -512; r->report->clamped++; }
-                            else if ( decoded_v > 511 ) { decoded_v = 511; r->report->clamped++; }
-                            value->delta = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -512 ) { decoded_v = -512; r->report->clamped++; }
+                    else if ( decoded_v > 511 ) { decoded_v = 511; r->report->clamped++; }
+                    value->delta = decoded_v;
                 }
                 break;
             }
@@ -3863,27 +3554,11 @@ static SCHEMA_UNUSED int mixed_hit_event_load_body( TableReader * r, MixedHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->target_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->target_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->target_id = decoded_v;
                 }
                 break;
             }
@@ -3933,38 +3608,12 @@ static SCHEMA_UNUSED int mixed_hit_event_load_body( TableReader * r, MixedHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4095ll ) { decoded_wide = 4095ll; r->report->clamped++; }
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4095ll ) { decoded_wide = 4095ll; r->report->clamped++; }
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 4095 ) { decoded_v = 4095; r->report->clamped++; }
-                            value->damage = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 4095 ) { decoded_v = 4095; r->report->clamped++; }
+                    value->damage = decoded_v;
                 }
                 break;
             }
@@ -4014,38 +3663,12 @@ static SCHEMA_UNUSED int mixed_hit_event_load_body( TableReader * r, MixedHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->hit_kind = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->hit_kind = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
-                            value->hit_kind = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
+                    value->hit_kind = decoded_v;
                 }
                 break;
             }
@@ -4057,16 +3680,8 @@ static SCHEMA_UNUSED int mixed_hit_event_load_body( TableReader * r, MixedHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->crit = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->crit = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -4394,38 +4009,12 @@ static SCHEMA_UNUSED int mixed_chat_event_load_body( TableReader * r, MixedChatE
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 3ll ) { decoded_wide = 3ll; r->report->clamped++; }
-                        value->channel = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 3ll ) { decoded_wide = 3ll; r->report->clamped++; }
-                        value->channel = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 3 ) { decoded_v = 3; r->report->clamped++; }
-                            value->channel = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 3 ) { decoded_v = 3; r->report->clamped++; }
+                    value->channel = decoded_v;
                 }
                 break;
             }
@@ -4464,27 +4053,11 @@ static SCHEMA_UNUSED int mixed_chat_event_load_body( TableReader * r, MixedChatE
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->speaker = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->speaker = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->speaker = decoded_v;
                 }
                 break;
             }
@@ -4752,27 +4325,11 @@ static SCHEMA_UNUSED int mixed_pickup_event_load_body( TableReader * r, MixedPic
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 1023ull ) { decoded_wide = 1023ull; r->report->clamped++; }
-                        value->item_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 1023ull ) { decoded_v = 1023ull; r->report->clamped++; } /* bits(10) width clamp */
-                            value->item_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 1023ull ) { decoded_v = 1023ull; r->report->clamped++; } /* bits(10) width clamp */
+                    value->item_id = decoded_v;
                 }
                 break;
             }
@@ -4822,38 +4379,12 @@ static SCHEMA_UNUSED int mixed_pickup_event_load_body( TableReader * r, MixedPic
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
-                            value->amount = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
+                    value->amount = decoded_v;
                 }
                 break;
             }
@@ -5487,26 +5018,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 65535ull ) { decoded_wide = 65535ull; r->report->clamped++; }
-                        value->sequence = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->sequence = decoded_v;
                 }
                 break;
             }
@@ -5556,38 +5071,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 65535ll ) { decoded_wide = 65535ll; r->report->clamped++; }
-                        value->ack_sequence = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 65535ll ) { decoded_wide = 65535ll; r->report->clamped++; }
-                        value->ack_sequence = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 65535 ) { decoded_v = 65535; r->report->clamped++; }
-                            value->ack_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 65535 ) { decoded_v = 65535; r->report->clamped++; }
+                    value->ack_sequence = decoded_v;
                 }
                 break;
             }
@@ -5633,34 +5122,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->ack_bits = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->ack_bits = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->ack_bits = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->ack_bits = decoded_v;
                 }
                 break;
             }
@@ -5711,39 +5176,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->session_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->session_id = decoded_v;
                 }
                 break;
             }
@@ -5787,32 +5223,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->client_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->client_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->client_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->client_id = decoded_v;
                 }
                 break;
             }
@@ -5863,39 +5277,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->nonce = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->nonce = decoded_v;
                 }
                 break;
             }
@@ -5954,47 +5339,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < -1000000000000ll ) { decoded_v = -1000000000000ll; r->report->clamped++; }
-                            else if ( decoded_v > 1000000000000ll ) { decoded_v = 1000000000000ll; r->report->clamped++; }
-                            value->world_time = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < -1000000000000ll ) { decoded_v = -1000000000000ll; r->report->clamped++; }
+                    else if ( decoded_v > 1000000000000ll ) { decoded_v = 1000000000000ll; r->report->clamped++; }
+                    value->world_time = decoded_v;
                 }
                 break;
             }
@@ -6049,43 +5399,11 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
-                            value->frame_tick = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
+                    value->frame_tick = decoded_v;
                 }
                 break;
             }
@@ -6097,20 +5415,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 22:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 16776960 ) { decoded_v = 16776960; r->report->clamped++; }
-                            value->server_time = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 16776960 ) { decoded_v = 16776960; r->report->clamped++; }
+                    value->server_time = decoded_v;
                 }
                 break;
             }
@@ -6320,20 +5630,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_x = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_x = decoded_f;
                 }
                 break;
             }
@@ -6345,20 +5647,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_y = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_y = decoded_f;
                 }
                 break;
             }
@@ -6370,20 +5664,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_z = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_z = decoded_f;
                 }
                 break;
             }
@@ -6395,16 +5681,8 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->recoil = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->recoil = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x5ab3f9c9341f6c04ull: /* drift */
@@ -6437,23 +5715,8 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->drift = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->drift = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->drift = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xa3348580461faf16ull: /* wide_key */
@@ -6513,50 +5776,10 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_uint128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get8( &(*r) ); decoded_wide.hi = 0;
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_uint128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get16( &(*r) ); decoded_wide.hi = 0;
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_uint128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get32( &(*r) ); decoded_wide.hi = 0;
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_uint128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get64( &(*r) ); decoded_wide.hi = 0;
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 19:
-                    {
-                        if ( !table_reader_has( &(*r), 16 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_uint128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get64( &(*r) ); decoded_wide.hi = table_reader_get64( &(*r) );
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 16 ) ) { r->report->malformed = 1; return 0; }
+                serialize_uint128_t decoded_wide;
+                decoded_wide.lo = table_reader_get64( &(*r) ); decoded_wide.hi = table_reader_get64( &(*r) );
+                value->wide_key = decoded_wide;
                 break;
             }
             case 0xd61bdd7908af2642ull: /* flux */
@@ -6660,94 +5883,18 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 16 ) ) { r->report->malformed = 1; return 0; }
+                serialize_int128_t decoded_wide;
+                decoded_wide.lo = table_reader_get64( &(*r) ); decoded_wide.hi = table_reader_get64( &(*r) );
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_int128_t decoded_wide;
-                        int64_t narrow = (int8_t) table_reader_get8( &(*r) );
-                        decoded_wide.lo = (uint64_t) narrow; decoded_wide.hi = narrow < 0 ? UINT64_MAX : 0;
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_int128_t decoded_wide;
-                        int64_t narrow = (int16_t) table_reader_get16( &(*r) );
-                        decoded_wide.lo = (uint64_t) narrow; decoded_wide.hi = narrow < 0 ? UINT64_MAX : 0;
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_int128_t decoded_wide;
-                        int64_t narrow = (int32_t) table_reader_get32( &(*r) );
-                        decoded_wide.lo = (uint64_t) narrow; decoded_wide.hi = narrow < 0 ? UINT64_MAX : 0;
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_int128_t decoded_wide;
-                        int64_t narrow = (int64_t) table_reader_get64( &(*r) );
-                        decoded_wide.lo = (uint64_t) narrow; decoded_wide.hi = narrow < 0 ? UINT64_MAX : 0;
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 18:
-                    {
-                        if ( !table_reader_has( &(*r), 16 ) ) { r->report->malformed = 1; return 0; }
-                        serialize_int128_t decoded_wide;
-                        decoded_wide.lo = table_reader_get64( &(*r) ); decoded_wide.hi = table_reader_get64( &(*r) );
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        {
-                            serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
-                            if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
-                        }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    serialize_int128_t bound = serialize_int128_make( 18446744004990074880ull, 0ull );
+                    if ( serialize_int128_compare( decoded_wide, bound ) < 0 ) { decoded_wide = bound; r->report->clamped++; }
                 }
+                {
+                    serialize_int128_t bound = serialize_int128_make( 68719476736ull, 0ull );
+                    if ( serialize_int128_compare( decoded_wide, bound ) > 0 ) { decoded_wide = bound; r->report->clamped++; }
+                }
+                value->flux = decoded_wide;
                 break;
             }
             case 0xbf30e00dc53307a9ull: /* ping */
@@ -6758,19 +5905,11 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 26:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 64000 ) { decoded_v = 64000; r->report->clamped++; }
-                            value->ping = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 64000 ) { decoded_v = 64000; r->report->clamped++; }
+                    value->ping = decoded_v;
                 }
                 break;
             }
@@ -6817,35 +5956,11 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 16777215ull ) { decoded_wide = 16777215ull; r->report->clamped++; }
-                        value->crc_hint = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 16777215ull ) { decoded_wide = 16777215ull; r->report->clamped++; }
-                        value->crc_hint = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v > 16777215ull ) { decoded_v = 16777215ull; r->report->clamped++; } /* bits(24) width clamp */
-                            value->crc_hint = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v > 16777215ull ) { decoded_v = 16777215ull; r->report->clamped++; } /* bits(24) width clamp */
+                    value->crc_hint = decoded_v;
                 }
                 break;
             }
@@ -6857,16 +5972,8 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_extra = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_extra = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0xfd29ee12a979cb69ull: /* extra */
@@ -6915,38 +6022,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->extra = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->extra = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
-                            value->extra = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
+                    value->extra = decoded_v;
                 }
                 break;
             }
@@ -6996,38 +6077,12 @@ static SCHEMA_UNUSED int bench_mixed_load_body( TableReader * r, BenchMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 15ll ) { decoded_wide = 15ll; r->report->clamped++; }
-                        value->idle_ticks = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 15ll ) { decoded_wide = 15ll; r->report->clamped++; }
-                        value->idle_ticks = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 15 ) { decoded_v = 15; r->report->clamped++; }
-                            value->idle_ticks = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 15 ) { decoded_v = 15; r->report->clamped++; }
+                    value->idle_ticks = decoded_v;
                 }
                 break;
             }

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -2051,27 +2051,11 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->entity_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->entity_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->entity_id = decoded_v;
                 }
                 break;
             }
@@ -2121,38 +2105,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_x = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_x = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_x = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_x = decoded_v;
                 }
                 break;
             }
@@ -2202,38 +2160,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_y = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_y = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_y = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_y = decoded_v;
                 }
                 break;
             }
@@ -2283,38 +2215,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_z = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -16383ll ) { decoded_wide = -16383ll; r->report->clamped++; }
-                        if ( decoded_wide > 16383ll ) { decoded_wide = 16383ll; r->report->clamped++; }
-                        value->pos_z = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
-                            else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
-                            value->pos_z = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -16383 ) { decoded_v = -16383; r->report->clamped++; }
+                    else if ( decoded_v > 16383 ) { decoded_v = 16383; r->report->clamped++; }
+                    value->pos_z = decoded_v;
                 }
                 break;
             }
@@ -2353,27 +2259,11 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 511ull ) { decoded_wide = 511ull; r->report->clamped++; }
-                        value->yaw = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
-                            value->yaw = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
+                    value->yaw = decoded_v;
                 }
                 break;
             }
@@ -2412,27 +2302,11 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 511ull ) { decoded_wide = 511ull; r->report->clamped++; }
-                        value->pitch = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
-                            value->pitch = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 511ull ) { decoded_v = 511ull; r->report->clamped++; } /* bits(9) width clamp */
+                    value->pitch = decoded_v;
                 }
                 break;
             }
@@ -2482,38 +2356,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_x = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_x = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_x = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_x = decoded_v;
                 }
                 break;
             }
@@ -2563,38 +2411,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_y = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_y = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_y = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_y = decoded_v;
                 }
                 break;
             }
@@ -2644,38 +2466,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_z = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2048ll ) { decoded_wide = -2048ll; r->report->clamped++; }
-                        if ( decoded_wide > 2047ll ) { decoded_wide = 2047ll; r->report->clamped++; }
-                        value->vel_z = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
-                            else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
-                            value->vel_z = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2048 ) { decoded_v = -2048; r->report->clamped++; }
+                    else if ( decoded_v > 2047 ) { decoded_v = 2047; r->report->clamped++; }
+                    value->vel_z = decoded_v;
                 }
                 break;
             }
@@ -2725,38 +2521,12 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->health = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->health = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
-                            value->health = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
+                    value->health = decoded_v;
                 }
                 break;
             }
@@ -2844,39 +2614,10 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->damage = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->damage = decoded_v;
                 }
                 break;
             }
@@ -2888,16 +2629,8 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->moving = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->moving = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x7674cfd19b9031caull: /* firing */
@@ -2908,16 +2641,8 @@ static SCHEMA_UNUSED int table_entity_load_body( TableReader * r, TableEntity * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->firing = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->firing = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -3537,18 +3262,10 @@ static SCHEMA_UNUSED int table_stat_load_body( TableReader * r, TableStat * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->stat_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->stat_id = decoded_v;
                 }
                 break;
             }
@@ -3598,38 +3315,12 @@ static SCHEMA_UNUSED int table_stat_load_body( TableReader * r, TableStat * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -512ll ) { decoded_wide = -512ll; r->report->clamped++; }
-                        if ( decoded_wide > 511ll ) { decoded_wide = 511ll; r->report->clamped++; }
-                        value->delta = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -512ll ) { decoded_wide = -512ll; r->report->clamped++; }
-                        if ( decoded_wide > 511ll ) { decoded_wide = 511ll; r->report->clamped++; }
-                        value->delta = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -512 ) { decoded_v = -512; r->report->clamped++; }
-                            else if ( decoded_v > 511 ) { decoded_v = 511; r->report->clamped++; }
-                            value->delta = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -512 ) { decoded_v = -512; r->report->clamped++; }
+                    else if ( decoded_v > 511 ) { decoded_v = 511; r->report->clamped++; }
+                    value->delta = decoded_v;
                 }
                 break;
             }
@@ -4270,25 +3961,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->protocol_magic = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->protocol_magic = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->protocol_magic = decoded_v;
                 }
                 break;
             }
@@ -4326,26 +4002,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 65535ull ) { decoded_wide = 65535ull; r->report->clamped++; }
-                        value->sequence = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->sequence = decoded_v;
                 }
                 break;
             }
@@ -4395,38 +4055,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 65535ll ) { decoded_wide = 65535ll; r->report->clamped++; }
-                        value->ack_sequence = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 65535ll ) { decoded_wide = 65535ll; r->report->clamped++; }
-                        value->ack_sequence = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 65535 ) { decoded_v = 65535; r->report->clamped++; }
-                            value->ack_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 65535 ) { decoded_v = 65535; r->report->clamped++; }
+                    value->ack_sequence = decoded_v;
                 }
                 break;
             }
@@ -4472,34 +4106,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->ack_bits = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->ack_bits = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->ack_bits = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->ack_bits = decoded_v;
                 }
                 break;
             }
@@ -4550,39 +4160,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->session_id = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->session_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->session_id = decoded_v;
                 }
                 break;
             }
@@ -4626,32 +4207,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->client_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->client_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->client_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->client_id = decoded_v;
                 }
                 break;
             }
@@ -4710,47 +4269,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775807ull ) { decoded_wide = 9223372036854775807ull; r->report->clamped++; }
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775807ull ) { decoded_wide = 9223372036854775807ull; r->report->clamped++; }
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775807ull ) { decoded_wide = 9223372036854775807ull; r->report->clamped++; }
-                        value->nonce = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
-                            else if ( decoded_v > 9223372036854775807ull ) { decoded_v = 9223372036854775807ull; r->report->clamped++; }
-                            value->nonce = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
+                    else if ( decoded_v > 9223372036854775807ull ) { decoded_v = 9223372036854775807ull; r->report->clamped++; }
+                    value->nonce = decoded_v;
                 }
                 break;
             }
@@ -4809,47 +4333,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < -1000000000000ll ) { decoded_wide = -1000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000ll ) { decoded_wide = 1000000000000ll; r->report->clamped++; }
-                        value->world_time = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < -1000000000000ll ) { decoded_v = -1000000000000ll; r->report->clamped++; }
-                            else if ( decoded_v > 1000000000000ll ) { decoded_v = 1000000000000ll; r->report->clamped++; }
-                            value->world_time = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < -1000000000000ll ) { decoded_v = -1000000000000ll; r->report->clamped++; }
+                    else if ( decoded_v > 1000000000000ll ) { decoded_v = 1000000000000ll; r->report->clamped++; }
+                    value->world_time = decoded_v;
                 }
                 break;
             }
@@ -4904,43 +4393,11 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->frame_tick = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
-                            value->frame_tick = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
+                    value->frame_tick = decoded_v;
                 }
                 break;
             }
@@ -4952,20 +4409,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < 0.0f ) { decoded_f = 0.0f; r->report->clamped++; }
-                            else if ( decoded_f > 65535.0f ) { decoded_f = 65535.0f; r->report->clamped++; }
-                            value->server_time = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < 0.0f ) { decoded_f = 0.0f; r->report->clamped++; }
+                    else if ( decoded_f > 65535.0f ) { decoded_f = 65535.0f; r->report->clamped++; }
+                    value->server_time = decoded_f;
                 }
                 break;
             }
@@ -5175,20 +4624,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_x = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_x = decoded_f;
                 }
                 break;
             }
@@ -5200,20 +4641,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_y = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_y = decoded_f;
                 }
                 break;
             }
@@ -5225,20 +4658,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
-                            else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
-                            value->aim_z = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < -1.0f ) { decoded_f = -1.0f; r->report->clamped++; }
+                    else if ( decoded_f > 1.0f ) { decoded_f = 1.0f; r->report->clamped++; }
+                    value->aim_z = decoded_f;
                 }
                 break;
             }
@@ -5250,16 +4675,8 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->recoil = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->recoil = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x5ab3f9c9341f6c04ull: /* drift */
@@ -5292,23 +4709,8 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->drift = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->drift = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->drift = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xa3348580461faf16ull: /* wide_key */
@@ -5358,39 +4760,10 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->wide_key = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->wide_key = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->wide_key = decoded_v;
                 }
                 break;
             }
@@ -5449,47 +4822,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -1000000000000000000ll ) { decoded_wide = -1000000000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000000000ll ) { decoded_wide = 1000000000000000000ll; r->report->clamped++; }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -1000000000000000000ll ) { decoded_wide = -1000000000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000000000ll ) { decoded_wide = 1000000000000000000ll; r->report->clamped++; }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < -1000000000000000000ll ) { decoded_wide = -1000000000000000000ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000000000000000000ll ) { decoded_wide = 1000000000000000000ll; r->report->clamped++; }
-                        value->flux = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < -1000000000000000000ll ) { decoded_v = -1000000000000000000ll; r->report->clamped++; }
-                            else if ( decoded_v > 1000000000000000000ll ) { decoded_v = 1000000000000000000ll; r->report->clamped++; }
-                            value->flux = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < -1000000000000000000ll ) { decoded_v = -1000000000000000000ll; r->report->clamped++; }
+                    else if ( decoded_v > 1000000000000000000ll ) { decoded_v = 1000000000000000000ll; r->report->clamped++; }
+                    value->flux = decoded_v;
                 }
                 break;
             }
@@ -5501,20 +4839,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
-                            if ( decoded_f < 0.0f ) { decoded_f = 0.0f; r->report->clamped++; }
-                            else if ( decoded_f > 250.0f ) { decoded_f = 250.0f; r->report->clamped++; }
-                            value->ping = decoded_f;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    float decoded_f = table_bits_to_float( table_reader_get32( &(*r) ) );
+                    if ( decoded_f < 0.0f ) { decoded_f = 0.0f; r->report->clamped++; }
+                    else if ( decoded_f > 250.0f ) { decoded_f = 250.0f; r->report->clamped++; }
+                    value->ping = decoded_f;
                 }
                 break;
             }
@@ -5561,35 +4891,11 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 16777215ull ) { decoded_wide = 16777215ull; r->report->clamped++; }
-                        value->crc_hint = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 16777215ull ) { decoded_wide = 16777215ull; r->report->clamped++; }
-                        value->crc_hint = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v > 16777215ull ) { decoded_v = 16777215ull; r->report->clamped++; } /* bits(24) width clamp */
-                            value->crc_hint = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v > 16777215ull ) { decoded_v = 16777215ull; r->report->clamped++; } /* bits(24) width clamp */
+                    value->crc_hint = decoded_v;
                 }
                 break;
             }
@@ -5601,16 +4907,8 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_extra = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_extra = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0xfd29ee12a979cb69ull: /* extra */
@@ -5659,38 +4957,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->extra = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->extra = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
-                            value->extra = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
+                    value->extra = decoded_v;
                 }
                 break;
             }
@@ -5740,38 +5012,12 @@ static SCHEMA_UNUSED int table_mixed_load_body( TableReader * r, TableMixed * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 15ll ) { decoded_wide = 15ll; r->report->clamped++; }
-                        value->idle_ticks = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 15ll ) { decoded_wide = 15ll; r->report->clamped++; }
-                        value->idle_ticks = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 15 ) { decoded_v = 15; r->report->clamped++; }
-                            value->idle_ticks = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 15 ) { decoded_v = 15; r->report->clamped++; }
+                    value->idle_ticks = decoded_v;
                 }
                 break;
             }
@@ -6831,27 +6077,11 @@ static SCHEMA_UNUSED int table_hit_event_load_body( TableReader * r, TableHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->target_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->target_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->target_id = decoded_v;
                 }
                 break;
             }
@@ -6901,38 +6131,12 @@ static SCHEMA_UNUSED int table_hit_event_load_body( TableReader * r, TableHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4095ll ) { decoded_wide = 4095ll; r->report->clamped++; }
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4095ll ) { decoded_wide = 4095ll; r->report->clamped++; }
-                        value->damage = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 4095 ) { decoded_v = 4095; r->report->clamped++; }
-                            value->damage = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 4095 ) { decoded_v = 4095; r->report->clamped++; }
+                    value->damage = decoded_v;
                 }
                 break;
             }
@@ -6982,38 +6186,12 @@ static SCHEMA_UNUSED int table_hit_event_load_body( TableReader * r, TableHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->hit_kind = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->hit_kind = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
-                            value->hit_kind = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
+                    value->hit_kind = decoded_v;
                 }
                 break;
             }
@@ -7025,16 +6203,8 @@ static SCHEMA_UNUSED int table_hit_event_load_body( TableReader * r, TableHitEve
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->crit = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->crit = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -7362,38 +6532,12 @@ static SCHEMA_UNUSED int table_chat_event_load_body( TableReader * r, TableChatE
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 3ll ) { decoded_wide = 3ll; r->report->clamped++; }
-                        value->channel = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 3ll ) { decoded_wide = 3ll; r->report->clamped++; }
-                        value->channel = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 3 ) { decoded_v = 3; r->report->clamped++; }
-                            value->channel = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 3 ) { decoded_v = 3; r->report->clamped++; }
+                    value->channel = decoded_v;
                 }
                 break;
             }
@@ -7432,27 +6576,11 @@ static SCHEMA_UNUSED int table_chat_event_load_body( TableReader * r, TableChatE
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->speaker = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->speaker = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->speaker = decoded_v;
                 }
                 break;
             }
@@ -7720,27 +6848,11 @@ static SCHEMA_UNUSED int table_pickup_event_load_body( TableReader * r, TablePic
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 1023ull ) { decoded_wide = 1023ull; r->report->clamped++; }
-                        value->item_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 1023ull ) { decoded_v = 1023ull; r->report->clamped++; } /* bits(10) width clamp */
-                            value->item_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 1023ull ) { decoded_v = 1023ull; r->report->clamped++; } /* bits(10) width clamp */
+                    value->item_id = decoded_v;
                 }
                 break;
             }
@@ -7790,38 +6902,12 @@ static SCHEMA_UNUSED int table_pickup_event_load_body( TableReader * r, TablePic
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 255ll ) { decoded_wide = 255ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
-                            value->amount = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 255 ) { decoded_v = 255; r->report->clamped++; }
+                    value->amount = decoded_v;
                 }
                 break;
             }

--- a/internal/codegen/ctable/wire_read.go
+++ b/internal/codegen/ctable/wire_read.go
@@ -270,7 +270,16 @@ func (g *tableGen) wireReadFieldPayload(f *ir.Field, kind int, dst, bounded stri
 		g.wireRefusalCheck(ind)
 		g.pf("%sif ( sub.offset != sub.size ) { r->report->malformed = 1; %s( &%s ); }\n", ind, g.api(f.Type.Name, "reset"), dst)
 	default:
-		g.wireScalarRead(f, dst, "(*r)", "kind", ind, "r->report->malformed = 1; return 0;")
+		// Kind already matched the declaration. Decode at that width;
+		// widening stays in the mismatch arm (emitWireRead).
+		onBad := "r->report->malformed = 1; return 0;"
+		if e := enumRef(f); e != nil {
+			g.wireEnumRead(e, dst, "(*r)", ind, onBad)
+		} else if tableKindWidth(kind) == 16 {
+			g.wireWideRead(f, kind, dst, "(*r)", ind, onBad)
+		} else {
+			g.emitTableReadScalarFrom(f, kind, dst, ind, "(*r)", onBad)
+		}
 	}
 }
 

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -1730,18 +1730,10 @@ static SCHEMA_UNUSED int padded_row_load_body( TableReader * r, PaddedRow * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->tag = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->tag = decoded_v;
                 }
                 break;
             }
@@ -1775,23 +1767,8 @@ static SCHEMA_UNUSED int padded_row_load_body( TableReader * r, PaddedRow * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->value = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->value = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->value = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xd5f2d079088c0b17ull: /* flag */
@@ -1802,16 +1779,8 @@ static SCHEMA_UNUSED int padded_row_load_body( TableReader * r, PaddedRow * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->flag = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->flag = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x08b72e07b55c3ac0ull: /* id */
@@ -1854,32 +1823,10 @@ static SCHEMA_UNUSED int padded_row_load_body( TableReader * r, PaddedRow * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->id = decoded_v;
                 }
                 break;
             }
@@ -2040,32 +1987,10 @@ static SCHEMA_UNUSED int padded_row_load_body( TableReader * r, PaddedRow * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->counter = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        value->counter = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            value->counter = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    value->counter = decoded_v;
                 }
                 value->counter_present = 1;
                 break;
@@ -2630,18 +2555,10 @@ static SCHEMA_UNUSED int padded_frame_load_body( TableReader * r, PaddedFrame * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->marker = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->marker = decoded_v;
                 }
                 break;
             }
@@ -2692,39 +2609,10 @@ static SCHEMA_UNUSED int padded_frame_load_body( TableReader * r, PaddedFrame * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->stamp = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->stamp = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->stamp = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->stamp = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->stamp = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -2061,32 +2061,10 @@ static SCHEMA_UNUSED int render_camera_load_body( TableReader * r, RenderCamera 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->camera_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->camera_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->camera_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->camera_id = decoded_v;
                 }
                 break;
             }
@@ -2130,32 +2108,10 @@ static SCHEMA_UNUSED int render_camera_load_body( TableReader * r, RenderCamera 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->camera_type = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->camera_type = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->camera_type = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->camera_type = decoded_v;
                 }
                 break;
             }
@@ -2199,32 +2155,10 @@ static SCHEMA_UNUSED int render_camera_load_body( TableReader * r, RenderCamera 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->target_object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->target_object_id = decoded_v;
                 }
                 break;
             }
@@ -2236,16 +2170,8 @@ static SCHEMA_UNUSED int render_camera_load_body( TableReader * r, RenderCamera 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->fov = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->fov = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             default:
@@ -2750,39 +2676,10 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -2826,32 +2723,10 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->object_id = decoded_v;
                 }
                 break;
             }
@@ -2895,32 +2770,10 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->target_object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->target_object_id = decoded_v;
                 }
                 break;
             }
@@ -2932,16 +2785,8 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->thrust = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->thrust = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x5de0015285763c46ull: /* object_sequence */
@@ -2952,18 +2797,10 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->object_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->object_sequence = decoded_v;
                 }
                 break;
             }
@@ -3026,16 +2863,8 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_target_lock = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_target_lock = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x4d5be97ba1b9cb81ull: /* predicted_explode */
@@ -3046,16 +2875,8 @@ static SCHEMA_UNUSED int render_ship_load_body( TableReader * r, RenderShip * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->predicted_explode = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->predicted_explode = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -3659,39 +3480,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -3735,32 +3527,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->object_id = decoded_v;
                 }
                 break;
             }
@@ -3804,32 +3574,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->parent_object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->parent_object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->parent_object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->parent_object_id = decoded_v;
                 }
                 break;
             }
@@ -3873,32 +3621,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->turret_index = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->turret_index = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->turret_index = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->turret_index = decoded_v;
                 }
                 break;
             }
@@ -3942,32 +3668,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->target_object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->target_object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->target_object_id = decoded_v;
                 }
                 break;
             }
@@ -3979,18 +3683,10 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->object_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->object_sequence = decoded_v;
                 }
                 break;
             }
@@ -4028,16 +3724,8 @@ static SCHEMA_UNUSED int render_turret_load_body( TableReader * r, RenderTurret 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_target_lock = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_target_lock = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -4599,39 +4287,10 @@ static SCHEMA_UNUSED int render_missile_load_body( TableReader * r, RenderMissil
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -4675,32 +4334,10 @@ static SCHEMA_UNUSED int render_missile_load_body( TableReader * r, RenderMissil
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->object_id = decoded_v;
                 }
                 break;
             }
@@ -4712,18 +4349,10 @@ static SCHEMA_UNUSED int render_missile_load_body( TableReader * r, RenderMissil
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->object_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->object_sequence = decoded_v;
                 }
                 break;
             }
@@ -5299,39 +4928,10 @@ static SCHEMA_UNUSED int render_dynamic_prop_load_body( TableReader * r, RenderD
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -5375,32 +4975,10 @@ static SCHEMA_UNUSED int render_dynamic_prop_load_body( TableReader * r, RenderD
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->object_id = decoded_v;
                 }
                 break;
             }
@@ -5412,18 +4990,10 @@ static SCHEMA_UNUSED int render_dynamic_prop_load_body( TableReader * r, RenderD
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->object_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->object_sequence = decoded_v;
                 }
                 break;
             }
@@ -5987,23 +5557,8 @@ static SCHEMA_UNUSED int render_static_prop_load_body( TableReader * r, RenderSt
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->scale = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->scale = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->scale = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0x17a3a1a985f75aecull: /* flags */
@@ -6053,39 +5608,10 @@ static SCHEMA_UNUSED int render_static_prop_load_body( TableReader * r, RenderSt
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -6129,32 +5655,10 @@ static SCHEMA_UNUSED int render_static_prop_load_body( TableReader * r, RenderSt
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->static_prop_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->static_prop_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->static_prop_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->static_prop_id = decoded_v;
                 }
                 break;
             }
@@ -6727,23 +6231,8 @@ static SCHEMA_UNUSED int render_cosmetic_prop_load_body( TableReader * r, Render
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->scale = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->scale = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->scale = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0x17a3a1a985f75aecull: /* flags */
@@ -6793,39 +6282,10 @@ static SCHEMA_UNUSED int render_cosmetic_prop_load_body( TableReader * r, Render
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->flags = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->flags = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->flags = decoded_v;
                 }
                 break;
             }
@@ -6869,32 +6329,10 @@ static SCHEMA_UNUSED int render_cosmetic_prop_load_body( TableReader * r, Render
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->cosmetic_prop_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->cosmetic_prop_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->cosmetic_prop_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->cosmetic_prop_id = decoded_v;
                 }
                 break;
             }
@@ -6906,18 +6344,10 @@ static SCHEMA_UNUSED int render_cosmetic_prop_load_body( TableReader * r, Render
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->prop_sequence = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->prop_sequence = decoded_v;
                 }
                 break;
             }
@@ -7499,23 +6929,8 @@ static SCHEMA_UNUSED int render_laser_load_body( TableReader * r, RenderLaser * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->t = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->t = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->t = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xcd29c05f390294ecull: /* laser_id */
@@ -7558,32 +6973,10 @@ static SCHEMA_UNUSED int render_laser_load_body( TableReader * r, RenderLaser * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->laser_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->laser_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->laser_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->laser_id = decoded_v;
                 }
                 break;
             }
@@ -8119,23 +7512,8 @@ static SCHEMA_UNUSED int render_explosion_load_body( TableReader * r, RenderExpl
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->t = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->t = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->t = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xfd7f3fa0b16ed778ull: /* explosion_id */
@@ -8178,32 +7556,10 @@ static SCHEMA_UNUSED int render_explosion_load_body( TableReader * r, RenderExpl
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->explosion_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->explosion_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->explosion_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->explosion_id = decoded_v;
                 }
                 break;
             }
@@ -8247,32 +7603,10 @@ static SCHEMA_UNUSED int render_explosion_load_body( TableReader * r, RenderExpl
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->parent_object_id = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->parent_object_id = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->parent_object_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->parent_object_id = decoded_v;
                 }
                 break;
             }
@@ -9307,39 +8641,10 @@ static SCHEMA_UNUSED int render_frame_load_body( TableReader * r, RenderFrame * 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->version = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->version = decoded_v;
                 }
                 break;
             }
@@ -10276,23 +9581,8 @@ static SCHEMA_UNUSED int render_vector3_load_body( TableReader * r, RenderVector
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->x = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->x = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->x = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xaf63f44c86021554ull: /* y */
@@ -10325,23 +9615,8 @@ static SCHEMA_UNUSED int render_vector3_load_body( TableReader * r, RenderVector
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->y = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->y = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->y = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xaf63f74c86021a6dull: /* z */
@@ -10374,23 +9649,8 @@ static SCHEMA_UNUSED int render_vector3_load_body( TableReader * r, RenderVector
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->z = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->z = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->z = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             default:
@@ -10704,23 +9964,8 @@ static SCHEMA_UNUSED int render_quaternion_load_body( TableReader * r, RenderQua
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->x = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->x = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->x = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xaf63f44c86021554ull: /* y */
@@ -10753,23 +9998,8 @@ static SCHEMA_UNUSED int render_quaternion_load_body( TableReader * r, RenderQua
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->y = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->y = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->y = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xaf63f74c86021a6dull: /* z */
@@ -10802,23 +10032,8 @@ static SCHEMA_UNUSED int render_quaternion_load_body( TableReader * r, RenderQua
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->z = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->z = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->z = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xaf63ea4c86020456ull: /* w */
@@ -10851,23 +10066,8 @@ static SCHEMA_UNUSED int render_quaternion_load_body( TableReader * r, RenderQua
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->w = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->w = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->w = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             default:

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -1623,16 +1623,8 @@ static SCHEMA_UNUSED int patrol_load_body( TableReader * r, Patrol * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->active = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->active = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x2281498aa0200e40ull: /* speed */
@@ -1643,16 +1635,8 @@ static SCHEMA_UNUSED int patrol_load_body( TableReader * r, Patrol * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->speed = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->speed = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x247f0e7f55aacfbdull: /* has_target */
@@ -1663,16 +1647,8 @@ static SCHEMA_UNUSED int patrol_load_body( TableReader * r, Patrol * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_target = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_target = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0xb7bc9ac015a25050ull: /* target_id */
@@ -1721,38 +1697,12 @@ static SCHEMA_UNUSED int patrol_load_body( TableReader * r, Patrol * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->target_id = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->target_id = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
-                            value->target_id = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
+                    value->target_id = decoded_v;
                 }
                 break;
             }
@@ -1764,16 +1714,8 @@ static SCHEMA_UNUSED int patrol_load_body( TableReader * r, Patrol * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->wander = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->wander = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x3bf8fbbad1587cddull: /* note */

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -1721,38 +1721,12 @@ static SCHEMA_UNUSED int team_config_load_body( TableReader * r, TeamConfig * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll; r->report->clamped++; }
-                        value->spawn_count = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll; r->report->clamped++; }
-                        value->spawn_count = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 64 ) { decoded_v = 64; r->report->clamped++; }
-                            value->spawn_count = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 64 ) { decoded_v = 64; r->report->clamped++; }
+                    value->spawn_count = decoded_v;
                 }
                 break;
             }
@@ -2021,16 +1995,8 @@ static SCHEMA_UNUSED int gunner_config_load_body( TableReader * r, GunnerConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->reaction = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->reaction = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0xa6bf719a4602b0bcull: /* tracking */
@@ -2041,16 +2007,8 @@ static SCHEMA_UNUSED int gunner_config_load_body( TableReader * r, GunnerConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->tracking = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->tracking = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             default:
@@ -2286,16 +2244,8 @@ static SCHEMA_UNUSED int turret_config_load_body( TableReader * r, TurretConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->damage = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->damage = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0xdc2cbe6953343d48ull: /* cooldown */
@@ -2306,16 +2256,8 @@ static SCHEMA_UNUSED int turret_config_load_body( TableReader * r, TurretConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->cooldown = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->cooldown = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x40dbb648c0cd44aaull: /* gunner */
@@ -2644,16 +2586,8 @@ static SCHEMA_UNUSED int hull_config_load_body( TableReader * r, HullConfig * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->health = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->health = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x1f3757a2ce7b0ab1ull: /* mass */
@@ -2664,16 +2598,8 @@ static SCHEMA_UNUSED int hull_config_load_body( TableReader * r, HullConfig * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->mass = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->mass = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x84f8260bc283608cull: /* turrets */

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -1602,38 +1602,12 @@ static SCHEMA_UNUSED int archive_config_load_body( TableReader * r, ArchiveConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 100ll ) { decoded_wide = 100ll; r->report->clamped++; }
-                        value->count = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 100ll ) { decoded_wide = 100ll; r->report->clamped++; }
-                        value->count = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 100 ) { decoded_v = 100; r->report->clamped++; }
-                            value->count = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 100 ) { decoded_v = 100; r->report->clamped++; }
+                    value->count = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -1669,16 +1669,8 @@ static SCHEMA_UNUSED int gunner_settings_load_body( TableReader * r, GunnerSetti
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->reaction = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->reaction = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0xa6bf719a4602b0bcull: /* tracking */
@@ -1689,16 +1681,8 @@ static SCHEMA_UNUSED int gunner_settings_load_body( TableReader * r, GunnerSetti
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->tracking = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->tracking = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x5bc44627b9848818ull: /* callsign */
@@ -2068,16 +2052,8 @@ static SCHEMA_UNUSED int ship_entry_load_body( TableReader * r, ShipEntry * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->health = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->health = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x1f3757a2ce7b0ab1ull: /* mass */
@@ -2088,16 +2064,8 @@ static SCHEMA_UNUSED int ship_entry_load_body( TableReader * r, ShipEntry * valu
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->mass = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->mass = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x95d0cce09ca82b73ull: /* hardpoints */
@@ -2611,38 +2579,12 @@ static SCHEMA_UNUSED int global_settings_load_body( TableReader * r, GlobalSetti
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 240ull ) { decoded_wide = 240ull; r->report->clamped++; }
-                        value->tick_rate = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 240ull ) { decoded_wide = 240ull; r->report->clamped++; }
-                        value->tick_rate = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            else if ( decoded_v > 240 ) { decoded_v = 240; r->report->clamped++; }
-                            value->tick_rate = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    else if ( decoded_v > 240 ) { decoded_v = 240; r->report->clamped++; }
+                    value->tick_rate = decoded_v;
                 }
                 break;
             }
@@ -3292,32 +3234,10 @@ static SCHEMA_UNUSED int pack_config_load_body( TableReader * r, PackConfig * va
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->version = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->version = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -1801,18 +1801,10 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
-                            value->i8_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
+                    value->i8_span = decoded_v;
                 }
                 break;
             }
@@ -1824,19 +1816,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v > 126 ) { decoded_v = 126; r->report->clamped++; }
-                            value->i8_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v > 126 ) { decoded_v = 126; r->report->clamped++; }
+                    value->i8_low = decoded_v;
                 }
                 break;
             }
@@ -1848,19 +1832,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v < -127 ) { decoded_v = -127; r->report->clamped++; }
-                            value->i8_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v < -127 ) { decoded_v = -127; r->report->clamped++; }
+                    value->i8_high = decoded_v;
                 }
                 break;
             }
@@ -1872,20 +1848,12 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v < -127 ) { decoded_v = -127; r->report->clamped++; }
-                            else if ( decoded_v > 126 ) { decoded_v = 126; r->report->clamped++; }
-                            value->i8_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v < -127 ) { decoded_v = -127; r->report->clamped++; }
+                    else if ( decoded_v > 126 ) { decoded_v = 126; r->report->clamped++; }
+                    value->i8_inside = decoded_v;
                 }
                 break;
             }
@@ -1924,27 +1892,10 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -32768ll ) { decoded_wide = -32768ll; r->report->clamped++; }
-                        if ( decoded_wide > 32767ll ) { decoded_wide = 32767ll; r->report->clamped++; }
-                        value->i16_span = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
-                            value->i16_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
+                    value->i16_span = decoded_v;
                 }
                 break;
             }
@@ -1984,28 +1935,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -32768ll ) { decoded_wide = -32768ll; r->report->clamped++; }
-                        if ( decoded_wide > 32766ll ) { decoded_wide = 32766ll; r->report->clamped++; }
-                        value->i16_low = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 32766 ) { decoded_v = 32766; r->report->clamped++; }
-                            value->i16_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 32766 ) { decoded_v = 32766; r->report->clamped++; }
+                    value->i16_low = decoded_v;
                 }
                 break;
             }
@@ -2045,28 +1979,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -32767ll ) { decoded_wide = -32767ll; r->report->clamped++; }
-                        if ( decoded_wide > 32767ll ) { decoded_wide = 32767ll; r->report->clamped++; }
-                        value->i16_high = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v < -32767 ) { decoded_v = -32767; r->report->clamped++; }
-                            value->i16_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v < -32767 ) { decoded_v = -32767; r->report->clamped++; }
+                    value->i16_high = decoded_v;
                 }
                 break;
             }
@@ -2107,29 +2024,12 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -32767ll ) { decoded_wide = -32767ll; r->report->clamped++; }
-                        if ( decoded_wide > 32766ll ) { decoded_wide = 32766ll; r->report->clamped++; }
-                        value->i16_inside = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v < -32767 ) { decoded_v = -32767; r->report->clamped++; }
-                            else if ( decoded_v > 32766 ) { decoded_v = 32766; r->report->clamped++; }
-                            value->i16_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v < -32767 ) { decoded_v = -32767; r->report->clamped++; }
+                    else if ( decoded_v > 32766 ) { decoded_v = 32766; r->report->clamped++; }
+                    value->i16_inside = decoded_v;
                 }
                 break;
             }
@@ -2177,36 +2077,10 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2147483648ll ) { decoded_wide = -2147483648ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483647ll ) { decoded_wide = 2147483647ll; r->report->clamped++; }
-                        value->i32_span = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2147483648ll ) { decoded_wide = -2147483648ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483647ll ) { decoded_wide = 2147483647ll; r->report->clamped++; }
-                        value->i32_span = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            value->i32_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    value->i32_span = decoded_v;
                 }
                 break;
             }
@@ -2255,37 +2129,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2147483648ll ) { decoded_wide = -2147483648ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483646ll ) { decoded_wide = 2147483646ll; r->report->clamped++; }
-                        value->i32_low = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2147483648ll ) { decoded_wide = -2147483648ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483646ll ) { decoded_wide = 2147483646ll; r->report->clamped++; }
-                        value->i32_low = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v > 2147483646 ) { decoded_v = 2147483646; r->report->clamped++; }
-                            value->i32_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v > 2147483646 ) { decoded_v = 2147483646; r->report->clamped++; }
+                    value->i32_low = decoded_v;
                 }
                 break;
             }
@@ -2334,37 +2182,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2147483647ll ) { decoded_wide = -2147483647ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483647ll ) { decoded_wide = 2147483647ll; r->report->clamped++; }
-                        value->i32_high = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2147483647ll ) { decoded_wide = -2147483647ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483647ll ) { decoded_wide = 2147483647ll; r->report->clamped++; }
-                        value->i32_high = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2147483647 ) { decoded_v = -2147483647; r->report->clamped++; }
-                            value->i32_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2147483647 ) { decoded_v = -2147483647; r->report->clamped++; }
+                    value->i32_high = decoded_v;
                 }
                 break;
             }
@@ -2414,38 +2236,12 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -2147483647ll ) { decoded_wide = -2147483647ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483646ll ) { decoded_wide = 2147483646ll; r->report->clamped++; }
-                        value->i32_inside = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -2147483647ll ) { decoded_wide = -2147483647ll; r->report->clamped++; }
-                        if ( decoded_wide > 2147483646ll ) { decoded_wide = 2147483646ll; r->report->clamped++; }
-                        value->i32_inside = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < -2147483647 ) { decoded_v = -2147483647; r->report->clamped++; }
-                            else if ( decoded_v > 2147483646 ) { decoded_v = 2147483646; r->report->clamped++; }
-                            value->i32_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < -2147483647 ) { decoded_v = -2147483647; r->report->clamped++; }
+                    else if ( decoded_v > 2147483646 ) { decoded_v = 2147483646; r->report->clamped++; }
+                    value->i32_inside = decoded_v;
                 }
                 break;
             }
@@ -2496,39 +2292,10 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->i64_span = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        value->i64_span = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        value->i64_span = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            value->i64_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    value->i64_span = decoded_v;
                 }
                 break;
             }
@@ -2583,43 +2350,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_low = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_low = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_low = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v > 9223372036854775806ll ) { decoded_v = 9223372036854775806ll; r->report->clamped++; }
-                            value->i64_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v > 9223372036854775806ll ) { decoded_v = 9223372036854775806ll; r->report->clamped++; }
+                    value->i64_low = decoded_v;
                 }
                 break;
             }
@@ -2674,43 +2409,11 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        value->i64_high = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        value->i64_high = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        value->i64_high = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < -9223372036854775807ll ) { decoded_v = -9223372036854775807ll; r->report->clamped++; }
-                            value->i64_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < -9223372036854775807ll ) { decoded_v = -9223372036854775807ll; r->report->clamped++; }
+                    value->i64_high = decoded_v;
                 }
                 break;
             }
@@ -2769,47 +2472,12 @@ static SCHEMA_UNUSED int ranged_signed_load_body( TableReader * r, RangedSigned 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_inside = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_inside = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < -9223372036854775807ll ) { decoded_wide = -9223372036854775807ll; r->report->clamped++; }
-                        if ( decoded_wide > 9223372036854775806ll ) { decoded_wide = 9223372036854775806ll; r->report->clamped++; }
-                        value->i64_inside = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < -9223372036854775807ll ) { decoded_v = -9223372036854775807ll; r->report->clamped++; }
-                            else if ( decoded_v > 9223372036854775806ll ) { decoded_v = 9223372036854775806ll; r->report->clamped++; }
-                            value->i64_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < -9223372036854775807ll ) { decoded_v = -9223372036854775807ll; r->report->clamped++; }
+                    else if ( decoded_v > 9223372036854775806ll ) { decoded_v = 9223372036854775806ll; r->report->clamped++; }
+                    value->i64_inside = decoded_v;
                 }
                 break;
             }
@@ -3681,18 +3349,10 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->u8_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->u8_span = decoded_v;
                 }
                 break;
             }
@@ -3704,19 +3364,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v > 254 ) { decoded_v = 254; r->report->clamped++; }
-                            value->u8_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v > 254 ) { decoded_v = 254; r->report->clamped++; }
+                    value->u8_low = decoded_v;
                 }
                 break;
             }
@@ -3728,19 +3380,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            value->u8_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    value->u8_high = decoded_v;
                 }
                 break;
             }
@@ -3752,20 +3396,12 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            else if ( decoded_v > 254 ) { decoded_v = 254; r->report->clamped++; }
-                            value->u8_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    else if ( decoded_v > 254 ) { decoded_v = 254; r->report->clamped++; }
+                    value->u8_inside = decoded_v;
                 }
                 break;
             }
@@ -3803,26 +3439,10 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 65535ull ) { decoded_wide = 65535ull; r->report->clamped++; }
-                        value->u16_span = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->u16_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->u16_span = decoded_v;
                 }
                 break;
             }
@@ -3861,27 +3481,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 65534ull ) { decoded_wide = 65534ull; r->report->clamped++; }
-                        value->u16_low = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 65534 ) { decoded_v = 65534; r->report->clamped++; }
-                            value->u16_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 65534 ) { decoded_v = 65534; r->report->clamped++; }
+                    value->u16_low = decoded_v;
                 }
                 break;
             }
@@ -3921,28 +3525,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 65535ull ) { decoded_wide = 65535ull; r->report->clamped++; }
-                        value->u16_high = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            value->u16_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    value->u16_high = decoded_v;
                 }
                 break;
             }
@@ -3983,29 +3570,12 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 65534ull ) { decoded_wide = 65534ull; r->report->clamped++; }
-                        value->u16_inside = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            else if ( decoded_v > 65534 ) { decoded_v = 65534; r->report->clamped++; }
-                            value->u16_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    else if ( decoded_v > 65534 ) { decoded_v = 65534; r->report->clamped++; }
+                    value->u16_inside = decoded_v;
                 }
                 break;
             }
@@ -4051,34 +3621,10 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->u32_span = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->u32_span = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->u32_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->u32_span = decoded_v;
                 }
                 break;
             }
@@ -4125,35 +3671,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4294967294ull ) { decoded_wide = 4294967294ull; r->report->clamped++; }
-                        value->u32_low = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 4294967294ull ) { decoded_wide = 4294967294ull; r->report->clamped++; }
-                        value->u32_low = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v > 4294967294 ) { decoded_v = 4294967294; r->report->clamped++; }
-                            value->u32_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v > 4294967294 ) { decoded_v = 4294967294; r->report->clamped++; }
+                    value->u32_low = decoded_v;
                 }
                 break;
             }
@@ -4202,37 +3724,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->u32_high = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->u32_high = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            value->u32_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    value->u32_high = decoded_v;
                 }
                 break;
             }
@@ -4282,38 +3778,12 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 4294967294ull ) { decoded_wide = 4294967294ull; r->report->clamped++; }
-                        value->u32_inside = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 4294967294ull ) { decoded_wide = 4294967294ull; r->report->clamped++; }
-                        value->u32_inside = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
-                            else if ( decoded_v > 4294967294 ) { decoded_v = 4294967294; r->report->clamped++; }
-                            value->u32_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 1 ) { decoded_v = 1; r->report->clamped++; }
+                    else if ( decoded_v > 4294967294 ) { decoded_v = 4294967294; r->report->clamped++; }
+                    value->u32_inside = decoded_v;
                 }
                 break;
             }
@@ -4364,39 +3834,10 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->u64_span = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->u64_span = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->u64_span = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->u64_span = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->u64_span = decoded_v;
                 }
                 break;
             }
@@ -4451,43 +3892,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_low = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_low = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_low = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v > 18446744073709551614ull ) { decoded_v = 18446744073709551614ull; r->report->clamped++; }
-                            value->u64_low = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v > 18446744073709551614ull ) { decoded_v = 18446744073709551614ull; r->report->clamped++; }
+                    value->u64_low = decoded_v;
                 }
                 break;
             }
@@ -4542,43 +3951,11 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        value->u64_high = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        value->u64_high = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        value->u64_high = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
-                            value->u64_high = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
+                    value->u64_high = decoded_v;
                 }
                 break;
             }
@@ -4637,47 +4014,12 @@ static SCHEMA_UNUSED int ranged_unsigned_load_body( TableReader * r, RangedUnsig
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_inside = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_inside = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide < 1ull ) { decoded_wide = 1ull; r->report->clamped++; }
-                        if ( decoded_wide > 18446744073709551614ull ) { decoded_wide = 18446744073709551614ull; r->report->clamped++; }
-                        value->u64_inside = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
-                            else if ( decoded_v > 18446744073709551614ull ) { decoded_v = 18446744073709551614ull; r->report->clamped++; }
-                            value->u64_inside = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v < 1ull ) { decoded_v = 1ull; r->report->clamped++; }
+                    else if ( decoded_v > 18446744073709551614ull ) { decoded_v = 18446744073709551614ull; r->report->clamped++; }
+                    value->u64_inside = decoded_v;
                 }
                 break;
             }
@@ -5461,18 +4803,10 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->b8 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->b8 = decoded_v;
                 }
                 break;
             }
@@ -5510,26 +4844,10 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 65535ull ) { decoded_wide = 65535ull; r->report->clamped++; }
-                        value->b16 = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->b16 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->b16 = decoded_v;
                 }
                 break;
             }
@@ -5575,34 +4893,10 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->b32 = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 4294967295ull ) { decoded_wide = 4294967295ull; r->report->clamped++; }
-                        value->b32 = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->b32 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->b32 = decoded_v;
                 }
                 break;
             }
@@ -5653,39 +4947,10 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->b64 = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->b64 = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->b64 = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->b64 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->b64 = decoded_v;
                 }
                 break;
             }
@@ -5724,27 +4989,11 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 4095ull ) { decoded_wide = 4095ull; r->report->clamped++; }
-                        value->b12 = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
-                            value->b12 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    if ( decoded_v > 4095ull ) { decoded_v = 4095ull; r->report->clamped++; } /* bits(12) width clamp */
+                    value->b12 = decoded_v;
                 }
                 break;
             }
@@ -5799,43 +5048,11 @@ static SCHEMA_UNUSED int ranged_widths_load_body( TableReader * r, RangedWidths 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->b48 = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->b48 = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        if ( decoded_wide > 281474976710655ull ) { decoded_wide = 281474976710655ull; r->report->clamped++; }
-                        value->b48 = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
-                            value->b48 = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    if ( decoded_v > 281474976710655ull ) { decoded_v = 281474976710655ull; r->report->clamped++; } /* bits(48) width clamp */
+                    value->b48 = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -1918,16 +1918,8 @@ static SCHEMA_UNUSED int weapon_config_load_body( TableReader * r, WeaponConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->damage = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->damage = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x1733055702acb1d2ull: /* speed */
@@ -1938,16 +1930,8 @@ static SCHEMA_UNUSED int weapon_config_load_body( TableReader * r, WeaponConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->speed = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->speed = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             case 0x4f31c5309e13e932ull: /* penetration */
@@ -1996,38 +1980,12 @@ static SCHEMA_UNUSED int weapon_config_load_body( TableReader * r, WeaponConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 10ll ) { decoded_wide = 10ll; r->report->clamped++; }
-                        value->penetration = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 10ll ) { decoded_wide = 10ll; r->report->clamped++; }
-                        value->penetration = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 10 ) { decoded_v = 10; r->report->clamped++; }
-                            value->penetration = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 10 ) { decoded_v = 10; r->report->clamped++; }
+                    value->penetration = decoded_v;
                 }
                 break;
             }
@@ -2039,19 +1997,11 @@ static SCHEMA_UNUSED int weapon_config_load_body( TableReader * r, WeaponConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            if ( decoded_v > 63ull ) { decoded_v = 63ull; r->report->clamped++; } /* bits(6) width clamp */
-                            value->channel = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    if ( decoded_v > 63ull ) { decoded_v = 63ull; r->report->clamped++; } /* bits(6) width clamp */
+                    value->channel = decoded_v;
                 }
                 break;
             }
@@ -2063,16 +2013,8 @@ static SCHEMA_UNUSED int weapon_config_load_body( TableReader * r, WeaponConfig 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->homing = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->homing = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x36c1c83b51f24394ull: /* effect */
@@ -2795,39 +2737,10 @@ static SCHEMA_UNUSED int loadout_config_load_body( TableReader * r, LoadoutConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->perks = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->perks = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->perks = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->perks = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->perks = decoded_v;
                 }
                 break;
             }
@@ -3635,32 +3548,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->experience = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->experience = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
-                            value->experience = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint32_t decoded_v = (uint32_t) table_reader_get32( &(*r) );
+                    value->experience = decoded_v;
                 }
                 break;
             }
@@ -3672,18 +3563,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
-                            value->tilt = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int8_t decoded_v = (int8_t) table_reader_get8( &(*r) );
+                    value->tilt = decoded_v;
                 }
                 break;
             }
@@ -3720,25 +3603,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->heading = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
-                            value->heading = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int16_t decoded_v = (int16_t) table_reader_get16( &(*r) );
+                    value->heading = decoded_v;
                 }
                 break;
             }
@@ -3789,39 +3657,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->timestamp = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        value->timestamp = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int32_t) table_reader_get32( &(*r) );
-                        value->timestamp = decoded_wide;
-                        break;
-                    }
-                    case 5:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
-                            value->timestamp = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int64_t decoded_v = (int64_t) table_reader_get64( &(*r) );
+                    value->timestamp = decoded_v;
                 }
                 break;
             }
@@ -3833,18 +3672,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->badge = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->badge = decoded_v;
                 }
                 break;
             }
@@ -3881,25 +3712,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->port = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
-                            value->port = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint16_t decoded_v = (uint16_t) table_reader_get16( &(*r) );
+                    value->port = decoded_v;
                 }
                 break;
             }
@@ -3950,39 +3766,10 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint8_t) table_reader_get8( &(*r) );
-                        value->epoch = decoded_wide;
-                        break;
-                    }
-                    case 7:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint16_t) table_reader_get16( &(*r) );
-                        value->epoch = decoded_wide;
-                        break;
-                    }
-                    case 8:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        uint64_t decoded_wide = (uint32_t) table_reader_get32( &(*r) );
-                        value->epoch = decoded_wide;
-                        break;
-                    }
-                    case 9:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
-                            value->epoch = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint64_t decoded_v = (uint64_t) table_reader_get64( &(*r) );
+                    value->epoch = decoded_v;
                 }
                 break;
             }
@@ -4016,23 +3803,8 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        double decoded_wide = table_wire_widen_f32( table_reader_get32( &(*r) ) );
-                        value->precision = decoded_wide;
-                        break;
-                    }
-                    case 11:
-                    {
-                        if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
-                        value->precision = table_bits_to_double( table_reader_get64( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 8 ) ) { r->report->malformed = 1; return 0; }
+                value->precision = table_bits_to_double( table_reader_get64( &(*r) ) );
                 break;
             }
             case 0xb921eb8a3d0cb0f9ull: /* ratings */
@@ -4083,16 +3855,8 @@ static SCHEMA_UNUSED int profile_config_load_body( TableReader * r, ProfileConfi
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 1:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        value->has_loadout = table_reader_get8( &(*r) ) != 0;
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
+                value->has_loadout = table_reader_get8( &(*r) ) != 0;
                 break;
             }
             case 0x5759ce7586bbb5a3ull: /* loadout */
@@ -5204,38 +4968,12 @@ static SCHEMA_UNUSED int attachment_load_body( TableReader * r, Attachment * val
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->slot = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 7ll ) { decoded_wide = 7ll; r->report->clamped++; }
-                        value->slot = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
-                            value->slot = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 7 ) { decoded_v = 7; r->report->clamped++; }
+                    value->slot = decoded_v;
                 }
                 break;
             }
@@ -5247,16 +4985,8 @@ static SCHEMA_UNUSED int attachment_load_body( TableReader * r, Attachment * val
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->power = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->power = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             default:
@@ -5484,16 +5214,8 @@ static SCHEMA_UNUSED int buff_load_body( TableReader * r, Buff * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
-                {
-                    case 10:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        value->multiplier = table_bits_to_float( table_reader_get32( &(*r) ) );
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
-                }
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
+                value->multiplier = table_bits_to_float( table_reader_get32( &(*r) ) );
                 break;
             }
             default:
@@ -5730,38 +5452,12 @@ static SCHEMA_UNUSED int debuff_load_body( TableReader * r, Debuff * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 100ll ) { decoded_wide = 100ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 100ll ) { decoded_wide = 100ll; r->report->clamped++; }
-                        value->amount = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 100 ) { decoded_v = 100; r->report->clamped++; }
-                            value->amount = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 100 ) { decoded_v = 100; r->report->clamped++; }
+                    value->amount = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -3594,38 +3594,12 @@ static SCHEMA_UNUSED int meta_load_body( TableReader * r, Meta * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->build = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->build = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
-                            value->build = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
+                    value->build = decoded_v;
                 }
                 break;
             }
@@ -3939,38 +3913,12 @@ static SCHEMA_UNUSED int settings_load_body( TableReader * r, Settings * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4ll ) { decoded_wide = 4ll; r->report->clamped++; }
-                        value->quality = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 4ll ) { decoded_wide = 4ll; r->report->clamped++; }
-                        value->quality = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 4 ) { decoded_v = 4; r->report->clamped++; }
-                            value->quality = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 4 ) { decoded_v = 4; r->report->clamped++; }
+                    value->quality = decoded_v;
                 }
                 break;
             }
@@ -4268,32 +4216,10 @@ static SCHEMA_UNUSED int list_node_load_body( TableReader * r, ListNode * value 
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->value = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        value->value = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            value->value = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    value->value = decoded_v;
                 }
                 break;
             }
@@ -4782,38 +4708,12 @@ static SCHEMA_UNUSED int layer_load_body( TableReader * r, Layer * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll; r->report->clamped++; }
-                        value->depth = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll; r->report->clamped++; }
-                        value->depth = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 64 ) { decoded_v = 64; r->report->clamped++; }
-                            value->depth = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 64 ) { decoded_v = 64; r->report->clamped++; }
+                    value->depth = decoded_v;
                 }
                 break;
             }
@@ -5175,38 +5075,12 @@ static SCHEMA_UNUSED int scene_load_body( TableReader * r, Scene * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 99ll ) { decoded_wide = 99ll; r->report->clamped++; }
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 99ll ) { decoded_wide = 99ll; r->report->clamped++; }
-                        value->version = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 99 ) { decoded_v = 99; r->report->clamped++; }
-                            value->version = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 99 ) { decoded_v = 99; r->report->clamped++; }
+                    value->version = decoded_v;
                 }
                 break;
             }
@@ -6656,57 +6530,18 @@ static SCHEMA_UNUSED int meta_load_body_retain( TableReader * r, Meta * value , 
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll;
-                        r->report->clamped++;
-                        }
-                        value->build = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll;
-                        r->report->clamped++;
-                        }
-                        value->build = decoded_wide;
-                        break;
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000;
-                            r->report->clamped++;
-                            }
-                            value->build = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->build = decoded_v;
                 }
                 break;
             }
@@ -6980,57 +6815,18 @@ static SCHEMA_UNUSED int settings_load_body_retain( TableReader * r, Settings * 
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 4ll ) { decoded_wide = 4ll;
-                        r->report->clamped++;
-                        }
-                        value->quality = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 4ll ) { decoded_wide = 4ll;
-                        r->report->clamped++;
-                        }
-                        value->quality = decoded_wide;
-                        break;
+                    else if ( decoded_v > 4 ) { decoded_v = 4;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 4 ) { decoded_v = 4;
-                            r->report->clamped++;
-                            }
-                            value->quality = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->quality = decoded_v;
                 }
                 break;
             }
@@ -7302,39 +7098,12 @@ static SCHEMA_UNUSED int list_node_load_body_retain( TableReader * r, ListNode *
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        value->value = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        value->value = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            value->value = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    value->value = decoded_v;
                 }
                 break;
             }
@@ -7881,57 +7650,18 @@ static SCHEMA_UNUSED int layer_load_body_retain( TableReader * r, Layer * value 
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll;
-                        r->report->clamped++;
-                        }
-                        value->depth = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 64ll ) { decoded_wide = 64ll;
-                        r->report->clamped++;
-                        }
-                        value->depth = decoded_wide;
-                        break;
+                    else if ( decoded_v > 64 ) { decoded_v = 64;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 64 ) { decoded_v = 64;
-                            r->report->clamped++;
-                            }
-                            value->depth = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->depth = decoded_v;
                 }
                 break;
             }
@@ -8407,57 +8137,18 @@ static SCHEMA_UNUSED int scene_load_body_retain( TableReader * r, Scene * value 
                     break;
                 }
                 retention=table_retain_step(body_keep,1,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 99ll ) { decoded_wide = 99ll;
-                        r->report->clamped++;
-                        }
-                        value->version = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 99ll ) { decoded_wide = 99ll;
-                        r->report->clamped++;
-                        }
-                        value->version = decoded_wide;
-                        break;
+                    else if ( decoded_v > 99 ) { decoded_v = 99;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 99 ) { decoded_v = 99;
-                            r->report->clamped++;
-                            }
-                            value->version = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->version = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -3309,38 +3309,12 @@ static SCHEMA_UNUSED int tally_load_body( TableReader * r, Tally * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 10000ll ) { decoded_wide = 10000ll; r->report->clamped++; }
-                        value->hits = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 10000ll ) { decoded_wide = 10000ll; r->report->clamped++; }
-                        value->hits = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 10000 ) { decoded_v = 10000; r->report->clamped++; }
-                            value->hits = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 10000 ) { decoded_v = 10000; r->report->clamped++; }
+                    value->hits = decoded_v;
                 }
                 break;
             }
@@ -3795,57 +3769,18 @@ static SCHEMA_UNUSED int tally_load_body_retain( TableReader * r, Tally * value 
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 10000ll ) { decoded_wide = 10000ll;
-                        r->report->clamped++;
-                        }
-                        value->hits = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 10000ll ) { decoded_wide = 10000ll;
-                        r->report->clamped++;
-                        }
-                        value->hits = decoded_wide;
-                        break;
+                    else if ( decoded_v > 10000 ) { decoded_v = 10000;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 10000 ) { decoded_v = 10000;
-                            r->report->clamped++;
-                            }
-                            value->hits = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->hits = decoded_v;
                 }
                 break;
             }

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -3238,38 +3238,12 @@ static SCHEMA_UNUSED int stamp_load_body( TableReader * r, Stamp * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->seq = decoded_wide;
-                        break;
-                    }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1; return 0; }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll; r->report->clamped++; }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll; r->report->clamped++; }
-                        value->seq = decoded_wide;
-                        break;
-                    }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
-                            value->seq = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0; r->report->clamped++; }
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000; r->report->clamped++; }
+                    value->seq = decoded_v;
                 }
                 break;
             }
@@ -3536,18 +3510,10 @@ static SCHEMA_UNUSED int colour_load_body( TableReader * r, Colour * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->r = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->r = decoded_v;
                 }
                 break;
             }
@@ -3559,18 +3525,10 @@ static SCHEMA_UNUSED int colour_load_body( TableReader * r, Colour * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->g = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->g = decoded_v;
                 }
                 break;
             }
@@ -3582,18 +3540,10 @@ static SCHEMA_UNUSED int colour_load_body( TableReader * r, Colour * value )
                     if ( !table_reader_skip( r, kind ) ) { r->report->malformed = 1; return 0; }
                     break;
                 }
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1; return 0; }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->b = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1; return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->b = decoded_v;
                 }
                 break;
             }
@@ -3977,57 +3927,18 @@ static SCHEMA_UNUSED int stamp_load_body_retain( TableReader * r, Stamp * value 
                     break;
                 }
                 retention=table_retain_step(body_keep,1,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 2:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int8_t) table_reader_get8( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll;
-                        r->report->clamped++;
-                        }
-                        value->seq = decoded_wide;
-                        break;
+                    int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
+                    if ( decoded_v < 0 ) { decoded_v = 0;
+                    r->report->clamped++;
                     }
-                    case 3:
-                    {
-                        if ( !table_reader_has( &(*r), 2 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        int64_t decoded_wide = (int16_t) table_reader_get16( &(*r) );
-                        if ( decoded_wide < 0ll ) { decoded_wide = 0ll;
-                        r->report->clamped++;
-                        }
-                        if ( decoded_wide > 1000ll ) { decoded_wide = 1000ll;
-                        r->report->clamped++;
-                        }
-                        value->seq = decoded_wide;
-                        break;
+                    else if ( decoded_v > 1000 ) { decoded_v = 1000;
+                    r->report->clamped++;
                     }
-                    case 4:
-                    {
-                        if ( !table_reader_has( &(*r), 4 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            int32_t decoded_v = (int32_t) table_reader_get32( &(*r) );
-                            if ( decoded_v < 0 ) { decoded_v = 0;
-                            r->report->clamped++;
-                            }
-                            else if ( decoded_v > 1000 ) { decoded_v = 1000;
-                            r->report->clamped++;
-                            }
-                            value->seq = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    value->seq = decoded_v;
                 }
                 break;
             }
@@ -4196,21 +4107,12 @@ static SCHEMA_UNUSED int colour_load_body_retain( TableReader * r, Colour * valu
                     break;
                 }
                 retention=table_retain_step(body_keep,0,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->r = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->r = decoded_v;
                 }
                 break;
             }
@@ -4225,21 +4127,12 @@ static SCHEMA_UNUSED int colour_load_body_retain( TableReader * r, Colour * valu
                     break;
                 }
                 retention=table_retain_step(body_keep,1,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->g = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->g = decoded_v;
                 }
                 break;
             }
@@ -4254,21 +4147,12 @@ static SCHEMA_UNUSED int colour_load_body_retain( TableReader * r, Colour * valu
                     break;
                 }
                 retention=table_retain_step(body_keep,2,0);
-                switch ( kind )
+                if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
+                return 0;
+                }
                 {
-                    case 6:
-                    {
-                        if ( !table_reader_has( &(*r), 1 ) ) { r->report->malformed = 1;
-                        return 0;
-                        }
-                        {
-                            uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
-                            value->b = decoded_v;
-                        }
-                        break;
-                    }
-                    default: r->report->malformed = 1;
-                    return 0;
+                    uint8_t decoded_v = (uint8_t) table_reader_get8( &(*r) );
+                    value->b = decoded_v;
                 }
                 break;
             }


### PR DESCRIPTION
C-7, C twin of #802. After kind matches the declaration, decode with has(N)+getN. Widen, array elem_kind, keyed, maps, and sequences still switch. Does not touch ctable/wire.go.

Head: d74e76d3ec77970fa7d852d46c5062e4bec16e43
Base: 0b42d653 (#803 merge)

Johnny Grok.