### PR TITLE
rust: export union modules from lib.rs and bring Stream trait into scope

### DIFF
--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -32,6 +32,7 @@ import (
 // declared initial values before decoding it, even when the tag is unchanged.
 func (g *gen) emitUnionFunctions(d *ir.Union) {
 	g.needsStreams = true
+	g.needsStreamTrait = true
 	snake := ir.RustSnake(d.Name)
 	maxBits := ir.MaxBitsUnion(d)
 	g.pf("// %s is the tag plus the largest arm; None costs the tag only (SPEC §4.8).\n", ir.RustConstName(d.Name+"MaxBits"))

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -100,7 +100,7 @@ func assembleLib(u *ir.Unit, modules map[string]string, extra []string) []byte {
 		has := f.Base == home
 		for _, d := range f.Decls {
 			switch d.(type) {
-			case *ir.Const, *ir.Enum, *ir.Flags, *ir.Struct:
+			case *ir.Const, *ir.Enum, *ir.Flags, *ir.Struct, *ir.Union:
 				has = true
 			}
 		}

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -97,13 +97,7 @@ func assembleLib(u *ir.Unit, modules map[string]string, extra []string) []byte {
 	exports := map[string]bool{}
 	home := ir.ProtocolIdHome(u)
 	for _, f := range u.Files {
-		has := f.Base == home
-		for _, d := range f.Decls {
-			switch d.(type) {
-			case *ir.Const, *ir.Enum, *ir.Flags, *ir.Struct, *ir.Union:
-				has = true
-			}
-		}
+		has := f.Base == home || len(f.Decls) > 0
 		exports[strings.ToLower(f.Base)] = has
 	}
 

--- a/internal/codegen/rust/rust_test.go
+++ b/internal/codegen/rust/rust_test.go
@@ -8,7 +8,11 @@
 package rust
 
 import (
+	"fmt"
 	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -137,7 +141,8 @@ func TestRenderArgOverflowGate(t *testing.T) {
 }
 
 // TestAssembleLibExportsUnionModule verifies that a module declaring ONLY a
-// union is re-exported via `pub use <mod>::*;` rather than marked as documentation-only.
+// union is re-exported via `pub use <mod>::*;` rather than marked as documentation-only,
+// and that its generated code imports the Stream trait so wire methods compile.
 func TestAssembleLibExportsUnionModule(t *testing.T) {
 	const srcHome = `package unionexport
 type Marker {
@@ -172,8 +177,80 @@ union Event {
 	}
 
 	lib := string(files["lib.rs"])
-	want := "mod types;\npub use types::*;\n"
-	if !strings.Contains(lib, want) {
+	wantLib := "mod types;\npub use types::*;\n"
+	if !strings.Contains(lib, wantLib) {
 		t.Fatalf("lib.rs does not export union module types:\n%s", lib)
+	}
+
+	types := string(files["types.rs"])
+	wantTrait := "use serialize::{ReadStream, Stream, WriteStream};\n"
+	if !strings.Contains(types, wantTrait) {
+		t.Fatalf("types.rs does not bring Stream trait into scope:\n%s", types)
+	}
+
+	// Verify compilation with cargo when available.
+	var serializePath string
+	if p := os.Getenv("SERIALIZE_RS"); p != "" {
+		if fi, err := os.Stat(filepath.Join(p, "Cargo.toml")); err == nil && !fi.IsDir() {
+			serializePath, _ = filepath.Abs(p)
+		}
+	}
+	if serializePath == "" {
+		candidates := []string{
+			"../../../../serialize.rs",
+			"../../../../../serialize.rs",
+			"../../../serialize.rs",
+			"../../serialize.rs",
+		}
+		for _, rel := range candidates {
+			p, err := filepath.Abs(rel)
+			if err == nil {
+				if fi, err := os.Stat(filepath.Join(p, "Cargo.toml")); err == nil && !fi.IsDir() {
+					serializePath = p
+					break
+				}
+			}
+		}
+	}
+
+	cargoBin, err := exec.LookPath("cargo")
+	if err != nil {
+		if fi, err2 := os.Stat("/opt/homebrew/opt/rustup/bin/cargo"); err2 == nil && !fi.IsDir() {
+			cargoBin = "/opt/homebrew/opt/rustup/bin/cargo"
+		}
+	}
+
+	if cargoBin == "" || serializePath == "" {
+		t.Logf("cargo (%s) or serialize.rs (%s) not found; skipping compilation check", cargoBin, serializePath)
+		return
+	}
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cargoToml := fmt.Sprintf(`[package]
+name = "unionexport"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+serialize = { package = "serialize-official", path = %q }
+`, serializePath)
+	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(cargoToml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(srcDir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.Command(cargoBin, "check", "--quiet")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "PATH="+filepath.Dir(cargoBin)+":"+os.Getenv("PATH"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generated union-only crate does not compile: %v\n%s", err, out)
 	}
 }

--- a/internal/codegen/rust/rust_test.go
+++ b/internal/codegen/rust/rust_test.go
@@ -135,3 +135,45 @@ func TestRenderArgOverflowGate(t *testing.T) {
 		t.Errorf("foldArg64(nil, -30000) = %q, want %q", got, "-30000_i64")
 	}
 }
+
+// TestAssembleLibExportsUnionModule verifies that a module declaring ONLY a
+// union is re-exported via `pub use <mod>::*;` rather than marked as documentation-only.
+func TestAssembleLibExportsUnionModule(t *testing.T) {
+	const srcHome = `package unionexport
+type Marker {
+    x int32
+}
+`
+	const srcUnion = `package unionexport
+union Event {
+    first
+    second
+}
+`
+	f1, perrs := parser.Parse("Home.schema", []byte(srcHome))
+	if len(perrs) > 0 {
+		t.Fatalf("parse Home: %v", perrs[0])
+	}
+	f2, perrs := parser.Parse("Types.schema", []byte(srcUnion))
+	if len(perrs) > 0 {
+		t.Fatalf("parse Types: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{
+		{Path: "Home.schema", Name: "Home.schema", Base: "Home", Bytes: []byte(srcHome), AST: f1},
+		{Path: "Types.schema", Name: "Types.schema", Base: "Types", Bytes: []byte(srcUnion), AST: f2},
+	})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lib := string(files["lib.rs"])
+	want := "mod types;\npub use types::*;\n"
+	if !strings.Contains(lib, want) {
+		t.Fatalf("lib.rs does not export union module types:\n%s", lib)
+	}
+}


### PR DESCRIPTION
## Rust Union Export & Stream Trait Scoping

Per Rowan's review of `emma/rust-union-export` at `301cc3f7` (note `from-rowan/2026-09-09T1421Z`):

1. **Stream trait in scope**: In `internal/codegen/rust/functions.go` line 35 (`emitUnionFunctions`), set `g.needsStreamTrait = true`. When a crate module declares unions but no structs, `assemble()` wrote `use serialize::{ReadStream, WriteStream};` without `Stream`, failing cargo build with four E0599 errors on `stream.serialize_bits` and `stream.serialize_int`.
2. **Declaration switch replacement**: In `internal/codegen/rust/rust.go` (`assembleLib`), replaced enumerated switch with `has := f.Base == home || len(f.Decls) > 0`. Byte-equivalent across corpus and future-proof.
3. **Verified Cargo compilation**: Expanded `TestAssembleLibExportsUnionModule` in `internal/codegen/rust/rust_test.go` to test both `pub use types::*;`, `use serialize::{ReadStream, Stream, WriteStream};`, and end-to-end `cargo check` against `serialize.rs`.

Full Commit Hash: `5d641d0320795df9f7c7bcf6a0da831bffbbc20e`

### Verification
- `go test -count=1 -v ./internal/codegen/rust/...`: PASS
- `go test ./internal/codegen/rusttable/...`: PASS
- `go test ./internal/goldens`: PASS
- `PATH="/opt/homebrew/opt/rustup/bin:/Users/glenn/.gemini/antigravity/bin:/Users/glenn/Library/Application Support/Antigravity/bin:/Users/glenn/.antigravity-ide/antigravity-ide/bin:/Users/glenn/.grok/bin:/Users/glenn/.unity/bin:/Users/glenn/.local/bin:/Users/glenn/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:.:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin" make test-rust`: PASS

I do not merge.