### PR TITLE
ctable: stop emitting check_default where no probe can set it (Card C-6)

### DIFF
--- a/compiler/tabledeadc_test.go
+++ b/compiler/tabledeadc_test.go
@@ -1,0 +1,338 @@
+package compiler
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Card C-6: Stop emitting check_default where no probe can set it.
+//
+// A TableWriter probe sets check_default = 1 to test whether a nested table's
+// body elides on the wire (returns offset 1 / bit 1 if all fields match their
+// defaults, or offset 2 / bit 2 early exit on the first non-default field).
+//
+// In units where no table is nested by value or keyed array, no probe can ever
+// set check_default. In such units:
+//   - TableWriter and TableBitWriter omit check_default entirely;
+//   - table_retain_tail omits if ( w->check_default );
+//   - scalar leaf measure omits && !w->check_default;
+//   - the string "check_default" is completely absent from the emitted header and source.
+//
+// In units with probes:
+//   - TableWriter and TableBitWriter carry check_default;
+//   - only structs that can be reached by a probe (targets of scalar table fields
+//     or enum-keyed table arrays) emit check_default early-return checks;
+//   - unprobed structs (such as root tables or tables only appearing in lists/unions)
+//     do not emit unreachable check_default tests.
+
+const deadCUnprobedSrc = `package probe
+
+table ScalarLeaf
+{
+    id    int32
+    scale float32 = 1.0
+    tag   string(16)
+}
+
+table RootTable
+{
+    count  int32
+    scores [4]int32
+}
+`
+
+const deadCProbedSrc = `package probe
+
+table Leaf
+{
+    x int32 = 0
+    y int32 = 0
+}
+
+table Outer
+{
+    id   int32
+    leaf Leaf
+}
+`
+
+func compileAndRunC(t *testing.T, u *ir.Unit, mainSource string) {
+	t.Helper()
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("generated C execution requires cc")
+	}
+	files, err := New().Generate(u, "c", Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.c"), []byte(mainSource), 0600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"-std=c99", "-Wall", "-Wextra", "-Werror", "-Wshadow", "-O2", "-I", dir, filepath.Join(dir, "main.c")}
+	for name := range files {
+		if strings.HasSuffix(name, ".c") {
+			args = append(args, filepath.Join(dir, name))
+		}
+	}
+	args = append(args, "-lm", "-o", filepath.Join(dir, "probe"))
+	cmd := exec.Command(cc, args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, output)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if output, err := exec.CommandContext(ctx, filepath.Join(dir, "probe")).CombinedOutput(); err != nil {
+		t.Fatalf("execute: %v\n%s", err, output)
+	}
+}
+
+// TestCTableDeadCheckDefault_Unprobed verifies that a unit without nested table
+// probes emits zero check_default symbols across both header and source,
+// and that the resulting codecs compile and execute cleanly.
+func TestCTableDeadCheckDefault_Unprobed(t *testing.T) {
+	u := unitFromSource(t, deadCUnprobedSrc)
+	files, err := New().Generate(u, "c", Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	header := string(files["ProbeTable.h"])
+	source := string(files["ProbeTable.c"])
+
+	// 1. check_default must NOT appear anywhere in the generated header or source.
+	if strings.Contains(header, "check_default") {
+		t.Errorf("unprobed unit header contains dead check_default symbol")
+	}
+	if strings.Contains(source, "check_default") {
+		t.Errorf("unprobed unit source contains dead check_default symbol")
+	}
+
+	// 2. TableWriter and TableBitWriter must omit check_default.
+	if !strings.Contains(header, "int overflow, id_checkpoint;") {
+		t.Errorf("expected TableWriter without check_default, got header:\n%s", header)
+	}
+	if !strings.Contains(header, "int overflow;") {
+		t.Errorf("expected TableBitWriter without check_default, got header:\n%s", header)
+	}
+
+	// 3. Scalar leaf measure must not have && !w->check_default.
+	if strings.Contains(header, "!w->check_default") {
+		t.Errorf("scalar leaf measure still contains dead !w->check_default")
+	}
+	if !strings.Contains(header, "if ( w->buffer == NULL )") {
+		t.Errorf("expected scalar leaf measure with 'if ( w->buffer == NULL )'")
+	}
+
+	// 4. Compile and verify roundtrip execution.
+	const driver = `#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ProbeTable.h"
+
+int main(void) {
+    uint8_t buf[512];
+
+    /* Test RootTable */
+    RootTable root;
+    root_table_reset(&root);
+    root.count = 42;
+    root.scores[0] = 10;
+    root.scores[1] = 20;
+
+    int64_t measured = root_table_measure(&root);
+    assert(measured > 0);
+    int64_t saved = root_table_save(&root, buf, sizeof(buf));
+    assert(saved == measured);
+
+    RootTable loaded;
+    root_table_reset(&loaded);
+    TableReport report;
+    memset(&report, 0, sizeof(report));
+    assert(root_table_load(&loaded, buf, saved, &report) == 1);
+    assert(report.malformed == 0);
+    assert(loaded.count == 42);
+    assert(loaded.scores[0] == 10);
+    assert(loaded.scores[1] == 20);
+
+    /* Test ScalarLeaf */
+    ScalarLeaf leaf;
+    scalar_leaf_reset(&leaf);
+    leaf.id = 7;
+    leaf.scale = 2.5f;
+    leaf.tag_length = 4;
+    memcpy(leaf.tag, "test", 4);
+
+    measured = scalar_leaf_measure(&leaf);
+    assert(measured > 0);
+    saved = scalar_leaf_save(&leaf, buf, sizeof(buf));
+    assert(saved == measured);
+
+    ScalarLeaf loaded_leaf;
+    scalar_leaf_reset(&loaded_leaf);
+    memset(&report, 0, sizeof(report));
+    assert(scalar_leaf_load(&loaded_leaf, buf, saved, &report) == 1);
+    assert(report.malformed == 0);
+    assert(loaded_leaf.id == 7);
+    assert(loaded_leaf.scale == 2.5f);
+    assert(loaded_leaf.tag_length == 4);
+    assert(memcmp(loaded_leaf.tag, "test", 4) == 0);
+
+    return 0;
+}
+`
+	compileAndRunC(t, u, driver)
+}
+
+// TestCTableDeadCheckDefault_Probed verifies that in a unit with nested table
+// probes, check_default is emitted only on probeable structs (Leaf) and on the
+// writer structs, and omitted from unprobeable structs (Outer).
+func TestCTableDeadCheckDefault_Probed(t *testing.T) {
+	u := unitFromSource(t, deadCProbedSrc)
+	files, err := New().Generate(u, "c", Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	header := string(files["ProbeTable.h"])
+
+	// 1. TableWriter and TableBitWriter must carry check_default.
+	if !strings.Contains(header, "int overflow, id_checkpoint, check_default;") {
+		t.Errorf("expected TableWriter with check_default")
+	}
+	if !strings.Contains(header, "int overflow,check_default;") {
+		t.Errorf("expected TableBitWriter with check_default")
+	}
+
+	// 2. Leaf (probed by Outer) must emit check_default early-return checks.
+	defLeaf := "int leaf_save_body( TableWriter * w, const Leaf * value )\n{"
+	defOuter := "int outer_save_body( TableWriter * w, const Outer * value )\n{"
+	leafIdx := strings.Index(header, defLeaf)
+	outerIdx := strings.Index(header, defOuter)
+	if leafIdx < 0 || outerIdx < 0 {
+		t.Fatalf("could not find save_body definitions in header (leafIdx=%d, outerIdx=%d)", leafIdx, outerIdx)
+	}
+
+	// Slice from the definition of each function to its closing return.
+	leafBody := header[leafIdx:]
+	if end := strings.Index(leafBody, "return !w->overflow;\n}"); end > 0 {
+		leafBody = leafBody[:end]
+	}
+	outerBody := header[outerIdx:]
+	if end := strings.Index(outerBody, "return !w->overflow;\n}"); end > 0 {
+		outerBody = outerBody[:end]
+	}
+
+	// leaf_save_body CAN be reached by a probe: it MUST have check_default early exit.
+	if !strings.Contains(leafBody, "if ( w->check_default ) { w->offset = 2; return 1; }") {
+		t.Errorf("leaf_save_body is probed but missing check_default check:\n%s", leafBody)
+	}
+	if !strings.Contains(leafBody, "if ( w->buffer == NULL && !w->check_default )") {
+		t.Errorf("leaf_save_body is probed but missing !w->check_default in scalar leaf measure:\n%s", leafBody)
+	}
+
+	// outer_save_body is NOT probed by anything: it MUST NOT have check_default early exit!
+	if strings.Contains(outerBody, "if ( w->check_default )") {
+		t.Errorf("outer_save_body is not probed but contains dead if ( w->check_default ):\n%s", outerBody)
+	}
+
+	// 3. Message save: leaf_save_message_body must have check_default; outer must not.
+	defMsgLeaf := "int leaf_save_message_body(TableBitWriter * w,const Leaf * value)\n{"
+	defMsgOuter := "int outer_save_message_body(TableBitWriter * w,const Outer * value)\n{"
+	leafMsgIdx := strings.Index(header, defMsgLeaf)
+	outerMsgIdx := strings.Index(header, defMsgOuter)
+	if leafMsgIdx < 0 || outerMsgIdx < 0 {
+		t.Fatalf("could not find save_message_body definitions in header (leafMsgIdx=%d, outerMsgIdx=%d)", leafMsgIdx, outerMsgIdx)
+	}
+
+	leafMsgBody := header[leafMsgIdx:]
+	if end := strings.Index(leafMsgBody, "return !w->overflow;\n}"); end > 0 {
+		leafMsgBody = leafMsgBody[:end]
+	}
+	outerMsgBody := header[outerMsgIdx:]
+	if end := strings.Index(outerMsgBody, "return !w->overflow;\n}"); end > 0 {
+		outerMsgBody = outerMsgBody[:end]
+	}
+
+	if !strings.Contains(leafMsgBody, "if(w->check_default)") {
+		t.Errorf("leaf_save_message_body is probed but missing check_default check:\n%s", leafMsgBody)
+	}
+	if strings.Contains(outerMsgBody, "if(w->check_default)") {
+		t.Errorf("outer_save_message_body is not probed but contains dead if(w->check_default):\n%s", outerMsgBody)
+	}
+
+	// 4. Compile and verify default elision and roundtrip execution.
+	const driver = `#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ProbeTable.h"
+
+int main(void) {
+    uint8_t buf_def[512];
+    uint8_t buf_nondef[512];
+
+    /* Case 1: Outer with default Leaf {0, 0}.
+       The default subtable MUST elide on the wire. */
+    Outer outer_def;
+    outer_reset(&outer_def);
+    outer_def.id = 1;
+    /* leaf.x and leaf.y are 0 (default) */
+
+    int64_t measured_def = outer_measure(&outer_def);
+    int64_t saved_def = outer_save(&outer_def, buf_def, sizeof(buf_def));
+    assert(saved_def == measured_def);
+
+    /* Case 2: Outer with non-default Leaf {42, 0}.
+       The subtable MUST be emitted. */
+    Outer outer_nondef;
+    outer_reset(&outer_nondef);
+    outer_nondef.id = 1;
+    outer_nondef.leaf.x = 42;
+
+    int64_t measured_nondef = outer_measure(&outer_nondef);
+    int64_t saved_nondef = outer_save(&outer_nondef, buf_nondef, sizeof(buf_nondef));
+    assert(saved_nondef == measured_nondef);
+
+    /* The non-default leaf takes strictly more bytes than the elided default leaf. */
+    assert(saved_nondef > saved_def);
+
+    /* Verify decode of both */
+    TableReport report;
+    Outer loaded;
+
+    /* Decode default outer */
+    outer_reset(&loaded);
+    memset(&report, 0, sizeof(report));
+    assert(outer_load(&loaded, buf_def, saved_def, &report) == 1);
+    assert(report.malformed == 0);
+    assert(loaded.id == 1);
+    assert(loaded.leaf.x == 0);
+    assert(loaded.leaf.y == 0);
+
+    /* Decode non-default outer */
+    outer_reset(&loaded);
+    memset(&report, 0, sizeof(report));
+    assert(outer_load(&loaded, buf_nondef, saved_nondef, &report) == 1);
+    assert(report.malformed == 0);
+    assert(loaded.id == 1);
+    assert(loaded.leaf.x == 42);
+    assert(loaded.leaf.y == 0);
+
+    return 0;
+}
+`
+	compileAndRunC(t, u, driver)
+}

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -1792,7 +1792,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* entity_id */
         if ( !( value->entity_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 11, 0x23fcfd6678e36712ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->entity_id ) );
         }
@@ -1800,7 +1799,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* pos_x */
         if ( !( value->pos_x == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 65, 0xcb4b37357667310eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_x ) );
         }
@@ -1808,7 +1806,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* pos_y */
         if ( !( value->pos_y == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 66, 0xcb4b3835766732c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_y ) );
         }
@@ -1816,7 +1813,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* pos_z */
         if ( !( value->pos_z == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 64, 0xcb4b353576672da8ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_z ) );
         }
@@ -1824,7 +1820,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* yaw */
         if ( !( value->yaw == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 58, 0xb54d8e19798e16e8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->yaw ) );
         }
@@ -1832,7 +1827,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* pitch */
         if ( !( value->pitch == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 22, 0x53a9f665a90cc1b1ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->pitch ) );
         }
@@ -1840,7 +1834,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* vel_x */
         if ( !( value->vel_x == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 27, 0x6cede6b6eb60ee67ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_x ) );
         }
@@ -1848,7 +1841,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* vel_y */
         if ( !( value->vel_y == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 26, 0x6cede5b6eb60ecb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_y ) );
         }
@@ -1856,7 +1848,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* vel_z */
         if ( !( value->vel_z == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x6cede8b6eb60f1cdull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_z ) );
         }
@@ -1864,7 +1855,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* health */
         if ( !( value->health == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0x7f69d4b5288ba9cfull, 4 );
             table_writer_put32( w, (uint32_t) ( value->health ) );
         }
@@ -1872,7 +1862,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* weapon */
         if ( !( value->weapon == MIXED_WEAPON_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 52, 0xa0b610205f2c6e01ull, 30 );
             switch ( value->weapon )
             {
@@ -1899,7 +1888,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* damage */
         if ( !( value->damage == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0x7f6308be8ab37fc0ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->damage ) );
         }
@@ -1907,7 +1895,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* moving */
         if ( !( value->moving == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 5, 0x11a44fc1d1243da7ull, 1 );
             table_writer_put8( w, value->moving ? 1 : 0 );
         }
@@ -1915,7 +1902,6 @@ static SCHEMA_UNUSED int mixed_entity_save_body( TableWriter * w, const MixedEnt
     { /* firing */
         if ( !( value->firing == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 32, 0x7674cfd19b9031caull, 1 );
             table_writer_put8( w, value->firing ? 1 : 0 );
         }
@@ -2883,99 +2869,66 @@ static SCHEMA_UNUSED int mixed_entity_save_message_body(TableBitWriter * w,const
  (void)value;
  { /* entity_id */
  if(!(value->entity_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,31,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->entity_id)-UINT64_C(0),12);
  }
  }
  { /* pos_x */
  if(!(value->pos_x == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,32,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_x)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* pos_y */
  if(!(value->pos_y == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,33,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_y)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* pos_z */
  if(!(value->pos_z == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,34,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_z)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* yaw */
  if(!(value->yaw == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,35,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->yaw)-UINT64_C(0),9);
  }
  }
  { /* pitch */
  if(!(value->pitch == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,36,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pitch)-UINT64_C(0),9);
  }
  }
  { /* vel_x */
  if(!(value->vel_x == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,37,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_x)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* vel_y */
  if(!(value->vel_y == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,38,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_y)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* vel_z */
  if(!(value->vel_z == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,39,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_z)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* health */
  if(!(value->health == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,40,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->health)-UINT64_C(0),10);
  }
  }
  { /* weapon */
  if(!(value->weapon == MIXED_WEAPON_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,41,kTableMessageRefBitsHere);
   switch(value->weapon) {
    case MIXED_WEAPON_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -3016,27 +2969,18 @@ static SCHEMA_UNUSED int mixed_entity_save_message_body(TableBitWriter * w,const
  }
  { /* damage */
  if(!(value->damage == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,42,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->damage)-UINT64_C(0),8);
  }
  }
  { /* moving */
  if(!(value->moving == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,43,kTableMessageRefBitsHere);
   table_bit_put(w,value->moving ? 1 : 0,1);
  }
  }
  { /* firing */
  if(!(value->firing == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,44,kTableMessageRefBitsHere);
   table_bit_put(w,value->firing ? 1 : 0,1);
  }
@@ -3400,7 +3344,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_entity_message_extent_(TableMessageR
 static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->stat_id == 0 ) )
@@ -3420,7 +3364,6 @@ static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat 
     { /* stat_id */
         if ( !( value->stat_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 38, 0x80ab75f0866dbf65ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->stat_id ) );
         }
@@ -3428,7 +3371,6 @@ static SCHEMA_UNUSED int mixed_stat_save_body( TableWriter * w, const MixedStat 
     { /* delta */
         if ( !( value->delta == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x52076675ec13a0c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->delta ) );
         }
@@ -3596,18 +3538,12 @@ static SCHEMA_UNUSED int mixed_stat_save_message_body(TableBitWriter * w,const M
  (void)value;
  { /* stat_id */
  if(!(value->stat_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,51,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->stat_id)-UINT64_C(0),8);
  }
  }
  { /* delta */
  if(!(value->delta == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,52,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->delta)-UINT64_C(18446744073709551104),10);
  }
@@ -3733,7 +3669,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_stat_message_extent_(TableMessageRea
 static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const MixedHitEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->target_id == 0 ) )
@@ -3763,7 +3699,6 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
     { /* target_id */
         if ( !( value->target_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 59, 0xb7bc9ac015a25050ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->target_id ) );
         }
@@ -3771,7 +3706,6 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
     { /* damage */
         if ( !( value->damage == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0x7f6308be8ab37fc0ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->damage ) );
         }
@@ -3779,7 +3713,6 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
     { /* hit_kind */
         if ( !( value->hit_kind == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x01fbc365b059b925ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hit_kind ) );
         }
@@ -3787,7 +3720,6 @@ static SCHEMA_UNUSED int mixed_hit_event_save_body( TableWriter * w, const Mixed
     { /* crit */
         if ( !( value->crit == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x126167908c9aa52dull, 1 );
             table_writer_put8( w, value->crit ? 1 : 0 );
         }
@@ -4092,36 +4024,24 @@ static SCHEMA_UNUSED int mixed_hit_event_save_message_body(TableBitWriter * w,co
  (void)value;
  { /* target_id */
  if(!(value->target_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,45,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_id)-UINT64_C(0),12);
  }
  }
  { /* damage */
  if(!(value->damage == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,46,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->damage)-UINT64_C(0),12);
  }
  }
  { /* hit_kind */
  if(!(value->hit_kind == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,47,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->hit_kind)-UINT64_C(0),3);
  }
  }
  { /* crit */
  if(!(value->crit == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,48,kTableMessageRefBitsHere);
   table_bit_put(w,value->crit ? 1 : 0,1);
  }
@@ -4279,7 +4199,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_hit_event_message_extent_(TableMessa
 static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const MixedChatEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->channel == 0 ) )
@@ -4299,7 +4219,6 @@ static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const Mixe
     { /* channel */
         if ( !( value->channel == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 54, 0xa5013e9ad5caeda4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->channel ) );
         }
@@ -4307,7 +4226,6 @@ static SCHEMA_UNUSED int mixed_chat_event_save_body( TableWriter * w, const Mixe
     { /* speaker */
         if ( !( value->speaker == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 76, 0xfbf1ac4d96ebd022ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->speaker ) );
         }
@@ -4511,18 +4429,12 @@ static SCHEMA_UNUSED int mixed_chat_event_save_message_body(TableBitWriter * w,c
  (void)value;
  { /* channel */
  if(!(value->channel == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->channel)-UINT64_C(0),2);
  }
  }
  { /* speaker */
  if(!(value->speaker == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,30,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->speaker)-UINT64_C(0),12);
  }
@@ -4648,7 +4560,7 @@ static SCHEMA_UNUSED int schema_bench_mixed_chat_event_message_extent_(TableMess
 static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const MixedPickupEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->item_id == 0 ) )
@@ -4668,7 +4580,6 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const Mi
     { /* item_id */
         if ( !( value->item_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 48, 0x9e7fd06d864fbd56ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->item_id ) );
         }
@@ -4676,7 +4587,6 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_body( TableWriter * w, const Mi
     { /* amount */
         if ( !( value->amount == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 39, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
@@ -4880,18 +4790,12 @@ static SCHEMA_UNUSED int mixed_pickup_event_save_message_body(TableBitWriter * w
  (void)value;
  { /* item_id */
  if(!(value->item_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,49,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->item_id)-UINT64_C(0),10);
  }
  }
  { /* amount */
  if(!(value->amount == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,50,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->amount)-UINT64_C(0),8);
  }

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -1465,7 +1465,6 @@ static SCHEMA_UNUSED int fixed_table_save_body( TableWriter * w, const FixedTabl
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 35, 0x7ce4fd9430e80ceaull, 13 );
             if ( w->buffer == NULL )
             {
@@ -1561,9 +1560,6 @@ static SCHEMA_UNUSED int fixed_table_save_message_body(TableBitWriter * w,const 
  probe.check_default=1;
  if(!bench_mixed_save_message_body(&probe,&value->value)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,28,kTableMessageRefBitsHere);
   if(!bench_mixed_save_message_body(w,&value->value)) return 0;
  }

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -270,7 +270,7 @@ typedef struct TableWriter
 {
     uint8_t * buffer;
     int64_t capacity, offset;
-    int overflow, id_checkpoint, check_default;
+    int overflow, id_checkpoint;
     TableWriteIds * vocabulary;
 
 } TableWriter;
@@ -863,7 +863,7 @@ static SCHEMA_UNUSED void table_cook_header(uint8_t * raw,uint64_t version,int64
 enum { kTableMessageRefBitsHere=7, kTableMessageEntriesHere=77, kTableAnnounceBytes=934, kTableMessageBatchMax=256 };
 static const uint8_t kTableAnnounce[kTableAnnounceBytes]={0x01,0x01,0x09,0x7f,0xa9,0x82,0x9c,0x0e,0x85,0xaa,0xa9,0x02,0x0e,0xfe,0x06,0x06,0xfb,0x06,0xa4,0xed,0xca,0xd5,0x9a,0x3e,0x01,0xa5,0x04,0x01,0x02,0x00,0x22,0xd0,0xeb,0x96,0x4d,0xac,0xf1,0xfb,0x07,0x01,0x0c,0x00,0x12,0x67,0xe3,0x78,0x66,0xfd,0xfc,0x23,0x07,0x01,0x0c,0x00,0x0e,0x31,0x67,0x76,0x35,0x37,0x4b,0xcb,0x04,0x01,0x0f,0xfd,0xff,0x01,0xc1,0x32,0x67,0x76,0x35,0x38,0x4b,0xcb,0x04,0x01,0x0f,0xfd,0xff,0x01,0xa8,0x2d,0x67,0x76,0x35,0x35,0x4b,0xcb,0x04,0x01,0x0f,0xfd,0xff,0x01,0xe8,0x16,0x8e,0x79,0x19,0x8e,0x4d,0xb5,0x07,0x01,0x09,0x00,0xb1,0xc1,0x0c,0xa9,0x65,0xf6,0xa9,0x53,0x07,0x01,0x09,0x00,0x67,0xee,0x60,0xeb,0xb6,0xe6,0xed,0x6c,0x04,0x01,0x0c,0xff,0x1f,0xb4,0xec,0x60,0xeb,0xb6,0xe5,0xed,0x6c,0x04,0x01,0x0c,0xff,0x1f,0xcd,0xf1,0x60,0xeb,0xb6,0xe8,0xed,0x6c,0x04,0x01,0x0c,0xff,0x1f,0xcf,0xa9,0x8b,0x28,0xb5,0xd4,0x69,0x7f,0x04,0x01,0x0a,0x00,0x01,0x6e,0x2c,0x5f,0x20,0x10,0xb6,0xa0,0x1e,0xc0,0x7f,0xb3,0x8a,0xbe,0x08,0x63,0x7f,0x09,0x01,0x08,0x00,0xa7,0x3d,0x24,0xd1,0xc1,0x4f,0xa4,0x11,0x01,0xca,0x31,0x90,0x9b,0xd1,0xcf,0x74,0x76,0x01,0x50,0x50,0xa2,0x15,0xc0,0x9a,0xbc,0xb7,0x07,0x01,0x0c,0x00,0xc0,0x7f,0xb3,0x8a,0xbe,0x08,0x63,0x7f,0x04,0x01,0x0c,0x00,0x25,0xb9,0x59,0xb0,0x65,0xc3,0xfb,0x01,0x04,0x01,0x03,0x00,0x2d,0xa5,0x9a,0x8c,0x90,0x67,0x61,0x12,0x01,0xfd,0x15,0xa1,0x1a,0xd9,0x70,0x5a,0x6a,0x07,0x00,0xa8,0x28,0xf5,0x81,0xa4,0xac,0x38,0xaa,0x07,0x01,0x10,0x00,0x3e,0x7c,0x69,0x56,0x5c,0x00,0xbe,0x0d,0x04,0x01,0x10,0x00,0x03,0xee,0x29,0xb8,0xa8,0x0d,0xae,0x9b,0x08,0x01,0x20,0x00,0x05,0x0b,0x59,0x0a,0x65,0xb5,0xd7,0xb7,0x09,0x00,0x7e,0x96,0x95,0xd0,0xe2,0x98,0x7b,0x6d,0x08,0x00,0xd8,0xc0,0x0d,0xd6,0x71,0x4c,0xa9,0x73,0x09,0x01,0x3f,0x01,0x85,0xfc,0x54,0xbe,0x51,0x6b,0xee,0x3e,0x05,0x01,0x29,0xff,0xbf,0xa8,0xca,0x9a,0x3a,0x12,0x01,0x6d,0x7b,0x5f,0x03,0xbc,0x7b,0x09,0x01,0x30,0x00,0xc6,0x69,0xbe,0xf9,0x75,0x04,0x46,0x3c,0x0a,0x02,0x00,0x00,0x00,0x00,0x00,0xff,0x7f,0x47,0x0a,0xd7,0x23,0x3c,0x2a,0x82,0xb3,0x7b,0xb0,0x0f,0x5d,0x93,0x0e,0x01,0x08,0x0d,0x4c,0x99,0xb1,0x45,0xad,0x9c,0x63,0xee,0x0e,0x00,0x50,0x0d,0x90,0x57,0xaa,0x21,0x53,0xdc,0x35,0x2e,0x0f,0xa3,0xb5,0xbb,0x86,0x75,0xce,0x59,0x57,0x0e,0x04,0x04,0x06,0x00,0x6e,0xe8,0xf8,0x2c,0x54,0x2f,0xa6,0x13,0x0c,0x0f,0xe5,0xe9,0xb5,0x63,0xd0,0xa9,0xb8,0xcf,0x0e,0x00,0x10,0x06,0x00,0xc9,0x96,0x42,0xe2,0xe5,0x7b,0xaf,0xdb,0x0a,0x02,0x00,0x00,0x80,0xbf,0x00,0x00,0x80,0x3f,0x0a,0xd7,0x23,0x3c,0x16,0x95,0x42,0xe2,0xe5,0x7a,0xaf,0xdb,0x0a,0x02,0x00,0x00,0x80,0xbf,0x00,0x00,0x80,0x3f,0x0a,0xd7,0x23,0x3c,0x63,0x93,0x42,0xe2,0xe5,0x79,0xaf,0xdb,0x0a,0x02,0x00,0x00,0x80,0xbf,0x00,0x00,0x80,0x3f,0x0a,0xd7,0x23,0x3c,0x57,0xe4,0xe2,0xf7,0xff,0x31,0xef,0x9c,0x0a,0x00,0x04,0x6c,0x1f,0x34,0xc9,0xf9,0xb3,0x5a,0x0b,0x16,0xaf,0x1f,0x46,0x80,0x85,0x34,0xa3,0x09,0x00,0x42,0x26,0xaf,0x08,0x79,0xdd,0x1b,0xd6,0x05,0x01,0x3d,0xff,0xff,0x9f,0xf6,0xf4,0xac,0xdb,0xe0,0x1b,0xa9,0x07,0x33,0xc5,0x0d,0xe0,0x30,0xbf,0x0a,0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x7a,0x43,0x0a,0xd7,0x23,0x3c,0x5f,0x51,0xd8,0xcc,0x27,0x65,0x0d,0x56,0x08,0x01,0x18,0x00,0x72,0x86,0xfd,0x6c,0x17,0x92,0x82,0xc0,0x01,0x69,0xcb,0x79,0xa9,0x12,0xee,0x29,0xfd,0x04,0x01,0x08,0x00,0xfe,0xbc,0x8c,0xaa,0xc0,0x1a,0x10,0x78,0x04,0x01,0x04,0x00,0x56,0xbd,0x4f,0x86,0x6d,0xd0,0x7f,0x9e,0x07,0x01,0x0a,0x00,0x69,0x69,0xb1,0xa2,0x7e,0xfe,0x13,0x81,0x04,0x01,0x08,0x00,0x65,0xbf,0x6d,0x86,0xf0,0x75,0xab,0x80,0x06,0x01,0x08,0x00,0xc1,0xa0,0x13,0xec,0x75,0x66,0x07,0x52,0x04,0x01,0x0a,0xff,0x07,0x0c,0xcf,0x66,0x27,0xe1,0xee,0x90,0xa7,0x00,0x76,0x84,0xda,0x35,0xa8,0xef,0xbf,0x9f,0x00,0x95,0x8a,0x92,0x83,0x17,0xbb,0x8b,0x18,0x00,0xf1,0x72,0xf2,0xc2,0xb9,0x67,0x36,0x2c,0x00,0xf6,0x55,0xd7,0x00,0x1b,0xb4,0xa8,0x0c,0x00,0x4e,0x1a,0xb2,0xfa,0x19,0xc8,0x5f,0x98,0x00,0x55,0x6a,0x08,0xc3,0x47,0x04,0x9d,0x22,0x00,0x9d,0x8f,0x22,0xa7,0x49,0x7b,0x1c,0x01,0x00,0x5f,0xe1,0x23,0x11,0x6e,0x56,0xf7,0x89,0x00,0x69,0x44,0x3b,0x8b,0x31,0x25,0x7f,0x8d,0x00,0x16,0x78,0x5b,0x28,0xcc,0x0d,0xcd,0xd9,0x00,0x76,0x52,0xff,0xa8,0xae,0x16,0xdc,0x04,0x00,0x17,0x92,0x12,0x41,0xc3,0x3b,0xe5,0x35,0x00,0x31,0x88,0xde,0xb0,0x2f,0x28,0xc8,0x2c,0x00,0x34,0xb3,0x8c,0xbc,0x21,0xda,0xba,0x20,0x00,0xaa,0x80,0x06,0x30,0x19,0x28,0x73,0x33,0x0d,0x8b,0x34,0x5b,0x0b,0x91,0x8d,0xa3,0xf2,0x0d,0x65,0xb7,0xec,0x86,0x1c,0xa4,0xa3,0x9f,0x0d,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0xe4,0x4f,0x1c,0x4f,0x47,0xc0,0x2e,0x2f,0x00,0x58,0xfc,0xaf,0xfa,0xd8,0xe0,0x4b,0x70,0x00,0xc7,0xd4,0x7b,0x26,0xb0,0x9d,0x29,0x5f,0x00,0xa8,0xcb,0xc6,0x96,0x35,0x72,0x61,0x31,0x00,0x8e,0x8a,0xf8,0xd6,0x59,0xe4,0x9a,0x43,0x00,0x95,0x9c,0xb9,0x69,0xe6,0xa8,0x6a,0x29,0x00,0x00,0xfe,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xfd,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,};
 
-typedef struct TableBitWriter { uint8_t * buffer; int64_t capacity,bits; int overflow,check_default;  } TableBitWriter;
+typedef struct TableBitWriter { uint8_t * buffer; int64_t capacity,bits; int overflow;  } TableBitWriter;
 typedef struct TableBitReader { const uint8_t * buffer; int64_t bits,offset; } TableBitReader;
 static SCHEMA_UNUSED TableBitWriter table_bit_writer(uint8_t * buffer,int64_t capacity)
 { TableBitWriter w;memset(&w,0,sizeof(w));w.buffer=buffer;w.capacity=capacity;return w; }
@@ -1852,7 +1852,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* entity_id */
         if ( !( value->entity_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 11, 0x23fcfd6678e36712ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->entity_id ) );
         }
@@ -1860,7 +1859,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* pos_x */
         if ( !( value->pos_x == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 65, 0xcb4b37357667310eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_x ) );
         }
@@ -1868,7 +1866,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* pos_y */
         if ( !( value->pos_y == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 66, 0xcb4b3835766732c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_y ) );
         }
@@ -1876,7 +1873,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* pos_z */
         if ( !( value->pos_z == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 64, 0xcb4b353576672da8ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->pos_z ) );
         }
@@ -1884,7 +1880,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* yaw */
         if ( !( value->yaw == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 59, 0xb54d8e19798e16e8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->yaw ) );
         }
@@ -1892,7 +1887,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* pitch */
         if ( !( value->pitch == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 24, 0x53a9f665a90cc1b1ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->pitch ) );
         }
@@ -1900,7 +1894,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* vel_x */
         if ( !( value->vel_x == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 30, 0x6cede6b6eb60ee67ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_x ) );
         }
@@ -1908,7 +1901,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* vel_y */
         if ( !( value->vel_y == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 29, 0x6cede5b6eb60ecb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_y ) );
         }
@@ -1916,7 +1908,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* vel_z */
         if ( !( value->vel_z == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 31, 0x6cede8b6eb60f1cdull, 4 );
             table_writer_put32( w, (uint32_t) ( value->vel_z ) );
         }
@@ -1924,7 +1915,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* health */
         if ( !( value->health == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 41, 0x7f69d4b5288ba9cfull, 4 );
             table_writer_put32( w, (uint32_t) ( value->health ) );
         }
@@ -1932,7 +1922,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* weapon */
         if ( !( value->weapon == TABLE_WEAPON_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 54, 0xa0b610205f2c6e01ull, 30 );
             switch ( value->weapon )
             {
@@ -1959,7 +1948,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* damage */
         if ( !( value->damage == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 40, 0x7f6308be8ab37fc0ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->damage ) );
         }
@@ -1967,7 +1955,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* moving */
         if ( !( value->moving == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 5, 0x11a44fc1d1243da7ull, 1 );
             table_writer_put8( w, value->moving ? 1 : 0 );
         }
@@ -1975,7 +1962,6 @@ static SCHEMA_UNUSED int table_entity_save_body( TableWriter * w, const TableEnt
     { /* firing */
         if ( !( value->firing == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0x7674cfd19b9031caull, 1 );
             table_writer_put8( w, value->firing ? 1 : 0 );
         }
@@ -2943,99 +2929,66 @@ static SCHEMA_UNUSED int table_entity_save_message_body(TableBitWriter * w,const
  (void)value;
  { /* entity_id */
  if(!(value->entity_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,3,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->entity_id)-UINT64_C(0),12);
  }
  }
  { /* pos_x */
  if(!(value->pos_x == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,4,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_x)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* pos_y */
  if(!(value->pos_y == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,5,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_y)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* pos_z */
  if(!(value->pos_z == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pos_z)-UINT64_C(18446744073709535233),15);
  }
  }
  { /* yaw */
  if(!(value->yaw == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,7,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->yaw)-UINT64_C(0),9);
  }
  }
  { /* pitch */
  if(!(value->pitch == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,8,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->pitch)-UINT64_C(0),9);
  }
  }
  { /* vel_x */
  if(!(value->vel_x == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,9,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_x)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* vel_y */
  if(!(value->vel_y == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,10,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_y)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* vel_z */
  if(!(value->vel_z == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,11,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->vel_z)-UINT64_C(18446744073709549568),12);
  }
  }
  { /* health */
  if(!(value->health == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,12,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->health)-UINT64_C(0),10);
  }
  }
  { /* weapon */
  if(!(value->weapon == TABLE_WEAPON_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   switch(value->weapon) {
    case TABLE_WEAPON_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -3076,27 +3029,18 @@ static SCHEMA_UNUSED int table_entity_save_message_body(TableBitWriter * w,const
  }
  { /* damage */
  if(!(value->damage == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->damage)-UINT64_C(0),8);
  }
  }
  { /* moving */
  if(!(value->moving == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,15,kTableMessageRefBitsHere);
   table_bit_put(w,value->moving ? 1 : 0,1);
  }
  }
  { /* firing */
  if(!(value->firing == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,16,kTableMessageRefBitsHere);
   table_bit_put(w,value->firing ? 1 : 0,1);
  }
@@ -3460,7 +3404,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_entity_message_extent_(TableMes
 static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->stat_id == 0 ) )
@@ -3480,7 +3424,6 @@ static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat 
     { /* stat_id */
         if ( !( value->stat_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 42, 0x80ab75f0866dbf65ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->stat_id ) );
         }
@@ -3488,7 +3431,6 @@ static SCHEMA_UNUSED int table_stat_save_body( TableWriter * w, const TableStat 
     { /* delta */
         if ( !( value->delta == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 23, 0x52076675ec13a0c1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->delta ) );
         }
@@ -3656,18 +3598,12 @@ static SCHEMA_UNUSED int table_stat_save_message_body(TableBitWriter * w,const T
  (void)value;
  { /* stat_id */
  if(!(value->stat_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,51,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->stat_id)-UINT64_C(0),8);
  }
  }
  { /* delta */
  if(!(value->delta == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,52,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->delta)-UINT64_C(18446744073709551104),10);
  }
@@ -3906,7 +3842,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* protocol_magic */
         if ( !( value->protocol_magic == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x6a5a70d91aa115fdull, 7 );
             table_writer_put16( w, (uint16_t) ( value->protocol_magic ) );
         }
@@ -3914,7 +3849,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* sequence */
         if ( !( value->sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 58, 0xaa38aca481f528a8ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->sequence ) );
         }
@@ -3922,7 +3856,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* ack_sequence */
         if ( !( value->ack_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 4, 0x0dbe005c56697c3eull, 4 );
             table_writer_put32( w, (uint32_t) ( value->ack_sequence ) );
         }
@@ -3930,7 +3863,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* ack_bits */
         if ( !( value->ack_bits == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 49, 0x9bae0da8b829ee03ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->ack_bits ) );
         }
@@ -3938,7 +3870,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* session_id */
         if ( !( value->session_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 61, 0xb7d7b5650a590b05ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->session_id ) );
         }
@@ -3946,7 +3877,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* client_id */
         if ( !( value->client_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 32, 0x6d7b98e2d095967eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->client_id ) );
         }
@@ -3954,7 +3884,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* nonce */
         if ( !( value->nonce == 1ull ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 34, 0x73a94c71d60dc0d8ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->nonce ) );
         }
@@ -3962,7 +3891,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* world_time */
         if ( !( value->world_time == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x3eee6b51be54fc85ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->world_time ) );
         }
@@ -3970,7 +3898,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* frame_tick */
         if ( !( value->frame_tick == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 39, 0x7bbc035f7b6d0112ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->frame_tick ) );
         }
@@ -3978,7 +3905,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* server_time */
         if ( !( value->server_time == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 20, 0x3c460475f9be69c6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->server_time ) );
         }
@@ -3987,7 +3913,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->entities_count < 0 || value->entities_count > 8 ) { return 0; }
         if ( value->entities_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 46, 0x935d0fb07bb3822aull, 14 );
             int64_t element_sizes[8]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -4009,7 +3934,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->stats_count < 0 || value->stats_count > 80 ) { return 0; }
         if ( value->stats_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 73, 0xee639cad45b1994cull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -4030,7 +3954,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* game_event */
         if ( value->game_event.type != TABLE_EVENT_TYPE_NONE )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 15, 0x2e35dc5321aa5790ull, 15 );
             if ( !schema_benchtable_table_event_wire_save_( w, &value->game_event ) ) { return 0; }
         }
@@ -4040,7 +3963,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         for ( i = 0; i < 4; i++ ) { if ( !( value->loadout[i] == 0 ) ) { rides = 1; break; } }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 26, 0x5759ce7586bbb5a3ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -4061,7 +3983,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->player_name_length < 0 || value->player_name_length > 15 ) { return 0; }
         if ( value->player_name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 7, 0x13a62f542cf8e86eull, 12 );
             if ( w->buffer == NULL )
             {
@@ -4082,7 +4003,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
         if ( value->payload_length < 0 || value->payload_length > 16 ) { return 0; }
         if ( value->payload_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 67, 0xcfb8a9d063b5e9e5ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -4102,7 +4022,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* aim_x */
         if ( !( value->aim_x == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 72, 0xdbaf7be5e24296c9ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_x ) );
         }
@@ -4110,7 +4029,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* aim_y */
         if ( !( value->aim_y == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 71, 0xdbaf7ae5e2429516ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_y ) );
         }
@@ -4118,7 +4036,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* aim_z */
         if ( !( value->aim_z == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 70, 0xdbaf79e5e2429363ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->aim_z ) );
         }
@@ -4126,7 +4043,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* recoil */
         if ( !( value->recoil == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 50, 0x9cef31fff7e2e457ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->recoil ) );
         }
@@ -4134,7 +4050,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* drift */
         if ( !( value->drift == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 27, 0x5ab3f9c9341f6c04ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->drift ) );
         }
@@ -4142,7 +4057,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* wide_key */
         if ( !( value->wide_key == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 55, 0xa3348580461faf16ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->wide_key ) );
         }
@@ -4150,7 +4064,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* flux */
         if ( !( value->flux == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 68, 0xd61bdd7908af2642ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->flux ) );
         }
@@ -4158,7 +4071,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* ping */
         if ( !( value->ping == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 62, 0xbf30e00dc53307a9ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->ping ) );
         }
@@ -4166,7 +4078,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* crc_hint */
         if ( !( value->crc_hint == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 25, 0x560d6527ccd8515full, 8 );
             table_writer_put32( w, (uint32_t) ( value->crc_hint ) );
         }
@@ -4174,7 +4085,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     { /* has_extra */
         if ( !( value->has_extra == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 63, 0xc08292176cfd8672ull, 1 );
             table_writer_put8( w, value->has_extra ? 1 : 0 );
         }
@@ -4184,7 +4094,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     {
         if ( !( value->extra == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 76, 0xfd29ee12a979cb69ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->extra ) );
         }
@@ -4195,7 +4104,6 @@ static SCHEMA_UNUSED int table_mixed_save_body( TableWriter * w, const TableMixe
     {
         if ( !( value->idle_ticks == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0x78101ac0aa8cbcfeull, 4 );
             table_writer_put32( w, (uint32_t) ( value->idle_ticks ) );
         }
@@ -5798,90 +5706,60 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  (void)value;
  { /* protocol_magic */
  if(!(value->protocol_magic == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,21,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->protocol_magic)-UINT64_C(0),16);
  }
  }
  { /* sequence */
  if(!(value->sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,22,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->sequence)-UINT64_C(0),16);
  }
  }
  { /* ack_sequence */
  if(!(value->ack_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,23,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->ack_sequence)-UINT64_C(0),16);
  }
  }
  { /* ack_bits */
  if(!(value->ack_bits == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->ack_bits)-UINT64_C(0),32);
  }
  }
  { /* session_id */
  if(!(value->session_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->session_id)-UINT64_C(0),64);
  }
  }
  { /* client_id */
  if(!(value->client_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->client_id)-UINT64_C(0),32);
  }
  }
  { /* nonce */
  if(!(value->nonce == 1ull)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,27,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->nonce)-UINT64_C(1),63);
  }
  }
  { /* world_time */
  if(!(value->world_time == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,28,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->world_time)-UINT64_C(18446743073709551616),41);
  }
  }
  { /* frame_tick */
  if(!(value->frame_tick == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->frame_tick)-UINT64_C(0),48);
  }
  }
  { /* server_time */
  if(!(value->server_time == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,30,kTableMessageRefBitsHere);
   table_bit_put(w,table_message_quantize(value->server_time,0.0f,65535.0f,6553500u),23);
  }
@@ -5889,9 +5767,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* entities */
  if(value->entities_count<0 || value->entities_count>8) return 0;
  if(value->entities_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,31,kTableMessageRefBitsHere);
   if(value->entities_count<0 || value->entities_count>8) return 0;
   table_bit_put(w,(uint64_t)value->entities_count-1,3);
@@ -5904,9 +5779,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* stats */
  if(value->stats_count<0 || value->stats_count>80) return 0;
  if(value->stats_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,32,kTableMessageRefBitsHere);
   if(value->stats_count<0 || value->stats_count>80) return 0;
   table_bit_put(w,(uint64_t)value->stats_count-0,7);
@@ -5918,9 +5790,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  }
  { /* game_event */
  if(value->game_event.type!=TABLE_EVENT_TYPE_NONE) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,33,kTableMessageRefBitsHere);
   if(!schema_benchtable_table_event_wire_message_save_(w,&value->game_event)) return 0;
  }
@@ -5932,9 +5801,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  break;
  } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,34,kTableMessageRefBitsHere);
   if(4<0 || 4>4) return 0;
   table_bit_put(w,(uint64_t)4-4,0);
@@ -5948,9 +5814,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* player_name */
  if(value->player_name_length<0 || value->player_name_length>15) return 0;
  if(value->player_name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,35,kTableMessageRefBitsHere);
   if(value->player_name_length<0 || value->player_name_length>15) return 0;
   table_bit_put(w,(uint64_t)value->player_name_length,4);
@@ -5961,9 +5824,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* payload */
  if(value->payload_length<0 || value->payload_length>16) return 0;
  if(value->payload_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,36,kTableMessageRefBitsHere);
   if(value->payload_length<0 || value->payload_length>16) return 0;
   table_bit_put(w,(uint64_t)value->payload_length,5);
@@ -5973,90 +5833,60 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  }
  { /* aim_x */
  if(!(value->aim_x == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,37,kTableMessageRefBitsHere);
   table_bit_put(w,table_message_quantize(value->aim_x,-1.0f,2.0f,200u),8);
  }
  }
  { /* aim_y */
  if(!(value->aim_y == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,38,kTableMessageRefBitsHere);
   table_bit_put(w,table_message_quantize(value->aim_y,-1.0f,2.0f,200u),8);
  }
  }
  { /* aim_z */
  if(!(value->aim_z == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,39,kTableMessageRefBitsHere);
   table_bit_put(w,table_message_quantize(value->aim_z,-1.0f,2.0f,200u),8);
  }
  }
  { /* recoil */
  if(!(value->recoil == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,40,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->recoil),32);
  }
  }
  { /* drift */
  if(!(value->drift == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,41,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->drift),64);
  }
  }
  { /* wide_key */
  if(!(value->wide_key == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,42,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->wide_key)-UINT64_C(0),64);
  }
  }
  { /* flux */
  if(!(value->flux == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,43,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flux)-UINT64_C(17446744073709551616),61);
  }
  }
  { /* ping */
  if(!(value->ping == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,44,kTableMessageRefBitsHere);
   table_bit_put(w,table_message_quantize(value->ping,0.0f,250.0f,25000u),15);
  }
  }
  { /* crc_hint */
  if(!(value->crc_hint == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,45,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->crc_hint)-UINT64_C(0),24);
  }
  }
  { /* has_extra */
  if(!(value->has_extra == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,46,kTableMessageRefBitsHere);
   table_bit_put(w,value->has_extra ? 1 : 0,1);
  }
@@ -6064,9 +5894,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* extra */
  if(value->has_extra) {
  if(!(value->extra == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,47,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->extra)-UINT64_C(0),8);
  }
@@ -6075,9 +5902,6 @@ static SCHEMA_UNUSED int table_mixed_save_message_body(TableBitWriter * w,const 
  { /* idle_ticks */
  if(!value->has_extra) {
  if(!(value->idle_ticks == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,48,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->idle_ticks)-UINT64_C(0),4);
  }
@@ -6701,7 +6525,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_mixed_message_extent_(TableMess
 static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const TableHitEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->target_id == 0 ) )
@@ -6731,7 +6555,6 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
     { /* target_id */
         if ( !( value->target_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 60, 0xb7bc9ac015a25050ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->target_id ) );
         }
@@ -6739,7 +6562,6 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
     { /* damage */
         if ( !( value->damage == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 40, 0x7f6308be8ab37fc0ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->damage ) );
         }
@@ -6747,7 +6569,6 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
     { /* hit_kind */
         if ( !( value->hit_kind == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x01fbc365b059b925ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hit_kind ) );
         }
@@ -6755,7 +6576,6 @@ static SCHEMA_UNUSED int table_hit_event_save_body( TableWriter * w, const Table
     { /* crit */
         if ( !( value->crit == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x126167908c9aa52dull, 1 );
             table_writer_put8( w, value->crit ? 1 : 0 );
         }
@@ -7060,36 +6880,24 @@ static SCHEMA_UNUSED int table_hit_event_save_message_body(TableBitWriter * w,co
  (void)value;
  { /* target_id */
  if(!(value->target_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,17,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_id)-UINT64_C(0),12);
  }
  }
  { /* damage */
  if(!(value->damage == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,18,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->damage)-UINT64_C(0),12);
  }
  }
  { /* hit_kind */
  if(!(value->hit_kind == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,19,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->hit_kind)-UINT64_C(0),3);
  }
  }
  { /* crit */
  if(!(value->crit == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,value->crit ? 1 : 0,1);
  }
@@ -7247,7 +7055,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_hit_event_message_extent_(Table
 static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const TableChatEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->channel == 0 ) )
@@ -7267,7 +7075,6 @@ static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const Tabl
     { /* channel */
         if ( !( value->channel == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xa5013e9ad5caeda4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->channel ) );
         }
@@ -7275,7 +7082,6 @@ static SCHEMA_UNUSED int table_chat_event_save_body( TableWriter * w, const Tabl
     { /* speaker */
         if ( !( value->speaker == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 75, 0xfbf1ac4d96ebd022ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->speaker ) );
         }
@@ -7479,18 +7285,12 @@ static SCHEMA_UNUSED int table_chat_event_save_message_body(TableBitWriter * w,c
  (void)value;
  { /* channel */
  if(!(value->channel == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,1,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->channel)-UINT64_C(0),2);
  }
  }
  { /* speaker */
  if(!(value->speaker == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,2,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->speaker)-UINT64_C(0),12);
  }
@@ -7616,7 +7416,7 @@ static SCHEMA_UNUSED int schema_benchtable_table_chat_event_message_extent_(Tabl
 static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const TablePickupEvent * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->item_id == 0 ) )
@@ -7636,7 +7436,6 @@ static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const Ta
     { /* item_id */
         if ( !( value->item_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 51, 0x9e7fd06d864fbd56ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->item_id ) );
         }
@@ -7644,7 +7443,6 @@ static SCHEMA_UNUSED int table_pickup_event_save_body( TableWriter * w, const Ta
     { /* amount */
         if ( !( value->amount == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 43, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
@@ -7848,18 +7646,12 @@ static SCHEMA_UNUSED int table_pickup_event_save_message_body(TableBitWriter * w
  (void)value;
  { /* item_id */
  if(!(value->item_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,49,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->item_id)-UINT64_C(0),10);
  }
  }
  { /* amount */
  if(!(value->amount == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,50,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->amount)-UINT64_C(0),8);
  }

--- a/internal/codegen/ctable/ctable.go
+++ b/internal/codegen/ctable/ctable.go
@@ -124,12 +124,44 @@ type tableGen struct {
 	owner    *ir.Struct      // the closure member whose codec is being emitted
 	variable map[string]bool // the derived VARIABLE-LENGTH members (ir.VariableTables)
 	targets  map[string]bool // tables some pointer targets (ir.PointerTargets)
+	probed   map[string]bool // structs that can be reached by a check_default probe
+	hasProbes bool           // unit carries at least one check_default probe
 	// idOrdinal is the unit's id vocabulary as id -> ORDINAL (§3): the index
 	// an id takes in ir.TableWireIds, which is what a generated header hands
 	// table_writer_id_at beside the id itself. Built on first use.
 	idOrdinal map[uint64]int
 	body      strings.Builder
 	includes  map[string]bool // referenced files -> #include "<base>Table.h"
+}
+
+func (g *tableGen) canProbe(st *ir.Struct) bool {
+	return g.hasProbes && g.probed != nil && g.probed[st.Name]
+}
+
+// tableDefaultProbedStructs returns the set of struct names that can be reached
+// by a default or slot probe (check_default = 1). A struct can only be probed if
+// it is the target of a scalar table write or an enum-keyed table slot write.
+func tableDefaultProbedStructs(u *ir.Unit) map[string]bool {
+	closure := ir.TableClosure(u)
+	probed := map[string]bool{}
+	for name := range closure {
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		for _, f := range st.Fields {
+			if ir.TableWireScalarKind(f) != tkTable {
+				continue
+			}
+			if f.KeyEnum != "" || (f.Array == ir.ArrayNone && !f.IsList() && !f.IsMap() && !f.Type.Optional) {
+				probed[f.Type.Name] = true
+			}
+		}
+	}
+	return probed
 }
 
 func (g *tableGen) pf(format string, args ...any) {
@@ -521,8 +553,10 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// table has one, and a consumer includes and compiles it only if it uses
 	// the form. The Table header below carries not one symbol of it.
 	out := generateBlockFiles(u, blocks, variable, targets)
+	probed := tableDefaultProbedStructs(u)
+	hasProbes := len(probed) > 0
 	for _, f := range u.Files {
-		g := &tableGen{unit: u, file: f, anyVariable: anyVariable, anyKeyed: anyKeyed, anySequence: anyList || anyMap, anyList: anyList, anyMap: anyMap, blocks: blocks, variable: variable, targets: targets,
+		g := &tableGen{unit: u, file: f, anyVariable: anyVariable, anyKeyed: anyKeyed, anySequence: anyList || anyMap, anyList: anyList, anyMap: anyMap, blocks: blocks, variable: variable, targets: targets, probed: probed, hasProbes: hasProbes,
 			includes: map[string]bool{}}
 		var members []*ir.Struct
 		members = append(members, orderTables(f.Tables)...)
@@ -531,7 +565,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 				members = append(members, st)
 			}
 		}
-		cg := &tableGen{unit: u, file: f, anyVariable: anyVariable, anyKeyed: anyKeyed, anySequence: anyList || anyMap, anyList: anyList, anyMap: anyMap, blocks: blocks, variable: variable, targets: targets,
+		cg := &tableGen{unit: u, file: f, anyVariable: anyVariable, anyKeyed: anyKeyed, anySequence: anyList || anyMap, anyList: anyList, anyMap: anyMap, blocks: blocks, variable: variable, targets: targets, probed: probed, hasProbes: hasProbes,
 			includes: map[string]bool{}}
 		g.emitTableShapes(members)
 		if len(members) > 0 {
@@ -730,7 +764,7 @@ func (g *tableGen) header(u *ir.Unit, f *ir.File, members []*ir.Struct) []byte {
 	h.WriteString("\n")
 	h.WriteString(tableCookRuntime(u.Package))
 	h.WriteString(tableCookWriteRuntime)
-	h.WriteString(tableMessageForm(u, g.anyVariable))
+	h.WriteString(tableMessageForm(u, g.anyVariable, g.hasProbes))
 	if g.anyVariable {
 		h.WriteString(tableCookGraphRuntime)
 		h.WriteString(g.retainRuntime())

--- a/internal/codegen/ctable/ctable.go
+++ b/internal/codegen/ctable/ctable.go
@@ -120,12 +120,12 @@ type tableGen struct {
 	// blocks is the unit's BLOCK FORM surface (docs/SPEC-TABLES.md §19), nil when
 	// no table is marked `| block`. Nil is what makes the zero-cost gate
 	// answerable by asking one question (§2.2).
-	blocks   *ir.BlockUnit
-	owner    *ir.Struct      // the closure member whose codec is being emitted
-	variable map[string]bool // the derived VARIABLE-LENGTH members (ir.VariableTables)
-	targets  map[string]bool // tables some pointer targets (ir.PointerTargets)
-	probed   map[string]bool // structs that can be reached by a check_default probe
-	hasProbes bool           // unit carries at least one check_default probe
+	blocks    *ir.BlockUnit
+	owner     *ir.Struct      // the closure member whose codec is being emitted
+	variable  map[string]bool // the derived VARIABLE-LENGTH members (ir.VariableTables)
+	targets   map[string]bool // tables some pointer targets (ir.PointerTargets)
+	probed    map[string]bool // structs that can be reached by a check_default probe
+	hasProbes bool            // unit carries at least one check_default probe
 	// idOrdinal is the unit's id vocabulary as id -> ORDINAL (§3): the index
 	// an id takes in ir.TableWireIds, which is what a generated header hands
 	// table_writer_id_at beside the id itself. Built on first use.

--- a/internal/codegen/ctable/message.go
+++ b/internal/codegen/ctable/message.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
-func tableMessageForm(u *ir.Unit, variable bool) string {
+func tableMessageForm(u *ir.Unit, variable, hasProbes bool) string {
 	var b strings.Builder
 	b.WriteString("#ifndef SCHEMA_" + strings.ToUpper(u.Package) + "_TABLE_MESSAGE\n#define SCHEMA_" + strings.ToUpper(u.Package) + "_TABLE_MESSAGE\n")
 	entries, announcement := ir.TableVocabulary(u), ir.TableAnnouncement(u)
@@ -21,7 +21,12 @@ func tableMessageForm(u *ir.Unit, variable bool) string {
 	if variable {
 		nodes = "TableNumbering * nodes; int64_t index_bits;"
 	}
-	b.WriteString(strings.ReplaceAll(cMessageBits, "@NODES@", nodes))
+	checkDefault := ""
+	if hasProbes {
+		checkDefault = ",check_default"
+	}
+	bits := strings.ReplaceAll(cMessageBits, "@CHECK_DEFAULT@", checkDefault)
+	b.WriteString(strings.ReplaceAll(bits, "@NODES@", nodes))
 	b.WriteString(cMessageNumbers)
 	b.WriteString(cMessageShape)
 	b.WriteString(cMessageAnnounce)
@@ -38,7 +43,7 @@ func tableMessageForm(u *ir.Unit, variable bool) string {
 // A null output performs exactly the same walk as a save, counting bits.
 // Reads and writes touch only the bytes occupied by the requested value.
 const cMessageBits = `
-typedef struct TableBitWriter { uint8_t * buffer; int64_t capacity,bits; int overflow,check_default; @NODES@ } TableBitWriter;
+typedef struct TableBitWriter { uint8_t * buffer; int64_t capacity,bits; int overflow@CHECK_DEFAULT@; @NODES@ } TableBitWriter;
 typedef struct TableBitReader { const uint8_t * buffer; int64_t bits,offset; } TableBitReader;
 static SCHEMA_UNUSED TableBitWriter table_bit_writer(uint8_t * buffer,int64_t capacity)
 { TableBitWriter w;memset(&w,0,sizeof(w));w.buffer=buffer;w.capacity=capacity;return w; }

--- a/internal/codegen/ctable/message_save.go
+++ b/internal/codegen/ctable/message_save.go
@@ -226,7 +226,10 @@ func (g *tableGen) emitMessageSave(st *ir.Struct) {
 		if f.Type.Optional {
 			condition = expr + "_present"
 		}
-		g.pf(" if(%s) {\n  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;return 1;}\n", condition)
+		g.pf(" if(%s) {\n", condition)
+		if g.canProbe(st) {
+			g.pf("  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;return 1;}\n")
+		}
 		g.messageHeader(ir.TableFieldEntry(f), "  ")
 		g.messageValue(f, ir.TableFieldEntry(f), expr, count, "  ")
 		g.pf(" }\n")

--- a/internal/codegen/ctable/retain.go
+++ b/internal/codegen/ctable/retain.go
@@ -14,7 +14,11 @@ func (g *tableGen) retainRuntime() string {
 	for _, id := range ir.TableWireIds(g.unit) {
 		fmt.Fprintf(&ids, "UINT64_C(0x%016x),", id)
 	}
-	return strings.NewReplacer("@DEPTH@", fmt.Sprint(g.retainDepth()), "@KNOWN@", ids.String(), "@RETAIN_OUT@", cRetainOut, "@RETAIN_MESSAGE@", cRetainMessage+cRetainGraph).Replace(cRetainRuntime)
+	retainOut := cRetainOut
+	if !g.hasProbes {
+		retainOut = strings.ReplaceAll(retainOut, " if(w->check_default){w->offset=2;return 1;}\n", "")
+	}
+	return strings.NewReplacer("@DEPTH@", fmt.Sprint(g.retainDepth()), "@KNOWN@", ids.String(), "@RETAIN_OUT@", retainOut, "@RETAIN_MESSAGE@", cRetainMessage+cRetainGraph).Replace(cRetainRuntime)
 }
 func (g *tableGen) retainDepth() int {
 	var field func(*ir.Field) int

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -76,6 +76,11 @@ func (g *tableGen) wirePrimitives() string {
 			writeNodes = "    struct TableNumbering * nodes;"
 			readNodes = "    struct TableNodeMap * nodes;"
 		}
+		checkDefault := ""
+		if g.hasProbes {
+			checkDefault = ", check_default"
+		}
+		runtime = strings.ReplaceAll(runtime, "@CHECK_DEFAULT@", checkDefault)
 		runtime = strings.ReplaceAll(runtime, "@WRITE_NODES@", writeNodes)
 		runtime = strings.ReplaceAll(runtime, "@READ_NODES@", readNodes)
 	}
@@ -108,7 +113,7 @@ typedef struct TableWriter
 {
     uint8_t * buffer;
     int64_t capacity, offset;
-    int overflow, id_checkpoint, check_default;
+    int overflow, id_checkpoint@CHECK_DEFAULT@;
     TableWriteIds * vocabulary;
 @WRITE_NODES@
 } TableWriter;
@@ -608,7 +613,11 @@ func (g *tableGen) emitWireScalarLeafMeasure(st *ir.Struct) {
 			return
 		}
 	}
-	g.pf("    if ( w->buffer == NULL && !w->check_default )\n    {\n")
+	if g.canProbe(st) {
+		g.pf("    if ( w->buffer == NULL && !w->check_default )\n    {\n")
+	} else {
+		g.pf("    if ( w->buffer == NULL )\n    {\n")
+	}
 	g.pf("        int64_t payload_bytes = 1; /* the zero reference ending this body */\n")
 	guards := tableGuardExprs(st)
 	for _, f := range st.Fields {
@@ -694,7 +703,9 @@ func (g *tableGen) emitWireWrite(st *ir.Struct) {
 			condition = expr + "_present"
 		}
 		g.pf("        if ( %s )\n        {\n", condition)
-		g.pf("            if ( w->check_default ) { w->offset = 2; return 1; }\n")
+		if g.canProbe(st) {
+			g.pf("            if ( w->check_default ) { w->offset = 2; return 1; }\n")
+		}
 		g.pf("            %s\n", g.wireHeaderCall(ir.TableFieldWireId(f), wireKind))
 		switch {
 		case framed:

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -1580,7 +1580,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
     { /* tag */
         if ( !( value->tag == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 25, 0x56d7ab194448a4f3ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->tag ) );
         }
@@ -1588,7 +1587,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
     { /* value */
         if ( !( value->value == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0x7ce4fd9430e80ceaull, 11 );
             table_writer_put64( w, table_double_to_bits( value->value ) );
         }
@@ -1596,7 +1594,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
     { /* flag */
         if ( !( value->flag == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 73, 0xd5f2d079088c0b17ull, 1 );
             table_writer_put8( w, value->flag ? 1 : 0 );
         }
@@ -1604,7 +1601,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
     { /* id */
         if ( !( value->id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 0, 0x08b72e07b55c3ac0ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->id ) );
         }
@@ -1613,7 +1609,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         if ( value->label_length < 0 || value->label_length > 15 ) { return 0; }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 16, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
@@ -1635,7 +1630,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         for ( i = 0; i < 4; i++ ) { if ( !( value->slots[i] == 0 ) ) { rides = 1; break; } }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 79, 0xe68c2e6bb1ee5646ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -1661,7 +1655,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 58, 0xbaaeb048a5a8fa6dull, 16 );
             if ( w->buffer == NULL )
             {
@@ -1681,7 +1674,6 @@ static SCHEMA_UNUSED int padded_row_save_body( TableWriter * w, const PaddedRow 
     { /* counter */
         if ( value->counter_present )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 35, 0x77976c7416517c63ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->counter ) );
         }
@@ -2093,36 +2085,24 @@ static SCHEMA_UNUSED int padded_row_save_message_body(TableBitWriter * w,const P
  (void)value;
  { /* tag */
  if(!(value->tag == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,5,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->tag)-UINT64_C(0),8);
  }
  }
  { /* value */
  if(!(value->value == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->value),64);
  }
  }
  { /* flag */
  if(!(value->flag == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,7,kTableMessageRefBitsHere);
   table_bit_put(w,value->flag ? 1 : 0,1);
  }
  }
  { /* id */
  if(!(value->id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,8,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->id)-UINT64_C(0),32);
  }
@@ -2130,9 +2110,6 @@ static SCHEMA_UNUSED int padded_row_save_message_body(TableBitWriter * w,const P
  { /* label */
  if(value->label_length<0 || value->label_length>15) return 0;
  if(value->label_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,9,kTableMessageRefBitsHere);
   if(value->label_length<0 || value->label_length>15) return 0;
   table_bit_put(w,(uint64_t)value->label_length,4);
@@ -2147,9 +2124,6 @@ static SCHEMA_UNUSED int padded_row_save_message_body(TableBitWriter * w,const P
  break;
  } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,10,kTableMessageRefBitsHere);
   if(4<0 || 4>4) return 0;
   table_bit_put(w,(uint64_t)4-4,0);
@@ -2168,9 +2142,6 @@ static SCHEMA_UNUSED int padded_row_save_message_body(TableBitWriter * w,const P
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,11,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -2200,9 +2171,6 @@ static SCHEMA_UNUSED int padded_row_save_message_body(TableBitWriter * w,const P
  }
  { /* counter */
  if(value->counter_present) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,12,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->counter)-UINT64_C(0),32);
  }
@@ -2530,7 +2498,6 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
     { /* marker */
         if ( !( value->marker == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 81, 0xeddcb72b15486e77ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->marker ) );
         }
@@ -2538,7 +2505,6 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
     { /* stamp */
         if ( !( value->stamp == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 83, 0xee7ba9ad45c64144ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->stamp ) );
         }
@@ -2547,7 +2513,6 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( value->rows_count < 0 || value->rows_count > 64 ) { return 0; }
         if ( value->rows_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 48, 0xa3a7061ff10a8138ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -2569,7 +2534,6 @@ static SCHEMA_UNUSED int padded_frame_save_body( TableWriter * w, const PaddedFr
         if ( value->blob_length < 0 || value->blob_length > 12 ) { return 0; }
         if ( value->blob_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 64, 0xc573b39bc29148caull, 14 );
             if ( w->buffer == NULL )
             {
@@ -2836,18 +2800,12 @@ static SCHEMA_UNUSED int padded_frame_save_message_body(TableBitWriter * w,const
  (void)value;
  { /* marker */
  if(!(value->marker == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,1,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->marker)-UINT64_C(0),8);
  }
  }
  { /* stamp */
  if(!(value->stamp == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,2,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->stamp)-UINT64_C(0),64);
  }
@@ -2855,9 +2813,6 @@ static SCHEMA_UNUSED int padded_frame_save_message_body(TableBitWriter * w,const
  { /* rows */
  if(value->rows_count<0 || value->rows_count>64) return 0;
  if(value->rows_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,3,kTableMessageRefBitsHere);
   if(value->rows_count<0 || value->rows_count>64) return 0;
   table_bit_put(w,(uint64_t)value->rows_count-0,7);
@@ -2870,9 +2825,6 @@ static SCHEMA_UNUSED int padded_frame_save_message_body(TableBitWriter * w,const
  { /* blob */
  if(value->blob_length<0 || value->blob_length>12) return 0;
  if(value->blob_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,4,kTableMessageRefBitsHere);
   if(value->blob_length<0 || value->blob_length>12) return 0;
   table_bit_put(w,(uint64_t)value->blob_length,4);

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -1885,7 +1885,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -1908,7 +1907,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -1928,7 +1926,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
     { /* camera_id */
         if ( !( value->camera_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 45, 0x9f61700f084ab92eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->camera_id ) );
         }
@@ -1936,7 +1933,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
     { /* camera_type */
         if ( !( value->camera_type == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 15, 0x336d3dc7fffd0c9bull, 8 );
             table_writer_put32( w, (uint32_t) ( value->camera_type ) );
         }
@@ -1944,7 +1940,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
     { /* target_object_id */
         if ( !( value->target_object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
@@ -1952,7 +1947,6 @@ static SCHEMA_UNUSED int render_camera_save_body( TableWriter * w, const RenderC
     { /* fov */
         if ( !( value->fov == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 76, 0xdcb27c18fed9e15cull, 10 );
             table_writer_put32( w, table_float_to_bits( value->fov ) );
         }
@@ -2277,9 +2271,6 @@ static SCHEMA_UNUSED int render_camera_save_message_body(TableBitWriter * w,cons
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -2292,45 +2283,30 @@ static SCHEMA_UNUSED int render_camera_save_message_body(TableBitWriter * w,cons
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* camera_id */
  if(!(value->camera_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,15,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->camera_id)-UINT64_C(0),32);
  }
  }
  { /* camera_type */
  if(!(value->camera_type == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,16,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->camera_type)-UINT64_C(0),32);
  }
  }
  { /* target_object_id */
  if(!(value->target_object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,17,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_object_id)-UINT64_C(0),32);
  }
  }
  { /* fov */
  if(!(value->fov == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,18,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->fov),32);
  }
@@ -2512,7 +2488,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -2535,7 +2510,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -2555,7 +2529,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -2563,7 +2536,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* object_id */
         if ( !( value->object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
@@ -2571,7 +2543,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* target_object_id */
         if ( !( value->target_object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
@@ -2579,7 +2550,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* thrust */
         if ( !( value->thrust == 0.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 70, 0xcfd587cb3100cd73ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->thrust ) );
         }
@@ -2587,7 +2557,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* object_sequence */
         if ( !( value->object_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
@@ -2595,7 +2564,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* ship_type */
         if ( !( value->ship_type == SHIP_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 11, 0x1f7d2e86a2e77268ull, 30 );
             switch ( value->ship_type )
             {
@@ -2610,7 +2578,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -2626,7 +2593,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* has_target_lock */
         if ( !( value->has_target_lock == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 7, 0x1554fa45a1220171ull, 1 );
             table_writer_put8( w, value->has_target_lock ? 1 : 0 );
         }
@@ -2634,7 +2600,6 @@ static SCHEMA_UNUSED int render_ship_save_body( TableWriter * w, const RenderShi
     { /* predicted_explode */
         if ( !( value->predicted_explode == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 22, 0x4d5be97ba1b9cb81ull, 1 );
             table_writer_put8( w, value->predicted_explode ? 1 : 0 );
         }
@@ -3087,9 +3052,6 @@ static SCHEMA_UNUSED int render_ship_save_message_body(TableBitWriter * w,const 
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -3102,63 +3064,42 @@ static SCHEMA_UNUSED int render_ship_save_message_body(TableBitWriter * w,const 
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,50,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),4);
  }
  }
  { /* object_id */
  if(!(value->object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_id)-UINT64_C(0),32);
  }
  }
  { /* target_object_id */
  if(!(value->target_object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,17,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_object_id)-UINT64_C(0),32);
  }
  }
  { /* thrust */
  if(!(value->thrust == 0.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,51,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->thrust),32);
  }
  }
  { /* object_sequence */
  if(!(value->object_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_sequence)-UINT64_C(0),8);
  }
  }
  { /* ship_type */
  if(!(value->ship_type == SHIP_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,52,kTableMessageRefBitsHere);
   switch(value->ship_type) {
    case SHIP_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -3175,9 +3116,6 @@ static SCHEMA_UNUSED int render_ship_save_message_body(TableBitWriter * w,const 
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -3196,18 +3134,12 @@ static SCHEMA_UNUSED int render_ship_save_message_body(TableBitWriter * w,const 
  }
  { /* has_target_lock */
  if(!(value->has_target_lock == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,53,kTableMessageRefBitsHere);
   table_bit_put(w,value->has_target_lock ? 1 : 0,1);
  }
  }
  { /* predicted_explode */
  if(!(value->predicted_explode == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,54,kTableMessageRefBitsHere);
   table_bit_put(w,value->predicted_explode ? 1 : 0,1);
  }
@@ -3473,7 +3405,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -3493,7 +3424,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -3501,7 +3431,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* object_id */
         if ( !( value->object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
@@ -3509,7 +3438,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* parent_object_id */
         if ( !( value->parent_object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 2, 0x0bee7b3cb4046c93ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->parent_object_id ) );
         }
@@ -3517,7 +3445,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* turret_index */
         if ( !( value->turret_index == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 40, 0x88a11a6aed541f54ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->turret_index ) );
         }
@@ -3525,7 +3452,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* target_object_id */
         if ( !( value->target_object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 31, 0x6a0c6a156952b9c2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->target_object_id ) );
         }
@@ -3533,7 +3459,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* object_sequence */
         if ( !( value->object_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
@@ -3541,7 +3466,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -3557,7 +3481,6 @@ static SCHEMA_UNUSED int render_turret_save_body( TableWriter * w, const RenderT
     { /* has_target_lock */
         if ( !( value->has_target_lock == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 7, 0x1554fa45a1220171ull, 1 );
             table_writer_put8( w, value->has_target_lock ? 1 : 0 );
         }
@@ -4069,72 +3992,48 @@ static SCHEMA_UNUSED int render_turret_save_message_body(TableBitWriter * w,cons
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),64);
  }
  }
  { /* object_id */
  if(!(value->object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_id)-UINT64_C(0),32);
  }
  }
  { /* parent_object_id */
  if(!(value->parent_object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->parent_object_id)-UINT64_C(0),32);
  }
  }
  { /* turret_index */
  if(!(value->turret_index == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,56,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->turret_index)-UINT64_C(0),32);
  }
  }
  { /* target_object_id */
  if(!(value->target_object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,17,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_object_id)-UINT64_C(0),32);
  }
  }
  { /* object_sequence */
  if(!(value->object_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_sequence)-UINT64_C(0),8);
  }
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -4153,9 +4052,6 @@ static SCHEMA_UNUSED int render_turret_save_message_body(TableBitWriter * w,cons
  }
  { /* has_target_lock */
  if(!(value->has_target_lock == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,53,kTableMessageRefBitsHere);
   table_bit_put(w,value->has_target_lock ? 1 : 0,1);
  }
@@ -4394,7 +4290,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -4417,7 +4312,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -4437,7 +4331,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -4445,7 +4338,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
     { /* object_id */
         if ( !( value->object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
@@ -4453,7 +4345,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
     { /* object_sequence */
         if ( !( value->object_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
@@ -4461,7 +4352,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
     { /* missile_type */
         if ( !( value->missile_type == MISSILE_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x151b2a0e2c07b4bcull, 30 );
             switch ( value->missile_type )
             {
@@ -4475,7 +4365,6 @@ static SCHEMA_UNUSED int render_missile_save_body( TableWriter * w, const Render
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -4806,9 +4695,6 @@ static SCHEMA_UNUSED int render_missile_save_message_body(TableBitWriter * w,con
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -4821,45 +4707,30 @@ static SCHEMA_UNUSED int render_missile_save_message_body(TableBitWriter * w,con
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),64);
  }
  }
  { /* object_id */
  if(!(value->object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_id)-UINT64_C(0),32);
  }
  }
  { /* object_sequence */
  if(!(value->object_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_sequence)-UINT64_C(0),8);
  }
  }
  { /* missile_type */
  if(!(value->missile_type == MISSILE_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,45,kTableMessageRefBitsHere);
   switch(value->missile_type) {
    case MISSILE_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -4874,9 +4745,6 @@ static SCHEMA_UNUSED int render_missile_save_message_body(TableBitWriter * w,con
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -5093,7 +4961,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -5116,7 +4983,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -5136,7 +5002,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -5144,7 +5009,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
     { /* object_id */
         if ( !( value->object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x0bdab42c07f19812ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->object_id ) );
         }
@@ -5152,7 +5016,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
     { /* object_sequence */
         if ( !( value->object_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x5de0015285763c46ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->object_sequence ) );
         }
@@ -5160,7 +5023,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
     { /* prop_type */
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
@@ -5175,7 +5037,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_body( TableWriter * w, const R
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -5507,9 +5368,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_message_body(TableBitWriter * 
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -5522,45 +5380,30 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_message_body(TableBitWriter * 
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),64);
  }
  }
  { /* object_id */
  if(!(value->object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_id)-UINT64_C(0),32);
  }
  }
  { /* object_sequence */
  if(!(value->object_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->object_sequence)-UINT64_C(0),8);
  }
  }
  { /* prop_type */
  if(!(value->prop_type == PROP_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,23,kTableMessageRefBitsHere);
   switch(value->prop_type) {
    case PROP_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -5577,9 +5420,6 @@ static SCHEMA_UNUSED int render_dynamic_prop_save_message_body(TableBitWriter * 
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -5798,7 +5638,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -5821,7 +5660,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -5841,7 +5679,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
     { /* scale */
         if ( !( value->scale == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 32, 0x6aacb9fbb71a1d91ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->scale ) );
         }
@@ -5849,7 +5686,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -5857,7 +5693,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
     { /* static_prop_id */
         if ( !( value->static_prop_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 72, 0xd23da7ab574b95c3ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->static_prop_id ) );
         }
@@ -5865,7 +5700,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
     { /* prop_type */
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
@@ -5880,7 +5714,6 @@ static SCHEMA_UNUSED int render_static_prop_save_body( TableWriter * w, const Re
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -6238,9 +6071,6 @@ static SCHEMA_UNUSED int render_static_prop_save_message_body(TableBitWriter * w
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -6253,45 +6083,30 @@ static SCHEMA_UNUSED int render_static_prop_save_message_body(TableBitWriter * w
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* scale */
  if(!(value->scale == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,19,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->scale),64);
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),64);
  }
  }
  { /* static_prop_id */
  if(!(value->static_prop_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,55,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->static_prop_id)-UINT64_C(0),32);
  }
  }
  { /* prop_type */
  if(!(value->prop_type == PROP_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,23,kTableMessageRefBitsHere);
   switch(value->prop_type) {
    case PROP_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -6308,9 +6123,6 @@ static SCHEMA_UNUSED int render_static_prop_save_message_body(TableBitWriter * w
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -6530,7 +6342,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -6553,7 +6364,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -6573,7 +6383,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* scale */
         if ( !( value->scale == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 32, 0x6aacb9fbb71a1d91ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->scale ) );
         }
@@ -6581,7 +6390,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* flags */
         if ( !( value->flags == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x17a3a1a985f75aecull, 9 );
             table_writer_put64( w, (uint64_t) ( value->flags ) );
         }
@@ -6589,7 +6397,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* cosmetic_prop_id */
         if ( !( value->cosmetic_prop_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 57, 0xb66e4449e56b2e26ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->cosmetic_prop_id ) );
         }
@@ -6597,7 +6404,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* prop_sequence */
         if ( !( value->prop_sequence == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 23, 0x4d7bf73bcbddc228ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->prop_sequence ) );
         }
@@ -6605,7 +6411,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* prop_type */
         if ( !( value->prop_type == PROP_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 78, 0xe5626f155e4c5dadull, 30 );
             switch ( value->prop_type )
             {
@@ -6620,7 +6425,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_body( TableWriter * w, const 
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -7001,9 +6805,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_message_body(TableBitWriter *
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -7016,54 +6817,36 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_message_body(TableBitWriter *
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* scale */
  if(!(value->scale == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,19,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->scale),64);
  }
  }
  { /* flags */
  if(!(value->flags == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->flags)-UINT64_C(0),64);
  }
  }
  { /* cosmetic_prop_id */
  if(!(value->cosmetic_prop_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,21,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->cosmetic_prop_id)-UINT64_C(0),32);
  }
  }
  { /* prop_sequence */
  if(!(value->prop_sequence == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,22,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->prop_sequence)-UINT64_C(0),8);
  }
  }
  { /* prop_type */
  if(!(value->prop_type == PROP_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,23,kTableMessageRefBitsHere);
   switch(value->prop_type) {
    case PROP_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -7080,9 +6863,6 @@ static SCHEMA_UNUSED int render_cosmetic_prop_save_message_body(TableBitWriter *
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -7319,7 +7099,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 82, 0xee5d97ad45ad251full, 13 );
             if ( w->buffer == NULL )
             {
@@ -7342,7 +7121,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 30, 0x6917a5bab91540f2ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -7362,7 +7140,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
     { /* t */
         if ( !( value->t == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 50, 0xaf63e94c860202a3ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->t ) );
         }
@@ -7370,7 +7147,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
     { /* laser_id */
         if ( !( value->laser_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 68, 0xcd29c05f390294ecull, 8 );
             table_writer_put32( w, (uint32_t) ( value->laser_id ) );
         }
@@ -7378,7 +7154,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
     { /* laser_type */
         if ( !( value->laser_type == LASER_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 43, 0x96b593c242133841ull, 30 );
             switch ( value->laser_type )
             {
@@ -7392,7 +7167,6 @@ static SCHEMA_UNUSED int render_laser_save_body( TableWriter * w, const RenderLa
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -7666,9 +7440,6 @@ static SCHEMA_UNUSED int render_laser_save_message_body(TableBitWriter * w,const
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->start)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,41,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->start)) return 0;
  }
@@ -7681,36 +7452,24 @@ static SCHEMA_UNUSED int render_laser_save_message_body(TableBitWriter * w,const
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->finish)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,42,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->finish)) return 0;
  }
  }
  { /* t */
  if(!(value->t == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,27,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->t),64);
  }
  }
  { /* laser_id */
  if(!(value->laser_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,43,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->laser_id)-UINT64_C(0),32);
  }
  }
  { /* laser_type */
  if(!(value->laser_type == LASER_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,44,kTableMessageRefBitsHere);
   switch(value->laser_type) {
    case LASER_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -7725,9 +7484,6 @@ static SCHEMA_UNUSED int render_laser_save_message_body(TableBitWriter * w,const
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -7931,7 +7687,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x4cbf3a26fca1d74aull, 13 );
             if ( w->buffer == NULL )
             {
@@ -7954,7 +7709,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 56, 0xb51afb05cd34709full, 13 );
             if ( w->buffer == NULL )
             {
@@ -7974,7 +7728,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
     { /* t */
         if ( !( value->t == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 50, 0xaf63e94c860202a3ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->t ) );
         }
@@ -7982,7 +7735,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
     { /* explosion_id */
         if ( !( value->explosion_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 86, 0xfd7f3fa0b16ed778ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->explosion_id ) );
         }
@@ -7990,7 +7742,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
     { /* parent_object_id */
         if ( !( value->parent_object_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 2, 0x0bee7b3cb4046c93ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->parent_object_id ) );
         }
@@ -7998,7 +7749,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
     { /* explosion_type */
         if ( !( value->explosion_type == EXPLOSION_TYPE_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 75, 0xdc89eb9cd3393be5ull, 30 );
             switch ( value->explosion_type )
             {
@@ -8012,7 +7762,6 @@ static SCHEMA_UNUSED int render_explosion_save_body( TableWriter * w, const Rend
     { /* team */
         if ( !( value->team == TEAM_NONE ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xfa23d9ef19afc32cull, 30 );
             switch ( value->team )
             {
@@ -8355,9 +8104,6 @@ static SCHEMA_UNUSED int render_explosion_save_message_body(TableBitWriter * w,c
  probe.check_default=1;
  if(!render_vector3_save_message_body(&probe,&value->position)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(!render_vector3_save_message_body(w,&value->position)) return 0;
  }
@@ -8370,45 +8116,30 @@ static SCHEMA_UNUSED int render_explosion_save_message_body(TableBitWriter * w,c
  probe.check_default=1;
  if(!render_quaternion_save_message_body(&probe,&value->rotation)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   if(!render_quaternion_save_message_body(w,&value->rotation)) return 0;
  }
  }
  { /* t */
  if(!(value->t == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,27,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->t),64);
  }
  }
  { /* explosion_id */
  if(!(value->explosion_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,28,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->explosion_id)-UINT64_C(0),32);
  }
  }
  { /* parent_object_id */
  if(!(value->parent_object_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->parent_object_id)-UINT64_C(0),32);
  }
  }
  { /* explosion_type */
  if(!(value->explosion_type == EXPLOSION_TYPE_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,30,kTableMessageRefBitsHere);
   switch(value->explosion_type) {
    case EXPLOSION_TYPE_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -8423,9 +8154,6 @@ static SCHEMA_UNUSED int render_explosion_save_message_body(TableBitWriter * w,c
  }
  { /* team */
  if(!(value->team == TEAM_NONE)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   switch(value->team) {
    case TEAM_NONE: table_bit_put(w,0,kTableMessageRefBitsHere);
@@ -9021,7 +8749,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
     { /* version */
         if ( !( value->version == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 59, 0xbb62c62c9808ea37ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->version ) );
         }
@@ -9030,7 +8757,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->cameras_count < 0 || value->cameras_count > 1 ) { return 0; }
         if ( value->cameras_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 4, 0x0f9222d2ba7aa2a7ull, 14 );
             int64_t element_sizes[1]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9052,7 +8778,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->ships_count < 0 || value->ships_count > 4096 ) { return 0; }
         if ( value->ships_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 12, 0x294a5c4913e1ad44ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9074,7 +8799,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->turrets_count < 0 || value->turrets_count > 1024 ) { return 0; }
         if ( value->turrets_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 38, 0x84f8260bc283608cull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9096,7 +8820,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->missiles_count < 0 || value->missiles_count > 4096 ) { return 0; }
         if ( value->missiles_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 9, 0x1c3027194b1ba4d0ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9118,7 +8841,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->dynamic_props_count < 0 || value->dynamic_props_count > 4096 ) { return 0; }
         if ( value->dynamic_props_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 19, 0x43125398a9903d27ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9140,7 +8862,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->static_props_count < 0 || value->static_props_count > 20000 ) { return 0; }
         if ( value->static_props_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 62, 0xc1f8d7edff7fcfd2ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9162,7 +8883,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->cosmetic_props_count < 0 || value->cosmetic_props_count > 8192 ) { return 0; }
         if ( value->cosmetic_props_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 14, 0x33408e39f5f480ffull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9184,7 +8904,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->lasers_count < 0 || value->lasers_count > 32000 ) { return 0; }
         if ( value->lasers_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 74, 0xd982b77b3e92d16dull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9206,7 +8925,6 @@ static SCHEMA_UNUSED int render_frame_save_body( TableWriter * w, const RenderFr
         if ( value->explosions_count < 0 || value->explosions_count > 32000 ) { return 0; }
         if ( value->explosions_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 39, 0x876a8c1a85806a69ull, 14 );
             int64_t element_sizes[64]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -9726,9 +9444,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  (void)value;
  { /* version */
  if(!(value->version == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,31,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->version)-UINT64_C(0),64);
  }
@@ -9736,9 +9451,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* cameras */
  if(value->cameras_count<0 || value->cameras_count>1) return 0;
  if(value->cameras_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,32,kTableMessageRefBitsHere);
   if(value->cameras_count<0 || value->cameras_count>1) return 0;
   table_bit_put(w,(uint64_t)value->cameras_count-0,1);
@@ -9751,9 +9463,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* ships */
  if(value->ships_count<0 || value->ships_count>4096) return 0;
  if(value->ships_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,33,kTableMessageRefBitsHere);
   if(value->ships_count<0 || value->ships_count>4096) return 0;
   table_bit_put(w,(uint64_t)value->ships_count-0,13);
@@ -9766,9 +9475,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* turrets */
  if(value->turrets_count<0 || value->turrets_count>1024) return 0;
  if(value->turrets_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,34,kTableMessageRefBitsHere);
   if(value->turrets_count<0 || value->turrets_count>1024) return 0;
   table_bit_put(w,(uint64_t)value->turrets_count-0,11);
@@ -9781,9 +9487,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* missiles */
  if(value->missiles_count<0 || value->missiles_count>4096) return 0;
  if(value->missiles_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,35,kTableMessageRefBitsHere);
   if(value->missiles_count<0 || value->missiles_count>4096) return 0;
   table_bit_put(w,(uint64_t)value->missiles_count-0,13);
@@ -9796,9 +9499,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* dynamic_props */
  if(value->dynamic_props_count<0 || value->dynamic_props_count>4096) return 0;
  if(value->dynamic_props_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,36,kTableMessageRefBitsHere);
   if(value->dynamic_props_count<0 || value->dynamic_props_count>4096) return 0;
   table_bit_put(w,(uint64_t)value->dynamic_props_count-0,13);
@@ -9811,9 +9511,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* static_props */
  if(value->static_props_count<0 || value->static_props_count>20000) return 0;
  if(value->static_props_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,37,kTableMessageRefBitsHere);
   if(value->static_props_count<0 || value->static_props_count>20000) return 0;
   table_bit_put(w,(uint64_t)value->static_props_count-0,15);
@@ -9826,9 +9523,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* cosmetic_props */
  if(value->cosmetic_props_count<0 || value->cosmetic_props_count>8192) return 0;
  if(value->cosmetic_props_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,38,kTableMessageRefBitsHere);
   if(value->cosmetic_props_count<0 || value->cosmetic_props_count>8192) return 0;
   table_bit_put(w,(uint64_t)value->cosmetic_props_count-0,14);
@@ -9841,9 +9535,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* lasers */
  if(value->lasers_count<0 || value->lasers_count>32000) return 0;
  if(value->lasers_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,39,kTableMessageRefBitsHere);
   if(value->lasers_count<0 || value->lasers_count>32000) return 0;
   table_bit_put(w,(uint64_t)value->lasers_count-0,15);
@@ -9856,9 +9547,6 @@ static SCHEMA_UNUSED int render_frame_save_message_body(TableBitWriter * w,const
  { /* explosions */
  if(value->explosions_count<0 || value->explosions_count>32000) return 0;
  if(value->explosions_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,40,kTableMessageRefBitsHere);
   if(value->explosions_count<0 || value->explosions_count>32000) return 0;
   table_bit_put(w,(uint64_t)value->explosions_count-0,15);

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -1506,7 +1506,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
     { /* active */
         if ( !( value->active == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 57, 0x6580790b036f0c6full, 1 );
             table_writer_put8( w, value->active ? 1 : 0 );
         }
@@ -1516,7 +1515,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
     {
         if ( !( value->speed == 1.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 22, 0x2281498aa0200e40ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->speed ) );
         }
@@ -1527,7 +1525,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
     {
         if ( !( value->has_target == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 23, 0x247f0e7f55aacfbdull, 1 );
             table_writer_put8( w, value->has_target ? 1 : 0 );
         }
@@ -1538,7 +1535,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
     {
         if ( !( value->target_id == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 103, 0xb7bc9ac015a25050ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->target_id ) );
         }
@@ -1549,7 +1545,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
     {
         if ( !( value->wander == 0.5f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 104, 0xb8c758d8bd1845d4ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->wander ) );
         }
@@ -1561,7 +1556,6 @@ static SCHEMA_UNUSED int patrol_save_body( TableWriter * w, const Patrol * value
         if ( value->note_length < 0 || value->note_length > 8 ) { return 0; }
         if ( value->note_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0x3bf8fbbad1587cddull, 12 );
             if ( w->buffer == NULL )
             {
@@ -1818,9 +1812,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  (void)value;
  { /* active */
  if(!(value->active == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,32,kTableMessageRefBitsHere);
   table_bit_put(w,value->active ? 1 : 0,1);
  }
@@ -1828,9 +1819,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  { /* speed */
  if(value->active) {
  if(!(value->speed == 1.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,33,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->speed),32);
  }
@@ -1839,9 +1827,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  { /* has_target */
  if(value->active) {
  if(!(value->has_target == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,34,kTableMessageRefBitsHere);
   table_bit_put(w,value->has_target ? 1 : 0,1);
  }
@@ -1850,9 +1835,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  { /* target_id */
  if(value->active && value->has_target) {
  if(!(value->target_id == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,35,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->target_id)-UINT64_C(0),10);
  }
@@ -1861,9 +1843,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  { /* wander */
  if(value->active && !value->has_target) {
  if(!(value->wander == 0.5f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,36,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->wander),32);
  }
@@ -1873,9 +1852,6 @@ static SCHEMA_UNUSED int patrol_save_message_body(TableBitWriter * w,const Patro
  if(!value->active) {
  if(value->note_length<0 || value->note_length>8) return 0;
  if(value->note_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,37,kTableMessageRefBitsHere);
   if(value->note_length<0 || value->note_length>8) return 0;
   table_bit_put(w,(uint64_t)value->note_length,4);

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -1944,7 +1944,7 @@ static SCHEMA_UNUSED int schema_tabledemo_team_config_message_extent_(TableMessa
 static SCHEMA_UNUSED int gunner_config_save_body( TableWriter * w, const GunnerConfig * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->reaction == 0.2f ) )
@@ -1964,7 +1964,6 @@ static SCHEMA_UNUSED int gunner_config_save_body( TableWriter * w, const GunnerC
     { /* reaction */
         if ( !( value->reaction == 0.2f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 101, 0xb75aa3662201646aull, 10 );
             table_writer_put32( w, table_float_to_bits( value->reaction ) );
         }
@@ -1972,7 +1971,6 @@ static SCHEMA_UNUSED int gunner_config_save_body( TableWriter * w, const GunnerC
     { /* tracking */
         if ( !( value->tracking == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 90, 0xa6bf719a4602b0bcull, 1 );
             table_writer_put8( w, value->tracking ? 1 : 0 );
         }
@@ -2076,18 +2074,12 @@ static SCHEMA_UNUSED int gunner_config_save_message_body(TableBitWriter * w,cons
  (void)value;
  { /* reaction */
  if(!(value->reaction == 0.2f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,11,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->reaction),32);
  }
  }
  { /* tracking */
  if(!(value->tracking == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,12,kTableMessageRefBitsHere);
   table_bit_put(w,value->tracking ? 1 : 0,1);
  }
@@ -3056,7 +3048,6 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 106, 0xbaaeb048a5a8fa6dull, 16 );
             if ( w->buffer == NULL )
             {
@@ -3085,7 +3076,6 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 119, 0xce0ac3c25694d8ffull, 16 );
             if ( w->buffer == NULL )
             {
@@ -3108,7 +3098,6 @@ static SCHEMA_UNUSED int keyed_config_save_body( TableWriter * w, const KeyedCon
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x01986b0b27400fb2ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -3279,9 +3268,6 @@ static SCHEMA_UNUSED int keyed_config_save_message_body(TableBitWriter * w,const
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,17,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -3334,9 +3320,6 @@ static SCHEMA_UNUSED int keyed_config_save_message_body(TableBitWriter * w,const
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,18,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -3382,9 +3365,6 @@ static SCHEMA_UNUSED int keyed_config_save_message_body(TableBitWriter * w,const
  probe.check_default=1;
  if(!score_board_save_message_body(&probe,&value->scores)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,19,kTableMessageRefBitsHere);
   if(!score_board_save_message_body(w,&value->scores)) return 0;
  }

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -1481,7 +1481,6 @@ static SCHEMA_UNUSED int archive_config_save_body( TableWriter * w, const Archiv
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 85, 0xa354fd1ff0c467c5ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -1501,7 +1500,6 @@ static SCHEMA_UNUSED int archive_config_save_body( TableWriter * w, const Archiv
     { /* count */
         if ( !( value->count == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 97, 0xb1e5e28e4479a274ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->count ) );
         }
@@ -1666,18 +1664,12 @@ static SCHEMA_UNUSED int archive_config_save_message_body(TableBitWriter * w,con
  probe.check_default=1;
  if(!root_config_save_message_body(&probe,&value->root)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,1,kTableMessageRefBitsHere);
   if(!root_config_save_message_body(w,&value->root)) return 0;
  }
  }
  { /* count */
  if(!(value->count == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,2,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->count)-UINT64_C(0),7);
  }

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -1591,7 +1591,6 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
     { /* reaction */
         if ( !( value->reaction == 0.2f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 101, 0xb75aa3662201646aull, 10 );
             table_writer_put32( w, table_float_to_bits( value->reaction ) );
         }
@@ -1599,7 +1598,6 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
     { /* tracking */
         if ( !( value->tracking == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 90, 0xa6bf719a4602b0bcull, 1 );
             table_writer_put8( w, value->tracking ? 1 : 0 );
         }
@@ -1608,7 +1606,6 @@ static SCHEMA_UNUSED int gunner_settings_save_body( TableWriter * w, const Gunne
         if ( value->callsign_length < 0 || value->callsign_length > 24 ) { return 0; }
         if ( value->callsign_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 53, 0x5bc44627b9848818ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -1743,18 +1740,12 @@ static SCHEMA_UNUSED int gunner_settings_save_message_body(TableBitWriter * w,co
  (void)value;
  { /* reaction */
  if(!(value->reaction == 0.2f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,11,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->reaction),32);
  }
  }
  { /* tracking */
  if(!(value->tracking == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,12,kTableMessageRefBitsHere);
   table_bit_put(w,value->tracking ? 1 : 0,1);
  }
@@ -1762,9 +1753,6 @@ static SCHEMA_UNUSED int gunner_settings_save_message_body(TableBitWriter * w,co
  { /* callsign */
  if(value->callsign_length<0 || value->callsign_length>24) return 0;
  if(value->callsign_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,13,kTableMessageRefBitsHere);
   if(value->callsign_length<0 || value->callsign_length>24) return 0;
   table_bit_put(w,(uint64_t)value->callsign_length,5);
@@ -3111,7 +3099,6 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
     { /* version */
         if ( !( value->version == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 107, 0xbb62c62c9808ea37ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->version ) );
         }
@@ -3122,7 +3109,6 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 68, 0x7fb43557b54149ceull, 13 );
             if ( w->buffer == NULL )
             {
@@ -3151,7 +3137,6 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 25, 0x294a5c4913e1ad44ull, 16 );
             if ( w->buffer == NULL )
             {
@@ -3177,7 +3162,6 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 80, 0x9cda940a344e1571ull, 16 );
             if ( w->buffer == NULL )
             {
@@ -3198,7 +3182,6 @@ static SCHEMA_UNUSED int pack_config_save_body( TableWriter * w, const PackConfi
         if ( value->reserves_count < 0 || value->reserves_count > 3 ) { return 0; }
         if ( value->reserves_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 64, 0x77707fccd201c228ull, 14 );
             int64_t element_sizes[3]; /* bounded sizing-to-write cache */
             if ( w->buffer == NULL )
@@ -3498,9 +3481,6 @@ static SCHEMA_UNUSED int pack_config_save_message_body(TableBitWriter * w,const 
  (void)value;
  { /* version */
  if(!(value->version == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,27,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->version)-UINT64_C(0),32);
  }
@@ -3513,9 +3493,6 @@ static SCHEMA_UNUSED int pack_config_save_message_body(TableBitWriter * w,const 
  probe.check_default=1;
  if(!global_settings_save_message_body(&probe,&value->global)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,28,kTableMessageRefBitsHere);
   if(!global_settings_save_message_body(w,&value->global)) return 0;
  }
@@ -3535,9 +3512,6 @@ static SCHEMA_UNUSED int pack_config_save_message_body(TableBitWriter * w,const 
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -3584,9 +3558,6 @@ static SCHEMA_UNUSED int pack_config_save_message_body(TableBitWriter * w,const 
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,30,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -3615,9 +3586,6 @@ static SCHEMA_UNUSED int pack_config_save_message_body(TableBitWriter * w,const 
  { /* reserves */
  if(value->reserves_count<0 || value->reserves_count>3) return 0;
  if(value->reserves_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,31,kTableMessageRefBitsHere);
   if(value->reserves_count<0 || value->reserves_count>3) return 0;
   table_bit_put(w,(uint64_t)value->reserves_count-0,2);

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -1611,7 +1611,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i8_span */
         if ( !( value->i8_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 43, 0x48121511bf702eb5ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_span ) );
         }
@@ -1619,7 +1618,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i8_low */
         if ( !( value->i8_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 76, 0x942bfe3168090f7dull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_low ) );
         }
@@ -1627,7 +1625,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i8_high */
         if ( !( value->i8_high == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 126, 0xd182acd105b55dd1ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_high ) );
         }
@@ -1635,7 +1632,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i8_inside */
         if ( !( value->i8_inside == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 141, 0xef9ded23c8912a81ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->i8_inside ) );
         }
@@ -1643,7 +1639,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i16_span */
         if ( !( value->i16_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 100, 0xb655574ea23760b4ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_span ) );
         }
@@ -1651,7 +1646,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i16_low */
         if ( !( value->i16_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 127, 0xd217b3af8d7a2bdeull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_low ) );
         }
@@ -1659,7 +1653,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i16_high */
         if ( !( value->i16_high == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 75, 0x90652f70c9127900ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_high ) );
         }
@@ -1667,7 +1660,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i16_inside */
         if ( !( value->i16_inside == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 58, 0x6a659d7c354db158ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->i16_inside ) );
         }
@@ -1675,7 +1667,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i32_span */
         if ( !( value->i32_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 137, 0xe693bd88532c91d6ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_span ) );
         }
@@ -1683,7 +1674,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i32_low */
         if ( !( value->i32_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 5, 0x065ee827cf99fbb4ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_low ) );
         }
@@ -1691,7 +1681,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i32_high */
         if ( !( value->i32_high == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 118, 0xc9b121c4c2a186eeull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_high ) );
         }
@@ -1699,7 +1688,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i32_inside */
         if ( !( value->i32_inside == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 129, 0xd363dfa465acf27aull, 4 );
             table_writer_put32( w, (uint32_t) ( value->i32_inside ) );
         }
@@ -1707,7 +1695,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i64_span */
         if ( !( value->i64_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 63, 0x7549c70700c49d6full, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_span ) );
         }
@@ -1715,7 +1702,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i64_low */
         if ( !( value->i64_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 16, 0x1cce6617419771dbull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_low ) );
         }
@@ -1723,7 +1709,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i64_high */
         if ( !( value->i64_high == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0x3b54fa60620b5597ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_high ) );
         }
@@ -1731,7 +1716,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
     { /* i64_inside */
         if ( !( value->i64_inside == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 128, 0xd308fcb98ece5d23ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->i64_inside ) );
         }
@@ -1740,7 +1724,6 @@ static SCHEMA_UNUSED int ranged_signed_save_body( TableWriter * w, const RangedS
         if ( value->edges_count < 0 || value->edges_count > 4 ) { return 0; }
         if ( value->edges_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 117, 0xc70cde6b85b6197dull, 14 );
             if ( w->buffer == NULL )
             {
@@ -2894,144 +2877,96 @@ static SCHEMA_UNUSED int ranged_signed_save_message_body(TableBitWriter * w,cons
  (void)value;
  { /* i8_span */
  if(!(value->i8_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,51,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i8_span)-UINT64_C(18446744073709551488),8);
  }
  }
  { /* i8_low */
  if(!(value->i8_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,52,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i8_low)-UINT64_C(18446744073709551488),8);
  }
  }
  { /* i8_high */
  if(!(value->i8_high == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,53,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i8_high)-UINT64_C(18446744073709551489),8);
  }
  }
  { /* i8_inside */
  if(!(value->i8_inside == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,54,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i8_inside)-UINT64_C(18446744073709551489),8);
  }
  }
  { /* i16_span */
  if(!(value->i16_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,55,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i16_span)-UINT64_C(18446744073709518848),16);
  }
  }
  { /* i16_low */
  if(!(value->i16_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,56,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i16_low)-UINT64_C(18446744073709518848),16);
  }
  }
  { /* i16_high */
  if(!(value->i16_high == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,57,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i16_high)-UINT64_C(18446744073709518849),16);
  }
  }
  { /* i16_inside */
  if(!(value->i16_inside == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,58,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i16_inside)-UINT64_C(18446744073709518849),16);
  }
  }
  { /* i32_span */
  if(!(value->i32_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,59,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i32_span)-UINT64_C(18446744071562067968),32);
  }
  }
  { /* i32_low */
  if(!(value->i32_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,60,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i32_low)-UINT64_C(18446744071562067968),32);
  }
  }
  { /* i32_high */
  if(!(value->i32_high == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,61,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i32_high)-UINT64_C(18446744071562067969),32);
  }
  }
  { /* i32_inside */
  if(!(value->i32_inside == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,62,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i32_inside)-UINT64_C(18446744071562067969),32);
  }
  }
  { /* i64_span */
  if(!(value->i64_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,63,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i64_span)-UINT64_C(9223372036854775808),64);
  }
  }
  { /* i64_low */
  if(!(value->i64_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,64,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i64_low)-UINT64_C(9223372036854775808),64);
  }
  }
  { /* i64_high */
  if(!(value->i64_high == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,65,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i64_high)-UINT64_C(9223372036854775809),64);
  }
  }
  { /* i64_inside */
  if(!(value->i64_inside == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,66,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->i64_inside)-UINT64_C(9223372036854775809),64);
  }
@@ -3039,9 +2974,6 @@ static SCHEMA_UNUSED int ranged_signed_save_message_body(TableBitWriter * w,cons
  { /* edges */
  if(value->edges_count<0 || value->edges_count>4) return 0;
  if(value->edges_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,67,kTableMessageRefBitsHere);
   if(value->edges_count<0 || value->edges_count>4) return 0;
   table_bit_put(w,(uint64_t)value->edges_count-0,3);
@@ -3491,7 +3423,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u8_span */
         if ( !( value->u8_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x0f8897557f37c021ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_span ) );
         }
@@ -3499,7 +3430,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u8_low */
         if ( !( value->u8_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 28, 0x2e17553f8200a2a1ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_low ) );
         }
@@ -3507,7 +3437,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u8_high */
         if ( !( value->u8_high == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 84, 0xa0e5c60df9301b7dull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_high ) );
         }
@@ -3515,7 +3444,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u8_inside */
         if ( !( value->u8_inside == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 15, 0x1cb2c073a6f5844dull, 6 );
             table_writer_put8( w, (uint8_t) ( value->u8_inside ) );
         }
@@ -3523,7 +3451,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u16_span */
         if ( !( value->u16_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 46, 0x4ca0c150b1790960ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_span ) );
         }
@@ -3531,7 +3458,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u16_low */
         if ( !( value->u16_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 143, 0xf252136836b04cb2ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_low ) );
         }
@@ -3539,7 +3465,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u16_high */
         if ( !( value->u16_high == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 48, 0x4f37e1f216e7610cull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_high ) );
         }
@@ -3547,7 +3472,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u16_inside */
         if ( !( value->u16_inside == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 125, 0xd176b605978f3304ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->u16_inside ) );
         }
@@ -3555,7 +3479,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u32_span */
         if ( !( value->u32_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x200b924de7479cdaull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_span ) );
         }
@@ -3563,7 +3486,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u32_low */
         if ( !( value->u32_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 87, 0xa53d2f2a31b5acb0ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_low ) );
         }
@@ -3571,7 +3493,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u32_high */
         if ( !( value->u32_high == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 78, 0x9759be8ea1a4e3d2ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_high ) );
         }
@@ -3579,7 +3500,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u32_inside */
         if ( !( value->u32_inside == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 74, 0x8dc515fc082e3c0eull, 8 );
             table_writer_put32( w, (uint32_t) ( value->u32_inside ) );
         }
@@ -3587,7 +3507,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u64_span */
         if ( !( value->u64_span == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 109, 0xbeecef11dbdf8973ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_span ) );
         }
@@ -3595,7 +3514,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u64_low */
         if ( !( value->u64_low == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 0, 0x0117ad66e0fff227ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_low ) );
         }
@@ -3603,7 +3521,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u64_high */
         if ( !( value->u64_high == 1ull ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 144, 0xf2b45af3b50689dbull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_high ) );
         }
@@ -3611,7 +3528,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
     { /* u64_inside */
         if ( !( value->u64_inside == 1ull ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 62, 0x713e12017eebcaf7ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->u64_inside ) );
         }
@@ -3620,7 +3536,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_body( TableWriter * w, const Range
         if ( value->counts_count < 0 || value->counts_count > 4 ) { return 0; }
         if ( value->counts_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 112, 0xc341febe5aae51e5ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -4774,144 +4689,96 @@ static SCHEMA_UNUSED int ranged_unsigned_save_message_body(TableBitWriter * w,co
  (void)value;
  { /* u8_span */
  if(!(value->u8_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,68,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u8_span)-UINT64_C(0),8);
  }
  }
  { /* u8_low */
  if(!(value->u8_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,69,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u8_low)-UINT64_C(0),8);
  }
  }
  { /* u8_high */
  if(!(value->u8_high == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,70,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u8_high)-UINT64_C(1),8);
  }
  }
  { /* u8_inside */
  if(!(value->u8_inside == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,71,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u8_inside)-UINT64_C(1),8);
  }
  }
  { /* u16_span */
  if(!(value->u16_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,72,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u16_span)-UINT64_C(0),16);
  }
  }
  { /* u16_low */
  if(!(value->u16_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,73,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u16_low)-UINT64_C(0),16);
  }
  }
  { /* u16_high */
  if(!(value->u16_high == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,74,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u16_high)-UINT64_C(1),16);
  }
  }
  { /* u16_inside */
  if(!(value->u16_inside == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,75,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u16_inside)-UINT64_C(1),16);
  }
  }
  { /* u32_span */
  if(!(value->u32_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,76,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u32_span)-UINT64_C(0),32);
  }
  }
  { /* u32_low */
  if(!(value->u32_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,77,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u32_low)-UINT64_C(0),32);
  }
  }
  { /* u32_high */
  if(!(value->u32_high == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,78,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u32_high)-UINT64_C(1),32);
  }
  }
  { /* u32_inside */
  if(!(value->u32_inside == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,79,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u32_inside)-UINT64_C(1),32);
  }
  }
  { /* u64_span */
  if(!(value->u64_span == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,80,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u64_span)-UINT64_C(0),64);
  }
  }
  { /* u64_low */
  if(!(value->u64_low == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,81,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u64_low)-UINT64_C(0),64);
  }
  }
  { /* u64_high */
  if(!(value->u64_high == 1ull)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,82,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u64_high)-UINT64_C(1),64);
  }
  }
  { /* u64_inside */
  if(!(value->u64_inside == 1ull)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,83,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->u64_inside)-UINT64_C(1),64);
  }
@@ -4919,9 +4786,6 @@ static SCHEMA_UNUSED int ranged_unsigned_save_message_body(TableBitWriter * w,co
  { /* counts */
  if(value->counts_count<0 || value->counts_count>4) return 0;
  if(value->counts_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,84,kTableMessageRefBitsHere);
   if(value->counts_count<0 || value->counts_count>4) return 0;
   table_bit_put(w,(uint64_t)value->counts_count-0,3);
@@ -5332,7 +5196,7 @@ static SCHEMA_UNUSED int schema_tabledemo_ranged_unsigned_message_extent_(TableM
 static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedWidths * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->b8 == 0 ) )
@@ -5372,7 +5236,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b8 */
         if ( !( value->b8 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x08a60c07b54d8dc7ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->b8 ) );
         }
@@ -5380,7 +5243,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b16 */
         if ( !( value->b16 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 149, 0xff95701912ad97beull, 7 );
             table_writer_put16( w, (uint16_t) ( value->b16 ) );
         }
@@ -5388,7 +5250,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b32 */
         if ( !( value->b32 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 151, 0xff9c5c1912b39470ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->b32 ) );
         }
@@ -5396,7 +5257,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b64 */
         if ( !( value->b64 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 148, 0xff92701912ab61e7ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->b64 ) );
         }
@@ -5404,7 +5264,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b12 */
         if ( !( value->b12 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 150, 0xff95741912ad9e8aull, 7 );
             table_writer_put16( w, (uint16_t) ( value->b12 ) );
         }
@@ -5412,7 +5271,6 @@ static SCHEMA_UNUSED int ranged_widths_save_body( TableWriter * w, const RangedW
     { /* b48 */
         if ( !( value->b48 == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 147, 0xff8b681912a535a1ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->b48 ) );
         }
@@ -5862,54 +5720,36 @@ static SCHEMA_UNUSED int ranged_widths_save_message_body(TableBitWriter * w,cons
  (void)value;
  { /* b8 */
  if(!(value->b8 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,85,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b8)-UINT64_C(0),8);
  }
  }
  { /* b16 */
  if(!(value->b16 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,86,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b16)-UINT64_C(0),16);
  }
  }
  { /* b32 */
  if(!(value->b32 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,87,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b32)-UINT64_C(0),32);
  }
  }
  { /* b64 */
  if(!(value->b64 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,88,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b64)-UINT64_C(0),64);
  }
  }
  { /* b12 */
  if(!(value->b12 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,89,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b12)-UINT64_C(0),12);
  }
  }
  { /* b48 */
  if(!(value->b48 == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,90,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->b48)-UINT64_C(0),48);
  }

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -3337,7 +3337,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( value->name_length < 0 || value->name_length > 32 ) { return 0; }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 116, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -3358,7 +3357,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         if ( value->icon_length < 0 || value->icon_length > 16 ) { return 0; }
         if ( value->icon_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 132, 0xdbff4cc56c2092f0ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -3378,7 +3376,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* experience */
         if ( !( value->experience == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 93, 0xab8b6d521f80b969ull, 8 );
             table_writer_put32( w, (uint32_t) ( value->experience ) );
         }
@@ -3386,7 +3383,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* tilt */
         if ( !( value->tilt == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 19, 0x1e5088ef2e9bafc6ull, 2 );
             table_writer_put8( w, (uint8_t) ( value->tilt ) );
         }
@@ -3394,7 +3390,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* heading */
         if ( !( value->heading == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 96, 0xb128829190ca0f75ull, 3 );
             table_writer_put16( w, (uint16_t) ( value->heading ) );
         }
@@ -3402,7 +3397,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* timestamp */
         if ( !( value->timestamp == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 54, 0x5ddc92338ef53403ull, 5 );
             table_writer_put64( w, (uint64_t) ( value->timestamp ) );
         }
@@ -3410,7 +3404,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* badge */
         if ( !( value->badge == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 9, 0x10bda981fe095518ull, 6 );
             table_writer_put8( w, (uint8_t) ( value->badge ) );
         }
@@ -3418,7 +3411,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* port */
         if ( !( value->port == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 73, 0x8c2cdb0da8933fa6ull, 7 );
             table_writer_put16( w, (uint16_t) ( value->port ) );
         }
@@ -3426,7 +3418,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* epoch */
         if ( !( value->epoch == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 146, 0xfc9697d1196e6ba6ull, 9 );
             table_writer_put64( w, (uint64_t) ( value->epoch ) );
         }
@@ -3434,7 +3425,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* precision */
         if ( !( value->precision == 0.0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 24, 0x288427f5babd05f7ull, 11 );
             table_writer_put64( w, table_double_to_bits( value->precision ) );
         }
@@ -3444,7 +3434,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         for ( i = 0; i < 4; i++ ) { if ( !( value->ratings[i] == 0.0f ) ) { rides = 1; break; } }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 105, 0xb921eb8a3d0cb0f9ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -3464,7 +3453,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
     { /* has_loadout */
         if ( !( value->has_loadout == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 83, 0xa06f5e0a148e253cull, 1 );
             table_writer_put8( w, value->has_loadout ? 1 : 0 );
         }
@@ -3477,7 +3465,6 @@ static SCHEMA_UNUSED int profile_config_save_body( TableWriter * w, const Profil
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 50, 0x5759ce7586bbb5a3ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -4133,9 +4120,6 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  { /* name */
  if(value->name_length<0 || value->name_length>32) return 0;
  if(value->name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,38,kTableMessageRefBitsHere);
   if(value->name_length<0 || value->name_length>32) return 0;
   table_bit_put(w,(uint64_t)value->name_length,6);
@@ -4146,9 +4130,6 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  { /* icon */
  if(value->icon_length<0 || value->icon_length>16) return 0;
  if(value->icon_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,39,kTableMessageRefBitsHere);
   if(value->icon_length<0 || value->icon_length>16) return 0;
   table_bit_put(w,(uint64_t)value->icon_length,5);
@@ -4158,72 +4139,48 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  }
  { /* experience */
  if(!(value->experience == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,40,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->experience)-UINT64_C(0),32);
  }
  }
  { /* tilt */
  if(!(value->tilt == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,41,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->tilt)-UINT64_C(0),8);
  }
  }
  { /* heading */
  if(!(value->heading == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,42,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->heading)-UINT64_C(0),16);
  }
  }
  { /* timestamp */
  if(!(value->timestamp == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,43,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->timestamp)-UINT64_C(0),64);
  }
  }
  { /* badge */
  if(!(value->badge == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,44,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->badge)-UINT64_C(0),8);
  }
  }
  { /* port */
  if(!(value->port == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,45,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->port)-UINT64_C(0),16);
  }
  }
  { /* epoch */
  if(!(value->epoch == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,46,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->epoch)-UINT64_C(0),64);
  }
  }
  { /* precision */
  if(!(value->precision == 0.0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,47,kTableMessageRefBitsHere);
   table_bit_put(w,table_double_to_bits(value->precision),64);
  }
@@ -4235,9 +4192,6 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  break;
  } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,48,kTableMessageRefBitsHere);
   if(4<0 || 4>4) return 0;
   table_bit_put(w,(uint64_t)4-4,0);
@@ -4249,9 +4203,6 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  }
  { /* has_loadout */
  if(!(value->has_loadout == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,49,kTableMessageRefBitsHere);
   table_bit_put(w,value->has_loadout ? 1 : 0,1);
  }
@@ -4265,9 +4216,6 @@ static SCHEMA_UNUSED int profile_config_save_message_body(TableBitWriter * w,con
  probe.check_default=1;
  if(!loadout_config_save_message_body(&probe,&value->loadout)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,50,kTableMessageRefBitsHere);
   if(!loadout_config_save_message_body(w,&value->loadout)) return 0;
  }
@@ -5089,7 +5037,7 @@ static SCHEMA_UNUSED int schema_tabledemo_root_config_message_extent_(TableMessa
 static SCHEMA_UNUSED int attachment_save_body( TableWriter * w, const Attachment * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->slot == 0 ) )
@@ -5109,7 +5057,6 @@ static SCHEMA_UNUSED int attachment_save_body( TableWriter * w, const Attachment
     { /* slot */
         if ( !( value->slot == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 59, 0x6a771618f6fe31d1ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->slot ) );
         }
@@ -5117,7 +5064,6 @@ static SCHEMA_UNUSED int attachment_save_body( TableWriter * w, const Attachment
     { /* power */
         if ( !( value->power == 1.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 140, 0xeef9d1358ae7b4e6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->power ) );
         }
@@ -5282,18 +5228,12 @@ static SCHEMA_UNUSED int attachment_save_message_body(TableBitWriter * w,const A
  (void)value;
  { /* slot */
  if(!(value->slot == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,3,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->slot)-UINT64_C(0),3);
  }
  }
  { /* power */
  if(!(value->power == 1.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,4,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->power),32);
  }
@@ -5420,7 +5360,7 @@ static SCHEMA_UNUSED int schema_tabledemo_attachment_message_extent_(TableMessag
 static SCHEMA_UNUSED int buff_save_body( TableWriter * w, const Buff * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->multiplier == 1.0f ) )
@@ -5435,7 +5375,6 @@ static SCHEMA_UNUSED int buff_save_body( TableWriter * w, const Buff * value )
     { /* multiplier */
         if ( !( value->multiplier == 1.0f ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 79, 0x9adc623a805c87c6ull, 10 );
             table_writer_put32( w, table_float_to_bits( value->multiplier ) );
         }
@@ -5519,9 +5458,6 @@ static SCHEMA_UNUSED int buff_save_message_body(TableBitWriter * w,const Buff * 
  (void)value;
  { /* multiplier */
  if(!(value->multiplier == 1.0f)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,5,kTableMessageRefBitsHere);
   table_bit_put(w,table_float_to_bits(value->multiplier),32);
  }
@@ -5628,7 +5564,7 @@ static SCHEMA_UNUSED int schema_tabledemo_buff_message_extent_(TableMessageReade
 static SCHEMA_UNUSED int debuff_save_body( TableWriter * w, const Debuff * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->amount == 0 ) )
@@ -5643,7 +5579,6 @@ static SCHEMA_UNUSED int debuff_save_body( TableWriter * w, const Debuff * value
     { /* amount */
         if ( !( value->amount == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 69, 0x8113fe7ea2b16969ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->amount ) );
         }
@@ -5788,9 +5723,6 @@ static SCHEMA_UNUSED int debuff_save_message_body(TableBitWriter * w,const Debuf
  (void)value;
  { /* amount */
  if(!(value->amount == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->amount)-UINT64_C(0),7);
  }

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -1513,7 +1513,6 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->label_length < 0 || value->label_length > 70000 ) { return 0; }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 35, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
@@ -1534,7 +1533,6 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->payload_length < 0 || value->payload_length > 70000 ) { return 0; }
         if ( value->payload_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 122, 0xcfb8a9d063b5e9e5ull, 14 );
             if ( w->buffer == NULL )
             {
@@ -1555,7 +1553,6 @@ static SCHEMA_UNUSED int wide_blob_save_body( TableWriter * w, const WideBlob * 
         if ( value->samples_count < 0 || value->samples_count > 70000 ) { return 0; }
         if ( value->samples_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 136, 0xe3b1ca6a3b48dddcull, 14 );
             if ( w->buffer == NULL )
             {
@@ -1752,9 +1749,6 @@ static SCHEMA_UNUSED int wide_blob_save_message_body(TableBitWriter * w,const Wi
  { /* label */
  if(value->label_length<0 || value->label_length>70000) return 0;
  if(value->label_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,107,kTableMessageRefBitsHere);
   if(value->label_length<0 || value->label_length>70000) return 0;
   table_bit_put(w,(uint64_t)value->label_length,17);
@@ -1765,9 +1759,6 @@ static SCHEMA_UNUSED int wide_blob_save_message_body(TableBitWriter * w,const Wi
  { /* payload */
  if(value->payload_length<0 || value->payload_length>70000) return 0;
  if(value->payload_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,108,kTableMessageRefBitsHere);
   if(value->payload_length<0 || value->payload_length>70000) return 0;
   table_bit_put(w,(uint64_t)value->payload_length,17);
@@ -1778,9 +1769,6 @@ static SCHEMA_UNUSED int wide_blob_save_message_body(TableBitWriter * w,const Wi
  { /* samples */
  if(value->samples_count<0 || value->samples_count>70000) return 0;
  if(value->samples_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,109,kTableMessageRefBitsHere);
   if(value->samples_count<0 || value->samples_count>70000) return 0;
   table_bit_put(w,(uint64_t)value->samples_count-0,17);

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -3831,7 +3831,6 @@ static SCHEMA_UNUSED int settings_save_body( TableWriter * w, const Settings * v
     { /* quality */
         if ( !( value->quality == 2 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 23, 0x7a8060916400fe66ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->quality ) );
         }
@@ -3840,7 +3839,6 @@ static SCHEMA_UNUSED int settings_save_body( TableWriter * w, const Settings * v
         if ( value->label_length < 0 || value->label_length > 16 ) { return 0; }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
@@ -4020,9 +4018,6 @@ static SCHEMA_UNUSED int settings_save_message_body(TableBitWriter * w,const Set
  (void)value;
  { /* quality */
  if(!(value->quality == 2)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,28,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->quality)-UINT64_C(0),3);
  }
@@ -4030,9 +4025,6 @@ static SCHEMA_UNUSED int settings_save_message_body(TableBitWriter * w,const Set
  { /* label */
  if(value->label_length<0 || value->label_length>16) return 0;
  if(value->label_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,29,kTableMessageRefBitsHere);
   if(value->label_length<0 || value->label_length>16) return 0;
   table_bit_put(w,(uint64_t)value->label_length,5);
@@ -4176,7 +4168,6 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
     { /* value */
         if ( !( value->value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 24, 0x7ce4fd9430e80ceaull, 4 );
             table_writer_put32( w, (uint32_t) ( value->value ) );
         }
@@ -4185,7 +4176,6 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
         if ( value->name_length < 0 || value->name_length > 12 ) { return 0; }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -4205,7 +4195,6 @@ static SCHEMA_UNUSED int list_node_save_body( TableWriter * w, const ListNode * 
     { /* next */
         if ( !( value->next.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 41, 0xe5316cbaa025f028ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->next); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -4345,9 +4334,6 @@ static SCHEMA_UNUSED int list_node_save_message_body(TableBitWriter * w,const Li
  (void)value;
  { /* value */
  if(!(value->value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,14,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->value)-UINT64_C(0),32);
  }
@@ -4355,9 +4341,6 @@ static SCHEMA_UNUSED int list_node_save_message_body(TableBitWriter * w,const Li
  { /* name */
  if(value->name_length<0 || value->name_length>12) return 0;
  if(value->name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,10,kTableMessageRefBitsHere);
   if(value->name_length<0 || value->name_length>12) return 0;
   table_bit_put(w,(uint64_t)value->name_length,4);
@@ -4367,9 +4350,6 @@ static SCHEMA_UNUSED int list_node_save_message_body(TableBitWriter * w,const Li
  }
  { /* next */
  if(!(value->next.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,15,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->next);
   uint64_t index=table_number_find(w->nodes,node);
@@ -4475,7 +4455,6 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
         if ( value->label_length < 0 || value->label_length > 12 ) { return 0; }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 6, 0x39f7fcec8fcb623dull, 12 );
             if ( w->buffer == NULL )
             {
@@ -4495,7 +4474,6 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
     { /* left */
         if ( !( value->left.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 2, 0x24b070ada2041cb0ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->left); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -4504,7 +4482,6 @@ static SCHEMA_UNUSED int tree_node_save_body( TableWriter * w, const TreeNode * 
     { /* right */
         if ( !( value->right.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 21, 0x76aaaa535714d805ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->right); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -4588,9 +4565,6 @@ static SCHEMA_UNUSED int tree_node_save_message_body(TableBitWriter * w,const Tr
  { /* label */
  if(value->label_length<0 || value->label_length>12) return 0;
  if(value->label_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,32,kTableMessageRefBitsHere);
   if(value->label_length<0 || value->label_length>12) return 0;
   table_bit_put(w,(uint64_t)value->label_length,4);
@@ -4600,9 +4574,6 @@ static SCHEMA_UNUSED int tree_node_save_message_body(TableBitWriter * w,const Tr
  }
  { /* left */
  if(!(value->left.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,33,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->left);
   uint64_t index=table_number_find(w->nodes,node);
@@ -4613,9 +4584,6 @@ static SCHEMA_UNUSED int tree_node_save_message_body(TableBitWriter * w,const Tr
  }
  { /* right */
  if(!(value->right.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,34,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->right);
   uint64_t index=table_number_find(w->nodes,node);
@@ -4965,7 +4933,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( value->name_length < 0 || value->name_length > 24 ) { return 0; }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -4985,7 +4952,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
     { /* version */
         if ( !( value->version == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 36, 0xbb62c62c9808ea37ull, 4 );
             table_writer_put32( w, (uint32_t) ( value->version ) );
         }
@@ -4993,7 +4959,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
     { /* head */
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -5002,7 +4967,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
     { /* tree */
         if ( !( value->tree.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 14, 0x5b25b8ef511eb395ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->tree); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -5011,7 +4975,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
     { /* settings */
         if ( !( value->settings.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 43, 0xee5f6d7b48b44de8ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->settings); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -5020,7 +4983,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
     { /* alias */
         if ( !( value->alias.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 12, 0x509220bb65a646b7ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->alias); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -5032,7 +4994,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 15, 0x60839e2395be697eull, 13 );
             if ( w->buffer == NULL )
             {
@@ -5053,7 +5014,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         if ( value->layers_count < 0 || value->layers_count > 4 ) { return 0; }
         if ( value->layers_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 10, 0x4554e34a747022dfull, 14 );
             if ( w->buffer == NULL )
             {
@@ -5076,7 +5036,6 @@ static SCHEMA_UNUSED int scene_save_body( TableWriter * w, const Scene * value )
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 8, 0x4320e9a2e32eac38ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -5344,9 +5303,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  { /* name */
  if(value->name_length<0 || value->name_length>24) return 0;
  if(value->name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,20,kTableMessageRefBitsHere);
   if(value->name_length<0 || value->name_length>24) return 0;
   table_bit_put(w,(uint64_t)value->name_length,5);
@@ -5356,18 +5312,12 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  }
  { /* version */
  if(!(value->version == 1)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,21,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->version)-UINT64_C(0),7);
  }
  }
  { /* head */
  if(!(value->head.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);
   uint64_t index=table_number_find(w->nodes,node);
@@ -5378,9 +5328,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  }
  { /* tree */
  if(!(value->tree.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,22,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->tree);
   uint64_t index=table_number_find(w->nodes,node);
@@ -5391,9 +5338,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  }
  { /* settings */
  if(!(value->settings.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,23,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->settings);
   uint64_t index=table_number_find(w->nodes,node);
@@ -5404,9 +5348,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  }
  { /* alias */
  if(!(value->alias.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,24,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->alias);
   uint64_t index=table_number_find(w->nodes,node);
@@ -5423,9 +5364,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  probe.check_default=1;
  if(!layer_save_message_body(&probe,&value->ground)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,25,kTableMessageRefBitsHere);
   if(!layer_save_message_body(w,&value->ground)) return 0;
  }
@@ -5433,9 +5371,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  { /* layers */
  if(value->layers_count<0 || value->layers_count>4) return 0;
  if(value->layers_count>0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,26,kTableMessageRefBitsHere);
   if(value->layers_count<0 || value->layers_count>4) return 0;
   table_bit_put(w,(uint64_t)value->layers_count-0,3);
@@ -5453,9 +5388,6 @@ static SCHEMA_UNUSED int scene_save_message_body(TableBitWriter * w,const Scene 
  probe.check_default=1;
  if(!meta_save_message_body(&probe,&value->meta)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,27,kTableMessageRefBitsHere);
   if(!meta_save_message_body(w,&value->meta)) return 0;
  }
@@ -5676,7 +5608,6 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         if ( value->name_length < 0 || value->name_length > 12 ) { return 0; }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -5705,7 +5636,6 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 40, 0xdd9eb981e152e90cull, 16 );
             if ( w->buffer == NULL )
             {
@@ -5725,7 +5655,6 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
     { /* spare */
         if ( value->spare_present )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 9, 0x4339ee8ab21c8380ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -5745,7 +5674,6 @@ static SCHEMA_UNUSED int depot_save_body( TableWriter * w, const Depot * value )
     { /* head */
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -5865,9 +5793,6 @@ static SCHEMA_UNUSED int depot_save_message_body(TableBitWriter * w,const Depot 
  { /* name */
  if(value->name_length<0 || value->name_length>12) return 0;
  if(value->name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,10,kTableMessageRefBitsHere);
   if(value->name_length<0 || value->name_length>12) return 0;
   table_bit_put(w,(uint64_t)value->name_length,4);
@@ -5890,9 +5815,6 @@ static SCHEMA_UNUSED int depot_save_message_body(TableBitWriter * w,const Depot 
   break;
   } }
  if(rides) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,11,kTableMessageRefBitsHere);
   { uint32_t count=0;
   int32_t i;
@@ -5930,18 +5852,12 @@ static SCHEMA_UNUSED int depot_save_message_body(TableBitWriter * w,const Depot 
  }
  { /* spare */
  if(value->spare_present) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,12,kTableMessageRefBitsHere);
   if(!meta_save_message_body(w,&value->spare)) return 0;
  }
  }
  { /* head */
  if(!(value->head.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);
   uint64_t index=table_number_find(w->nodes,node);
@@ -6067,7 +5983,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         if ( value->name_length < 0 || value->name_length > 16 ) { return 0; }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 37, 0xc4bcadba8e631b86ull, 12 );
             if ( w->buffer == NULL )
             {
@@ -6090,7 +6005,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 1, 0x1e4984ef2e958a4cull, 13 );
             if ( w->buffer == NULL )
             {
@@ -6113,7 +6027,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 44, 0xee7ba9ad45c64144ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -6136,7 +6049,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
         table_writer_rewind(&default_probe);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 42, 0xeddcb72b15486e77ull, 13 );
             if ( w->buffer == NULL )
             {
@@ -6156,7 +6068,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
     { /* pin */
         if ( !( value->pin.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 22, 0x77af761956600b54ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->pin); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -6165,7 +6076,6 @@ static SCHEMA_UNUSED int album_save_body( TableWriter * w, const Album * value )
     { /* head */
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 0, 0x0a8f12cc5f9a0c03ull, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head); uint64_t index=table_number_find(w->nodes,node);
               if(node!=NULL && index==0) { return 0; } table_writer_leb(w,index); }
@@ -6291,9 +6201,6 @@ static SCHEMA_UNUSED int album_save_message_body(TableBitWriter * w,const Album 
  { /* name */
  if(value->name_length<0 || value->name_length>16) return 0;
  if(value->name_length != 0) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,1,kTableMessageRefBitsHere);
   if(value->name_length<0 || value->name_length>16) return 0;
   table_bit_put(w,(uint64_t)value->name_length,5);
@@ -6309,9 +6216,6 @@ static SCHEMA_UNUSED int album_save_message_body(TableBitWriter * w,const Album 
  probe.check_default=1;
  if(!colour_save_message_body(&probe,&value->tint)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,2,kTableMessageRefBitsHere);
   if(!colour_save_message_body(w,&value->tint)) return 0;
  }
@@ -6324,9 +6228,6 @@ static SCHEMA_UNUSED int album_save_message_body(TableBitWriter * w,const Album 
  probe.check_default=1;
  if(!stamp_save_message_body(&probe,&value->stamp)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,3,kTableMessageRefBitsHere);
   if(!stamp_save_message_body(w,&value->stamp)) return 0;
  }
@@ -6339,18 +6240,12 @@ static SCHEMA_UNUSED int album_save_message_body(TableBitWriter * w,const Album 
  probe.check_default=1;
  if(!marker_save_message_body(&probe,&value->marker)) return 0;
  if(probe.bits>kTableMessageRefBitsHere) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,4,kTableMessageRefBitsHere);
   if(!marker_save_message_body(w,&value->marker)) return 0;
  }
  }
  { /* pin */
  if(!(value->pin.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,5,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->pin);
   uint64_t index=table_number_find(w->nodes,node);
@@ -6361,9 +6256,6 @@ static SCHEMA_UNUSED int album_save_message_body(TableBitWriter * w,const Album 
  }
  { /* head */
  if(!(value->head.value == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,6,kTableMessageRefBitsHere);
   { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);
   uint64_t index=table_number_find(w->nodes,node);
@@ -6842,9 +6734,6 @@ static SCHEMA_UNUSED int settings_save_body_retain( TableWriter * w, const Setti
     retention=table_retain_step(body_keep,0,0);
         if ( !( value->quality == 2 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x7a8060916400fe66ull , retention);
             table_writer_put8( w, 4 );
             table_writer_put32( w, (uint32_t) ( value->quality ) );
@@ -6856,9 +6745,6 @@ static SCHEMA_UNUSED int settings_save_body_retain( TableWriter * w, const Setti
         }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x39f7fcec8fcb623dull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -7166,9 +7052,6 @@ static SCHEMA_UNUSED int list_node_save_body_retain( TableWriter * w, const List
     retention=table_retain_step(body_keep,0,0);
         if ( !( value->value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x7ce4fd9430e80ceaull , retention);
             table_writer_put8( w, 4 );
             table_writer_put32( w, (uint32_t) ( value->value ) );
@@ -7180,9 +7063,6 @@ static SCHEMA_UNUSED int list_node_save_body_retain( TableWriter * w, const List
         }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xc4bcadba8e631b86ull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -7208,9 +7088,6 @@ static SCHEMA_UNUSED int list_node_save_body_retain( TableWriter * w, const List
     retention=table_retain_step(body_keep,2,0);
         if ( !( value->next.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xe5316cbaa025f028ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->next);
@@ -7504,9 +7381,6 @@ static SCHEMA_UNUSED int tree_node_save_body_retain( TableWriter * w, const Tree
         }
         if ( value->label_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x39f7fcec8fcb623dull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -7532,9 +7406,6 @@ static SCHEMA_UNUSED int tree_node_save_body_retain( TableWriter * w, const Tree
     retention=table_retain_step(body_keep,1,0);
         if ( !( value->left.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x24b070ada2041cb0ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->left);
@@ -7548,9 +7419,6 @@ static SCHEMA_UNUSED int tree_node_save_body_retain( TableWriter * w, const Tree
     retention=table_retain_step(body_keep,2,0);
         if ( !( value->right.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x76aaaa535714d805ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->right);
@@ -8079,9 +7947,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
         }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xc4bcadba8e631b86ull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -8107,9 +7972,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
     retention=table_retain_step(body_keep,1,0);
         if ( !( value->version == 1 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xbb62c62c9808ea37ull , retention);
             table_writer_put8( w, 4 );
             table_writer_put32( w, (uint32_t) ( value->version ) );
@@ -8119,9 +7981,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
     retention=table_retain_step(body_keep,2,0);
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x0a8f12cc5f9a0c03ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);
@@ -8135,9 +7994,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
     retention=table_retain_step(body_keep,3,0);
         if ( !( value->tree.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x5b25b8ef511eb395ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->tree);
@@ -8151,9 +8007,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
     retention=table_retain_step(body_keep,4,0);
         if ( !( value->settings.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xee5f6d7b48b44de8ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->settings);
@@ -8167,9 +8020,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
     retention=table_retain_step(body_keep,5,0);
         if ( !( value->alias.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x509220bb65a646b7ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->alias);
@@ -8188,9 +8038,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
         table_retain_rewind(&default_probe, retention);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x60839e2395be697eull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -8218,9 +8065,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
         }
         if ( value->layers_count > 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x4554e34a747022dfull , retention);
             table_writer_put8( w, 14 );
             if ( w->buffer == NULL )
@@ -8251,9 +8095,6 @@ static SCHEMA_UNUSED int scene_save_body_retain( TableWriter * w, const Scene * 
         table_retain_rewind(&default_probe, retention);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x4320e9a2e32eac38ull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -8911,9 +8752,6 @@ static SCHEMA_UNUSED int depot_save_body_retain( TableWriter * w, const Depot * 
         }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xc4bcadba8e631b86ull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -8954,9 +8792,6 @@ static SCHEMA_UNUSED int depot_save_body_retain( TableWriter * w, const Depot * 
         }
         if ( rides )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xdd9eb981e152e90cull , retention);
             table_writer_put8( w, 16 );
             if ( w->buffer == NULL )
@@ -8982,9 +8817,6 @@ static SCHEMA_UNUSED int depot_save_body_retain( TableWriter * w, const Depot * 
     retention=table_retain_step(body_keep,2,0);
         if ( value->spare_present )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x4339ee8ab21c8380ull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -9010,9 +8842,6 @@ static SCHEMA_UNUSED int depot_save_body_retain( TableWriter * w, const Depot * 
     retention=table_retain_step(body_keep,3,0);
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x0a8f12cc5f9a0c03ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);
@@ -9326,9 +9155,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
         }
         if ( value->name_length != 0 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xc4bcadba8e631b86ull , retention);
             table_writer_put8( w, 12 );
             if ( w->buffer == NULL )
@@ -9359,9 +9185,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
         table_retain_rewind(&default_probe, retention);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x1e4984ef2e958a4cull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -9392,9 +9215,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
         table_retain_rewind(&default_probe, retention);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xee7ba9ad45c64144ull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -9425,9 +9245,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
         table_retain_rewind(&default_probe, retention);
         if ( default_probe.offset > 1 )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0xeddcb72b15486e77ull , retention);
             table_writer_put8( w, 13 );
             if ( w->buffer == NULL )
@@ -9453,9 +9270,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
     retention=table_retain_step(body_keep,4,0);
         if ( !( value->pin.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x77af761956600b54ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->pin);
@@ -9469,9 +9283,6 @@ static SCHEMA_UNUSED int album_save_body_retain( TableWriter * w, const Album * 
     retention=table_retain_step(body_keep,5,0);
         if ( !( value->head.value == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x0a8f12cc5f9a0c03ull , retention);
             table_writer_put8( w, 17 );
             { const void * node=table_ref_at(w->nodes ? w->nodes->ctx : NULL,&value->head);

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -3207,7 +3207,7 @@ static SCHEMA_UNUSED int schema_graphdemo_marker_message_extent_(TableMessageRea
 static SCHEMA_UNUSED int tally_save_body( TableWriter * w, const Tally * value )
 {
     (void) value;
-    if ( w->buffer == NULL && !w->check_default )
+    if ( w->buffer == NULL )
     {
         int64_t payload_bytes = 1; /* the zero reference ending this body */
         if ( !( value->hits == 0 ) )
@@ -3222,7 +3222,6 @@ static SCHEMA_UNUSED int tally_save_body( TableWriter * w, const Tally * value )
     { /* hits */
         if ( !( value->hits == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2; return 1; }
             table_writer_header_at( w, 19, 0x732dfbcc9b0cf0bbull, 4 );
             table_writer_put32( w, (uint32_t) ( value->hits ) );
         }
@@ -3371,9 +3370,6 @@ static SCHEMA_UNUSED int tally_save_message_body(TableBitWriter * w,const Tally 
  (void)value;
  { /* hits */
  if(!(value->hits == 0)) {
-  if(w->check_default) {w->bits=kTableMessageRefBitsHere+1;
-  return 1;
-  }
   table_bit_put(w,31,kTableMessageRefBitsHere);
   table_bit_put(w,(uint64_t)(value->hits)-UINT64_C(0),14);
  }
@@ -3687,9 +3683,6 @@ static SCHEMA_UNUSED int tally_save_body_retain( TableWriter * w, const Tally * 
     retention=table_retain_step(body_keep,0,0);
         if ( !( value->hits == 0 ) )
         {
-            if ( w->check_default ) { w->offset = 2;
-            return 1;
-            }
             table_retain_writer_id( w, 0x732dfbcc9b0cf0bbull , retention);
             table_writer_put8( w, 4 );
             table_writer_put32( w, (uint32_t) ( value->hits ) );


### PR DESCRIPTION
## Card C-6: Stop emitting check_default where no probe can set it

Eliminate unreachable `check_default` emission in C table code generation (`internal/codegen/ctable/`).

In C table codegen, `TableWriter` and `TableBitWriter` set `check_default = 1` during default-body and enum-keyed slot probes to test whether a nested subtable elides on the wire by exiting early on the first non-default field (`w->offset = 2; return 1;` or `w->bits = kTableMessageRefBitsHere + 1; return 1;`).

Previously, `check_default` was unconditionally emitted in `TableWriter` and `TableBitWriter`, and unreachable checks were emitted across every struct save function and scalar leaf measure regardless of whether any probe could ever run.

### 1. Unit-level Gating
- When no struct in the unit can be probed (`!hasProbes`), `TableWriter` and `TableBitWriter` omit `check_default` entirely.
- `table_retain_tail` omits `if (w->check_default)`.
- The symbol `check_default` is completely eliminated from the unit's emitted header and source files.

### 2. Struct-level Gating
- In units with probes, only structs that are reachable targets of a probe (scalar table fields or enum-keyed table arrays) emit `if (w->check_default)` early returns in `save_body` and `save_message_body`.
- Unprobed structs (such as root tables or subtables only appearing in counted arrays, fixed arrays, or unions) omit these checks.
- In `emitWireScalarLeafMeasure`, `&& !w->check_default` is only emitted for probed structs; unprobed structs emit `if (w->buffer == NULL)`.

### 3. Glenn's Cross-Language Audit
- **C++ (`cpptable`)**: Uses `MeasureBody` returning `body > 1` (`codecs.go:1468-1475`) to decide elision prior to emitting table headers; has no runtime probe flag.
- **Go (`gotable`)**: Uses `MeasureBody` returning `n > 1` (`write.go:207-216`) to decide elision; has no runtime probe flag.
- **C# (`cstable`)**: Uses descriptors and measuring; has no runtime probe flag.
- **Result**: C table codegen was the only target with dead `check_default`.

### 4. Both-Ways Compiler Fixture
Added `compiler/tabledeadc_test.go`:
- `TestCTableDeadCheckDefault_Unprobed`: verifies complete absence of `check_default` across header and source, verifies struct declarations, and verifies roundtrip execution.
- `TestCTableDeadCheckDefault_Probed`: verifies `check_default` is present on probeable `Leaf` and writers, but absent on unprobeable `Outer`, and verifies wire subtable elision and roundtrip decode.

### 5. Line Count Reductions
- `generated/`: 318 lines removed across 3 files (-308 net).
- `testdata/golden/`: 886 lines removed across 11 files (-880 net).
- Total diff: -793 net lines across the repository.

### 6. Verification
- `go test ./internal/codegen/ctable/...`: **PASS**
- `go test ./internal/goldens`: **PASS**
- `go test -v ./compiler -run 'TestCTableDeadCheckDefault.*'`: **PASS**
- `go test ./compiler -run 'Test(CTable|CBlock|CExternals|CForceInline|CEmits|CGenerator)'`: **PASS** (59.9s)
- `PATH="/Users/glenn/.dotnet:$PATH" go run ./bench/paired -mode gate -langs c,cpp`: **PASS**
  - 64 identical logical records verified byte-for-byte.
  - C corpus_id: `6b213fbfa1a03a99` (bench) / `07c57b4fa34b2700` (tables).
  - C++ corpus_id: `6b213fbfa1a03a99` (bench) / `07c57b4fa34b2700` (tables).