### PR TITLE
cstable: annotate hot TableWire Writer and Reader primitives with AggressiveInlining

### DIFF
--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -2573,8 +2573,11 @@ namespace Bench
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2587,6 +2590,7 @@ namespace Bench
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2597,6 +2601,7 @@ namespace Bench
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2612,8 +2617,11 @@ namespace Bench
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2631,6 +2639,7 @@ namespace Bench
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2656,6 +2665,7 @@ namespace Bench
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -2657,8 +2657,11 @@ namespace Benchtable
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2671,6 +2674,7 @@ namespace Benchtable
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2681,6 +2685,7 @@ namespace Benchtable
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2696,8 +2701,11 @@ namespace Benchtable
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2715,6 +2723,7 @@ namespace Benchtable
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2740,6 +2749,7 @@ namespace Benchtable
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -166,8 +166,11 @@ public static partial class TableWire
         public Span<byte> Buffer;
         public int Offset;
         public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Byte(byte v) { Buffer[Offset++] = v; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Fixed(ulong v, int n)
         {
             switch (n)
@@ -180,6 +183,7 @@ public static partial class TableWire
             }
             Offset += n;
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Header(ulong reference, byte kind)
         {
             if (reference < 128)
@@ -190,6 +194,7 @@ public static partial class TableWire
             }
             Var(reference); Byte(kind);
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Var(ulong v)
         {
             if (v < 128) { Byte((byte)v); return; }
@@ -205,8 +210,11 @@ public static partial class TableWire
         public int Offset;
         public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
         { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte Byte() { return Buffer[Offset++]; }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong Fixed(int n)
         {
             ulong v;
@@ -224,6 +232,7 @@ public static partial class TableWire
             Offset += n;
             return v;
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Var(out ulong v)
         {
             if ((uint)Offset < (uint)Buffer.Length)
@@ -249,6 +258,7 @@ public static partial class TableWire
             Offset = start;
             return false;
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Ref(out ulong reference, out ulong id)
         {
             id = 0;

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -2689,8 +2689,11 @@ namespace Blockdemo
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2703,6 +2706,7 @@ namespace Blockdemo
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2713,6 +2717,7 @@ namespace Blockdemo
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2728,8 +2733,11 @@ namespace Blockdemo
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2747,6 +2755,7 @@ namespace Blockdemo
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2772,6 +2781,7 @@ namespace Blockdemo
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -2573,8 +2573,11 @@ namespace Blockhome
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2587,6 +2590,7 @@ namespace Blockhome
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2597,6 +2601,7 @@ namespace Blockhome
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2612,8 +2617,11 @@ namespace Blockhome
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2631,6 +2639,7 @@ namespace Blockhome
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2656,6 +2665,7 @@ namespace Blockhome
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -2689,8 +2689,11 @@ namespace Tabledemo
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2703,6 +2706,7 @@ namespace Tabledemo
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2713,6 +2717,7 @@ namespace Tabledemo
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2728,8 +2733,11 @@ namespace Tabledemo
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2747,6 +2755,7 @@ namespace Tabledemo
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2772,6 +2781,7 @@ namespace Tabledemo
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -2573,8 +2573,11 @@ namespace Wide
                 public Span<byte> Buffer;
                 public int Offset;
                 public Writer(Span<byte> buffer) { Buffer = buffer; Offset = 0; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Byte(byte v) { Buffer[Offset++] = v; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Raw(ReadOnlySpan<byte> v) { v.CopyTo(Buffer.Slice(Offset)); Offset += v.Length; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Fixed(ulong v, int n)
                 {
                     switch (n)
@@ -2587,6 +2590,7 @@ namespace Wide
                     }
                     Offset += n;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Header(ulong reference, byte kind)
                 {
                     if (reference < 128)
@@ -2597,6 +2601,7 @@ namespace Wide
                     }
                     Var(reference); Byte(kind);
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
                 {
                     if (v < 128) { Byte((byte)v); return; }
@@ -2612,8 +2617,11 @@ namespace Wide
                 public int Offset;
                 public Reader(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> vocabulary)
                 { Buffer = buffer; Vocabulary = vocabulary; Offset = 0; Graph = null; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Has(int n) { return n >= 0 && n <= Buffer.Length - Offset; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public byte Byte() { return Buffer[Offset++]; }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Fixed(int n)
                 {
                     ulong v;
@@ -2631,6 +2639,7 @@ namespace Wide
                     Offset += n;
                     return v;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Var(out ulong v)
                 {
                     if ((uint)Offset < (uint)Buffer.Length)
@@ -2656,6 +2665,7 @@ namespace Wide
                     Offset = start;
                     return false;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public bool Ref(out ulong reference, out ulong id)
                 {
                     id = 0;


### PR DESCRIPTION
## C# Fixed Table: AggressiveInlining on Hot TableWire Primitives

Per Rowan's review of `emma/cs-typed-leaf-phase1` (`1080318e`), this splits out the clean, uncontroversial inlining parcel onto its own isolated branch.

- Adds `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to hot TableWire primitives:
  - Writer: `Byte`, `Raw`, `Fixed`, `Header`, `Var`
  - Reader: `Byte`, `Fixed`, `Has`, `Var`, `Ref`
- Ensures `using System.Runtime.CompilerServices;` is in the emitted header.
- Leaves `TableWire.Ids` completely untouched (no ordinal accelerator, no `Truncate` probe changes).
- Re-pins golden files and updates `generated/bench/paired/cs` and `generated/bench/tables/cs`.

### Verification
- `go test -count=1 ./internal/codegen/cstable/...`: PASS (0.190s)
- `go test -count=1 ./internal/goldens`: PASS (0.607s)
- `PATH="/Users/glenn/.dotnet:/Users/glenn/.gemini/antigravity/bin:/Users/glenn/Library/Application Support/Antigravity/bin:/Users/glenn/.antigravity-ide/antigravity-ide/bin:/Users/glenn/.grok/bin:/Users/glenn/.unity/bin:/Users/glenn/.local/bin:/Users/glenn/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:.:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin" go run ./bench/paired -mode gate -langs cs`: PASS (packet `6b213fbfa1a03a99` / table `07c57b4fa34b2700`).

I do not merge.