### PR TITLE
gotable: omit tableWidenFloat when the unit declares no kind 11

### DIFF
--- a/compiler/tablesgo_test.go
+++ b/compiler/tablesgo_test.go
@@ -139,6 +139,7 @@ func TestTableRuntimeNamesAreClaimedGo(t *testing.T) {
 		goRuntimeSrc + "\ntable Graph {head *Graph\ndata *bytes\ncaption *string\n}\n",
 		goRuntimeSrc + "\ntable Lists {rows []int32}\n",
 		goRuntimeSrc + "\ntable Wide {label wstring(16)\n}\n",
+		goRuntimeSrc + "\ntable Drift {ratio float64\n}\n",
 	} {
 		generated, err := New().Generate(unitFromSource(t, source), "go", Options{})
 		if err != nil {
@@ -220,5 +221,62 @@ func TestTableRuntimeNamesAreClaimedGo(t *testing.T) {
 				"Go declares it — drop the registration or fix the backend; a claim nothing needs takes "+
 				"a name away from every schema for free", name)
 		}
+	}
+}
+
+// tableWidenFloat is reached only from a declared kind 11. The nearest
+// neighbour respells that one field float32, so the helper has no call site
+// and must not be emitted. tableKindWidens stays: a kind comparison is every
+// unit's.
+const goWidenF64Src = `package probe
+
+table Note
+{
+    ratio float64
+}
+`
+
+const goWidenF32Src = `package probe
+
+table Note
+{
+    ratio float32
+}
+`
+
+func goTableFile(t *testing.T, src string) string {
+	t.Helper()
+	files, err := New().Generate(unitFromSource(t, src), "go", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.go") {
+			b.Write(data)
+		}
+	}
+	out := b.String()
+	if out == "" {
+		t.Fatal("the unit emitted no Table.go")
+	}
+	return out
+}
+
+func TestGoTableWidenFloatFollowsDeclaredKind11(t *testing.T) {
+	with := goTableFile(t, goWidenF64Src)
+	if !strings.Contains(with, "func tableWidenFloat(b uint32) uint64") {
+		t.Error("a unit that declares kind 11 must define tableWidenFloat")
+	}
+	if !strings.Contains(with, "math.Float64frombits(tableWidenFloat(") {
+		t.Error("tableWidenFloat must be called by the unit that carries it")
+	}
+
+	without := goTableFile(t, goWidenF32Src)
+	if strings.Contains(without, "tableWidenFloat") {
+		t.Error("the nearest neighbour declares no kind 11 and must carry none of tableWidenFloat")
+	}
+	if !strings.Contains(without, "func tableKindWidens") {
+		t.Error("tableKindWidens is every unit's and left one")
 	}
 }

--- a/internal/codegen/gotable/wire.go
+++ b/internal/codegen/gotable/wire.go
@@ -20,6 +20,9 @@ func tableWireRuntime(u *ir.Unit) string {
 		source = strings.Replace(source, "type TableReader struct {", "type TableReader struct {\nNodes TableNodeMap", 1)
 		source = strings.ReplaceAll(source, "Ids:r.Ids, Nested:true", "Ids:r.Ids, Nested:true, Nodes:r.Nodes")
 	}
+	if unitDeclaresTableKind(u, ir.TableKindF64) {
+		source = tableSourceReplace(source, "func tableUtf8Valid", tableWidenFloatSource+"func tableUtf8Valid", 1)
+	}
 	res := fmt.Sprintf(`
 const tableIdCapacity = %d
 const tableIdBuckets = %d
@@ -28,6 +31,57 @@ const tableIdBuckets = %d
 		res += tableWStringSource
 	}
 	return res
+}
+
+// unitDeclaresTableKind is the declared-kind census tableWidenFloat is gated
+// on: a kind anywhere in the table closure — a field, an arm, an element or a
+// generated map-entry slot. It is a safe superset over the call sites. A
+// subset would omit a helper a codec still names.
+func unitDeclaresTableKind(u *ir.Unit, kind int) bool {
+	seen := map[*ir.Union]bool{}
+	var note func(f *ir.Field) bool
+	var walkUnion func(un *ir.Union) bool
+	note = func(f *ir.Field) bool {
+		if f == nil {
+			return false
+		}
+		if ir.TableWireScalarKind(f) == kind || ir.TableWireElemKind(f) == kind {
+			return true
+		}
+		if f.Type.Kind == ir.TNamed {
+			if un, ok := f.Type.Ref.(*ir.Union); ok {
+				return walkUnion(un)
+			}
+		}
+		return false
+	}
+	walkUnion = func(un *ir.Union) bool {
+		if un == nil || seen[un] {
+			return false
+		}
+		seen[un] = true
+		for _, v := range un.Variants {
+			if note(v.F) {
+				return true
+			}
+		}
+		return false
+	}
+	for name := range ir.TableClosure(u) {
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		for _, f := range st.Fields {
+			if note(f) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 const tableWireSource = `
@@ -462,11 +516,6 @@ func (r *TableReader) Signed(kind uint8) int64 {
  switch tableKindBytes(kind) { case 1: return int64(int8(r.Get8())); case 2: return int64(int16(r.Get16())); case 4: return int64(int32(r.Get32())); default: return int64(r.Get64()) }
 }
 
-func tableWidenFloat(b uint32) uint64 {
- if b & 0x7f800000 == 0x7f800000 { return uint64(b >> 31) << 63 | 0x7ff0000000000000 | uint64(b & 0x7fffff) << 29 }
- return math.Float64bits(float64(math.Float32frombits(b)))
-}
-
 func tableUtf8Valid(data []byte) bool {
 	if !utf8.Valid(data) { return false }
 	for _, b := range data { if b == 0 { return false } }
@@ -477,4 +526,13 @@ func tableUtf8Clamp(data []byte, n int64) int64 {
 	for n > 0 && n < int64(len(data)) && data[n]&0xc0 == 0x80 { n-- }
 	return n
 }
+`
+
+// tableWidenFloatSource is the float rung, kind 10 into kind 11. It is spliced
+// into tableWireSource only where the unit declares kind 11.
+const tableWidenFloatSource = `func tableWidenFloat(b uint32) uint64 {
+ if b & 0x7f800000 == 0x7f800000 { return uint64(b >> 31) << 63 | 0x7ff0000000000000 | uint64(b & 0x7fffff) << 29 }
+ return math.Float64bits(float64(math.Float32frombits(b)))
+}
+
 `

--- a/internal/codegen/gotable/wire.go
+++ b/internal/codegen/gotable/wire.go
@@ -3,6 +3,7 @@ package gotable
 import (
 	"fmt"
 	"math/bits"
+	"slices"
 	"strings"
 
 	"github.com/mas-bandwidth/schema/v2/ir"
@@ -75,10 +76,8 @@ func unitDeclaresTableKind(u *ir.Unit, kind int) bool {
 		if st == nil {
 			continue
 		}
-		for _, f := range st.Fields {
-			if note(f) {
-				return true
-			}
+		if slices.ContainsFunc(st.Fields, note) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
GO-DEAD-1. Gate tableWidenFloat beside WideTextFields. Both committed units still declare f64, so 0 dead lines in the corpus. Both-ways fixture in compiler/tablesgo_test.go.

Head: 864218a81984ed87f63bccf9a31c0bf9f6106cf8
Base: 0b42d653 (#803 merge)

Johnny Grok.