### PR TITLE
cstable: typed child table array fast path for fixed tables

### DIFF
--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -4,6 +4,9 @@ package compiler
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -376,3 +379,218 @@ table Subject {
 		t.Errorf("found bare Instance. in SubjectTableInfo holder body:\n%s", holderBody)
 	}
 }
+
+// TestCsTypedVsDynamicWireEquivalence verifies that typed fast paths and dynamic
+// descriptor walks produce identical wire bytes across normal, guarded, and optional
+// array fields.
+func TestCsTypedVsDynamicWireEquivalence(t *testing.T) {
+	const src = `package probe
+
+type Leaf {
+    value int32 = 0
+}
+
+table Subject {
+    normal [2]Leaf
+    counted [..2]Leaf
+    on bool
+    if on {
+        guarded [2]Leaf
+    }
+    opt ?[2]Leaf
+    opt_counted ?[..2]Leaf
+}
+`
+	files := csFiles(t, src)
+	subjectCs, ok := files["ProbeTable.cs"]
+	if !ok {
+		t.Fatalf("ProbeTable.cs not found in generated output; got keys: %v", files)
+	}
+	text := string(subjectCs)
+
+	// Structural assertions:
+	// 1. Leaf typed helpers must be generated.
+	for _, want := range []string{
+		"public static bool LeafCollectTyped(Leaf v, ref TableWire.Ids ids)",
+		"public static long LeafBodySizeTyped(Leaf v, ref TableWire.Ids ids",
+		"public static void LeafWriteBodyTyped(ref TableWire.Writer w, Leaf v, ref TableWire.Ids ids",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("expected %q in generated output", want)
+		}
+	}
+
+	// 2. Normal and counted arrays must use the typed helper calls.
+	if !strings.Contains(text, "LeafBodySizeTyped(v.Normal[i_0], ref ids)") {
+		t.Errorf("expected LeafBodySizeTyped call for normal array")
+	}
+	if !strings.Contains(text, "LeafBodySizeTyped(v.Counted[i_1], ref ids)") {
+		t.Errorf("expected LeafBodySizeTyped call for counted array")
+	}
+	if !strings.Contains(text, "LeafWriteBodyTyped(ref w, v.Normal[i_0], ref ids)") {
+		t.Errorf("expected LeafWriteBodyTyped call for normal array")
+	}
+	if !strings.Contains(text, "LeafWriteBodyTyped(ref w, v.Counted[i_1], ref ids)") {
+		t.Errorf("expected LeafWriteBodyTyped call for counted array")
+	}
+
+	// 3. Guarded and optional arrays must NOT use typed child calls directly;
+	// they must fall back to dynamic descriptor dispatch (BodySizeField / WriteBodyField).
+	if strings.Contains(text, "LeafBodySizeTyped(v.Guarded") {
+		t.Errorf("guarded array must not use typed child delegation")
+	}
+	if strings.Contains(text, "LeafBodySizeTyped(v.Opt[") {
+		t.Errorf("optional uncounted array must not use typed child delegation")
+	}
+	if strings.Contains(text, "LeafBodySizeTyped(v.OptCounted[") {
+		t.Errorf("optional counted array must not use typed child delegation")
+	}
+
+	// 4. Unqualified alias overloads must not be emitted.
+	for _, unwanted := range []string{
+		"public static bool CollectTyped(Subject ",
+		"public static long BodySizeTyped(Subject ",
+		"public static void WriteBodyTyped(ref TableWire.Writer w, Subject ",
+		"public static long SaveTyped(Subject ",
+	} {
+		if strings.Contains(text, unwanted) {
+			t.Errorf("found unwanted unqualified alias overload: %q", unwanted)
+		}
+	}
+
+	// 5. If dotnet is available, compile and run end-to-end wire equivalence verification.
+	dotnet := findDotnet()
+	if dotnet == "" {
+		return
+	}
+
+	runtime, err := filepath.Abs("../../serialize.cs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(runtime, "src", "Serialize.cs")); err != nil {
+		t.Skip("serialize.cs unavailable")
+	}
+
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	csproj := `<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType><AllowUnsafeBlocks>true</AllowUnsafeBlocks></PropertyGroup>
+<ItemGroup><Compile Include="` + filepath.ToSlash(runtime) + `/src/Serialize.cs" /><Compile Include="` + filepath.ToSlash(runtime) + `/src/Int128Pair.cs" /></ItemGroup>
+</Project>`
+	if err := os.WriteFile(filepath.Join(dir, "probe.csproj"), []byte(csproj), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const programCs = `using System;
+using Probe;
+
+static class Program
+{
+    static void AssertEqual(string name, Subject s)
+    {
+        Span<ulong> ids1 = stackalloc ulong[64];
+        Span<ulong> ids2 = stackalloc ulong[64];
+        Span<byte> buf1 = stackalloc byte[1024];
+        Span<byte> buf2 = stackalloc byte[1024];
+
+        long mTyped = Schema.SubjectMeasure(s);
+        long mDyn = Schema.TableWire.Save(s, Schema.SubjectTableType(), Span<byte>.Empty, ids2, true);
+        if (mTyped != mDyn)
+        {
+            Console.Error.WriteLine($"{name}: measure divergence: typed {mTyped} vs dynamic {mDyn}");
+            Environment.Exit(1);
+        }
+
+        long nTyped = Schema.SubjectSave(s, buf1);
+        long nDyn = Schema.TableWire.Save(s, Schema.SubjectTableType(), buf2, ids1, false);
+        if (nTyped != nDyn)
+        {
+            Console.Error.WriteLine($"{name}: size divergence: typed {nTyped} vs dynamic {nDyn}");
+            Environment.Exit(1);
+        }
+        if (nTyped != mTyped)
+        {
+            Console.Error.WriteLine($"{name}: save len {nTyped} != measure {mTyped}");
+            Environment.Exit(1);
+        }
+        if (!buf1.Slice(0, (int)nTyped).SequenceEqual(buf2.Slice(0, (int)nDyn)))
+        {
+            Console.Error.WriteLine($"{name}: byte divergence between typed and dynamic save!");
+            Environment.Exit(1);
+        }
+    }
+
+    static void Main()
+    {
+        // 1. All defaults
+        AssertEqual("defaults", new Subject());
+
+        // 2. Normal populated
+        Subject s2 = new Subject();
+        s2.Normal[0].Value = 10; s2.Normal[1].Value = 20;
+        s2.CountedCount = 2; s2.Counted[0].Value = 30; s2.Counted[1].Value = 40;
+        AssertEqual("normal populated", s2);
+
+        // 3. Guarded array: on = false, elements nonzero
+        Subject s3 = new Subject();
+        s3.On = false;
+        s3.Guarded[0].Value = 50; s3.Guarded[1].Value = 60;
+        AssertEqual("guarded on=false", s3);
+
+        // 4. Guarded array: on = true, elements nonzero
+        Subject s4 = new Subject();
+        s4.On = true;
+        s4.Guarded[0].Value = 50; s4.Guarded[1].Value = 60;
+        AssertEqual("guarded on=true", s4);
+
+        // 5. Optional uncounted array: opt_present = false, elements nonzero
+        Subject s5 = new Subject();
+        s5.OptPresent = false;
+        s5.Opt[0].Value = 70; s5.Opt[1].Value = 80;
+        AssertEqual("opt uncounted absent", s5);
+
+        // 6. Optional uncounted array: opt_present = true
+        Subject s6 = new Subject();
+        s6.OptPresent = true;
+        s6.Opt[0].Value = 70; s6.Opt[1].Value = 80;
+        AssertEqual("opt uncounted present", s6);
+
+        // 7. Optional counted array: opt_counted_present = false, opt_counted_count = 2 (Rowan case c1)
+        Subject s7 = new Subject();
+        s7.OptCountedPresent = false;
+        s7.OptCountedCount = 2;
+        s7.OptCounted[0].Value = 90; s7.OptCounted[1].Value = 100;
+        AssertEqual("opt counted absent with count=2", s7);
+
+        // 8. Optional counted array: opt_counted_present = true, opt_counted_count = 0 (Rowan case c2)
+        Subject s8 = new Subject();
+        s8.OptCountedPresent = true;
+        s8.OptCountedCount = 0;
+        AssertEqual("opt counted present with count=0", s8);
+
+        // 9. Optional counted array: opt_counted_present = true, opt_counted_count = 2
+        Subject s9 = new Subject();
+        s9.OptCountedPresent = true;
+        s9.OptCountedCount = 2;
+        s9.OptCounted[0].Value = 90; s9.OptCounted[1].Value = 100;
+        AssertEqual("opt counted present with count=2", s9);
+    }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "Program.cs"), []byte(programCs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dotnet, "run", "--configuration", "Release", "-property:UseSharedCompilation=false")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dotnet run failed: %v\n%s", err, out)
+	}
+}
+

--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -593,4 +593,3 @@ static class Program
 		t.Fatalf("dotnet run failed: %v\n%s", err, out)
 	}
 }
-

--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -4936,8 +4936,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(MixedEntity v, ref TableWire.Ids ids) => MixedEntityCollectTyped(v, ref ids);
-
         public static long MixedEntityBodySizeTyped(MixedEntity v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -4958,8 +4956,6 @@ namespace Bench
             if (v.Firing != false) { n += TableWire.VarSize(ids.Reference(0x7674cfd19b9031caul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(MixedEntity v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedEntityBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void MixedEntityWriteBodyTyped(ref TableWire.Writer w, MixedEntity v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5029,8 +5025,6 @@ namespace Bench
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, MixedEntity v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedEntityWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long MixedEntitySaveTyped(MixedEntity value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = MixedEntityTableType();
@@ -5057,8 +5051,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(MixedEntity value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedEntitySaveTyped(value, buffer, vocabulary, measure);
 
         public static long MixedEntityMeasure(MixedEntity value)
         {
@@ -5104,8 +5096,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(MixedStat v, ref TableWire.Ids ids) => MixedStatCollectTyped(v, ref ids);
-
         public static long MixedStatBodySizeTyped(MixedStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -5113,8 +5103,6 @@ namespace Bench
             if (v.Delta != 0) { n += TableWire.VarSize(ids.Reference(0x52076675ec13a0c1ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(MixedStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedStatBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void MixedStatWriteBodyTyped(ref TableWire.Writer w, MixedStat v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5130,8 +5118,6 @@ namespace Bench
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, MixedStat v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedStatWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long MixedStatSaveTyped(MixedStat value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -5159,8 +5145,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(MixedStat value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedStatSaveTyped(value, buffer, vocabulary, measure);
 
         public static long MixedStatMeasure(MixedStat value)
         {
@@ -5210,8 +5194,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(MixedHitEvent v, ref TableWire.Ids ids) => MixedHitEventCollectTyped(v, ref ids);
-
         public static long MixedHitEventBodySizeTyped(MixedHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -5221,8 +5203,6 @@ namespace Bench
             if (v.Crit != false) { n += TableWire.VarSize(ids.Reference(0x126167908c9aa52dul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(MixedHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedHitEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void MixedHitEventWriteBodyTyped(ref TableWire.Writer w, MixedHitEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5248,8 +5228,6 @@ namespace Bench
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, MixedHitEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedHitEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long MixedHitEventSaveTyped(MixedHitEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -5277,8 +5255,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(MixedHitEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedHitEventSaveTyped(value, buffer, vocabulary, measure);
 
         public static long MixedHitEventMeasure(MixedHitEvent value)
         {
@@ -5324,8 +5300,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(MixedChatEvent v, ref TableWire.Ids ids) => MixedChatEventCollectTyped(v, ref ids);
-
         public static long MixedChatEventBodySizeTyped(MixedChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -5333,8 +5307,6 @@ namespace Bench
             if (v.Speaker != 0) { n += TableWire.VarSize(ids.Reference(0xfbf1ac4d96ebd022ul)) + 3; }
             return n;
         }
-
-        public static long BodySizeTyped(MixedChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedChatEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void MixedChatEventWriteBodyTyped(ref TableWire.Writer w, MixedChatEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5350,8 +5322,6 @@ namespace Bench
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, MixedChatEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedChatEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long MixedChatEventSaveTyped(MixedChatEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -5379,8 +5349,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(MixedChatEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedChatEventSaveTyped(value, buffer, vocabulary, measure);
 
         public static long MixedChatEventMeasure(MixedChatEvent value)
         {
@@ -5426,8 +5394,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(MixedPickupEvent v, ref TableWire.Ids ids) => MixedPickupEventCollectTyped(v, ref ids);
-
         public static long MixedPickupEventBodySizeTyped(MixedPickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -5435,8 +5401,6 @@ namespace Bench
             if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(MixedPickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedPickupEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void MixedPickupEventWriteBodyTyped(ref TableWire.Writer w, MixedPickupEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5452,8 +5416,6 @@ namespace Bench
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, MixedPickupEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedPickupEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long MixedPickupEventSaveTyped(MixedPickupEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -5481,8 +5443,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(MixedPickupEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedPickupEventSaveTyped(value, buffer, vocabulary, measure);
 
         public static long MixedPickupEventMeasure(MixedPickupEvent value)
         {
@@ -5598,8 +5558,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(BenchMixed v, ref TableWire.Ids ids) => BenchMixedCollectTyped(v, ref ids);
-
         public static long BenchMixedBodySizeTyped(BenchMixed v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -5665,8 +5623,6 @@ namespace Bench
             n += TableWire.BodySizeField(v, fields[26], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(BenchMixed v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => BenchMixedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void BenchMixedWriteBodyTyped(ref TableWire.Writer w, BenchMixed v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -5804,8 +5760,6 @@ namespace Bench
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, BenchMixed v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => BenchMixedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long BenchMixedSaveTyped(BenchMixed value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = BenchMixedTableType();
@@ -5832,8 +5786,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(BenchMixed value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => BenchMixedSaveTyped(value, buffer, vocabulary, measure);
 
         public static long BenchMixedMeasure(BenchMixed value)
         {

--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -2529,12 +2529,12 @@ namespace Bench
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2568,7 +2568,7 @@ namespace Bench
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4024,7 +4024,7 @@ namespace Bench
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4061,7 +4061,7 @@ namespace Bench
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4281,6 +4281,44 @@ namespace Bench
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {
@@ -4878,16 +4916,160 @@ namespace Bench
             value.Firing = false;
         }
 
+        public static bool MixedEntityCollectTyped(MixedEntity v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = MixedEntityTableType().Fields;
+            if (v.EntityId != 0 && !ids.Add(0x23fcfd6678e36712ul)) return false;
+            if (v.PosX != 0 && !ids.Add(0xcb4b37357667310eul)) return false;
+            if (v.PosY != 0 && !ids.Add(0xcb4b3835766732c1ul)) return false;
+            if (v.PosZ != 0 && !ids.Add(0xcb4b353576672da8ul)) return false;
+            if (v.Yaw != 0 && !ids.Add(0xb54d8e19798e16e8ul)) return false;
+            if (v.Pitch != 0 && !ids.Add(0x53a9f665a90cc1b1ul)) return false;
+            if (v.VelX != 0 && !ids.Add(0x6cede6b6eb60ee67ul)) return false;
+            if (v.VelY != 0 && !ids.Add(0x6cede5b6eb60ecb4ul)) return false;
+            if (v.VelZ != 0 && !ids.Add(0x6cede8b6eb60f1cdul)) return false;
+            if (v.Health != 0 && !ids.Add(0x7f69d4b5288ba9cful)) return false;
+            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[11], ref ids)) return false;
+            if (v.Moving != false && !ids.Add(0x11a44fc1d1243da7ul)) return false;
+            if (v.Firing != false && !ids.Add(0x7674cfd19b9031caul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(MixedEntity v, ref TableWire.Ids ids) => MixedEntityCollectTyped(v, ref ids);
+
+        public static long MixedEntityBodySizeTyped(MixedEntity v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = MixedEntityTableType().Fields;
+            if (v.EntityId != 0) { n += TableWire.VarSize(ids.Reference(0x23fcfd6678e36712ul)) + 3; }
+            if (v.PosX != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b37357667310eul)) + 5; }
+            if (v.PosY != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b3835766732c1ul)) + 5; }
+            if (v.PosZ != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b353576672da8ul)) + 5; }
+            if (v.Yaw != 0) { n += TableWire.VarSize(ids.Reference(0xb54d8e19798e16e8ul)) + 3; }
+            if (v.Pitch != 0) { n += TableWire.VarSize(ids.Reference(0x53a9f665a90cc1b1ul)) + 3; }
+            if (v.VelX != 0) { n += TableWire.VarSize(ids.Reference(0x6cede6b6eb60ee67ul)) + 5; }
+            if (v.VelY != 0) { n += TableWire.VarSize(ids.Reference(0x6cede5b6eb60ecb4ul)) + 5; }
+            if (v.VelZ != 0) { n += TableWire.VarSize(ids.Reference(0x6cede8b6eb60f1cdul)) + 5; }
+            if (v.Health != 0) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            n += TableWire.BodySizeField(v, fields[10], ref ids);
+            n += TableWire.BodySizeField(v, fields[11], ref ids);
+            if (v.Moving != false) { n += TableWire.VarSize(ids.Reference(0x11a44fc1d1243da7ul)) + 2; }
+            if (v.Firing != false) { n += TableWire.VarSize(ids.Reference(0x7674cfd19b9031caul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(MixedEntity v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedEntityBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void MixedEntityWriteBodyTyped(ref TableWire.Writer w, MixedEntity v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = MixedEntityTableType().Fields;
+            if (v.EntityId != 0)
+            {
+                w.Header(ids.Reference(0x23fcfd6678e36712ul), 7);
+                w.Fixed((ulong)v.EntityId, 2);
+            }
+            if (v.PosX != 0)
+            {
+                w.Header(ids.Reference(0xcb4b37357667310eul), 4);
+                w.Fixed((ulong)(long)v.PosX, 4);
+            }
+            if (v.PosY != 0)
+            {
+                w.Header(ids.Reference(0xcb4b3835766732c1ul), 4);
+                w.Fixed((ulong)(long)v.PosY, 4);
+            }
+            if (v.PosZ != 0)
+            {
+                w.Header(ids.Reference(0xcb4b353576672da8ul), 4);
+                w.Fixed((ulong)(long)v.PosZ, 4);
+            }
+            if (v.Yaw != 0)
+            {
+                w.Header(ids.Reference(0xb54d8e19798e16e8ul), 7);
+                w.Fixed((ulong)v.Yaw, 2);
+            }
+            if (v.Pitch != 0)
+            {
+                w.Header(ids.Reference(0x53a9f665a90cc1b1ul), 7);
+                w.Fixed((ulong)v.Pitch, 2);
+            }
+            if (v.VelX != 0)
+            {
+                w.Header(ids.Reference(0x6cede6b6eb60ee67ul), 4);
+                w.Fixed((ulong)(long)v.VelX, 4);
+            }
+            if (v.VelY != 0)
+            {
+                w.Header(ids.Reference(0x6cede5b6eb60ecb4ul), 4);
+                w.Fixed((ulong)(long)v.VelY, 4);
+            }
+            if (v.VelZ != 0)
+            {
+                w.Header(ids.Reference(0x6cede8b6eb60f1cdul), 4);
+                w.Fixed((ulong)(long)v.VelZ, 4);
+            }
+            if (v.Health != 0)
+            {
+                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 4);
+                w.Fixed((ulong)(long)v.Health, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[10], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
+            if (v.Moving != false)
+            {
+                w.Header(ids.Reference(0x11a44fc1d1243da7ul), 1);
+                w.Fixed(v.Moving ? 1ul : 0ul, 1);
+            }
+            if (v.Firing != false)
+            {
+                w.Header(ids.Reference(0x7674cfd19b9031caul), 1);
+                w.Fixed(v.Firing ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, MixedEntity v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedEntityWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long MixedEntitySaveTyped(MixedEntity value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = MixedEntityTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!MixedEntityCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + MixedEntityBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            MixedEntityWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(MixedEntity value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedEntitySaveTyped(value, buffer, vocabulary, measure);
+
         public static long MixedEntityMeasure(MixedEntity value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedEntityTableType(), Span<byte>.Empty, ids, true);
+            return MixedEntitySaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long MixedEntitySave(MixedEntity value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedEntityTableType(), buffer, ids, false);
+            return MixedEntitySaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict MixedEntityLoadVerdict(MixedEntity value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -4915,16 +5097,81 @@ namespace Bench
             value.Delta = 0;
         }
 
+        public static bool MixedStatCollectTyped(MixedStat v, ref TableWire.Ids ids)
+        {
+            if (v.StatId != 0 && !ids.Add(0x80ab75f0866dbf65ul)) return false;
+            if (v.Delta != 0 && !ids.Add(0x52076675ec13a0c1ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(MixedStat v, ref TableWire.Ids ids) => MixedStatCollectTyped(v, ref ids);
+
+        public static long MixedStatBodySizeTyped(MixedStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.StatId != 0) { n += TableWire.VarSize(ids.Reference(0x80ab75f0866dbf65ul)) + 2; }
+            if (v.Delta != 0) { n += TableWire.VarSize(ids.Reference(0x52076675ec13a0c1ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(MixedStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedStatBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void MixedStatWriteBodyTyped(ref TableWire.Writer w, MixedStat v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.StatId != 0)
+            {
+                w.Header(ids.Reference(0x80ab75f0866dbf65ul), 6);
+                w.Fixed((ulong)v.StatId, 1);
+            }
+            if (v.Delta != 0)
+            {
+                w.Header(ids.Reference(0x52076675ec13a0c1ul), 4);
+                w.Fixed((ulong)(long)v.Delta, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, MixedStat v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedStatWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long MixedStatSaveTyped(MixedStat value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = MixedStatTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!MixedStatCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + MixedStatBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            MixedStatWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(MixedStat value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedStatSaveTyped(value, buffer, vocabulary, measure);
+
         public static long MixedStatMeasure(MixedStat value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedStatTableType(), Span<byte>.Empty, ids, true);
+            return MixedStatSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long MixedStatSave(MixedStat value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedStatTableType(), buffer, ids, false);
+            return MixedStatSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict MixedStatLoadVerdict(MixedStat value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -4954,16 +5201,95 @@ namespace Bench
             value.Crit = false;
         }
 
+        public static bool MixedHitEventCollectTyped(MixedHitEvent v, ref TableWire.Ids ids)
+        {
+            if (v.TargetId != 0 && !ids.Add(0xb7bc9ac015a25050ul)) return false;
+            if (v.Damage != 0 && !ids.Add(0x7f6308be8ab37fc0ul)) return false;
+            if (v.HitKind != 0 && !ids.Add(0x01fbc365b059b925ul)) return false;
+            if (v.Crit != false && !ids.Add(0x126167908c9aa52dul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(MixedHitEvent v, ref TableWire.Ids ids) => MixedHitEventCollectTyped(v, ref ids);
+
+        public static long MixedHitEventBodySizeTyped(MixedHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.TargetId != 0) { n += TableWire.VarSize(ids.Reference(0xb7bc9ac015a25050ul)) + 3; }
+            if (v.Damage != 0) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.HitKind != 0) { n += TableWire.VarSize(ids.Reference(0x01fbc365b059b925ul)) + 5; }
+            if (v.Crit != false) { n += TableWire.VarSize(ids.Reference(0x126167908c9aa52dul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(MixedHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedHitEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void MixedHitEventWriteBodyTyped(ref TableWire.Writer w, MixedHitEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.TargetId != 0)
+            {
+                w.Header(ids.Reference(0xb7bc9ac015a25050ul), 7);
+                w.Fixed((ulong)v.TargetId, 2);
+            }
+            if (v.Damage != 0)
+            {
+                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 4);
+                w.Fixed((ulong)(long)v.Damage, 4);
+            }
+            if (v.HitKind != 0)
+            {
+                w.Header(ids.Reference(0x01fbc365b059b925ul), 4);
+                w.Fixed((ulong)(long)v.HitKind, 4);
+            }
+            if (v.Crit != false)
+            {
+                w.Header(ids.Reference(0x126167908c9aa52dul), 1);
+                w.Fixed(v.Crit ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, MixedHitEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedHitEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long MixedHitEventSaveTyped(MixedHitEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = MixedHitEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!MixedHitEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + MixedHitEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            MixedHitEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(MixedHitEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedHitEventSaveTyped(value, buffer, vocabulary, measure);
+
         public static long MixedHitEventMeasure(MixedHitEvent value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedHitEventTableType(), Span<byte>.Empty, ids, true);
+            return MixedHitEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long MixedHitEventSave(MixedHitEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedHitEventTableType(), buffer, ids, false);
+            return MixedHitEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict MixedHitEventLoadVerdict(MixedHitEvent value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -4991,16 +5317,81 @@ namespace Bench
             value.Speaker = 0;
         }
 
+        public static bool MixedChatEventCollectTyped(MixedChatEvent v, ref TableWire.Ids ids)
+        {
+            if (v.Channel != 0 && !ids.Add(0xa5013e9ad5caeda4ul)) return false;
+            if (v.Speaker != 0 && !ids.Add(0xfbf1ac4d96ebd022ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(MixedChatEvent v, ref TableWire.Ids ids) => MixedChatEventCollectTyped(v, ref ids);
+
+        public static long MixedChatEventBodySizeTyped(MixedChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 5; }
+            if (v.Speaker != 0) { n += TableWire.VarSize(ids.Reference(0xfbf1ac4d96ebd022ul)) + 3; }
+            return n;
+        }
+
+        public static long BodySizeTyped(MixedChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedChatEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void MixedChatEventWriteBodyTyped(ref TableWire.Writer w, MixedChatEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Channel != 0)
+            {
+                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 4);
+                w.Fixed((ulong)(long)v.Channel, 4);
+            }
+            if (v.Speaker != 0)
+            {
+                w.Header(ids.Reference(0xfbf1ac4d96ebd022ul), 7);
+                w.Fixed((ulong)v.Speaker, 2);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, MixedChatEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedChatEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long MixedChatEventSaveTyped(MixedChatEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = MixedChatEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!MixedChatEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + MixedChatEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            MixedChatEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(MixedChatEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedChatEventSaveTyped(value, buffer, vocabulary, measure);
+
         public static long MixedChatEventMeasure(MixedChatEvent value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedChatEventTableType(), Span<byte>.Empty, ids, true);
+            return MixedChatEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long MixedChatEventSave(MixedChatEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedChatEventTableType(), buffer, ids, false);
+            return MixedChatEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict MixedChatEventLoadVerdict(MixedChatEvent value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5028,16 +5419,81 @@ namespace Bench
             value.Amount = 0;
         }
 
+        public static bool MixedPickupEventCollectTyped(MixedPickupEvent v, ref TableWire.Ids ids)
+        {
+            if (v.ItemId != 0 && !ids.Add(0x9e7fd06d864fbd56ul)) return false;
+            if (v.Amount != 0 && !ids.Add(0x8113fe7ea2b16969ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(MixedPickupEvent v, ref TableWire.Ids ids) => MixedPickupEventCollectTyped(v, ref ids);
+
+        public static long MixedPickupEventBodySizeTyped(MixedPickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.ItemId != 0) { n += TableWire.VarSize(ids.Reference(0x9e7fd06d864fbd56ul)) + 3; }
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(MixedPickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => MixedPickupEventBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void MixedPickupEventWriteBodyTyped(ref TableWire.Writer w, MixedPickupEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.ItemId != 0)
+            {
+                w.Header(ids.Reference(0x9e7fd06d864fbd56ul), 7);
+                w.Fixed((ulong)v.ItemId, 2);
+            }
+            if (v.Amount != 0)
+            {
+                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.Fixed((ulong)(long)v.Amount, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, MixedPickupEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => MixedPickupEventWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long MixedPickupEventSaveTyped(MixedPickupEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = MixedPickupEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!MixedPickupEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + MixedPickupEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            MixedPickupEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(MixedPickupEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => MixedPickupEventSaveTyped(value, buffer, vocabulary, measure);
+
         public static long MixedPickupEventMeasure(MixedPickupEvent value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedPickupEventTableType(), Span<byte>.Empty, ids, true);
+            return MixedPickupEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long MixedPickupEventSave(MixedPickupEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, MixedPickupEventTableType(), buffer, ids, false);
+            return MixedPickupEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict MixedPickupEventLoadVerdict(MixedPickupEvent value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5100,16 +5556,253 @@ namespace Bench
             value.IdleTicks = 0;
         }
 
+        public static bool BenchMixedCollectTyped(BenchMixed v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = BenchMixedTableType().Fields;
+            if (v.Sequence != 0 && !ids.Add(0xaa38aca481f528a8ul)) return false;
+            if (v.AckSequence != 0 && !ids.Add(0x0dbe005c56697c3eul)) return false;
+            if (v.AckBits != 0 && !ids.Add(0x9bae0da8b829ee03ul)) return false;
+            if (v.SessionId != 0 && !ids.Add(0xb7d7b5650a590b05ul)) return false;
+            if (v.ClientId != 0 && !ids.Add(0x6d7b98e2d095967eul)) return false;
+            if (v.Nonce != 0 && !ids.Add(0x73a94c71d60dc0d8ul)) return false;
+            if (v.WorldTime != 0 && !ids.Add(0x3eee6b51be54fc85ul)) return false;
+            if (v.FrameTick != 0 && !ids.Add(0x7bbc035f7b6d0112ul)) return false;
+            if (!TableWire.CollectField(v, fields[8], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[9], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[11], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[12], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[13], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[14], ref ids)) return false;
+            if (v.AimX != 0.0f && !ids.Add(0xdbaf7be5e24296c9ul)) return false;
+            if (v.AimY != 0.0f && !ids.Add(0xdbaf7ae5e2429516ul)) return false;
+            if (v.AimZ != 0.0f && !ids.Add(0xdbaf79e5e2429363ul)) return false;
+            if (v.Recoil != 0.0f && !ids.Add(0x9cef31fff7e2e457ul)) return false;
+            if (v.Drift != 0.0 && !ids.Add(0x5ab3f9c9341f6c04ul)) return false;
+            if (!TableWire.CollectField(v, fields[20], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[21], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[22], ref ids)) return false;
+            if (v.CrcHint != 0 && !ids.Add(0x560d6527ccd8515ful)) return false;
+            if (v.HasExtra != true && !ids.Add(0xc08292176cfd8672ul)) return false;
+            if (!TableWire.CollectField(v, fields[25], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[26], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(BenchMixed v, ref TableWire.Ids ids) => BenchMixedCollectTyped(v, ref ids);
+
+        public static long BenchMixedBodySizeTyped(BenchMixed v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = BenchMixedTableType().Fields;
+            int elemOffset = 0;
+            if (v.Sequence != 0) { n += TableWire.VarSize(ids.Reference(0xaa38aca481f528a8ul)) + 3; }
+            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.Reference(0x0dbe005c56697c3eul)) + 5; }
+            if (v.AckBits != 0) { n += TableWire.VarSize(ids.Reference(0x9bae0da8b829ee03ul)) + 5; }
+            if (v.SessionId != 0) { n += TableWire.VarSize(ids.Reference(0xb7d7b5650a590b05ul)) + 9; }
+            if (v.ClientId != 0) { n += TableWire.VarSize(ids.Reference(0x6d7b98e2d095967eul)) + 5; }
+            if (v.Nonce != 0) { n += TableWire.VarSize(ids.Reference(0x73a94c71d60dc0d8ul)) + 9; }
+            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.Reference(0x3eee6b51be54fc85ul)) + 9; }
+            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.Reference(0x7bbc035f7b6d0112ul)) + 9; }
+            n += TableWire.BodySizeField(v, fields[8], ref ids);
+            scoped Span<long> elemCache_9 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[9]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_9 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[9], ref ids, elemCache_9, out long payload_9);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[9] = payload_9; }
+            scoped Span<long> elemCache_10 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[10]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[10], ref ids, elemCache_10, out long payload_10);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
+            n += TableWire.BodySizeField(v, fields[11], ref ids);
+            n += TableWire.BodySizeField(v, fields[12], ref ids, default, out long payload_12);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[12] = payload_12; }
+            n += TableWire.BodySizeField(v, fields[13], ref ids, default, out long payload_13);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[13] = payload_13; }
+            n += TableWire.BodySizeField(v, fields[14], ref ids);
+            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7be5e24296c9ul)) + 5; }
+            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7ae5e2429516ul)) + 5; }
+            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf79e5e2429363ul)) + 5; }
+            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.Reference(0x9cef31fff7e2e457ul)) + 5; }
+            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.Reference(0x5ab3f9c9341f6c04ul)) + 9; }
+            n += TableWire.BodySizeField(v, fields[20], ref ids);
+            n += TableWire.BodySizeField(v, fields[21], ref ids);
+            n += TableWire.BodySizeField(v, fields[22], ref ids);
+            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.Reference(0x560d6527ccd8515ful)) + 5; }
+            if (v.HasExtra != true) { n += TableWire.VarSize(ids.Reference(0xc08292176cfd8672ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[25], ref ids);
+            n += TableWire.BodySizeField(v, fields[26], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(BenchMixed v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => BenchMixedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void BenchMixedWriteBodyTyped(ref TableWire.Writer w, BenchMixed v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = BenchMixedTableType().Fields;
+            int elemOffset = 0;
+            if (v.Sequence != 0)
+            {
+                w.Header(ids.Reference(0xaa38aca481f528a8ul), 7);
+                w.Fixed((ulong)v.Sequence, 2);
+            }
+            if (v.AckSequence != 0)
+            {
+                w.Header(ids.Reference(0x0dbe005c56697c3eul), 4);
+                w.Fixed((ulong)(long)v.AckSequence, 4);
+            }
+            if (v.AckBits != 0)
+            {
+                w.Header(ids.Reference(0x9bae0da8b829ee03ul), 8);
+                w.Fixed((ulong)v.AckBits, 4);
+            }
+            if (v.SessionId != 0)
+            {
+                w.Header(ids.Reference(0xb7d7b5650a590b05ul), 9);
+                w.Fixed((ulong)v.SessionId, 8);
+            }
+            if (v.ClientId != 0)
+            {
+                w.Header(ids.Reference(0x6d7b98e2d095967eul), 8);
+                w.Fixed((ulong)v.ClientId, 4);
+            }
+            if (v.Nonce != 0)
+            {
+                w.Header(ids.Reference(0x73a94c71d60dc0d8ul), 9);
+                w.Fixed((ulong)v.Nonce, 8);
+            }
+            if (v.WorldTime != 0)
+            {
+                w.Header(ids.Reference(0x3eee6b51be54fc85ul), 5);
+                w.Fixed((ulong)(long)v.WorldTime, 8);
+            }
+            if (v.FrameTick != 0)
+            {
+                w.Header(ids.Reference(0x7bbc035f7b6d0112ul), 9);
+                w.Fixed((ulong)v.FrameTick, 8);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[8], ref ids);
+            scoped ReadOnlySpan<long> elemCache_9 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[9]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_9 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_9 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[9] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[9], ref ids, elemCache_9, payload_9);
+            scoped ReadOnlySpan<long> elemCache_10 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[10]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[10], ref ids, elemCache_10, payload_10);
+            TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
+            long payload_12 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[12] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[12], ref ids, default, payload_12);
+            long payload_13 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[13] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[13], ref ids, default, payload_13);
+            TableWire.WriteBodyField(ref w, v, fields[14], ref ids);
+            if (v.AimX != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf7be5e24296c9ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimX)), 4);
+            }
+            if (v.AimY != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf7ae5e2429516ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimY)), 4);
+            }
+            if (v.AimZ != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf79e5e2429363ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimZ)), 4);
+            }
+            if (v.Recoil != 0.0f)
+            {
+                w.Header(ids.Reference(0x9cef31fff7e2e457ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Recoil)), 4);
+            }
+            if (v.Drift != 0.0)
+            {
+                w.Header(ids.Reference(0x5ab3f9c9341f6c04ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Drift)), 8);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[20], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[21], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[22], ref ids);
+            if (v.CrcHint != 0)
+            {
+                w.Header(ids.Reference(0x560d6527ccd8515ful), 8);
+                w.Fixed((ulong)v.CrcHint, 4);
+            }
+            if (v.HasExtra != true)
+            {
+                w.Header(ids.Reference(0xc08292176cfd8672ul), 1);
+                w.Fixed(v.HasExtra ? 1ul : 0ul, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[25], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[26], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, BenchMixed v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => BenchMixedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long BenchMixedSaveTyped(BenchMixed value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = BenchMixedTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!BenchMixedCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + BenchMixedBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            BenchMixedWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(BenchMixed value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => BenchMixedSaveTyped(value, buffer, vocabulary, measure);
+
         public static long BenchMixedMeasure(BenchMixed value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, BenchMixedTableType(), Span<byte>.Empty, ids, true);
+            return BenchMixedSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long BenchMixedSave(BenchMixed value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, BenchMixedTableType(), buffer, ids, false);
+            return BenchMixedSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict BenchMixedLoadVerdict(BenchMixed value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -5569,7 +5569,16 @@ namespace Bench
             if (v.FrameTick != 0 && !ids.Add(0x7bbc035f7b6d0112ul)) return false;
             if (!TableWire.CollectField(v, fields[8], ref ids)) return false;
             if (!TableWire.CollectField(v, fields[9], ref ids)) return false;
-            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            int count_10 = v.StatsCount;
+            if (count_10 < 0 || count_10 > 80) return false;
+            if (count_10 > 0)
+            {
+                if (!ids.Add(0xee639cad45b1994cul)) return false;
+                for (int i_10 = 0; i_10 < count_10; i_10++)
+                {
+                    if (!MixedStatCollectTyped(v.Stats[i_10], ref ids)) return false;
+                }
+            }
             if (!TableWire.CollectField(v, fields[11], ref ids)) return false;
             if (!TableWire.CollectField(v, fields[12], ref ids)) return false;
             if (!TableWire.CollectField(v, fields[13], ref ids)) return false;
@@ -5615,16 +5624,27 @@ namespace Bench
             }
             n += TableWire.BodySizeField(v, fields[9], ref ids, elemCache_9, out long payload_9);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[9] = payload_9; }
-            scoped Span<long> elemCache_10 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_10 = v.StatsCount;
+            if (count_10 > 0)
             {
-                int c = TableWire.Count(v, fields[10]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                scoped Span<long> elemCache_10 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_10, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long nChild_10 = 0;
+                for (int i_10 = 0; i_10 < count_10; i_10++)
+                {
+                    long childBody = MixedStatBodySizeTyped(v.Stats[i_10], ref ids);
+                    if (!elemCache_10.IsEmpty && i_10 < elemCache_10.Length) { elemCache_10[i_10] = childBody; }
+                    nChild_10 += TableWire.VarSize((ulong)childBody) + childBody;
+                }
+                long payload_10 = 1 + TableWire.VarSize((ulong)count_10) + nChild_10;
+                n += TableWire.VarSize(ids.Reference(0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_10) + payload_10;
+                if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
             }
-            n += TableWire.BodySizeField(v, fields[10], ref ids, elemCache_10, out long payload_10);
-            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
             n += TableWire.BodySizeField(v, fields[11], ref ids);
             n += TableWire.BodySizeField(v, fields[12], ref ids, default, out long payload_12);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[12] = payload_12; }
@@ -5703,16 +5723,38 @@ namespace Bench
             }
             long payload_9 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[9] : -1;
             TableWire.WriteBodyField(ref w, v, fields[9], ref ids, elemCache_9, payload_9);
-            scoped ReadOnlySpan<long> elemCache_10 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_10 = v.StatsCount;
+            if (count_10 > 0)
             {
-                int c = TableWire.Count(v, fields[10]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                w.Header(ids.Reference(0xee639cad45b1994cul), 14);
+                scoped ReadOnlySpan<long> elemCache_10 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_10, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
+                if (payload_10 < 0)
+                {
+                    long nChild_10 = 0;
+                    for (int i_10 = 0; i_10 < count_10; i_10++)
+                    {
+                        long childBody = (!elemCache_10.IsEmpty && i_10 < elemCache_10.Length) ? elemCache_10[i_10] : MixedStatBodySizeTyped(v.Stats[i_10], ref ids);
+                        nChild_10 += TableWire.VarSize((ulong)childBody) + childBody;
+                    }
+                    payload_10 = 1 + TableWire.VarSize((ulong)count_10) + nChild_10;
+                }
+                w.Var((ulong)payload_10);
+                w.Byte(13);
+                w.Var((ulong)count_10);
+                for (int i_10 = 0; i_10 < count_10; i_10++)
+                {
+                    long childBody = (!elemCache_10.IsEmpty && i_10 < elemCache_10.Length) ? elemCache_10[i_10] : MixedStatBodySizeTyped(v.Stats[i_10], ref ids);
+                    w.Var((ulong)childBody);
+                    MixedStatWriteBodyTyped(ref w, v.Stats[i_10], ref ids);
+                }
             }
-            long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
-            TableWire.WriteBodyField(ref w, v, fields[10], ref ids, elemCache_10, payload_10);
             TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
             long payload_12 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[12] : -1;
             TableWire.WriteBodyField(ref w, v, fields[12], ref ids, default, payload_12);

--- a/generated/bench/paired/cs/FixedTableTable.cs
+++ b/generated/bench/paired/cs/FixedTableTable.cs
@@ -30,16 +30,75 @@ namespace Bench
             TableReset(value.Value);
         }
 
+        public static bool FixedTableCollectTyped(FixedTable v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = FixedTableTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(FixedTable v, ref TableWire.Ids ids) => FixedTableCollectTyped(v, ref ids);
+
+        public static long FixedTableBodySizeTyped(FixedTable v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = FixedTableTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            return n;
+        }
+
+        public static long BodySizeTyped(FixedTable v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => FixedTableBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void FixedTableWriteBodyTyped(ref TableWire.Writer w, FixedTable v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = FixedTableTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, FixedTable v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => FixedTableWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long FixedTableSaveTyped(FixedTable value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = FixedTableTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!FixedTableCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + FixedTableBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            FixedTableWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(FixedTable value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => FixedTableSaveTyped(value, buffer, vocabulary, measure);
+
         public static long FixedTableMeasure(FixedTable value)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, FixedTableTableType(), Span<byte>.Empty, ids, true);
+            return FixedTableSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long FixedTableSave(FixedTable value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[79];
-            return TableWire.Save(value, FixedTableTableType(), buffer, ids, false);
+            return FixedTableSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict FixedTableLoadVerdict(FixedTable value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/generated/bench/paired/cs/FixedTableTable.cs
+++ b/generated/bench/paired/cs/FixedTableTable.cs
@@ -37,8 +37,6 @@ namespace Bench
             return true;
         }
 
-        public static bool CollectTyped(FixedTable v, ref TableWire.Ids ids) => FixedTableCollectTyped(v, ref ids);
-
         public static long FixedTableBodySizeTyped(FixedTable v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -48,8 +46,6 @@ namespace Bench
             return n;
         }
 
-        public static long BodySizeTyped(FixedTable v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => FixedTableBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void FixedTableWriteBodyTyped(ref TableWire.Writer w, FixedTable v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = FixedTableTableType().Fields;
@@ -57,8 +53,6 @@ namespace Bench
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, FixedTable v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => FixedTableWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long FixedTableSaveTyped(FixedTable value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -86,8 +80,6 @@ namespace Bench
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(FixedTable value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => FixedTableSaveTyped(value, buffer, vocabulary, measure);
 
         public static long FixedTableMeasure(FixedTable value)
         {

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -2613,12 +2613,12 @@ namespace Benchtable
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2652,7 +2652,7 @@ namespace Benchtable
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4108,7 +4108,7 @@ namespace Benchtable
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4145,7 +4145,7 @@ namespace Benchtable
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4365,6 +4365,44 @@ namespace Benchtable
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {
@@ -4962,16 +5000,152 @@ namespace Benchtable
             value.Firing = false;
         }
 
+        public static bool TableEntityCollectTyped(TableEntity v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = TableEntityTableType().Fields;
+            if (v.EntityId != 0 && !ids.Add(0x23fcfd6678e36712ul)) return false;
+            if (v.PosX != 0 && !ids.Add(0xcb4b37357667310eul)) return false;
+            if (v.PosY != 0 && !ids.Add(0xcb4b3835766732c1ul)) return false;
+            if (v.PosZ != 0 && !ids.Add(0xcb4b353576672da8ul)) return false;
+            if (v.Yaw != 0 && !ids.Add(0xb54d8e19798e16e8ul)) return false;
+            if (v.Pitch != 0 && !ids.Add(0x53a9f665a90cc1b1ul)) return false;
+            if (v.VelX != 0 && !ids.Add(0x6cede6b6eb60ee67ul)) return false;
+            if (v.VelY != 0 && !ids.Add(0x6cede5b6eb60ecb4ul)) return false;
+            if (v.VelZ != 0 && !ids.Add(0x6cede8b6eb60f1cdul)) return false;
+            if (v.Health != 0 && !ids.Add(0x7f69d4b5288ba9cful)) return false;
+            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[11], ref ids)) return false;
+            if (v.Moving != false && !ids.Add(0x11a44fc1d1243da7ul)) return false;
+            if (v.Firing != false && !ids.Add(0x7674cfd19b9031caul)) return false;
+            return true;
+        }
+
+        public static long TableEntityBodySizeTyped(TableEntity v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = TableEntityTableType().Fields;
+            if (v.EntityId != 0) { n += TableWire.VarSize(ids.Reference(0x23fcfd6678e36712ul)) + 3; }
+            if (v.PosX != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b37357667310eul)) + 5; }
+            if (v.PosY != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b3835766732c1ul)) + 5; }
+            if (v.PosZ != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b353576672da8ul)) + 5; }
+            if (v.Yaw != 0) { n += TableWire.VarSize(ids.Reference(0xb54d8e19798e16e8ul)) + 3; }
+            if (v.Pitch != 0) { n += TableWire.VarSize(ids.Reference(0x53a9f665a90cc1b1ul)) + 3; }
+            if (v.VelX != 0) { n += TableWire.VarSize(ids.Reference(0x6cede6b6eb60ee67ul)) + 5; }
+            if (v.VelY != 0) { n += TableWire.VarSize(ids.Reference(0x6cede5b6eb60ecb4ul)) + 5; }
+            if (v.VelZ != 0) { n += TableWire.VarSize(ids.Reference(0x6cede8b6eb60f1cdul)) + 5; }
+            if (v.Health != 0) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            n += TableWire.BodySizeField(v, fields[10], ref ids);
+            n += TableWire.BodySizeField(v, fields[11], ref ids);
+            if (v.Moving != false) { n += TableWire.VarSize(ids.Reference(0x11a44fc1d1243da7ul)) + 2; }
+            if (v.Firing != false) { n += TableWire.VarSize(ids.Reference(0x7674cfd19b9031caul)) + 2; }
+            return n;
+        }
+
+        public static void TableEntityWriteBodyTyped(ref TableWire.Writer w, TableEntity v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = TableEntityTableType().Fields;
+            if (v.EntityId != 0)
+            {
+                w.Header(ids.Reference(0x23fcfd6678e36712ul), 7);
+                w.Fixed((ulong)v.EntityId, 2);
+            }
+            if (v.PosX != 0)
+            {
+                w.Header(ids.Reference(0xcb4b37357667310eul), 4);
+                w.Fixed((ulong)(long)v.PosX, 4);
+            }
+            if (v.PosY != 0)
+            {
+                w.Header(ids.Reference(0xcb4b3835766732c1ul), 4);
+                w.Fixed((ulong)(long)v.PosY, 4);
+            }
+            if (v.PosZ != 0)
+            {
+                w.Header(ids.Reference(0xcb4b353576672da8ul), 4);
+                w.Fixed((ulong)(long)v.PosZ, 4);
+            }
+            if (v.Yaw != 0)
+            {
+                w.Header(ids.Reference(0xb54d8e19798e16e8ul), 7);
+                w.Fixed((ulong)v.Yaw, 2);
+            }
+            if (v.Pitch != 0)
+            {
+                w.Header(ids.Reference(0x53a9f665a90cc1b1ul), 7);
+                w.Fixed((ulong)v.Pitch, 2);
+            }
+            if (v.VelX != 0)
+            {
+                w.Header(ids.Reference(0x6cede6b6eb60ee67ul), 4);
+                w.Fixed((ulong)(long)v.VelX, 4);
+            }
+            if (v.VelY != 0)
+            {
+                w.Header(ids.Reference(0x6cede5b6eb60ecb4ul), 4);
+                w.Fixed((ulong)(long)v.VelY, 4);
+            }
+            if (v.VelZ != 0)
+            {
+                w.Header(ids.Reference(0x6cede8b6eb60f1cdul), 4);
+                w.Fixed((ulong)(long)v.VelZ, 4);
+            }
+            if (v.Health != 0)
+            {
+                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 4);
+                w.Fixed((ulong)(long)v.Health, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[10], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
+            if (v.Moving != false)
+            {
+                w.Header(ids.Reference(0x11a44fc1d1243da7ul), 1);
+                w.Fixed(v.Moving ? 1ul : 0ul, 1);
+            }
+            if (v.Firing != false)
+            {
+                w.Header(ids.Reference(0x7674cfd19b9031caul), 1);
+                w.Fixed(v.Firing ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static long TableEntitySaveTyped(TableEntity value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TableEntityTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TableEntityCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TableEntityBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TableEntityWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TableEntityMeasure(TableEntity value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableEntityTableType(), Span<byte>.Empty, ids, true);
+            return TableEntitySaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TableEntitySave(TableEntity value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableEntityTableType(), buffer, ids, false);
+            return TableEntitySaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TableEntityLoadVerdict(TableEntity value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -4999,16 +5173,73 @@ namespace Benchtable
             value.Delta = 0;
         }
 
+        public static bool TableStatCollectTyped(TableStat v, ref TableWire.Ids ids)
+        {
+            if (v.StatId != 0 && !ids.Add(0x80ab75f0866dbf65ul)) return false;
+            if (v.Delta != 0 && !ids.Add(0x52076675ec13a0c1ul)) return false;
+            return true;
+        }
+
+        public static long TableStatBodySizeTyped(TableStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.StatId != 0) { n += TableWire.VarSize(ids.Reference(0x80ab75f0866dbf65ul)) + 2; }
+            if (v.Delta != 0) { n += TableWire.VarSize(ids.Reference(0x52076675ec13a0c1ul)) + 5; }
+            return n;
+        }
+
+        public static void TableStatWriteBodyTyped(ref TableWire.Writer w, TableStat v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.StatId != 0)
+            {
+                w.Header(ids.Reference(0x80ab75f0866dbf65ul), 6);
+                w.Fixed((ulong)v.StatId, 1);
+            }
+            if (v.Delta != 0)
+            {
+                w.Header(ids.Reference(0x52076675ec13a0c1ul), 4);
+                w.Fixed((ulong)(long)v.Delta, 4);
+            }
+            w.Var(0);
+        }
+
+        public static long TableStatSaveTyped(TableStat value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TableStatTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TableStatCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TableStatBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TableStatWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TableStatMeasure(TableStat value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableStatTableType(), Span<byte>.Empty, ids, true);
+            return TableStatSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TableStatSave(TableStat value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableStatTableType(), buffer, ids, false);
+            return TableStatSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TableStatLoadVerdict(TableStat value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5072,16 +5303,310 @@ namespace Benchtable
             value.IdleTicks = 0;
         }
 
+        public static bool TableMixedCollectTyped(TableMixed v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = TableMixedTableType().Fields;
+            if (v.ProtocolMagic != 0 && !ids.Add(0x6a5a70d91aa115fdul)) return false;
+            if (v.Sequence != 0 && !ids.Add(0xaa38aca481f528a8ul)) return false;
+            if (v.AckSequence != 0 && !ids.Add(0x0dbe005c56697c3eul)) return false;
+            if (v.AckBits != 0 && !ids.Add(0x9bae0da8b829ee03ul)) return false;
+            if (v.SessionId != 0 && !ids.Add(0xb7d7b5650a590b05ul)) return false;
+            if (v.ClientId != 0 && !ids.Add(0x6d7b98e2d095967eul)) return false;
+            if (v.Nonce != 1ul && !ids.Add(0x73a94c71d60dc0d8ul)) return false;
+            if (v.WorldTime != 0 && !ids.Add(0x3eee6b51be54fc85ul)) return false;
+            if (v.FrameTick != 0 && !ids.Add(0x7bbc035f7b6d0112ul)) return false;
+            if (v.ServerTime != 0.0f && !ids.Add(0x3c460475f9be69c6ul)) return false;
+            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            int count_11 = v.StatsCount;
+            if (count_11 < 0 || count_11 > 80) return false;
+            if (count_11 > 0)
+            {
+                if (!ids.Add(0xee639cad45b1994cul)) return false;
+                for (int i_11 = 0; i_11 < count_11; i_11++)
+                {
+                    if (!TableStatCollectTyped(v.Stats[i_11], ref ids)) return false;
+                }
+            }
+            if (!TableWire.CollectField(v, fields[12], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[13], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[14], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[15], ref ids)) return false;
+            if (v.AimX != 0.0f && !ids.Add(0xdbaf7be5e24296c9ul)) return false;
+            if (v.AimY != 0.0f && !ids.Add(0xdbaf7ae5e2429516ul)) return false;
+            if (v.AimZ != 0.0f && !ids.Add(0xdbaf79e5e2429363ul)) return false;
+            if (v.Recoil != 0.0f && !ids.Add(0x9cef31fff7e2e457ul)) return false;
+            if (v.Drift != 0.0 && !ids.Add(0x5ab3f9c9341f6c04ul)) return false;
+            if (v.WideKey != 0 && !ids.Add(0xa3348580461faf16ul)) return false;
+            if (v.Flux != 0 && !ids.Add(0xd61bdd7908af2642ul)) return false;
+            if (v.Ping != 0.0f && !ids.Add(0xbf30e00dc53307a9ul)) return false;
+            if (v.CrcHint != 0 && !ids.Add(0x560d6527ccd8515ful)) return false;
+            if (v.HasExtra != false && !ids.Add(0xc08292176cfd8672ul)) return false;
+            if (!TableWire.CollectField(v, fields[26], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[27], ref ids)) return false;
+            return true;
+        }
+
+        public static long TableMixedBodySizeTyped(TableMixed v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = TableMixedTableType().Fields;
+            int elemOffset = 0;
+            if (v.ProtocolMagic != 0) { n += TableWire.VarSize(ids.Reference(0x6a5a70d91aa115fdul)) + 3; }
+            if (v.Sequence != 0) { n += TableWire.VarSize(ids.Reference(0xaa38aca481f528a8ul)) + 3; }
+            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.Reference(0x0dbe005c56697c3eul)) + 5; }
+            if (v.AckBits != 0) { n += TableWire.VarSize(ids.Reference(0x9bae0da8b829ee03ul)) + 5; }
+            if (v.SessionId != 0) { n += TableWire.VarSize(ids.Reference(0xb7d7b5650a590b05ul)) + 9; }
+            if (v.ClientId != 0) { n += TableWire.VarSize(ids.Reference(0x6d7b98e2d095967eul)) + 5; }
+            if (v.Nonce != 1ul) { n += TableWire.VarSize(ids.Reference(0x73a94c71d60dc0d8ul)) + 9; }
+            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.Reference(0x3eee6b51be54fc85ul)) + 9; }
+            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.Reference(0x7bbc035f7b6d0112ul)) + 9; }
+            if (v.ServerTime != 0.0f) { n += TableWire.VarSize(ids.Reference(0x3c460475f9be69c6ul)) + 5; }
+            scoped Span<long> elemCache_10 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[10]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[10], ref ids, elemCache_10, out long payload_10);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
+            int count_11 = v.StatsCount;
+            if (count_11 > 0)
+            {
+                scoped Span<long> elemCache_11 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_11, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_11 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long nChild_11 = 0;
+                for (int i_11 = 0; i_11 < count_11; i_11++)
+                {
+                    long childBody = TableStatBodySizeTyped(v.Stats[i_11], ref ids);
+                    if (!elemCache_11.IsEmpty && i_11 < elemCache_11.Length) { elemCache_11[i_11] = childBody; }
+                    nChild_11 += TableWire.VarSize((ulong)childBody) + childBody;
+                }
+                long payload_11 = 1 + TableWire.VarSize((ulong)count_11) + nChild_11;
+                n += TableWire.VarSize(ids.Reference(0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_11) + payload_11;
+                if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[11] = payload_11; }
+            }
+            n += TableWire.BodySizeField(v, fields[12], ref ids);
+            n += TableWire.BodySizeField(v, fields[13], ref ids, default, out long payload_13);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[13] = payload_13; }
+            n += TableWire.BodySizeField(v, fields[14], ref ids, default, out long payload_14);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[14] = payload_14; }
+            n += TableWire.BodySizeField(v, fields[15], ref ids);
+            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7be5e24296c9ul)) + 5; }
+            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7ae5e2429516ul)) + 5; }
+            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf79e5e2429363ul)) + 5; }
+            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.Reference(0x9cef31fff7e2e457ul)) + 5; }
+            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.Reference(0x5ab3f9c9341f6c04ul)) + 9; }
+            if (v.WideKey != 0) { n += TableWire.VarSize(ids.Reference(0xa3348580461faf16ul)) + 9; }
+            if (v.Flux != 0) { n += TableWire.VarSize(ids.Reference(0xd61bdd7908af2642ul)) + 9; }
+            if (v.Ping != 0.0f) { n += TableWire.VarSize(ids.Reference(0xbf30e00dc53307a9ul)) + 5; }
+            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.Reference(0x560d6527ccd8515ful)) + 5; }
+            if (v.HasExtra != false) { n += TableWire.VarSize(ids.Reference(0xc08292176cfd8672ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[26], ref ids);
+            n += TableWire.BodySizeField(v, fields[27], ref ids);
+            return n;
+        }
+
+        public static void TableMixedWriteBodyTyped(ref TableWire.Writer w, TableMixed v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = TableMixedTableType().Fields;
+            int elemOffset = 0;
+            if (v.ProtocolMagic != 0)
+            {
+                w.Header(ids.Reference(0x6a5a70d91aa115fdul), 7);
+                w.Fixed((ulong)v.ProtocolMagic, 2);
+            }
+            if (v.Sequence != 0)
+            {
+                w.Header(ids.Reference(0xaa38aca481f528a8ul), 7);
+                w.Fixed((ulong)v.Sequence, 2);
+            }
+            if (v.AckSequence != 0)
+            {
+                w.Header(ids.Reference(0x0dbe005c56697c3eul), 4);
+                w.Fixed((ulong)(long)v.AckSequence, 4);
+            }
+            if (v.AckBits != 0)
+            {
+                w.Header(ids.Reference(0x9bae0da8b829ee03ul), 8);
+                w.Fixed((ulong)v.AckBits, 4);
+            }
+            if (v.SessionId != 0)
+            {
+                w.Header(ids.Reference(0xb7d7b5650a590b05ul), 9);
+                w.Fixed((ulong)v.SessionId, 8);
+            }
+            if (v.ClientId != 0)
+            {
+                w.Header(ids.Reference(0x6d7b98e2d095967eul), 8);
+                w.Fixed((ulong)v.ClientId, 4);
+            }
+            if (v.Nonce != 1ul)
+            {
+                w.Header(ids.Reference(0x73a94c71d60dc0d8ul), 9);
+                w.Fixed((ulong)v.Nonce, 8);
+            }
+            if (v.WorldTime != 0)
+            {
+                w.Header(ids.Reference(0x3eee6b51be54fc85ul), 5);
+                w.Fixed((ulong)(long)v.WorldTime, 8);
+            }
+            if (v.FrameTick != 0)
+            {
+                w.Header(ids.Reference(0x7bbc035f7b6d0112ul), 9);
+                w.Fixed((ulong)v.FrameTick, 8);
+            }
+            if (v.ServerTime != 0.0f)
+            {
+                w.Header(ids.Reference(0x3c460475f9be69c6ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.ServerTime)), 4);
+            }
+            scoped ReadOnlySpan<long> elemCache_10 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[10]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_10 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[10], ref ids, elemCache_10, payload_10);
+            int count_11 = v.StatsCount;
+            if (count_11 > 0)
+            {
+                w.Header(ids.Reference(0xee639cad45b1994cul), 14);
+                scoped ReadOnlySpan<long> elemCache_11 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_11, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_11 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long payload_11 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[11] : -1;
+                if (payload_11 < 0)
+                {
+                    long nChild_11 = 0;
+                    for (int i_11 = 0; i_11 < count_11; i_11++)
+                    {
+                        long childBody = (!elemCache_11.IsEmpty && i_11 < elemCache_11.Length) ? elemCache_11[i_11] : TableStatBodySizeTyped(v.Stats[i_11], ref ids);
+                        nChild_11 += TableWire.VarSize((ulong)childBody) + childBody;
+                    }
+                    payload_11 = 1 + TableWire.VarSize((ulong)count_11) + nChild_11;
+                }
+                w.Var((ulong)payload_11);
+                w.Byte(13);
+                w.Var((ulong)count_11);
+                for (int i_11 = 0; i_11 < count_11; i_11++)
+                {
+                    long childBody = (!elemCache_11.IsEmpty && i_11 < elemCache_11.Length) ? elemCache_11[i_11] : TableStatBodySizeTyped(v.Stats[i_11], ref ids);
+                    w.Var((ulong)childBody);
+                    TableStatWriteBodyTyped(ref w, v.Stats[i_11], ref ids);
+                }
+            }
+            TableWire.WriteBodyField(ref w, v, fields[12], ref ids);
+            long payload_13 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[13] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[13], ref ids, default, payload_13);
+            long payload_14 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[14] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[14], ref ids, default, payload_14);
+            TableWire.WriteBodyField(ref w, v, fields[15], ref ids);
+            if (v.AimX != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf7be5e24296c9ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimX)), 4);
+            }
+            if (v.AimY != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf7ae5e2429516ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimY)), 4);
+            }
+            if (v.AimZ != 0.0f)
+            {
+                w.Header(ids.Reference(0xdbaf79e5e2429363ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimZ)), 4);
+            }
+            if (v.Recoil != 0.0f)
+            {
+                w.Header(ids.Reference(0x9cef31fff7e2e457ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Recoil)), 4);
+            }
+            if (v.Drift != 0.0)
+            {
+                w.Header(ids.Reference(0x5ab3f9c9341f6c04ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Drift)), 8);
+            }
+            if (v.WideKey != 0)
+            {
+                w.Header(ids.Reference(0xa3348580461faf16ul), 9);
+                w.Fixed((ulong)v.WideKey, 8);
+            }
+            if (v.Flux != 0)
+            {
+                w.Header(ids.Reference(0xd61bdd7908af2642ul), 5);
+                w.Fixed((ulong)(long)v.Flux, 8);
+            }
+            if (v.Ping != 0.0f)
+            {
+                w.Header(ids.Reference(0xbf30e00dc53307a9ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Ping)), 4);
+            }
+            if (v.CrcHint != 0)
+            {
+                w.Header(ids.Reference(0x560d6527ccd8515ful), 8);
+                w.Fixed((ulong)v.CrcHint, 4);
+            }
+            if (v.HasExtra != false)
+            {
+                w.Header(ids.Reference(0xc08292176cfd8672ul), 1);
+                w.Fixed(v.HasExtra ? 1ul : 0ul, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[26], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[27], ref ids);
+            w.Var(0);
+        }
+
+        public static long TableMixedSaveTyped(TableMixed value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TableMixedTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TableMixedCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TableMixedBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TableMixedWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TableMixedMeasure(TableMixed value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableMixedTableType(), Span<byte>.Empty, ids, true);
+            return TableMixedSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TableMixedSave(TableMixed value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableMixedTableType(), buffer, ids, false);
+            return TableMixedSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TableMixedLoadVerdict(TableMixed value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5111,16 +5636,87 @@ namespace Benchtable
             value.Crit = false;
         }
 
+        public static bool TableHitEventCollectTyped(TableHitEvent v, ref TableWire.Ids ids)
+        {
+            if (v.TargetId != 0 && !ids.Add(0xb7bc9ac015a25050ul)) return false;
+            if (v.Damage != 0 && !ids.Add(0x7f6308be8ab37fc0ul)) return false;
+            if (v.HitKind != 0 && !ids.Add(0x01fbc365b059b925ul)) return false;
+            if (v.Crit != false && !ids.Add(0x126167908c9aa52dul)) return false;
+            return true;
+        }
+
+        public static long TableHitEventBodySizeTyped(TableHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.TargetId != 0) { n += TableWire.VarSize(ids.Reference(0xb7bc9ac015a25050ul)) + 3; }
+            if (v.Damage != 0) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.HitKind != 0) { n += TableWire.VarSize(ids.Reference(0x01fbc365b059b925ul)) + 5; }
+            if (v.Crit != false) { n += TableWire.VarSize(ids.Reference(0x126167908c9aa52dul)) + 2; }
+            return n;
+        }
+
+        public static void TableHitEventWriteBodyTyped(ref TableWire.Writer w, TableHitEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.TargetId != 0)
+            {
+                w.Header(ids.Reference(0xb7bc9ac015a25050ul), 7);
+                w.Fixed((ulong)v.TargetId, 2);
+            }
+            if (v.Damage != 0)
+            {
+                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 4);
+                w.Fixed((ulong)(long)v.Damage, 4);
+            }
+            if (v.HitKind != 0)
+            {
+                w.Header(ids.Reference(0x01fbc365b059b925ul), 4);
+                w.Fixed((ulong)(long)v.HitKind, 4);
+            }
+            if (v.Crit != false)
+            {
+                w.Header(ids.Reference(0x126167908c9aa52dul), 1);
+                w.Fixed(v.Crit ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static long TableHitEventSaveTyped(TableHitEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TableHitEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TableHitEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TableHitEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TableHitEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TableHitEventMeasure(TableHitEvent value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableHitEventTableType(), Span<byte>.Empty, ids, true);
+            return TableHitEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TableHitEventSave(TableHitEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableHitEventTableType(), buffer, ids, false);
+            return TableHitEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TableHitEventLoadVerdict(TableHitEvent value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5148,16 +5744,73 @@ namespace Benchtable
             value.Speaker = 0;
         }
 
+        public static bool TableChatEventCollectTyped(TableChatEvent v, ref TableWire.Ids ids)
+        {
+            if (v.Channel != 0 && !ids.Add(0xa5013e9ad5caeda4ul)) return false;
+            if (v.Speaker != 0 && !ids.Add(0xfbf1ac4d96ebd022ul)) return false;
+            return true;
+        }
+
+        public static long TableChatEventBodySizeTyped(TableChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 5; }
+            if (v.Speaker != 0) { n += TableWire.VarSize(ids.Reference(0xfbf1ac4d96ebd022ul)) + 3; }
+            return n;
+        }
+
+        public static void TableChatEventWriteBodyTyped(ref TableWire.Writer w, TableChatEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Channel != 0)
+            {
+                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 4);
+                w.Fixed((ulong)(long)v.Channel, 4);
+            }
+            if (v.Speaker != 0)
+            {
+                w.Header(ids.Reference(0xfbf1ac4d96ebd022ul), 7);
+                w.Fixed((ulong)v.Speaker, 2);
+            }
+            w.Var(0);
+        }
+
+        public static long TableChatEventSaveTyped(TableChatEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TableChatEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TableChatEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TableChatEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TableChatEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TableChatEventMeasure(TableChatEvent value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableChatEventTableType(), Span<byte>.Empty, ids, true);
+            return TableChatEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TableChatEventSave(TableChatEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TableChatEventTableType(), buffer, ids, false);
+            return TableChatEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TableChatEventLoadVerdict(TableChatEvent value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -5185,16 +5838,73 @@ namespace Benchtable
             value.Amount = 0;
         }
 
+        public static bool TablePickupEventCollectTyped(TablePickupEvent v, ref TableWire.Ids ids)
+        {
+            if (v.ItemId != 0 && !ids.Add(0x9e7fd06d864fbd56ul)) return false;
+            if (v.Amount != 0 && !ids.Add(0x8113fe7ea2b16969ul)) return false;
+            return true;
+        }
+
+        public static long TablePickupEventBodySizeTyped(TablePickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.ItemId != 0) { n += TableWire.VarSize(ids.Reference(0x9e7fd06d864fbd56ul)) + 3; }
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            return n;
+        }
+
+        public static void TablePickupEventWriteBodyTyped(ref TableWire.Writer w, TablePickupEvent v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.ItemId != 0)
+            {
+                w.Header(ids.Reference(0x9e7fd06d864fbd56ul), 7);
+                w.Fixed((ulong)v.ItemId, 2);
+            }
+            if (v.Amount != 0)
+            {
+                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.Fixed((ulong)(long)v.Amount, 4);
+            }
+            w.Var(0);
+        }
+
+        public static long TablePickupEventSaveTyped(TablePickupEvent value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TablePickupEventTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TablePickupEventCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TablePickupEventBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TablePickupEventWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
         public static long TablePickupEventMeasure(TablePickupEvent value)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TablePickupEventTableType(), Span<byte>.Empty, ids, true);
+            return TablePickupEventSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TablePickupEventSave(TablePickupEvent value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[78];
-            return TableWire.Save(value, TablePickupEventTableType(), buffer, ids, false);
+            return TablePickupEventSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TablePickupEventLoadVerdict(TablePickupEvent value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/internal/codegen/cstable/cstable_test.go
+++ b/internal/codegen/cstable/cstable_test.go
@@ -1,0 +1,150 @@
+package cstable
+
+import (
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func TestIsChildScalarArray(t *testing.T) {
+	leafStruct := &ir.Struct{
+		Name: "Leaf",
+		Fields: []*ir.Field{
+			{Name: "value", Type: ir.FieldType{Kind: ir.TInt, Width: 32}},
+		},
+	}
+	nonLeafStruct := &ir.Struct{
+		Name: "NonLeaf",
+		Fields: []*ir.Field{
+			{Name: "text", Type: ir.FieldType{Kind: ir.TString}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		field     *ir.Field
+		wantOk    bool
+		wantMatch *ir.Struct
+	}{
+		{
+			name: "normal fixed scalar array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk:    true,
+			wantMatch: leafStruct,
+		},
+		{
+			name: "normal counted scalar array",
+			field: &ir.Field{
+				Name:       "items",
+				Array:      ir.ArrayCounted,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk:    true,
+			wantMatch: leafStruct,
+		},
+		{
+			name: "guarded fixed scalar array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Guard:      "on",
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk: false,
+		},
+		{
+			name: "guarded counted scalar array",
+			field: &ir.Field{
+				Name:       "items",
+				Array:      ir.ArrayCounted,
+				ArrayBound: 4,
+				Guard:      "on",
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk: false,
+		},
+		{
+			name: "optional fixed scalar array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct, Optional: true},
+			},
+			wantOk: false,
+		},
+		{
+			name: "optional counted scalar array",
+			field: &ir.Field{
+				Name:       "items",
+				Array:      ir.ArrayCounted,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct, Optional: true},
+			},
+			wantOk: false,
+		},
+		{
+			name: "pointer scalar array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct, Pointer: true},
+			},
+			wantOk: false,
+		},
+		{
+			name: "keyed scalar array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				KeyEnum:    "Slot",
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk: false,
+		},
+		{
+			name: "non-scalar leaf struct array",
+			field: &ir.Field{
+				Name:       "rows",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: nonLeafStruct},
+			},
+			wantOk: false,
+		},
+		{
+			name: "primitive array not TNamed",
+			field: &ir.Field{
+				Name:       "nums",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TInt, Width: 32},
+			},
+			wantOk: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, ok := isChildScalarArray(tc.field)
+			if ok != tc.wantOk {
+				t.Fatalf("isChildScalarArray() ok = %v, want %v", ok, tc.wantOk)
+			}
+			if tc.wantOk && st != tc.wantMatch {
+				t.Fatalf("isChildScalarArray() st = %v, want %v", st, tc.wantMatch)
+			}
+			if !tc.wantOk && st != nil {
+				t.Fatalf("isChildScalarArray() returned non-nil struct on failure: %v", st)
+			}
+		})
+	}
+}

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -41,7 +41,7 @@ func isChildScalarArray(f *ir.Field) (*ir.Struct, bool) {
 		return nil, false
 	}
 	st, ok := f.Type.Ref.(*ir.Struct)
-	if !ok || !st.IsTable {
+	if !ok {
 		return nil, false
 	}
 	if !isScalarLeafStruct(st) {

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -9,6 +9,286 @@ import (
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
+func isCleanScalarLeaf(f *ir.Field) bool {
+	if f.Array != ir.ArrayNone || f.Type.Optional || f.Guard != "" || f.IsMap() || f.IsList() || f.Type.Pointer {
+		return false
+	}
+	switch f.Type.Kind {
+	case ir.TBool, ir.TFloat32, ir.TFloat64:
+		return true
+	case ir.TInt:
+		return f.Type.Width <= 64
+	case ir.TBits:
+		return f.Type.Width <= 64
+	}
+	return false
+}
+
+func isScalarLeafStruct(st *ir.Struct) bool {
+	if st == nil || len(st.Fields) == 0 {
+		return false
+	}
+	for _, f := range st.Fields {
+		if !isCleanScalarLeaf(f) {
+			return false
+		}
+	}
+	return true
+}
+
+func isChildScalarArray(f *ir.Field) (*ir.Struct, bool) {
+	if f.Array == ir.ArrayNone || f.KeyEnum != "" || f.Type.Pointer || f.Type.Kind != ir.TNamed {
+		return nil, false
+	}
+	st, ok := f.Type.Ref.(*ir.Struct)
+	if !ok || !st.IsTable {
+		return nil, false
+	}
+	if !isScalarLeafStruct(st) {
+		return nil, false
+	}
+	return st, true
+}
+
+func needsElemOffset(st *ir.Struct) bool {
+	for _, f := range st.Fields {
+		if f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable {
+			return true
+		}
+	}
+	return false
+}
+
+func needsFieldsArray(st *ir.Struct) bool {
+	for _, f := range st.Fields {
+		if isCleanScalarLeaf(f) {
+			continue
+		}
+		if _, ok := isChildScalarArray(f); ok {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isPayloadPrefixed(f *ir.Field) bool {
+	kind := tableScalarKind(f)
+	return f.Array != ir.ArrayNone || kind == tkString || kind == 33 || kind == tkTable
+}
+
+func leafRideCondition(f *ir.Field) string {
+	def := fieldDefaultExpr(f)
+	prop := member(f)
+	return fmt.Sprintf("v.%s != %s", prop, def)
+}
+
+func (g *tableGen) emitCollectTyped(st *ir.Struct) {
+	name := st.Name
+	g.pf("public static bool %sCollectTyped(%s v, ref TableWire.Ids ids)\n{\n", name, name)
+	if needsFieldsArray(st) {
+		g.pf("    TableFieldInfo[] fields = %sTableType().Fields;\n", name)
+	}
+	for i, f := range st.Fields {
+		id := ir.TableFieldWireId(f)
+		if isCleanScalarLeaf(f) {
+			cond := leafRideCondition(f)
+			g.pf("    if (%s && !ids.Add(0x%016xul)) return false;\n", cond, id)
+		} else if childSt, ok := isChildScalarArray(f); ok {
+			prop := member(f)
+			childName := childSt.Name
+			if f.CountedOnWire() {
+				g.pf("    int count_%d = v.%sCount;\n", i, prop)
+				g.pf("    if (count_%d < 0 || count_%d > %d) return false;\n", i, i, f.ArrayBound)
+				g.pf("    if (count_%d > 0)\n    {\n", i)
+				g.pf("        if (!ids.Add(0x%016xul)) return false;\n", id)
+				g.pf("        for (int i_%d = 0; i_%d < count_%d; i_%d++)\n        {\n", i, i, i, i)
+				g.pf("            if (!%sCollectTyped(v.%s[i_%d], ref ids)) return false;\n", childName, prop, i)
+				g.pf("        }\n    }\n")
+			} else {
+				g.pf("    if (!ids.Add(0x%016xul)) return false;\n", id)
+				g.pf("    for (int i_%d = 0; i_%d < %d; i_%d++)\n    {\n", i, i, f.ArrayBound, i)
+				g.pf("        if (!%sCollectTyped(v.%s[i_%d], ref ids)) return false;\n", childName, prop, i)
+				g.pf("    }\n")
+			}
+		} else {
+			g.pf("    if (!TableWire.CollectField(v, fields[%d], ref ids)) return false;\n", i)
+		}
+	}
+	g.pf("    return true;\n}\n\n")
+	g.pf("public static bool CollectTyped(%s v, ref TableWire.Ids ids) => %sCollectTyped(v, ref ids);\n\n", name, name)
+}
+
+func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
+	name := st.Name
+	g.pf("public static long %sBodySizeTyped(%s v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)\n{\n", name, name)
+	g.pf("    long n = 1;\n")
+	if needsFieldsArray(st) {
+		g.pf("    TableFieldInfo[] fields = %sTableType().Fields;\n", name)
+	}
+	if needsElemOffset(st) {
+		g.pf("    int elemOffset = 0;\n")
+	}
+	for i, f := range st.Fields {
+		id := ir.TableFieldWireId(f)
+		if isCleanScalarLeaf(f) {
+			cond := leafRideCondition(f)
+			kind := tableScalarKind(f)
+			width := tableKindWidth(kind)
+			g.pf("    if (%s) { n += TableWire.VarSize(ids.Reference(0x%016xul)) + %d; }\n", cond, id, 1+width)
+		} else if childSt, ok := isChildScalarArray(f); ok {
+			prop := member(f)
+			childName := childSt.Name
+			if f.CountedOnWire() {
+				g.pf("    int count_%d = v.%sCount;\n", i, prop)
+				g.pf("    if (count_%d > 0)\n    {\n", i)
+			} else {
+				g.pf("    int count_%d = %d;\n    {\n", i, f.ArrayBound)
+			}
+			g.pf("        scoped Span<long> elemCache_%d = default;\n", i)
+			g.pf("        if (!rootElemSizes.IsEmpty)\n        {\n")
+			g.pf("            int take = System.Math.Min(count_%d, System.Math.Max(0, rootElemSizes.Length - elemOffset));\n", i)
+			g.pf("            elemCache_%d = rootElemSizes.Slice(elemOffset, take);\n", i)
+			g.pf("            elemOffset += take;\n        }\n")
+			g.pf("        long nChild_%d = 0;\n", i)
+			g.pf("        for (int i_%d = 0; i_%d < count_%d; i_%d++)\n        {\n", i, i, i, i)
+			g.pf("            long childBody = %sBodySizeTyped(v.%s[i_%d], ref ids);\n", childName, prop, i)
+			g.pf("            if (!elemCache_%d.IsEmpty && i_%d < elemCache_%d.Length) { elemCache_%d[i_%d] = childBody; }\n", i, i, i, i, i)
+			g.pf("            nChild_%d += TableWire.VarSize((ulong)childBody) + childBody;\n", i)
+			g.pf("        }\n")
+			g.pf("        long payload_%d = 1 + TableWire.VarSize((ulong)count_%d) + nChild_%d;\n", i, i, i)
+			g.pf("        n += TableWire.VarSize(ids.Reference(0x%016xul)) + 1 + TableWire.VarSize((ulong)payload_%d) + payload_%d;\n", id, i, i)
+			g.pf("        if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
+			g.pf("    }\n")
+		} else {
+			if f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable {
+				g.pf("    scoped Span<long> elemCache_%d = default;\n", i)
+				g.pf("    if (!rootElemSizes.IsEmpty)\n    {\n")
+				g.pf("        int c = TableWire.Count(v, fields[%d]);\n", i)
+				g.pf("        int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));\n")
+				g.pf("        elemCache_%d = rootElemSizes.Slice(elemOffset, take);\n", i)
+				g.pf("        elemOffset += take;\n    }\n")
+				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids, elemCache_%d, out long payload_%d);\n", i, i, i)
+				g.pf("    if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
+			} else if isPayloadPrefixed(f) {
+				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids, default, out long payload_%d);\n", i, i)
+				g.pf("    if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
+			} else {
+				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids);\n", i)
+			}
+		}
+	}
+	g.pf("    return n;\n}\n\n")
+	g.pf("public static long BodySizeTyped(%s v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => %sBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);\n\n", name, name)
+}
+
+func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
+	name := st.Name
+	g.pf("public static void %sWriteBodyTyped(ref TableWire.Writer w, %s v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)\n{\n", name, name)
+	if needsFieldsArray(st) {
+		g.pf("    TableFieldInfo[] fields = %sTableType().Fields;\n", name)
+	}
+	if needsElemOffset(st) {
+		g.pf("    int elemOffset = 0;\n")
+	}
+	for i, f := range st.Fields {
+		id := ir.TableFieldWireId(f)
+		if isCleanScalarLeaf(f) {
+			cond := leafRideCondition(f)
+			kind := tableScalarKind(f)
+			width := tableKindWidth(kind)
+			raw := csRawGet("v."+member(f), f.Type)
+			g.pf("    if (%s)\n    {\n", cond)
+			g.pf("        w.Header(ids.Reference(0x%016xul), %d);\n", id, kind)
+			g.pf("        w.Fixed(%s, %d);\n", raw, width)
+			g.pf("    }\n")
+		} else if childSt, ok := isChildScalarArray(f); ok {
+			prop := member(f)
+			childName := childSt.Name
+			if f.CountedOnWire() {
+				g.pf("    int count_%d = v.%sCount;\n", i, prop)
+				g.pf("    if (count_%d > 0)\n    {\n", i)
+			} else {
+				g.pf("    int count_%d = %d;\n    {\n", i, f.ArrayBound)
+			}
+			g.pf("        w.Header(ids.Reference(0x%016xul), 14);\n", id)
+			g.pf("        scoped ReadOnlySpan<long> elemCache_%d = default;\n", i)
+			g.pf("        if (!rootElemSizes.IsEmpty)\n        {\n")
+			g.pf("            int take = System.Math.Min(count_%d, System.Math.Max(0, rootElemSizes.Length - elemOffset));\n", i)
+			g.pf("            elemCache_%d = rootElemSizes.Slice(elemOffset, take);\n", i)
+			g.pf("            elemOffset += take;\n        }\n")
+			g.pf("        long payload_%d = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[%d] : -1;\n", i, i)
+			g.pf("        if (payload_%d < 0)\n        {\n", i)
+			g.pf("            long nChild_%d = 0;\n", i)
+			g.pf("            for (int i_%d = 0; i_%d < count_%d; i_%d++)\n            {\n", i, i, i, i)
+			g.pf("                long childBody = (!elemCache_%d.IsEmpty && i_%d < elemCache_%d.Length) ? elemCache_%d[i_%d] : %sBodySizeTyped(v.%s[i_%d], ref ids);\n", i, i, i, i, i, childName, prop, i)
+			g.pf("                nChild_%d += TableWire.VarSize((ulong)childBody) + childBody;\n            }\n", i)
+			g.pf("            payload_%d = 1 + TableWire.VarSize((ulong)count_%d) + nChild_%d;\n", i, i, i)
+			g.pf("        }\n")
+			g.pf("        w.Var((ulong)payload_%d);\n", i)
+			g.pf("        w.Byte(13);\n")
+			g.pf("        w.Var((ulong)count_%d);\n", i)
+			g.pf("        for (int i_%d = 0; i_%d < count_%d; i_%d++)\n        {\n", i, i, i, i)
+			g.pf("            long childBody = (!elemCache_%d.IsEmpty && i_%d < elemCache_%d.Length) ? elemCache_%d[i_%d] : %sBodySizeTyped(v.%s[i_%d], ref ids);\n", i, i, i, i, i, childName, prop, i)
+			g.pf("            w.Var((ulong)childBody);\n")
+			g.pf("            %sWriteBodyTyped(ref w, v.%s[i_%d], ref ids);\n", childName, prop, i)
+			g.pf("        }\n    }\n")
+		} else {
+			if f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable {
+				g.pf("    scoped ReadOnlySpan<long> elemCache_%d = default;\n", i)
+				g.pf("    if (!rootElemSizes.IsEmpty)\n    {\n")
+				g.pf("        int c = TableWire.Count(v, fields[%d]);\n", i)
+				g.pf("        int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));\n")
+				g.pf("        elemCache_%d = rootElemSizes.Slice(elemOffset, take);\n", i)
+				g.pf("        elemOffset += take;\n    }\n")
+				g.pf("    long payload_%d = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[%d] : -1;\n", i, i)
+				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids, elemCache_%d, payload_%d);\n", i, i, i)
+			} else if isPayloadPrefixed(f) {
+				g.pf("    long payload_%d = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[%d] : -1;\n", i, i)
+				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids, default, payload_%d);\n", i, i)
+			} else {
+				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids);\n", i)
+			}
+		}
+	}
+	g.pf("    w.Var(0);\n}\n\n")
+	g.pf("public static void WriteBodyTyped(ref TableWire.Writer w, %s v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => %sWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);\n\n", name, name)
+}
+
+func (g *tableGen) emitSaveTyped(st *ir.Struct) {
+	name := st.Name
+	g.pf("public static long %sSaveTyped(%s value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)\n{\n", name, name)
+	g.pf("    TableTypeInfo type = %sTableType();\n", name)
+	g.pf("    int slots = 0;\n")
+	g.pf("    if (vocabulary.Length <= 1024)\n    {\n")
+	g.pf("        slots = 1;\n")
+	g.pf("        while (slots < vocabulary.Length * 2) { slots <<= 1; }\n    }\n")
+	g.pf("    Span<int> index = stackalloc int[slots];\n")
+	g.pf("    TableWire.Ids ids = new TableWire.Ids(vocabulary, index);\n")
+	g.pf("    if (!%sCollectTyped(value, ref ids)) { return -1; }\n", name)
+	g.pf("    int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;\n")
+	g.pf("    Span<long> rootPayloadSizes = stackalloc long[cachedFields];\n")
+	g.pf("    int cachedElemSlots = !measure ? type.RootElemSlots : 0;\n")
+	g.pf("    Span<long> rootElemSizes = stackalloc long[cachedElemSlots];\n")
+	g.pf("    long n = 1 + %sBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;\n", name)
+	g.pf("    if (measure) { return n; }\n")
+	g.pf("    if (n > buffer.Length) { return -1; }\n")
+	g.pf("    scoped TableWire.Writer w = new TableWire.Writer(buffer);\n")
+	g.pf("    w.Byte(1);\n")
+	g.pf("    %sWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);\n", name)
+	g.pf("    for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }\n")
+	g.pf("    w.Fixed((ulong)ids.Count, 8);\n")
+	g.pf("    return w.Offset;\n}\n\n")
+	g.pf("public static long SaveTyped(%s value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => %sSaveTyped(value, buffer, vocabulary, measure);\n\n", name, name)
+}
+
+func (g *tableGen) emitTypedWireSurface(st *ir.Struct) {
+	g.emitCollectTyped(st)
+	g.emitBodySizeTyped(st)
+	g.emitWriteBodyTyped(st)
+	g.emitSaveTyped(st)
+}
+
 func (g *tableGen) emitWireSurface(st *ir.Struct) {
 	if st.IsMapEntry() {
 		return
@@ -18,8 +298,14 @@ func (g *tableGen) emitWireSurface(st *ir.Struct) {
 		g.pf("public static long %sLoadMeasure(ReadOnlySpan<byte> bytes, out TableRefuseReason reason) { long size = TableWire.LoadMeasure(%sTableType(), bytes, out string why); reason = why == null ? TableRefuseReason.ok : Enum.Parse<TableRefuseReason>(why); return size; }\n", st.Name, st.Name)
 	}
 	cap := ir.TableWireIdCapacity(g.unit)
-	g.pf("public static long %sMeasure(%s value)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return TableWire.Save(value, %sTableType(), Span<byte>.Empty, ids, true);\n}\n\n", st.Name, st.Name, cap, st.Name)
-	g.pf("public static long %sSave(%s value, Span<byte> buffer)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return TableWire.Save(value, %sTableType(), buffer, ids, false);\n}\n\n", st.Name, st.Name, cap, st.Name)
+	if !ir.VariableTables(g.unit)[st.Name] {
+		g.emitTypedWireSurface(st)
+		g.pf("public static long %sMeasure(%s value)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return %sSaveTyped(value, Span<byte>.Empty, ids, true);\n}\n\n", st.Name, st.Name, cap, st.Name)
+		g.pf("public static long %sSave(%s value, Span<byte> buffer)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return %sSaveTyped(value, buffer, ids, false);\n}\n\n", st.Name, st.Name, cap, st.Name)
+	} else {
+		g.pf("public static long %sMeasure(%s value)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return TableWire.Save(value, %sTableType(), Span<byte>.Empty, ids, true);\n}\n\n", st.Name, st.Name, cap, st.Name)
+		g.pf("public static long %sSave(%s value, Span<byte> buffer)\n{\n    Span<ulong> ids = stackalloc ulong[%d];\n    return TableWire.Save(value, %sTableType(), buffer, ids, false);\n}\n\n", st.Name, st.Name, cap, st.Name)
+	}
 	g.pf("public static TableWire.Verdict %sLoadVerdict(%s value, ReadOnlySpan<byte> bytes, TableReport report)\n{\n    return TableWire.Load(value, %sTableType(), bytes, report);\n}\n\n", st.Name, st.Name, st.Name)
 	g.pf("public static bool %sLoad(%s value, ReadOnlySpan<byte> bytes, TableReport report)\n{\n    return %sLoadVerdict(value, bytes, report) == TableWire.Verdict.Ok;\n}\n\n", st.Name, st.Name, st.Name)
 }
@@ -122,12 +408,12 @@ public static partial class TableWire
     // One schema-bounded vocabulary lives on the caller's stack for a save.
     // Collect follows the emitted fields in order. Measuring and writing then
     // look up stable references, so a nested length never needs patching.
-    ref struct Ids
+    public ref struct Ids
     {
         public Span<ulong> Values;
         public Span<int> Slots;
         public int Count;
-        public Graph Graph;
+        internal Graph Graph;
         public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
         public Ids(Span<ulong> values, Span<int> slots)
         { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -161,7 +447,7 @@ public static partial class TableWire
         }
     }
 
-    ref struct Writer
+    public ref struct Writer
     {
         public Span<byte> Buffer;
         public int Offset;
@@ -302,7 +588,7 @@ public static partial class TableWire
             default: return 0;
         }
     }
-    static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+    public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
     static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
     static bool Named(string name) { return name != null && name != "???"; }
     static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -339,7 +625,7 @@ public static partial class TableWire
         for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
         return false;
     }
-    static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+    public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
     static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
     {
         if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -559,6 +845,44 @@ public static partial class TableWire
         }
         if (root) { WriteNodes(ref w, ref ids); }
         w.Var(0);
+    }
+    public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+    {
+        if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+        if (f.Optional && !f.GetPresent(value)) { return true; }
+        if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+        return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+    }
+    public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+    {
+        payload = 0;
+        if (!Rides(value, f)) { return 0; }
+        long n = VarSize(ids.Reference(f.Id)) + 1;
+        if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+        {
+            payload = PayloadSize(value, f, ref ids, elemCache);
+            n += VarSize((ulong)payload) + payload;
+        }
+        else
+        {
+            n += ElementSize(value, f, 0, ref ids, true);
+        }
+        return n;
+    }
+    public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+    {
+        return BodySizeField(value, f, ref ids, elemCache, out _);
+    }
+    public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+    {
+        if (!Rides(value, f)) { return; }
+        w.Header(ids.Reference(f.Id), Kind(f));
+        if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+        {
+            long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+            w.Var((ulong)payload);
+        }
+        WritePayload(ref w, value, f, ref ids, elemCache);
     }
     public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
     {

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -37,7 +37,7 @@ func isScalarLeafStruct(st *ir.Struct) bool {
 }
 
 func isChildScalarArray(f *ir.Field) (*ir.Struct, bool) {
-	if f.Array == ir.ArrayNone || f.KeyEnum != "" || f.Type.Pointer || f.Type.Kind != ir.TNamed {
+	if f.Array == ir.ArrayNone || f.Type.Optional || f.Guard != "" || f.KeyEnum != "" || f.Type.Pointer || f.Type.Kind != ir.TNamed {
 		return nil, false
 	}
 	st, ok := f.Type.Ref.(*ir.Struct)
@@ -116,7 +116,6 @@ func (g *tableGen) emitCollectTyped(st *ir.Struct) {
 		}
 	}
 	g.pf("    return true;\n}\n\n")
-	g.pf("public static bool CollectTyped(%s v, ref TableWire.Ids ids) => %sCollectTyped(v, ref ids);\n\n", name, name)
 }
 
 func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
@@ -161,7 +160,8 @@ func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
 			g.pf("        if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
 			g.pf("    }\n")
 		} else {
-			if f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable {
+			switch {
+			case f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable:
 				g.pf("    scoped Span<long> elemCache_%d = default;\n", i)
 				g.pf("    if (!rootElemSizes.IsEmpty)\n    {\n")
 				g.pf("        int c = TableWire.Count(v, fields[%d]);\n", i)
@@ -170,16 +170,15 @@ func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
 				g.pf("        elemOffset += take;\n    }\n")
 				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids, elemCache_%d, out long payload_%d);\n", i, i, i)
 				g.pf("    if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
-			} else if isPayloadPrefixed(f) {
+			case isPayloadPrefixed(f):
 				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids, default, out long payload_%d);\n", i, i)
 				g.pf("    if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
-			} else {
+			default:
 				g.pf("    n += TableWire.BodySizeField(v, fields[%d], ref ids);\n", i)
 			}
 		}
 	}
 	g.pf("    return n;\n}\n\n")
-	g.pf("public static long BodySizeTyped(%s v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => %sBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);\n\n", name, name)
 }
 
 func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
@@ -234,7 +233,8 @@ func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
 			g.pf("            %sWriteBodyTyped(ref w, v.%s[i_%d], ref ids);\n", childName, prop, i)
 			g.pf("        }\n    }\n")
 		} else {
-			if f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable {
+			switch {
+			case f.Array != ir.ArrayNone && f.KeyEnum == "" && tableScalarKind(f) == tkTable:
 				g.pf("    scoped ReadOnlySpan<long> elemCache_%d = default;\n", i)
 				g.pf("    if (!rootElemSizes.IsEmpty)\n    {\n")
 				g.pf("        int c = TableWire.Count(v, fields[%d]);\n", i)
@@ -243,16 +243,15 @@ func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
 				g.pf("        elemOffset += take;\n    }\n")
 				g.pf("    long payload_%d = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[%d] : -1;\n", i, i)
 				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids, elemCache_%d, payload_%d);\n", i, i, i)
-			} else if isPayloadPrefixed(f) {
+			case isPayloadPrefixed(f):
 				g.pf("    long payload_%d = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[%d] : -1;\n", i, i)
 				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids, default, payload_%d);\n", i, i)
-			} else {
+			default:
 				g.pf("    TableWire.WriteBodyField(ref w, v, fields[%d], ref ids);\n", i)
 			}
 		}
 	}
 	g.pf("    w.Var(0);\n}\n\n")
-	g.pf("public static void WriteBodyTyped(ref TableWire.Writer w, %s v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => %sWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);\n\n", name, name)
 }
 
 func (g *tableGen) emitSaveTyped(st *ir.Struct) {
@@ -279,7 +278,6 @@ func (g *tableGen) emitSaveTyped(st *ir.Struct) {
 	g.pf("    for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }\n")
 	g.pf("    w.Fixed((ulong)ids.Count, 8);\n")
 	g.pf("    return w.Offset;\n}\n\n")
-	g.pf("public static long SaveTyped(%s value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => %sSaveTyped(value, buffer, vocabulary, measure);\n\n", name, name)
 }
 
 func (g *tableGen) emitTypedWireSurface(st *ir.Struct) {

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -2645,12 +2645,12 @@ namespace Blockdemo
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2684,7 +2684,7 @@ namespace Blockdemo
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4140,7 +4140,7 @@ namespace Blockdemo
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4177,7 +4177,7 @@ namespace Blockdemo
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4397,6 +4397,44 @@ namespace Blockdemo
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {

--- a/testdata/golden/tables/block-cs/PaddedTable.cs
+++ b/testdata/golden/tables/block-cs/PaddedTable.cs
@@ -68,16 +68,116 @@ namespace Blockdemo
             value.CounterPresent = false;
         }
 
+        public static bool PaddedRowCollectTyped(PaddedRow v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PaddedRowTableType().Fields;
+            if (v.Tag != 0 && !ids.Add(0x56d7ab194448a4f3ul)) return false;
+            if (v.Value != 0.0 && !ids.Add(0x7ce4fd9430e80ceaul)) return false;
+            if (v.Flag != false && !ids.Add(0xd5f2d079088c0b17ul)) return false;
+            if (v.Id != 0 && !ids.Add(0x08b72e07b55c3ac0ul)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[7], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(PaddedRow v, ref TableWire.Ids ids) => PaddedRowCollectTyped(v, ref ids);
+
+        public static long PaddedRowBodySizeTyped(PaddedRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PaddedRowTableType().Fields;
+            if (v.Tag != 0) { n += TableWire.VarSize(ids.Reference(0x56d7ab194448a4f3ul)) + 2; }
+            if (v.Value != 0.0) { n += TableWire.VarSize(ids.Reference(0x7ce4fd9430e80ceaul)) + 9; }
+            if (v.Flag != false) { n += TableWire.VarSize(ids.Reference(0xd5f2d079088c0b17ul)) + 2; }
+            if (v.Id != 0) { n += TableWire.VarSize(ids.Reference(0x08b72e07b55c3ac0ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[4], ref ids, default, out long payload_4);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids, default, out long payload_5);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
+            n += TableWire.BodySizeField(v, fields[6], ref ids, default, out long payload_6);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
+            n += TableWire.BodySizeField(v, fields[7], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(PaddedRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PaddedRowBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PaddedRowWriteBodyTyped(ref TableWire.Writer w, PaddedRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PaddedRowTableType().Fields;
+            if (v.Tag != 0)
+            {
+                w.Header(ids.Reference(0x56d7ab194448a4f3ul), 6);
+                w.Fixed((ulong)v.Tag, 1);
+            }
+            if (v.Value != 0.0)
+            {
+                w.Header(ids.Reference(0x7ce4fd9430e80ceaul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Value)), 8);
+            }
+            if (v.Flag != false)
+            {
+                w.Header(ids.Reference(0xd5f2d079088c0b17ul), 1);
+                w.Fixed(v.Flag ? 1ul : 0ul, 1);
+            }
+            if (v.Id != 0)
+            {
+                w.Header(ids.Reference(0x08b72e07b55c3ac0ul), 8);
+                w.Fixed((ulong)v.Id, 4);
+            }
+            long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids, default, payload_4);
+            long payload_5 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[5] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids, default, payload_5);
+            long payload_6 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[6] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids, default, payload_6);
+            TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, PaddedRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PaddedRowWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PaddedRowSaveTyped(PaddedRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PaddedRowTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PaddedRowCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PaddedRowBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PaddedRowWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(PaddedRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PaddedRowSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PaddedRowMeasure(PaddedRow value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, PaddedRowTableType(), Span<byte>.Empty, ids, true);
+            return PaddedRowSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PaddedRowSave(PaddedRow value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, PaddedRowTableType(), buffer, ids, false);
+            return PaddedRowSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PaddedRowLoadVerdict(PaddedRow value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -112,16 +212,110 @@ namespace Blockdemo
             value.BlobLength = 0;
         }
 
+        public static bool PaddedFrameCollectTyped(PaddedFrame v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PaddedFrameTableType().Fields;
+            if (v.Marker != 0 && !ids.Add(0xeddcb72b15486e77ul)) return false;
+            if (v.Stamp != 0 && !ids.Add(0xee7ba9ad45c64144ul)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(PaddedFrame v, ref TableWire.Ids ids) => PaddedFrameCollectTyped(v, ref ids);
+
+        public static long PaddedFrameBodySizeTyped(PaddedFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PaddedFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Marker != 0) { n += TableWire.VarSize(ids.Reference(0xeddcb72b15486e77ul)) + 2; }
+            if (v.Stamp != 0) { n += TableWire.VarSize(ids.Reference(0xee7ba9ad45c64144ul)) + 9; }
+            scoped Span<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, elemCache_2, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(PaddedFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PaddedFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PaddedFrameWriteBodyTyped(ref TableWire.Writer w, PaddedFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PaddedFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Marker != 0)
+            {
+                w.Header(ids.Reference(0xeddcb72b15486e77ul), 6);
+                w.Fixed((ulong)v.Marker, 1);
+            }
+            if (v.Stamp != 0)
+            {
+                w.Header(ids.Reference(0xee7ba9ad45c64144ul), 9);
+                w.Fixed((ulong)v.Stamp, 8);
+            }
+            scoped ReadOnlySpan<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, elemCache_2, payload_2);
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, PaddedFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PaddedFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PaddedFrameSaveTyped(PaddedFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PaddedFrameTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PaddedFrameCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PaddedFrameBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PaddedFrameWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(PaddedFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PaddedFrameSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PaddedFrameMeasure(PaddedFrame value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, PaddedFrameTableType(), Span<byte>.Empty, ids, true);
+            return PaddedFrameSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PaddedFrameSave(PaddedFrame value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, PaddedFrameTableType(), buffer, ids, false);
+            return PaddedFrameSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PaddedFrameLoadVerdict(PaddedFrame value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/block-cs/PaddedTable.cs
+++ b/testdata/golden/tables/block-cs/PaddedTable.cs
@@ -82,8 +82,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(PaddedRow v, ref TableWire.Ids ids) => PaddedRowCollectTyped(v, ref ids);
-
         public static long PaddedRowBodySizeTyped(PaddedRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -101,8 +99,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[7], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(PaddedRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PaddedRowBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PaddedRowWriteBodyTyped(ref TableWire.Writer w, PaddedRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -137,8 +133,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, PaddedRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PaddedRowWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long PaddedRowSaveTyped(PaddedRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = PaddedRowTableType();
@@ -165,8 +159,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(PaddedRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PaddedRowSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PaddedRowMeasure(PaddedRow value)
         {
@@ -222,8 +214,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(PaddedFrame v, ref TableWire.Ids ids) => PaddedFrameCollectTyped(v, ref ids);
-
         public static long PaddedFrameBodySizeTyped(PaddedFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -244,8 +234,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[3], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(PaddedFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PaddedFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PaddedFrameWriteBodyTyped(ref TableWire.Writer w, PaddedFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -275,8 +263,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, PaddedFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PaddedFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long PaddedFrameSaveTyped(PaddedFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = PaddedFrameTableType();
@@ -303,8 +289,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(PaddedFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PaddedFrameSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PaddedFrameMeasure(PaddedFrame value)
         {

--- a/testdata/golden/tables/block-cs/RenderTable.cs
+++ b/testdata/golden/tables/block-cs/RenderTable.cs
@@ -407,16 +407,268 @@ namespace Blockdemo
             value.ExplosionsCount = 0;
         }
 
+        public static bool RenderFrameCollectTyped(RenderFrame v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderFrameTableType().Fields;
+            if (v.Version != 0 && !ids.Add(0xbb62c62c9808ea37ul)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[7], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[8], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[9], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderFrame v, ref TableWire.Ids ids) => RenderFrameCollectTyped(v, ref ids);
+
+        public static long RenderFrameBodySizeTyped(RenderFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 0) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 9; }
+            scoped Span<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, elemCache_1, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            scoped Span<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, elemCache_2, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            scoped Span<long> elemCache_3 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[3]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_3 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[3], ref ids, elemCache_3, out long payload_3);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
+            scoped Span<long> elemCache_4 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[4]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_4 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[4], ref ids, elemCache_4, out long payload_4);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
+            scoped Span<long> elemCache_5 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[5]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_5 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[5], ref ids, elemCache_5, out long payload_5);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
+            scoped Span<long> elemCache_6 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[6]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[6], ref ids, elemCache_6, out long payload_6);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
+            scoped Span<long> elemCache_7 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[7]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_7 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[7], ref ids, elemCache_7, out long payload_7);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[7] = payload_7; }
+            scoped Span<long> elemCache_8 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[8]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_8 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[8], ref ids, elemCache_8, out long payload_8);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[8] = payload_8; }
+            scoped Span<long> elemCache_9 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[9]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_9 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[9], ref ids, elemCache_9, out long payload_9);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[9] = payload_9; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderFrameWriteBodyTyped(ref TableWire.Writer w, RenderFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 0)
+            {
+                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 9);
+                w.Fixed((ulong)v.Version, 8);
+            }
+            scoped ReadOnlySpan<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
+            scoped ReadOnlySpan<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, elemCache_2, payload_2);
+            scoped ReadOnlySpan<long> elemCache_3 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[3]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_3 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_3 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[3] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids, elemCache_3, payload_3);
+            scoped ReadOnlySpan<long> elemCache_4 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[4]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_4 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids, elemCache_4, payload_4);
+            scoped ReadOnlySpan<long> elemCache_5 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[5]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_5 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_5 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[5] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids, elemCache_5, payload_5);
+            scoped ReadOnlySpan<long> elemCache_6 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[6]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_6 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[6] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids, elemCache_6, payload_6);
+            scoped ReadOnlySpan<long> elemCache_7 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[7]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_7 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_7 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[7] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[7], ref ids, elemCache_7, payload_7);
+            scoped ReadOnlySpan<long> elemCache_8 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[8]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_8 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_8 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[8] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[8], ref ids, elemCache_8, payload_8);
+            scoped ReadOnlySpan<long> elemCache_9 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[9]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_9 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_9 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[9] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[9], ref ids, elemCache_9, payload_9);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderFrameSaveTyped(RenderFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderFrameTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderFrameCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderFrameBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderFrameWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderFrameSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderFrameMeasure(RenderFrame value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderFrameTableType(), Span<byte>.Empty, ids, true);
+            return RenderFrameSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderFrameSave(RenderFrame value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderFrameTableType(), buffer, ids, false);
+            return RenderFrameSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderFrameLoadVerdict(RenderFrame value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -448,16 +700,108 @@ namespace Blockdemo
             value.Fov = 0.0f;
         }
 
+        public static bool RenderCameraCollectTyped(RenderCamera v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderCameraTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.CameraId != 0 && !ids.Add(0x9f61700f084ab92eul)) return false;
+            if (v.CameraType != 0 && !ids.Add(0x336d3dc7fffd0c9bul)) return false;
+            if (v.TargetObjectId != 0 && !ids.Add(0x6a0c6a156952b9c2ul)) return false;
+            if (v.Fov != 0.0f && !ids.Add(0xdcb27c18fed9e15cul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderCamera v, ref TableWire.Ids ids) => RenderCameraCollectTyped(v, ref ids);
+
+        public static long RenderCameraBodySizeTyped(RenderCamera v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderCameraTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.CameraId != 0) { n += TableWire.VarSize(ids.Reference(0x9f61700f084ab92eul)) + 5; }
+            if (v.CameraType != 0) { n += TableWire.VarSize(ids.Reference(0x336d3dc7fffd0c9bul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.Fov != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdcb27c18fed9e15cul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderCamera v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderCameraBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderCameraWriteBodyTyped(ref TableWire.Writer w, RenderCamera v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderCameraTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.CameraId != 0)
+            {
+                w.Header(ids.Reference(0x9f61700f084ab92eul), 8);
+                w.Fixed((ulong)v.CameraId, 4);
+            }
+            if (v.CameraType != 0)
+            {
+                w.Header(ids.Reference(0x336d3dc7fffd0c9bul), 8);
+                w.Fixed((ulong)v.CameraType, 4);
+            }
+            if (v.TargetObjectId != 0)
+            {
+                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.Fixed((ulong)v.TargetObjectId, 4);
+            }
+            if (v.Fov != 0.0f)
+            {
+                w.Header(ids.Reference(0xdcb27c18fed9e15cul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Fov)), 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderCamera v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderCameraWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderCameraSaveTyped(RenderCamera value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderCameraTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderCameraCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderCameraBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderCameraWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderCamera value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderCameraSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderCameraMeasure(RenderCamera value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderCameraTableType(), Span<byte>.Empty, ids, true);
+            return RenderCameraSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderCameraSave(RenderCamera value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderCameraTableType(), buffer, ids, false);
+            return RenderCameraSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderCameraLoadVerdict(RenderCamera value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -494,16 +838,131 @@ namespace Blockdemo
             value.PredictedExplode = false;
         }
 
+        public static bool RenderShipCollectTyped(RenderShip v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderShipTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (v.ObjectId != 0 && !ids.Add(0x0bdab42c07f19812ul)) return false;
+            if (v.TargetObjectId != 0 && !ids.Add(0x6a0c6a156952b9c2ul)) return false;
+            if (v.Thrust != 0.0f && !ids.Add(0xcfd587cb3100cd73ul)) return false;
+            if (v.ObjectSequence != 0 && !ids.Add(0x5de0015285763c46ul)) return false;
+            if (!TableWire.CollectField(v, fields[7], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[8], ref ids)) return false;
+            if (v.HasTargetLock != false && !ids.Add(0x1554fa45a1220171ul)) return false;
+            if (v.PredictedExplode != false && !ids.Add(0x4d5be97ba1b9cb81ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderShip v, ref TableWire.Ids ids) => RenderShipCollectTyped(v, ref ids);
+
+        public static long RenderShipBodySizeTyped(RenderShip v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderShipTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids);
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.Thrust != 0.0f) { n += TableWire.VarSize(ids.Reference(0xcfd587cb3100cd73ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[7], ref ids);
+            n += TableWire.BodySizeField(v, fields[8], ref ids);
+            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.Reference(0x1554fa45a1220171ul)) + 2; }
+            if (v.PredictedExplode != false) { n += TableWire.VarSize(ids.Reference(0x4d5be97ba1b9cb81ul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderShip v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderShipBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderShipWriteBodyTyped(ref TableWire.Writer w, RenderShip v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderShipTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids);
+            if (v.ObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.Fixed((ulong)v.ObjectId, 4);
+            }
+            if (v.TargetObjectId != 0)
+            {
+                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.Fixed((ulong)v.TargetObjectId, 4);
+            }
+            if (v.Thrust != 0.0f)
+            {
+                w.Header(ids.Reference(0xcfd587cb3100cd73ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Thrust)), 4);
+            }
+            if (v.ObjectSequence != 0)
+            {
+                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.Fixed((ulong)v.ObjectSequence, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[8], ref ids);
+            if (v.HasTargetLock != false)
+            {
+                w.Header(ids.Reference(0x1554fa45a1220171ul), 1);
+                w.Fixed(v.HasTargetLock ? 1ul : 0ul, 1);
+            }
+            if (v.PredictedExplode != false)
+            {
+                w.Header(ids.Reference(0x4d5be97ba1b9cb81ul), 1);
+                w.Fixed(v.PredictedExplode ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderShip v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderShipWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderShipSaveTyped(RenderShip value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderShipTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderShipCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderShipBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderShipWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderShip value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderShipSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderShipMeasure(RenderShip value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderShipTableType(), Span<byte>.Empty, ids, true);
+            return RenderShipSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderShipSave(RenderShip value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderShipTableType(), buffer, ids, false);
+            return RenderShipSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderShipLoadVerdict(RenderShip value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -538,16 +997,127 @@ namespace Blockdemo
             value.HasTargetLock = false;
         }
 
+        public static bool RenderTurretCollectTyped(RenderTurret v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderTurretTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (v.Flags != 0 && !ids.Add(0x17a3a1a985f75aecul)) return false;
+            if (v.ObjectId != 0 && !ids.Add(0x0bdab42c07f19812ul)) return false;
+            if (v.ParentObjectId != 0 && !ids.Add(0x0bee7b3cb4046c93ul)) return false;
+            if (v.TurretIndex != 0 && !ids.Add(0x88a11a6aed541f54ul)) return false;
+            if (v.TargetObjectId != 0 && !ids.Add(0x6a0c6a156952b9c2ul)) return false;
+            if (v.ObjectSequence != 0 && !ids.Add(0x5de0015285763c46ul)) return false;
+            if (!TableWire.CollectField(v, fields[7], ref ids)) return false;
+            if (v.HasTargetLock != false && !ids.Add(0x1554fa45a1220171ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderTurret v, ref TableWire.Ids ids) => RenderTurretCollectTyped(v, ref ids);
+
+        public static long RenderTurretBodySizeTyped(RenderTurret v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderTurretTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
+            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bee7b3cb4046c93ul)) + 5; }
+            if (v.TurretIndex != 0) { n += TableWire.VarSize(ids.Reference(0x88a11a6aed541f54ul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[7], ref ids);
+            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.Reference(0x1554fa45a1220171ul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderTurret v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderTurretBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderTurretWriteBodyTyped(ref TableWire.Writer w, RenderTurret v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderTurretTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            if (v.Flags != 0)
+            {
+                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.Fixed((ulong)v.Flags, 8);
+            }
+            if (v.ObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.Fixed((ulong)v.ObjectId, 4);
+            }
+            if (v.ParentObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bee7b3cb4046c93ul), 8);
+                w.Fixed((ulong)v.ParentObjectId, 4);
+            }
+            if (v.TurretIndex != 0)
+            {
+                w.Header(ids.Reference(0x88a11a6aed541f54ul), 8);
+                w.Fixed((ulong)v.TurretIndex, 4);
+            }
+            if (v.TargetObjectId != 0)
+            {
+                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.Fixed((ulong)v.TargetObjectId, 4);
+            }
+            if (v.ObjectSequence != 0)
+            {
+                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.Fixed((ulong)v.ObjectSequence, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
+            if (v.HasTargetLock != false)
+            {
+                w.Header(ids.Reference(0x1554fa45a1220171ul), 1);
+                w.Fixed(v.HasTargetLock ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderTurret v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderTurretWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderTurretSaveTyped(RenderTurret value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderTurretTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderTurretCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderTurretBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderTurretWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderTurret value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderTurretSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderTurretMeasure(RenderTurret value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderTurretTableType(), Span<byte>.Empty, ids, true);
+            return RenderTurretSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderTurretSave(RenderTurret value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderTurretTableType(), buffer, ids, false);
+            return RenderTurretSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderTurretLoadVerdict(RenderTurret value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -580,16 +1150,107 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderMissileCollectTyped(RenderMissile v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderMissileTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Flags != 0 && !ids.Add(0x17a3a1a985f75aecul)) return false;
+            if (v.ObjectId != 0 && !ids.Add(0x0bdab42c07f19812ul)) return false;
+            if (v.ObjectSequence != 0 && !ids.Add(0x5de0015285763c46ul)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderMissile v, ref TableWire.Ids ids) => RenderMissileCollectTyped(v, ref ids);
+
+        public static long RenderMissileBodySizeTyped(RenderMissile v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderMissileTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            n += TableWire.BodySizeField(v, fields[6], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderMissile v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderMissileBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderMissileWriteBodyTyped(ref TableWire.Writer w, RenderMissile v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderMissileTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.Flags != 0)
+            {
+                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.Fixed((ulong)v.Flags, 8);
+            }
+            if (v.ObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.Fixed((ulong)v.ObjectId, 4);
+            }
+            if (v.ObjectSequence != 0)
+            {
+                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.Fixed((ulong)v.ObjectSequence, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderMissile v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderMissileWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderMissileSaveTyped(RenderMissile value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderMissileTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderMissileCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderMissileBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderMissileWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderMissile value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderMissileSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderMissileMeasure(RenderMissile value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderMissileTableType(), Span<byte>.Empty, ids, true);
+            return RenderMissileSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderMissileSave(RenderMissile value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderMissileTableType(), buffer, ids, false);
+            return RenderMissileSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderMissileLoadVerdict(RenderMissile value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -622,16 +1283,107 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderDynamicPropCollectTyped(RenderDynamicProp v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderDynamicPropTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Flags != 0 && !ids.Add(0x17a3a1a985f75aecul)) return false;
+            if (v.ObjectId != 0 && !ids.Add(0x0bdab42c07f19812ul)) return false;
+            if (v.ObjectSequence != 0 && !ids.Add(0x5de0015285763c46ul)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderDynamicProp v, ref TableWire.Ids ids) => RenderDynamicPropCollectTyped(v, ref ids);
+
+        public static long RenderDynamicPropBodySizeTyped(RenderDynamicProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderDynamicPropTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            n += TableWire.BodySizeField(v, fields[6], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderDynamicProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderDynamicPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderDynamicPropWriteBodyTyped(ref TableWire.Writer w, RenderDynamicProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderDynamicPropTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.Flags != 0)
+            {
+                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.Fixed((ulong)v.Flags, 8);
+            }
+            if (v.ObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.Fixed((ulong)v.ObjectId, 4);
+            }
+            if (v.ObjectSequence != 0)
+            {
+                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.Fixed((ulong)v.ObjectSequence, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderDynamicProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderDynamicPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderDynamicPropSaveTyped(RenderDynamicProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderDynamicPropTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderDynamicPropCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderDynamicPropBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderDynamicPropWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderDynamicProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderDynamicPropSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderDynamicPropMeasure(RenderDynamicProp value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderDynamicPropTableType(), Span<byte>.Empty, ids, true);
+            return RenderDynamicPropSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderDynamicPropSave(RenderDynamicProp value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderDynamicPropTableType(), buffer, ids, false);
+            return RenderDynamicPropSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderDynamicPropLoadVerdict(RenderDynamicProp value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -664,16 +1416,107 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderStaticPropCollectTyped(RenderStaticProp v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderStaticPropTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Scale != 0.0 && !ids.Add(0x6aacb9fbb71a1d91ul)) return false;
+            if (v.Flags != 0 && !ids.Add(0x17a3a1a985f75aecul)) return false;
+            if (v.StaticPropId != 0 && !ids.Add(0xd23da7ab574b95c3ul)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderStaticProp v, ref TableWire.Ids ids) => RenderStaticPropCollectTyped(v, ref ids);
+
+        public static long RenderStaticPropBodySizeTyped(RenderStaticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderStaticPropTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.Reference(0x6aacb9fbb71a1d91ul)) + 9; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
+            if (v.StaticPropId != 0) { n += TableWire.VarSize(ids.Reference(0xd23da7ab574b95c3ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            n += TableWire.BodySizeField(v, fields[6], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderStaticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderStaticPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderStaticPropWriteBodyTyped(ref TableWire.Writer w, RenderStaticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderStaticPropTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.Scale != 0.0)
+            {
+                w.Header(ids.Reference(0x6aacb9fbb71a1d91ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Scale)), 8);
+            }
+            if (v.Flags != 0)
+            {
+                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.Fixed((ulong)v.Flags, 8);
+            }
+            if (v.StaticPropId != 0)
+            {
+                w.Header(ids.Reference(0xd23da7ab574b95c3ul), 8);
+                w.Fixed((ulong)v.StaticPropId, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderStaticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderStaticPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderStaticPropSaveTyped(RenderStaticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderStaticPropTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderStaticPropCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderStaticPropBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderStaticPropWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderStaticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderStaticPropSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderStaticPropMeasure(RenderStaticProp value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderStaticPropTableType(), Span<byte>.Empty, ids, true);
+            return RenderStaticPropSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderStaticPropSave(RenderStaticProp value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderStaticPropTableType(), buffer, ids, false);
+            return RenderStaticPropSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderStaticPropLoadVerdict(RenderStaticProp value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -707,16 +1550,114 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderCosmeticPropCollectTyped(RenderCosmeticProp v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderCosmeticPropTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Scale != 0.0 && !ids.Add(0x6aacb9fbb71a1d91ul)) return false;
+            if (v.Flags != 0 && !ids.Add(0x17a3a1a985f75aecul)) return false;
+            if (v.CosmeticPropId != 0 && !ids.Add(0xb66e4449e56b2e26ul)) return false;
+            if (v.PropSequence != 0 && !ids.Add(0x4d7bf73bcbddc228ul)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[7], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderCosmeticProp v, ref TableWire.Ids ids) => RenderCosmeticPropCollectTyped(v, ref ids);
+
+        public static long RenderCosmeticPropBodySizeTyped(RenderCosmeticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderCosmeticPropTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.Reference(0x6aacb9fbb71a1d91ul)) + 9; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
+            if (v.CosmeticPropId != 0) { n += TableWire.VarSize(ids.Reference(0xb66e4449e56b2e26ul)) + 5; }
+            if (v.PropSequence != 0) { n += TableWire.VarSize(ids.Reference(0x4d7bf73bcbddc228ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[6], ref ids);
+            n += TableWire.BodySizeField(v, fields[7], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderCosmeticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderCosmeticPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderCosmeticPropWriteBodyTyped(ref TableWire.Writer w, RenderCosmeticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderCosmeticPropTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.Scale != 0.0)
+            {
+                w.Header(ids.Reference(0x6aacb9fbb71a1d91ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Scale)), 8);
+            }
+            if (v.Flags != 0)
+            {
+                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.Fixed((ulong)v.Flags, 8);
+            }
+            if (v.CosmeticPropId != 0)
+            {
+                w.Header(ids.Reference(0xb66e4449e56b2e26ul), 8);
+                w.Fixed((ulong)v.CosmeticPropId, 4);
+            }
+            if (v.PropSequence != 0)
+            {
+                w.Header(ids.Reference(0x4d7bf73bcbddc228ul), 6);
+                w.Fixed((ulong)v.PropSequence, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderCosmeticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderCosmeticPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderCosmeticPropSaveTyped(RenderCosmeticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderCosmeticPropTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderCosmeticPropCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderCosmeticPropBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderCosmeticPropWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderCosmeticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderCosmeticPropSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderCosmeticPropMeasure(RenderCosmeticProp value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderCosmeticPropTableType(), Span<byte>.Empty, ids, true);
+            return RenderCosmeticPropSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderCosmeticPropSave(RenderCosmeticProp value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderCosmeticPropTableType(), buffer, ids, false);
+            return RenderCosmeticPropSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderCosmeticPropLoadVerdict(RenderCosmeticProp value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -748,16 +1689,100 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderLaserCollectTyped(RenderLaser v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderLaserTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.T != 0.0 && !ids.Add(0xaf63e94c860202a3ul)) return false;
+            if (v.LaserId != 0 && !ids.Add(0xcd29c05f390294ecul)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderLaser v, ref TableWire.Ids ids) => RenderLaserCollectTyped(v, ref ids);
+
+        public static long RenderLaserBodySizeTyped(RenderLaser v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderLaserTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.T != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63e94c860202a3ul)) + 9; }
+            if (v.LaserId != 0) { n += TableWire.VarSize(ids.Reference(0xcd29c05f390294ecul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[4], ref ids);
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderLaser v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderLaserBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderLaserWriteBodyTyped(ref TableWire.Writer w, RenderLaser v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderLaserTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.T != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63e94c860202a3ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.T)), 8);
+            }
+            if (v.LaserId != 0)
+            {
+                w.Header(ids.Reference(0xcd29c05f390294ecul), 8);
+                w.Fixed((ulong)v.LaserId, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderLaser v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderLaserWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderLaserSaveTyped(RenderLaser value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderLaserTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderLaserCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderLaserBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderLaserWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderLaser value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderLaserSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderLaserMeasure(RenderLaser value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderLaserTableType(), Span<byte>.Empty, ids, true);
+            return RenderLaserSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderLaserSave(RenderLaser value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderLaserTableType(), buffer, ids, false);
+            return RenderLaserSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderLaserLoadVerdict(RenderLaser value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -790,16 +1815,107 @@ namespace Blockdemo
             value.Team = global::Blockdemo.Team.None;
         }
 
+        public static bool RenderExplosionCollectTyped(RenderExplosion v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RenderExplosionTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.T != 0.0 && !ids.Add(0xaf63e94c860202a3ul)) return false;
+            if (v.ExplosionId != 0 && !ids.Add(0xfd7f3fa0b16ed778ul)) return false;
+            if (v.ParentObjectId != 0 && !ids.Add(0x0bee7b3cb4046c93ul)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderExplosion v, ref TableWire.Ids ids) => RenderExplosionCollectTyped(v, ref ids);
+
+        public static long RenderExplosionBodySizeTyped(RenderExplosion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RenderExplosionTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.T != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63e94c860202a3ul)) + 9; }
+            if (v.ExplosionId != 0) { n += TableWire.VarSize(ids.Reference(0xfd7f3fa0b16ed778ul)) + 5; }
+            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bee7b3cb4046c93ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            n += TableWire.BodySizeField(v, fields[6], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderExplosion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderExplosionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderExplosionWriteBodyTyped(ref TableWire.Writer w, RenderExplosion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RenderExplosionTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.T != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63e94c860202a3ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.T)), 8);
+            }
+            if (v.ExplosionId != 0)
+            {
+                w.Header(ids.Reference(0xfd7f3fa0b16ed778ul), 8);
+                w.Fixed((ulong)v.ExplosionId, 4);
+            }
+            if (v.ParentObjectId != 0)
+            {
+                w.Header(ids.Reference(0x0bee7b3cb4046c93ul), 8);
+                w.Fixed((ulong)v.ParentObjectId, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderExplosion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderExplosionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderExplosionSaveTyped(RenderExplosion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderExplosionTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderExplosionCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderExplosionBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderExplosionWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderExplosion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderExplosionSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderExplosionMeasure(RenderExplosion value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderExplosionTableType(), Span<byte>.Empty, ids, true);
+            return RenderExplosionSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderExplosionSave(RenderExplosion value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderExplosionTableType(), buffer, ids, false);
+            return RenderExplosionSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderExplosionLoadVerdict(RenderExplosion value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -828,16 +1944,88 @@ namespace Blockdemo
             value.Z = 0.0;
         }
 
+        public static bool RenderVector3CollectTyped(RenderVector3 v, ref TableWire.Ids ids)
+        {
+            if (v.X != 0.0 && !ids.Add(0xaf63f54c86021707ul)) return false;
+            if (v.Y != 0.0 && !ids.Add(0xaf63f44c86021554ul)) return false;
+            if (v.Z != 0.0 && !ids.Add(0xaf63f74c86021a6dul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderVector3 v, ref TableWire.Ids ids) => RenderVector3CollectTyped(v, ref ids);
+
+        public static long RenderVector3BodySizeTyped(RenderVector3 v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.X != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f54c86021707ul)) + 9; }
+            if (v.Y != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f44c86021554ul)) + 9; }
+            if (v.Z != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f74c86021a6dul)) + 9; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderVector3 v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderVector3BodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderVector3WriteBodyTyped(ref TableWire.Writer w, RenderVector3 v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.X != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f54c86021707ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.X)), 8);
+            }
+            if (v.Y != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f44c86021554ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Y)), 8);
+            }
+            if (v.Z != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f74c86021a6dul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Z)), 8);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderVector3 v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderVector3WriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderVector3SaveTyped(RenderVector3 value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderVector3TableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderVector3CollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderVector3BodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderVector3WriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderVector3 value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderVector3SaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderVector3Measure(RenderVector3 value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderVector3TableType(), Span<byte>.Empty, ids, true);
+            return RenderVector3SaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderVector3Save(RenderVector3 value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderVector3TableType(), buffer, ids, false);
+            return RenderVector3SaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderVector3LoadVerdict(RenderVector3 value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -867,16 +2055,95 @@ namespace Blockdemo
             value.W = 1.0;
         }
 
+        public static bool RenderQuaternionCollectTyped(RenderQuaternion v, ref TableWire.Ids ids)
+        {
+            if (v.X != 0.0 && !ids.Add(0xaf63f54c86021707ul)) return false;
+            if (v.Y != 0.0 && !ids.Add(0xaf63f44c86021554ul)) return false;
+            if (v.Z != 0.0 && !ids.Add(0xaf63f74c86021a6dul)) return false;
+            if (v.W != 1.0 && !ids.Add(0xaf63ea4c86020456ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RenderQuaternion v, ref TableWire.Ids ids) => RenderQuaternionCollectTyped(v, ref ids);
+
+        public static long RenderQuaternionBodySizeTyped(RenderQuaternion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.X != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f54c86021707ul)) + 9; }
+            if (v.Y != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f44c86021554ul)) + 9; }
+            if (v.Z != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f74c86021a6dul)) + 9; }
+            if (v.W != 1.0) { n += TableWire.VarSize(ids.Reference(0xaf63ea4c86020456ul)) + 9; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RenderQuaternion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderQuaternionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RenderQuaternionWriteBodyTyped(ref TableWire.Writer w, RenderQuaternion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.X != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f54c86021707ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.X)), 8);
+            }
+            if (v.Y != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f44c86021554ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Y)), 8);
+            }
+            if (v.Z != 0.0)
+            {
+                w.Header(ids.Reference(0xaf63f74c86021a6dul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Z)), 8);
+            }
+            if (v.W != 1.0)
+            {
+                w.Header(ids.Reference(0xaf63ea4c86020456ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.W)), 8);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RenderQuaternion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderQuaternionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RenderQuaternionSaveTyped(RenderQuaternion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RenderQuaternionTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RenderQuaternionCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RenderQuaternionBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RenderQuaternionWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RenderQuaternion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderQuaternionSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RenderQuaternionMeasure(RenderQuaternion value)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderQuaternionTableType(), Span<byte>.Empty, ids, true);
+            return RenderQuaternionSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RenderQuaternionSave(RenderQuaternion value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[88];
-            return TableWire.Save(value, RenderQuaternionTableType(), buffer, ids, false);
+            return RenderQuaternionSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RenderQuaternionLoadVerdict(RenderQuaternion value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/block-cs/RenderTable.cs
+++ b/testdata/golden/tables/block-cs/RenderTable.cs
@@ -423,8 +423,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderFrame v, ref TableWire.Ids ids) => RenderFrameCollectTyped(v, ref ids);
-
         public static long RenderFrameBodySizeTyped(RenderFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -523,8 +521,6 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[9] = payload_9; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderFrameWriteBodyTyped(ref TableWire.Writer w, RenderFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -628,8 +624,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderFrameSaveTyped(RenderFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderFrameTableType();
@@ -656,8 +650,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderFrameSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderFrameMeasure(RenderFrame value)
         {
@@ -712,8 +704,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderCamera v, ref TableWire.Ids ids) => RenderCameraCollectTyped(v, ref ids);
-
         public static long RenderCameraBodySizeTyped(RenderCamera v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -728,8 +718,6 @@ namespace Blockdemo
             if (v.Fov != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdcb27c18fed9e15cul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderCamera v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderCameraBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderCameraWriteBodyTyped(ref TableWire.Writer w, RenderCamera v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -761,8 +749,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderCamera v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderCameraWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderCameraSaveTyped(RenderCamera value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderCameraTableType();
@@ -789,8 +775,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderCamera value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderCameraSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderCameraMeasure(RenderCamera value)
         {
@@ -855,8 +839,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderShip v, ref TableWire.Ids ids) => RenderShipCollectTyped(v, ref ids);
-
         public static long RenderShipBodySizeTyped(RenderShip v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -876,8 +858,6 @@ namespace Blockdemo
             if (v.PredictedExplode != false) { n += TableWire.VarSize(ids.Reference(0x4d5be97ba1b9cb81ul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderShip v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderShipBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderShipWriteBodyTyped(ref TableWire.Writer w, RenderShip v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -922,8 +902,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderShip v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderShipWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderShipSaveTyped(RenderShip value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderShipTableType();
@@ -950,8 +928,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderShip value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderShipSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderShipMeasure(RenderShip value)
         {
@@ -1012,8 +988,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderTurret v, ref TableWire.Ids ids) => RenderTurretCollectTyped(v, ref ids);
-
         public static long RenderTurretBodySizeTyped(RenderTurret v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1030,8 +1004,6 @@ namespace Blockdemo
             if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.Reference(0x1554fa45a1220171ul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderTurret v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderTurretBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderTurretWriteBodyTyped(ref TableWire.Writer w, RenderTurret v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1077,8 +1049,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderTurret v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderTurretWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderTurretSaveTyped(RenderTurret value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderTurretTableType();
@@ -1105,8 +1075,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderTurret value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderTurretSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderTurretMeasure(RenderTurret value)
         {
@@ -1163,8 +1131,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderMissile v, ref TableWire.Ids ids) => RenderMissileCollectTyped(v, ref ids);
-
         public static long RenderMissileBodySizeTyped(RenderMissile v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1180,8 +1146,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderMissile v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderMissileBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderMissileWriteBodyTyped(ref TableWire.Writer w, RenderMissile v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1210,8 +1174,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderMissile v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderMissileWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderMissileSaveTyped(RenderMissile value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderMissileTableType();
@@ -1238,8 +1200,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderMissile value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderMissileSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderMissileMeasure(RenderMissile value)
         {
@@ -1296,8 +1256,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderDynamicProp v, ref TableWire.Ids ids) => RenderDynamicPropCollectTyped(v, ref ids);
-
         public static long RenderDynamicPropBodySizeTyped(RenderDynamicProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1313,8 +1271,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderDynamicProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderDynamicPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderDynamicPropWriteBodyTyped(ref TableWire.Writer w, RenderDynamicProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1343,8 +1299,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderDynamicProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderDynamicPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderDynamicPropSaveTyped(RenderDynamicProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderDynamicPropTableType();
@@ -1371,8 +1325,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderDynamicProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderDynamicPropSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderDynamicPropMeasure(RenderDynamicProp value)
         {
@@ -1429,8 +1381,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderStaticProp v, ref TableWire.Ids ids) => RenderStaticPropCollectTyped(v, ref ids);
-
         public static long RenderStaticPropBodySizeTyped(RenderStaticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1446,8 +1396,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderStaticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderStaticPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderStaticPropWriteBodyTyped(ref TableWire.Writer w, RenderStaticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1476,8 +1424,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderStaticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderStaticPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderStaticPropSaveTyped(RenderStaticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderStaticPropTableType();
@@ -1504,8 +1450,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderStaticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderStaticPropSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderStaticPropMeasure(RenderStaticProp value)
         {
@@ -1564,8 +1508,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderCosmeticProp v, ref TableWire.Ids ids) => RenderCosmeticPropCollectTyped(v, ref ids);
-
         public static long RenderCosmeticPropBodySizeTyped(RenderCosmeticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1582,8 +1524,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[7], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderCosmeticProp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderCosmeticPropBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderCosmeticPropWriteBodyTyped(ref TableWire.Writer w, RenderCosmeticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1617,8 +1557,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderCosmeticProp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderCosmeticPropWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderCosmeticPropSaveTyped(RenderCosmeticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderCosmeticPropTableType();
@@ -1645,8 +1583,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderCosmeticProp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderCosmeticPropSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderCosmeticPropMeasure(RenderCosmeticProp value)
         {
@@ -1701,8 +1637,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderLaser v, ref TableWire.Ids ids) => RenderLaserCollectTyped(v, ref ids);
-
         public static long RenderLaserBodySizeTyped(RenderLaser v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1717,8 +1651,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderLaser v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderLaserBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderLaserWriteBodyTyped(ref TableWire.Writer w, RenderLaser v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1741,8 +1673,6 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderLaser v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderLaserWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long RenderLaserSaveTyped(RenderLaser value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -1770,8 +1700,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderLaser value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderLaserSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderLaserMeasure(RenderLaser value)
         {
@@ -1828,8 +1756,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderExplosion v, ref TableWire.Ids ids) => RenderExplosionCollectTyped(v, ref ids);
-
         public static long RenderExplosionBodySizeTyped(RenderExplosion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1845,8 +1771,6 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(RenderExplosion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderExplosionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderExplosionWriteBodyTyped(ref TableWire.Writer w, RenderExplosion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1875,8 +1799,6 @@ namespace Blockdemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderExplosion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderExplosionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RenderExplosionSaveTyped(RenderExplosion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RenderExplosionTableType();
@@ -1903,8 +1825,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderExplosion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderExplosionSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderExplosionMeasure(RenderExplosion value)
         {
@@ -1952,8 +1872,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderVector3 v, ref TableWire.Ids ids) => RenderVector3CollectTyped(v, ref ids);
-
         public static long RenderVector3BodySizeTyped(RenderVector3 v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -1962,8 +1880,6 @@ namespace Blockdemo
             if (v.Z != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f74c86021a6dul)) + 9; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderVector3 v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderVector3BodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderVector3WriteBodyTyped(ref TableWire.Writer w, RenderVector3 v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1984,8 +1900,6 @@ namespace Blockdemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderVector3 v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderVector3WriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long RenderVector3SaveTyped(RenderVector3 value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -2013,8 +1927,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderVector3 value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderVector3SaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderVector3Measure(RenderVector3 value)
         {
@@ -2064,8 +1976,6 @@ namespace Blockdemo
             return true;
         }
 
-        public static bool CollectTyped(RenderQuaternion v, ref TableWire.Ids ids) => RenderQuaternionCollectTyped(v, ref ids);
-
         public static long RenderQuaternionBodySizeTyped(RenderQuaternion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -2075,8 +1985,6 @@ namespace Blockdemo
             if (v.W != 1.0) { n += TableWire.VarSize(ids.Reference(0xaf63ea4c86020456ul)) + 9; }
             return n;
         }
-
-        public static long BodySizeTyped(RenderQuaternion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RenderQuaternionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RenderQuaternionWriteBodyTyped(ref TableWire.Writer w, RenderQuaternion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -2102,8 +2010,6 @@ namespace Blockdemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, RenderQuaternion v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RenderQuaternionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long RenderQuaternionSaveTyped(RenderQuaternion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -2131,8 +2037,6 @@ namespace Blockdemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RenderQuaternion value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RenderQuaternionSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RenderQuaternionMeasure(RenderQuaternion value)
         {

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -2529,12 +2529,12 @@ namespace Blockhome
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2568,7 +2568,7 @@ namespace Blockhome
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4024,7 +4024,7 @@ namespace Blockhome
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4061,7 +4061,7 @@ namespace Blockhome
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4281,6 +4281,44 @@ namespace Blockhome
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -25,16 +25,88 @@ namespace Blockhome
             value.Layer = 0;
         }
 
+        public static bool ArmorPlateCollectTyped(ArmorPlate v, ref TableWire.Ids ids)
+        {
+            if (v.Thickness != 0.0 && !ids.Add(0xdbae65ca25b4f315ul)) return false;
+            if (v.Material != 0 && !ids.Add(0x026f7568983161e0ul)) return false;
+            if (v.Layer != 0 && !ids.Add(0x84e39fec29768c56ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ArmorPlate v, ref TableWire.Ids ids) => ArmorPlateCollectTyped(v, ref ids);
+
+        public static long ArmorPlateBodySizeTyped(ArmorPlate v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Thickness != 0.0) { n += TableWire.VarSize(ids.Reference(0xdbae65ca25b4f315ul)) + 9; }
+            if (v.Material != 0) { n += TableWire.VarSize(ids.Reference(0x026f7568983161e0ul)) + 5; }
+            if (v.Layer != 0) { n += TableWire.VarSize(ids.Reference(0x84e39fec29768c56ul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ArmorPlate v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArmorPlateBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ArmorPlateWriteBodyTyped(ref TableWire.Writer w, ArmorPlate v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Thickness != 0.0)
+            {
+                w.Header(ids.Reference(0xdbae65ca25b4f315ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Thickness)), 8);
+            }
+            if (v.Material != 0)
+            {
+                w.Header(ids.Reference(0x026f7568983161e0ul), 8);
+                w.Fixed((ulong)v.Material, 4);
+            }
+            if (v.Layer != 0)
+            {
+                w.Header(ids.Reference(0x84e39fec29768c56ul), 6);
+                w.Fixed((ulong)v.Layer, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ArmorPlate v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArmorPlateWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ArmorPlateSaveTyped(ArmorPlate value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ArmorPlateTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ArmorPlateCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ArmorPlateBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ArmorPlateWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ArmorPlate value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArmorPlateSaveTyped(value, buffer, vocabulary, measure);
+
         public static long ArmorPlateMeasure(ArmorPlate value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, ArmorPlateTableType(), Span<byte>.Empty, ids, true);
+            return ArmorPlateSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ArmorPlateSave(ArmorPlate value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, ArmorPlateTableType(), buffer, ids, false);
+            return ArmorPlateSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ArmorPlateLoadVerdict(ArmorPlate value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -64,16 +136,94 @@ namespace Blockhome
             value.Tier = 0;
         }
 
+        public static bool ArmorConfigCollectTyped(ArmorConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = ArmorConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Rating != 0.0f && !ids.Add(0x4e79ecbefe5ff4d0ul)) return false;
+            if (v.Tier != 0 && !ids.Add(0x1e6f84ef2eb65989ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ArmorConfig v, ref TableWire.Ids ids) => ArmorConfigCollectTyped(v, ref ids);
+
+        public static long ArmorConfigBodySizeTyped(ArmorConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = ArmorConfigTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.Rating != 0.0f) { n += TableWire.VarSize(ids.Reference(0x4e79ecbefe5ff4d0ul)) + 5; }
+            if (v.Tier != 0) { n += TableWire.VarSize(ids.Reference(0x1e6f84ef2eb65989ul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ArmorConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArmorConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ArmorConfigWriteBodyTyped(ref TableWire.Writer w, ArmorConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = ArmorConfigTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.Rating != 0.0f)
+            {
+                w.Header(ids.Reference(0x4e79ecbefe5ff4d0ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Rating)), 4);
+            }
+            if (v.Tier != 0)
+            {
+                w.Header(ids.Reference(0x1e6f84ef2eb65989ul), 6);
+                w.Fixed((ulong)v.Tier, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ArmorConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArmorConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ArmorConfigSaveTyped(ArmorConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ArmorConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ArmorConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ArmorConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ArmorConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ArmorConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArmorConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long ArmorConfigMeasure(ArmorConfig value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, ArmorConfigTableType(), Span<byte>.Empty, ids, true);
+            return ArmorConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ArmorConfigSave(ArmorConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, ArmorConfigTableType(), buffer, ids, false);
+            return ArmorConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ArmorConfigLoadVerdict(ArmorConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -101,16 +251,81 @@ namespace Blockhome
             value.Cooldown = 0.0f;
         }
 
+        public static bool FiringGroupCollectTyped(FiringGroup v, ref TableWire.Ids ids)
+        {
+            if (v.Barrel != 0 && !ids.Add(0x8ece059ad360b651ul)) return false;
+            if (v.Cooldown != 0.0f && !ids.Add(0xdc2cbe6953343d48ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(FiringGroup v, ref TableWire.Ids ids) => FiringGroupCollectTyped(v, ref ids);
+
+        public static long FiringGroupBodySizeTyped(FiringGroup v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Barrel != 0) { n += TableWire.VarSize(ids.Reference(0x8ece059ad360b651ul)) + 5; }
+            if (v.Cooldown != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdc2cbe6953343d48ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(FiringGroup v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => FiringGroupBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void FiringGroupWriteBodyTyped(ref TableWire.Writer w, FiringGroup v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Barrel != 0)
+            {
+                w.Header(ids.Reference(0x8ece059ad360b651ul), 8);
+                w.Fixed((ulong)v.Barrel, 4);
+            }
+            if (v.Cooldown != 0.0f)
+            {
+                w.Header(ids.Reference(0xdc2cbe6953343d48ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Cooldown)), 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, FiringGroup v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => FiringGroupWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long FiringGroupSaveTyped(FiringGroup value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = FiringGroupTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!FiringGroupCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + FiringGroupBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            FiringGroupWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(FiringGroup value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => FiringGroupSaveTyped(value, buffer, vocabulary, measure);
+
         public static long FiringGroupMeasure(FiringGroup value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, FiringGroupTableType(), Span<byte>.Empty, ids, true);
+            return FiringGroupSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long FiringGroupSave(FiringGroup value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, FiringGroupTableType(), buffer, ids, false);
+            return FiringGroupSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict FiringGroupLoadVerdict(FiringGroup value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -148,16 +363,128 @@ namespace Blockhome
             value.GunnerId = 0;
         }
 
+        public static bool GunnerSettingsCollectTyped(GunnerSettings v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.ReloadSeconds != 0.0f && !ids.Add(0xad9b64728ea52486ul)) return false;
+            if (v.GunnerId != 0 && !ids.Add(0xbd9be53180256e02ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(GunnerSettings v, ref TableWire.Ids ids) => GunnerSettingsCollectTyped(v, ref ids);
+
+        public static long GunnerSettingsBodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            int elemOffset = 0;
+            scoped Span<long> elemCache_0 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[0]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_0 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[0], ref ids, elemCache_0, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            scoped Span<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, elemCache_1, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.ReloadSeconds != 0.0f) { n += TableWire.VarSize(ids.Reference(0xad9b64728ea52486ul)) + 5; }
+            if (v.GunnerId != 0) { n += TableWire.VarSize(ids.Reference(0xbd9be53180256e02ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void GunnerSettingsWriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            int elemOffset = 0;
+            scoped ReadOnlySpan<long> elemCache_0 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[0]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_0 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, elemCache_0, payload_0);
+            scoped ReadOnlySpan<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
+            if (v.ReloadSeconds != 0.0f)
+            {
+                w.Header(ids.Reference(0xad9b64728ea52486ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.ReloadSeconds)), 4);
+            }
+            if (v.GunnerId != 0)
+            {
+                w.Header(ids.Reference(0xbd9be53180256e02ul), 8);
+                w.Fixed((ulong)v.GunnerId, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long GunnerSettingsSaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = GunnerSettingsTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!GunnerSettingsCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + GunnerSettingsBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            GunnerSettingsWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerSettingsSaveTyped(value, buffer, vocabulary, measure);
+
         public static long GunnerSettingsMeasure(GunnerSettings value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, GunnerSettingsTableType(), Span<byte>.Empty, ids, true);
+            return GunnerSettingsSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long GunnerSettingsSave(GunnerSettings value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, GunnerSettingsTableType(), buffer, ids, false);
+            return GunnerSettingsSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict GunnerSettingsLoadVerdict(GunnerSettings value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -33,8 +33,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(ArmorPlate v, ref TableWire.Ids ids) => ArmorPlateCollectTyped(v, ref ids);
-
         public static long ArmorPlateBodySizeTyped(ArmorPlate v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -43,8 +41,6 @@ namespace Blockhome
             if (v.Layer != 0) { n += TableWire.VarSize(ids.Reference(0x84e39fec29768c56ul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(ArmorPlate v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArmorPlateBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void ArmorPlateWriteBodyTyped(ref TableWire.Writer w, ArmorPlate v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -65,8 +61,6 @@ namespace Blockhome
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, ArmorPlate v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArmorPlateWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long ArmorPlateSaveTyped(ArmorPlate value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -94,8 +88,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ArmorPlate value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArmorPlateSaveTyped(value, buffer, vocabulary, measure);
 
         public static long ArmorPlateMeasure(ArmorPlate value)
         {
@@ -146,8 +138,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(ArmorConfig v, ref TableWire.Ids ids) => ArmorConfigCollectTyped(v, ref ids);
-
         public static long ArmorConfigBodySizeTyped(ArmorConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -160,8 +150,6 @@ namespace Blockhome
             if (v.Tier != 0) { n += TableWire.VarSize(ids.Reference(0x1e6f84ef2eb65989ul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(ArmorConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArmorConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void ArmorConfigWriteBodyTyped(ref TableWire.Writer w, ArmorConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -182,8 +170,6 @@ namespace Blockhome
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, ArmorConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArmorConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long ArmorConfigSaveTyped(ArmorConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -211,8 +197,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ArmorConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArmorConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long ArmorConfigMeasure(ArmorConfig value)
         {
@@ -258,8 +242,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(FiringGroup v, ref TableWire.Ids ids) => FiringGroupCollectTyped(v, ref ids);
-
         public static long FiringGroupBodySizeTyped(FiringGroup v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -267,8 +249,6 @@ namespace Blockhome
             if (v.Cooldown != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdc2cbe6953343d48ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(FiringGroup v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => FiringGroupBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void FiringGroupWriteBodyTyped(ref TableWire.Writer w, FiringGroup v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -284,8 +264,6 @@ namespace Blockhome
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, FiringGroup v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => FiringGroupWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long FiringGroupSaveTyped(FiringGroup value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -313,8 +291,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(FiringGroup value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => FiringGroupSaveTyped(value, buffer, vocabulary, measure);
 
         public static long FiringGroupMeasure(FiringGroup value)
         {
@@ -390,8 +366,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(GunnerSettings v, ref TableWire.Ids ids) => GunnerSettingsCollectTyped(v, ref ids);
-
         public static long GunnerSettingsBodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -442,8 +416,6 @@ namespace Blockhome
             if (v.GunnerId != 0) { n += TableWire.VarSize(ids.Reference(0xbd9be53180256e02ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void GunnerSettingsWriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -525,8 +497,6 @@ namespace Blockhome
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long GunnerSettingsSaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = GunnerSettingsTableType();
@@ -553,8 +523,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerSettingsSaveTyped(value, buffer, vocabulary, measure);
 
         public static long GunnerSettingsMeasure(GunnerSettings value)
         {

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -365,9 +365,26 @@ namespace Blockhome
 
         public static bool GunnerSettingsCollectTyped(GunnerSettings v, ref TableWire.Ids ids)
         {
-            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
-            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
-            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            int count_0 = v.FiringGroupsCount;
+            if (count_0 < 0 || count_0 > 32) return false;
+            if (count_0 > 0)
+            {
+                if (!ids.Add(0x260b8ca6b0c3db7ful)) return false;
+                for (int i_0 = 0; i_0 < count_0; i_0++)
+                {
+                    if (!FiringGroupCollectTyped(v.FiringGroups[i_0], ref ids)) return false;
+                }
+            }
+            int count_1 = v.MissileGroupsCount;
+            if (count_1 < 0 || count_1 > 4) return false;
+            if (count_1 > 0)
+            {
+                if (!ids.Add(0x3c99105aa087f6bcul)) return false;
+                for (int i_1 = 0; i_1 < count_1; i_1++)
+                {
+                    if (!FiringGroupCollectTyped(v.MissileGroups[i_1], ref ids)) return false;
+                }
+            }
             if (v.ReloadSeconds != 0.0f && !ids.Add(0xad9b64728ea52486ul)) return false;
             if (v.GunnerId != 0 && !ids.Add(0xbd9be53180256e02ul)) return false;
             return true;
@@ -378,28 +395,49 @@ namespace Blockhome
         public static long GunnerSettingsBodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
             int elemOffset = 0;
-            scoped Span<long> elemCache_0 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_0 = v.FiringGroupsCount;
+            if (count_0 > 0)
             {
-                int c = TableWire.Count(v, fields[0]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_0 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                scoped Span<long> elemCache_0 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_0, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_0 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long nChild_0 = 0;
+                for (int i_0 = 0; i_0 < count_0; i_0++)
+                {
+                    long childBody = FiringGroupBodySizeTyped(v.FiringGroups[i_0], ref ids);
+                    if (!elemCache_0.IsEmpty && i_0 < elemCache_0.Length) { elemCache_0[i_0] = childBody; }
+                    nChild_0 += TableWire.VarSize((ulong)childBody) + childBody;
+                }
+                long payload_0 = 1 + TableWire.VarSize((ulong)count_0) + nChild_0;
+                n += TableWire.VarSize(ids.Reference(0x260b8ca6b0c3db7ful)) + 1 + TableWire.VarSize((ulong)payload_0) + payload_0;
+                if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             }
-            n += TableWire.BodySizeField(v, fields[0], ref ids, elemCache_0, out long payload_0);
-            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
-            scoped Span<long> elemCache_1 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_1 = v.MissileGroupsCount;
+            if (count_1 > 0)
             {
-                int c = TableWire.Count(v, fields[1]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                scoped Span<long> elemCache_1 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_1, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long nChild_1 = 0;
+                for (int i_1 = 0; i_1 < count_1; i_1++)
+                {
+                    long childBody = FiringGroupBodySizeTyped(v.MissileGroups[i_1], ref ids);
+                    if (!elemCache_1.IsEmpty && i_1 < elemCache_1.Length) { elemCache_1[i_1] = childBody; }
+                    nChild_1 += TableWire.VarSize((ulong)childBody) + childBody;
+                }
+                long payload_1 = 1 + TableWire.VarSize((ulong)count_1) + nChild_1;
+                n += TableWire.VarSize(ids.Reference(0x3c99105aa087f6bcul)) + 1 + TableWire.VarSize((ulong)payload_1) + payload_1;
+                if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             }
-            n += TableWire.BodySizeField(v, fields[1], ref ids, elemCache_1, out long payload_1);
-            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             if (v.ReloadSeconds != 0.0f) { n += TableWire.VarSize(ids.Reference(0xad9b64728ea52486ul)) + 5; }
             if (v.GunnerId != 0) { n += TableWire.VarSize(ids.Reference(0xbd9be53180256e02ul)) + 5; }
             return n;
@@ -409,28 +447,71 @@ namespace Blockhome
 
         public static void GunnerSettingsWriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
-            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
             int elemOffset = 0;
-            scoped ReadOnlySpan<long> elemCache_0 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_0 = v.FiringGroupsCount;
+            if (count_0 > 0)
             {
-                int c = TableWire.Count(v, fields[0]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_0 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                w.Header(ids.Reference(0x260b8ca6b0c3db7ful), 14);
+                scoped ReadOnlySpan<long> elemCache_0 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_0, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_0 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+                if (payload_0 < 0)
+                {
+                    long nChild_0 = 0;
+                    for (int i_0 = 0; i_0 < count_0; i_0++)
+                    {
+                        long childBody = (!elemCache_0.IsEmpty && i_0 < elemCache_0.Length) ? elemCache_0[i_0] : FiringGroupBodySizeTyped(v.FiringGroups[i_0], ref ids);
+                        nChild_0 += TableWire.VarSize((ulong)childBody) + childBody;
+                    }
+                    payload_0 = 1 + TableWire.VarSize((ulong)count_0) + nChild_0;
+                }
+                w.Var((ulong)payload_0);
+                w.Byte(13);
+                w.Var((ulong)count_0);
+                for (int i_0 = 0; i_0 < count_0; i_0++)
+                {
+                    long childBody = (!elemCache_0.IsEmpty && i_0 < elemCache_0.Length) ? elemCache_0[i_0] : FiringGroupBodySizeTyped(v.FiringGroups[i_0], ref ids);
+                    w.Var((ulong)childBody);
+                    FiringGroupWriteBodyTyped(ref w, v.FiringGroups[i_0], ref ids);
+                }
             }
-            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
-            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, elemCache_0, payload_0);
-            scoped ReadOnlySpan<long> elemCache_1 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_1 = v.MissileGroupsCount;
+            if (count_1 > 0)
             {
-                int c = TableWire.Count(v, fields[1]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                w.Header(ids.Reference(0x3c99105aa087f6bcul), 14);
+                scoped ReadOnlySpan<long> elemCache_1 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_1, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+                if (payload_1 < 0)
+                {
+                    long nChild_1 = 0;
+                    for (int i_1 = 0; i_1 < count_1; i_1++)
+                    {
+                        long childBody = (!elemCache_1.IsEmpty && i_1 < elemCache_1.Length) ? elemCache_1[i_1] : FiringGroupBodySizeTyped(v.MissileGroups[i_1], ref ids);
+                        nChild_1 += TableWire.VarSize((ulong)childBody) + childBody;
+                    }
+                    payload_1 = 1 + TableWire.VarSize((ulong)count_1) + nChild_1;
+                }
+                w.Var((ulong)payload_1);
+                w.Byte(13);
+                w.Var((ulong)count_1);
+                for (int i_1 = 0; i_1 < count_1; i_1++)
+                {
+                    long childBody = (!elemCache_1.IsEmpty && i_1 < elemCache_1.Length) ? elemCache_1[i_1] : FiringGroupBodySizeTyped(v.MissileGroups[i_1], ref ids);
+                    w.Var((ulong)childBody);
+                    FiringGroupWriteBodyTyped(ref w, v.MissileGroups[i_1], ref ids);
+                }
             }
-            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
-            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
             if (v.ReloadSeconds != 0.0f)
             {
                 w.Header(ids.Reference(0xad9b64728ea52486ul), 10);

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -53,16 +53,94 @@ namespace Blockhome
             value.Slot = 0;
         }
 
+        public static bool PartRowCollectTyped(PartRow v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PartRowTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.PartId != 0 && !ids.Add(0x04d6206b33415104ul)) return false;
+            if (v.Slot != 0 && !ids.Add(0x6a771618f6fe31d1ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(PartRow v, ref TableWire.Ids ids) => PartRowCollectTyped(v, ref ids);
+
+        public static long PartRowBodySizeTyped(PartRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PartRowTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            if (v.PartId != 0) { n += TableWire.VarSize(ids.Reference(0x04d6206b33415104ul)) + 5; }
+            if (v.Slot != 0) { n += TableWire.VarSize(ids.Reference(0x6a771618f6fe31d1ul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(PartRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PartRowBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PartRowWriteBodyTyped(ref TableWire.Writer w, PartRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PartRowTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            if (v.PartId != 0)
+            {
+                w.Header(ids.Reference(0x04d6206b33415104ul), 8);
+                w.Fixed((ulong)v.PartId, 4);
+            }
+            if (v.Slot != 0)
+            {
+                w.Header(ids.Reference(0x6a771618f6fe31d1ul), 6);
+                w.Fixed((ulong)v.Slot, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, PartRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PartRowWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PartRowSaveTyped(PartRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PartRowTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PartRowCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PartRowBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PartRowWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(PartRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PartRowSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PartRowMeasure(PartRow value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, PartRowTableType(), Span<byte>.Empty, ids, true);
+            return PartRowSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PartRowSave(PartRow value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, PartRowTableType(), buffer, ids, false);
+            return PartRowSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PartRowLoadVerdict(PartRow value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -94,16 +172,100 @@ namespace Blockhome
             value.PartsCount = 0;
         }
 
+        public static bool PartFrameCollectTyped(PartFrame v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PartFrameTableType().Fields;
+            if (v.Version != 0 && !ids.Add(0xbb62c62c9808ea37ul)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(PartFrame v, ref TableWire.Ids ids) => PartFrameCollectTyped(v, ref ids);
+
+        public static long PartFrameBodySizeTyped(PartFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PartFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 0) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 9; }
+            scoped Span<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, elemCache_1, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            return n;
+        }
+
+        public static long BodySizeTyped(PartFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PartFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PartFrameWriteBodyTyped(ref TableWire.Writer w, PartFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PartFrameTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 0)
+            {
+                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 9);
+                w.Fixed((ulong)v.Version, 8);
+            }
+            scoped ReadOnlySpan<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, PartFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PartFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PartFrameSaveTyped(PartFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PartFrameTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PartFrameCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PartFrameBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PartFrameWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(PartFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PartFrameSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PartFrameMeasure(PartFrame value)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, PartFrameTableType(), Span<byte>.Empty, ids, true);
+            return PartFrameSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PartFrameSave(PartFrame value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[28];
-            return TableWire.Save(value, PartFrameTableType(), buffer, ids, false);
+            return PartFrameSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PartFrameLoadVerdict(PartFrame value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -63,8 +63,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(PartRow v, ref TableWire.Ids ids) => PartRowCollectTyped(v, ref ids);
-
         public static long PartRowBodySizeTyped(PartRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -77,8 +75,6 @@ namespace Blockhome
             if (v.Slot != 0) { n += TableWire.VarSize(ids.Reference(0x6a771618f6fe31d1ul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(PartRow v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PartRowBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PartRowWriteBodyTyped(ref TableWire.Writer w, PartRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -99,8 +95,6 @@ namespace Blockhome
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, PartRow v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PartRowWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long PartRowSaveTyped(PartRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -128,8 +122,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(PartRow value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PartRowSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PartRowMeasure(PartRow value)
         {
@@ -180,8 +172,6 @@ namespace Blockhome
             return true;
         }
 
-        public static bool CollectTyped(PartFrame v, ref TableWire.Ids ids) => PartFrameCollectTyped(v, ref ids);
-
         public static long PartFrameBodySizeTyped(PartFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -200,8 +190,6 @@ namespace Blockhome
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             return n;
         }
-
-        public static long BodySizeTyped(PartFrame v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PartFrameBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PartFrameWriteBodyTyped(ref TableWire.Writer w, PartFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -224,8 +212,6 @@ namespace Blockhome
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, PartFrame v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PartFrameWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long PartFrameSaveTyped(PartFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -253,8 +239,6 @@ namespace Blockhome
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(PartFrame value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PartFrameSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PartFrameMeasure(PartFrame value)
         {

--- a/testdata/golden/tables/examples-cs/GuardedTable.cs
+++ b/testdata/golden/tables/examples-cs/GuardedTable.cs
@@ -66,8 +66,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(Patrol v, ref TableWire.Ids ids) => PatrolCollectTyped(v, ref ids);
-
         public static long PatrolBodySizeTyped(Patrol v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -81,8 +79,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
             return n;
         }
-
-        public static long BodySizeTyped(Patrol v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PatrolBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PatrolWriteBodyTyped(ref TableWire.Writer w, Patrol v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -100,8 +96,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids, default, payload_5);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Patrol v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PatrolWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long PatrolSaveTyped(Patrol value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -129,8 +123,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Patrol value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PatrolSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PatrolMeasure(Patrol value)
         {

--- a/testdata/golden/tables/examples-cs/GuardedTable.cs
+++ b/testdata/golden/tables/examples-cs/GuardedTable.cs
@@ -54,16 +54,94 @@ namespace Tabledemo
             value.NoteLength = 0;
         }
 
+        public static bool PatrolCollectTyped(Patrol v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PatrolTableType().Fields;
+            if (v.Active != false && !ids.Add(0x6580790b036f0c6ful)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Patrol v, ref TableWire.Ids ids) => PatrolCollectTyped(v, ref ids);
+
+        public static long PatrolBodySizeTyped(Patrol v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PatrolTableType().Fields;
+            if (v.Active != false) { n += TableWire.VarSize(ids.Reference(0x6580790b036f0c6ful)) + 2; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids);
+            n += TableWire.BodySizeField(v, fields[2], ref ids);
+            n += TableWire.BodySizeField(v, fields[3], ref ids);
+            n += TableWire.BodySizeField(v, fields[4], ref ids);
+            n += TableWire.BodySizeField(v, fields[5], ref ids, default, out long payload_5);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Patrol v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PatrolBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PatrolWriteBodyTyped(ref TableWire.Writer w, Patrol v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PatrolTableType().Fields;
+            if (v.Active != false)
+            {
+                w.Header(ids.Reference(0x6580790b036f0c6ful), 1);
+                w.Fixed(v.Active ? 1ul : 0ul, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids);
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids);
+            long payload_5 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[5] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids, default, payload_5);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Patrol v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PatrolWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PatrolSaveTyped(Patrol value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PatrolTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PatrolCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PatrolBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PatrolWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Patrol value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PatrolSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PatrolMeasure(Patrol value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, PatrolTableType(), Span<byte>.Empty, ids, true);
+            return PatrolSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PatrolSave(Patrol value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, PatrolTableType(), buffer, ids, false);
+            return PatrolSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PatrolLoadVerdict(Patrol value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/KeyedTable.cs
+++ b/testdata/golden/tables/examples-cs/KeyedTable.cs
@@ -176,8 +176,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(TeamConfig v, ref TableWire.Ids ids) => TeamConfigCollectTyped(v, ref ids);
-
         public static long TeamConfigBodySizeTyped(TeamConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -187,8 +185,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             return n;
         }
-
-        public static long BodySizeTyped(TeamConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => TeamConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void TeamConfigWriteBodyTyped(ref TableWire.Writer w, TeamConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -202,8 +198,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, TeamConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => TeamConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long TeamConfigSaveTyped(TeamConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -231,8 +225,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(TeamConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => TeamConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long TeamConfigMeasure(TeamConfig value)
         {
@@ -278,8 +270,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(GunnerConfig v, ref TableWire.Ids ids) => GunnerConfigCollectTyped(v, ref ids);
-
         public static long GunnerConfigBodySizeTyped(GunnerConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -287,8 +277,6 @@ namespace Tabledemo
             if (v.Tracking != false) { n += TableWire.VarSize(ids.Reference(0xa6bf719a4602b0bcul)) + 2; }
             return n;
         }
-
-        public static long BodySizeTyped(GunnerConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void GunnerConfigWriteBodyTyped(ref TableWire.Writer w, GunnerConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -304,8 +292,6 @@ namespace Tabledemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long GunnerConfigSaveTyped(GunnerConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -333,8 +319,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(GunnerConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long GunnerConfigMeasure(GunnerConfig value)
         {
@@ -384,8 +368,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(TurretConfig v, ref TableWire.Ids ids) => TurretConfigCollectTyped(v, ref ids);
-
         public static long TurretConfigBodySizeTyped(TurretConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -396,8 +378,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
         }
-
-        public static long BodySizeTyped(TurretConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => TurretConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void TurretConfigWriteBodyTyped(ref TableWire.Writer w, TurretConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -416,8 +396,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, TurretConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => TurretConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long TurretConfigSaveTyped(TurretConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -445,8 +423,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(TurretConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => TurretConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long TurretConfigMeasure(TurretConfig value)
         {
@@ -498,8 +474,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(HullConfig v, ref TableWire.Ids ids) => HullConfigCollectTyped(v, ref ids);
-
         public static long HullConfigBodySizeTyped(HullConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -510,8 +484,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
         }
-
-        public static long BodySizeTyped(HullConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => HullConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void HullConfigWriteBodyTyped(ref TableWire.Writer w, HullConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -530,8 +502,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, HullConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => HullConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long HullConfigSaveTyped(HullConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -559,8 +529,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(HullConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => HullConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long HullConfigMeasure(HullConfig value)
         {
@@ -615,8 +583,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(KeyedConfig v, ref TableWire.Ids ids) => KeyedConfigCollectTyped(v, ref ids);
-
         public static long KeyedConfigBodySizeTyped(KeyedConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -630,8 +596,6 @@ namespace Tabledemo
             return n;
         }
 
-        public static long BodySizeTyped(KeyedConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => KeyedConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void KeyedConfigWriteBodyTyped(ref TableWire.Writer w, KeyedConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = KeyedConfigTableType().Fields;
@@ -643,8 +607,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, KeyedConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => KeyedConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long KeyedConfigSaveTyped(KeyedConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -672,8 +634,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(KeyedConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => KeyedConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long KeyedConfigMeasure(KeyedConfig value)
         {
@@ -718,8 +678,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(ScoreBoard v, ref TableWire.Ids ids) => ScoreBoardCollectTyped(v, ref ids);
-
         public static long ScoreBoardBodySizeTyped(ScoreBoard v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -729,8 +687,6 @@ namespace Tabledemo
             return n;
         }
 
-        public static long BodySizeTyped(ScoreBoard v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ScoreBoardBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void ScoreBoardWriteBodyTyped(ref TableWire.Writer w, ScoreBoard v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = ScoreBoardTableType().Fields;
@@ -738,8 +694,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, ScoreBoard v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ScoreBoardWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long ScoreBoardSaveTyped(ScoreBoard value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -767,8 +721,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ScoreBoard value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ScoreBoardSaveTyped(value, buffer, vocabulary, measure);
 
         public static long ScoreBoardMeasure(ScoreBoard value)
         {

--- a/testdata/golden/tables/examples-cs/KeyedTable.cs
+++ b/testdata/golden/tables/examples-cs/KeyedTable.cs
@@ -168,16 +168,82 @@ namespace Tabledemo
             value.BannerLength = 0;
         }
 
+        public static bool TeamConfigCollectTyped(TeamConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = TeamConfigTableType().Fields;
+            if (v.SpawnCount != 4 && !ids.Add(0xceec99e2d65db674ul)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(TeamConfig v, ref TableWire.Ids ids) => TeamConfigCollectTyped(v, ref ids);
+
+        public static long TeamConfigBodySizeTyped(TeamConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = TeamConfigTableType().Fields;
+            if (v.SpawnCount != 4) { n += TableWire.VarSize(ids.Reference(0xceec99e2d65db674ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            return n;
+        }
+
+        public static long BodySizeTyped(TeamConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => TeamConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void TeamConfigWriteBodyTyped(ref TableWire.Writer w, TeamConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = TeamConfigTableType().Fields;
+            if (v.SpawnCount != 4)
+            {
+                w.Header(ids.Reference(0xceec99e2d65db674ul), 4);
+                w.Fixed((ulong)(long)v.SpawnCount, 4);
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, TeamConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => TeamConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long TeamConfigSaveTyped(TeamConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TeamConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TeamConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TeamConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TeamConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(TeamConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => TeamConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long TeamConfigMeasure(TeamConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, TeamConfigTableType(), Span<byte>.Empty, ids, true);
+            return TeamConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TeamConfigSave(TeamConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, TeamConfigTableType(), buffer, ids, false);
+            return TeamConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TeamConfigLoadVerdict(TeamConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -205,16 +271,81 @@ namespace Tabledemo
             value.Tracking = false;
         }
 
+        public static bool GunnerConfigCollectTyped(GunnerConfig v, ref TableWire.Ids ids)
+        {
+            if (v.Reaction != 0.2f && !ids.Add(0xb75aa3662201646aul)) return false;
+            if (v.Tracking != false && !ids.Add(0xa6bf719a4602b0bcul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(GunnerConfig v, ref TableWire.Ids ids) => GunnerConfigCollectTyped(v, ref ids);
+
+        public static long GunnerConfigBodySizeTyped(GunnerConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.Reference(0xb75aa3662201646aul)) + 5; }
+            if (v.Tracking != false) { n += TableWire.VarSize(ids.Reference(0xa6bf719a4602b0bcul)) + 2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(GunnerConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void GunnerConfigWriteBodyTyped(ref TableWire.Writer w, GunnerConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Reaction != 0.2f)
+            {
+                w.Header(ids.Reference(0xb75aa3662201646aul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Reaction)), 4);
+            }
+            if (v.Tracking != false)
+            {
+                w.Header(ids.Reference(0xa6bf719a4602b0bcul), 1);
+                w.Fixed(v.Tracking ? 1ul : 0ul, 1);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long GunnerConfigSaveTyped(GunnerConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = GunnerConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!GunnerConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + GunnerConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            GunnerConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(GunnerConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long GunnerConfigMeasure(GunnerConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GunnerConfigTableType(), Span<byte>.Empty, ids, true);
+            return GunnerConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long GunnerConfigSave(GunnerConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GunnerConfigTableType(), buffer, ids, false);
+            return GunnerConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict GunnerConfigLoadVerdict(GunnerConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -244,16 +375,89 @@ namespace Tabledemo
             value.GunnerPresent = false;
         }
 
+        public static bool TurretConfigCollectTyped(TurretConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = TurretConfigTableType().Fields;
+            if (v.Damage != 10.0f && !ids.Add(0x7f6308be8ab37fc0ul)) return false;
+            if (v.Cooldown != 0.5f && !ids.Add(0xdc2cbe6953343d48ul)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(TurretConfig v, ref TableWire.Ids ids) => TurretConfigCollectTyped(v, ref ids);
+
+        public static long TurretConfigBodySizeTyped(TurretConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = TurretConfigTableType().Fields;
+            if (v.Damage != 10.0f) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.Cooldown != 0.5f) { n += TableWire.VarSize(ids.Reference(0xdc2cbe6953343d48ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(TurretConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => TurretConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void TurretConfigWriteBodyTyped(ref TableWire.Writer w, TurretConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = TurretConfigTableType().Fields;
+            if (v.Damage != 10.0f)
+            {
+                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Damage)), 4);
+            }
+            if (v.Cooldown != 0.5f)
+            {
+                w.Header(ids.Reference(0xdc2cbe6953343d48ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Cooldown)), 4);
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, TurretConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => TurretConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long TurretConfigSaveTyped(TurretConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = TurretConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!TurretConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + TurretConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            TurretConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(TurretConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => TurretConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long TurretConfigMeasure(TurretConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, TurretConfigTableType(), Span<byte>.Empty, ids, true);
+            return TurretConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long TurretConfigSave(TurretConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, TurretConfigTableType(), buffer, ids, false);
+            return TurretConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict TurretConfigLoadVerdict(TurretConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -285,16 +489,89 @@ namespace Tabledemo
             }
         }
 
+        public static bool HullConfigCollectTyped(HullConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = HullConfigTableType().Fields;
+            if (v.Health != 100.0f && !ids.Add(0x7f69d4b5288ba9cful)) return false;
+            if (v.Mass != 1.0f && !ids.Add(0x1f3757a2ce7b0ab1ul)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(HullConfig v, ref TableWire.Ids ids) => HullConfigCollectTyped(v, ref ids);
+
+        public static long HullConfigBodySizeTyped(HullConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = HullConfigTableType().Fields;
+            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.Reference(0x1f3757a2ce7b0ab1ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(HullConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => HullConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void HullConfigWriteBodyTyped(ref TableWire.Writer w, HullConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = HullConfigTableType().Fields;
+            if (v.Health != 100.0f)
+            {
+                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Health)), 4);
+            }
+            if (v.Mass != 1.0f)
+            {
+                w.Header(ids.Reference(0x1f3757a2ce7b0ab1ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Mass)), 4);
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, HullConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => HullConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long HullConfigSaveTyped(HullConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = HullConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!HullConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + HullConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            HullConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(HullConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => HullConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long HullConfigMeasure(HullConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, HullConfigTableType(), Span<byte>.Empty, ids, true);
+            return HullConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long HullConfigSave(HullConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, HullConfigTableType(), buffer, ids, false);
+            return HullConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict HullConfigLoadVerdict(HullConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -329,16 +606,85 @@ namespace Tabledemo
             TableReset(value.Scores);
         }
 
+        public static bool KeyedConfigCollectTyped(KeyedConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = KeyedConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(KeyedConfig v, ref TableWire.Ids ids) => KeyedConfigCollectTyped(v, ref ids);
+
+        public static long KeyedConfigBodySizeTyped(KeyedConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = KeyedConfigTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(KeyedConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => KeyedConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void KeyedConfigWriteBodyTyped(ref TableWire.Writer w, KeyedConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = KeyedConfigTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, KeyedConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => KeyedConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long KeyedConfigSaveTyped(KeyedConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = KeyedConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!KeyedConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + KeyedConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            KeyedConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(KeyedConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => KeyedConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long KeyedConfigMeasure(KeyedConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, KeyedConfigTableType(), Span<byte>.Empty, ids, true);
+            return KeyedConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long KeyedConfigSave(KeyedConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, KeyedConfigTableType(), buffer, ids, false);
+            return KeyedConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict KeyedConfigLoadVerdict(KeyedConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -365,16 +711,75 @@ namespace Tabledemo
             Array.Clear(value.PerTeam, 0, value.PerTeam.Length);
         }
 
+        public static bool ScoreBoardCollectTyped(ScoreBoard v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = ScoreBoardTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ScoreBoard v, ref TableWire.Ids ids) => ScoreBoardCollectTyped(v, ref ids);
+
+        public static long ScoreBoardBodySizeTyped(ScoreBoard v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = ScoreBoardTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ScoreBoard v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ScoreBoardBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ScoreBoardWriteBodyTyped(ref TableWire.Writer w, ScoreBoard v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = ScoreBoardTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ScoreBoard v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ScoreBoardWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ScoreBoardSaveTyped(ScoreBoard value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ScoreBoardTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ScoreBoardCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ScoreBoardBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ScoreBoardWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ScoreBoard value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ScoreBoardSaveTyped(value, buffer, vocabulary, measure);
+
         public static long ScoreBoardMeasure(ScoreBoard value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ScoreBoardTableType(), Span<byte>.Empty, ids, true);
+            return ScoreBoardSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ScoreBoardSave(ScoreBoard value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ScoreBoardTableType(), buffer, ids, false);
+            return ScoreBoardSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ScoreBoardLoadVerdict(ScoreBoard value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/NestedTable.cs
+++ b/testdata/golden/tables/examples-cs/NestedTable.cs
@@ -32,16 +32,82 @@ namespace Tabledemo
             value.Count = 1;
         }
 
+        public static bool ArchiveConfigCollectTyped(ArchiveConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = ArchiveConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (v.Count != 1 && !ids.Add(0xb1e5e28e4479a274ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ArchiveConfig v, ref TableWire.Ids ids) => ArchiveConfigCollectTyped(v, ref ids);
+
+        public static long ArchiveConfigBodySizeTyped(ArchiveConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = ArchiveConfigTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            if (v.Count != 1) { n += TableWire.VarSize(ids.Reference(0xb1e5e28e4479a274ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ArchiveConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArchiveConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ArchiveConfigWriteBodyTyped(ref TableWire.Writer w, ArchiveConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = ArchiveConfigTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            if (v.Count != 1)
+            {
+                w.Header(ids.Reference(0xb1e5e28e4479a274ul), 4);
+                w.Fixed((ulong)(long)v.Count, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ArchiveConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArchiveConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ArchiveConfigSaveTyped(ArchiveConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ArchiveConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ArchiveConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ArchiveConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ArchiveConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ArchiveConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArchiveConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long ArchiveConfigMeasure(ArchiveConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ArchiveConfigTableType(), Span<byte>.Empty, ids, true);
+            return ArchiveConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ArchiveConfigSave(ArchiveConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ArchiveConfigTableType(), buffer, ids, false);
+            return ArchiveConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ArchiveConfigLoadVerdict(ArchiveConfig value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/NestedTable.cs
+++ b/testdata/golden/tables/examples-cs/NestedTable.cs
@@ -40,8 +40,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(ArchiveConfig v, ref TableWire.Ids ids) => ArchiveConfigCollectTyped(v, ref ids);
-
         public static long ArchiveConfigBodySizeTyped(ArchiveConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -51,8 +49,6 @@ namespace Tabledemo
             if (v.Count != 1) { n += TableWire.VarSize(ids.Reference(0xb1e5e28e4479a274ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(ArchiveConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ArchiveConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void ArchiveConfigWriteBodyTyped(ref TableWire.Writer w, ArchiveConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -66,8 +62,6 @@ namespace Tabledemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, ArchiveConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ArchiveConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long ArchiveConfigSaveTyped(ArchiveConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -95,8 +89,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ArchiveConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ArchiveConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long ArchiveConfigMeasure(ArchiveConfig value)
         {

--- a/testdata/golden/tables/examples-cs/PackTable.cs
+++ b/testdata/golden/tables/examples-cs/PackTable.cs
@@ -146,8 +146,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(GunnerSettings v, ref TableWire.Ids ids) => GunnerSettingsCollectTyped(v, ref ids);
-
         public static long GunnerSettingsBodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -158,8 +156,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
         }
-
-        public static long BodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void GunnerSettingsWriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -178,8 +174,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long GunnerSettingsSaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -207,8 +201,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerSettingsSaveTyped(value, buffer, vocabulary, measure);
 
         public static long GunnerSettingsMeasure(GunnerSettings value)
         {
@@ -264,8 +256,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(ShipEntry v, ref TableWire.Ids ids) => ShipEntryCollectTyped(v, ref ids);
-
         public static long ShipEntryBodySizeTyped(ShipEntry v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -280,8 +270,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
             return n;
         }
-
-        public static long BodySizeTyped(ShipEntry v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ShipEntryBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void ShipEntryWriteBodyTyped(ref TableWire.Writer w, ShipEntry v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -304,8 +292,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[4], ref ids, default, payload_4);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, ShipEntry v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ShipEntryWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long ShipEntrySaveTyped(ShipEntry value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -333,8 +319,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ShipEntry value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ShipEntrySaveTyped(value, buffer, vocabulary, measure);
 
         public static long ShipEntryMeasure(ShipEntry value)
         {
@@ -386,8 +370,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(GlobalSettings v, ref TableWire.Ids ids) => GlobalSettingsCollectTyped(v, ref ids);
-
         public static long GlobalSettingsBodySizeTyped(GlobalSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -400,8 +382,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
             return n;
         }
-
-        public static long BodySizeTyped(GlobalSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GlobalSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void GlobalSettingsWriteBodyTyped(ref TableWire.Writer w, GlobalSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -418,8 +398,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[3], ref ids, default, payload_3);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, GlobalSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GlobalSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long GlobalSettingsSaveTyped(GlobalSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -447,8 +425,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(GlobalSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GlobalSettingsSaveTyped(value, buffer, vocabulary, measure);
 
         public static long GlobalSettingsMeasure(GlobalSettings value)
         {
@@ -508,8 +484,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(PackConfig v, ref TableWire.Ids ids) => PackConfigCollectTyped(v, ref ids);
-
         public static long PackConfigBodySizeTyped(PackConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -534,8 +508,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
             return n;
         }
-
-        public static long BodySizeTyped(PackConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PackConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void PackConfigWriteBodyTyped(ref TableWire.Writer w, PackConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -565,8 +537,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, PackConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PackConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long PackConfigSaveTyped(PackConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = PackConfigTableType();
@@ -593,8 +563,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(PackConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PackConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long PackConfigMeasure(PackConfig value)
         {

--- a/testdata/golden/tables/examples-cs/PackTable.cs
+++ b/testdata/golden/tables/examples-cs/PackTable.cs
@@ -137,16 +137,89 @@ namespace Tabledemo
             value.CallsignLength = 0;
         }
 
+        public static bool GunnerSettingsCollectTyped(GunnerSettings v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            if (v.Reaction != 0.2f && !ids.Add(0xb75aa3662201646aul)) return false;
+            if (v.Tracking != false && !ids.Add(0xa6bf719a4602b0bcul)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(GunnerSettings v, ref TableWire.Ids ids) => GunnerSettingsCollectTyped(v, ref ids);
+
+        public static long GunnerSettingsBodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.Reference(0xb75aa3662201646aul)) + 5; }
+            if (v.Tracking != false) { n += TableWire.VarSize(ids.Reference(0xa6bf719a4602b0bcul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(GunnerSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GunnerSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void GunnerSettingsWriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
+            if (v.Reaction != 0.2f)
+            {
+                w.Header(ids.Reference(0xb75aa3662201646aul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Reaction)), 4);
+            }
+            if (v.Tracking != false)
+            {
+                w.Header(ids.Reference(0xa6bf719a4602b0bcul), 1);
+                w.Fixed(v.Tracking ? 1ul : 0ul, 1);
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, GunnerSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GunnerSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long GunnerSettingsSaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = GunnerSettingsTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!GunnerSettingsCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + GunnerSettingsBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            GunnerSettingsWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(GunnerSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GunnerSettingsSaveTyped(value, buffer, vocabulary, measure);
+
         public static long GunnerSettingsMeasure(GunnerSettings value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GunnerSettingsTableType(), Span<byte>.Empty, ids, true);
+            return GunnerSettingsSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long GunnerSettingsSave(GunnerSettings value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GunnerSettingsTableType(), buffer, ids, false);
+            return GunnerSettingsSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict GunnerSettingsLoadVerdict(GunnerSettings value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -180,16 +253,99 @@ namespace Tabledemo
             value.GunnerPresent = false;
         }
 
+        public static bool ShipEntryCollectTyped(ShipEntry v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = ShipEntryTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (v.Health != 100.0f && !ids.Add(0x7f69d4b5288ba9cful)) return false;
+            if (v.Mass != 1.0f && !ids.Add(0x1f3757a2ce7b0ab1ul)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ShipEntry v, ref TableWire.Ids ids) => ShipEntryCollectTyped(v, ref ids);
+
+        public static long ShipEntryBodySizeTyped(ShipEntry v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = ShipEntryTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.Reference(0x1f3757a2ce7b0ab1ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids, default, out long payload_3);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
+            n += TableWire.BodySizeField(v, fields[4], ref ids, default, out long payload_4);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ShipEntry v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ShipEntryBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ShipEntryWriteBodyTyped(ref TableWire.Writer w, ShipEntry v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = ShipEntryTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            if (v.Health != 100.0f)
+            {
+                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Health)), 4);
+            }
+            if (v.Mass != 1.0f)
+            {
+                w.Header(ids.Reference(0x1f3757a2ce7b0ab1ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Mass)), 4);
+            }
+            long payload_3 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[3] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids, default, payload_3);
+            long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids, default, payload_4);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ShipEntry v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ShipEntryWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ShipEntrySaveTyped(ShipEntry value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ShipEntryTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ShipEntryCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ShipEntryBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ShipEntryWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ShipEntry value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ShipEntrySaveTyped(value, buffer, vocabulary, measure);
+
         public static long ShipEntryMeasure(ShipEntry value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ShipEntryTableType(), Span<byte>.Empty, ids, true);
+            return ShipEntrySaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ShipEntrySave(ShipEntry value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ShipEntryTableType(), buffer, ids, false);
+            return ShipEntrySaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ShipEntryLoadVerdict(ShipEntry value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -220,16 +376,90 @@ namespace Tabledemo
             Array.Clear(value.SpawnDelays, 0, value.SpawnDelays.Length);
         }
 
+        public static bool GlobalSettingsCollectTyped(GlobalSettings v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = GlobalSettingsTableType().Fields;
+            if (v.TickRate != 60 && !ids.Add(0xa65f859b617deaf3ul)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(GlobalSettings v, ref TableWire.Ids ids) => GlobalSettingsCollectTyped(v, ref ids);
+
+        public static long GlobalSettingsBodySizeTyped(GlobalSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = GlobalSettingsTableType().Fields;
+            if (v.TickRate != 60) { n += TableWire.VarSize(ids.Reference(0xa65f859b617deaf3ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids);
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids, default, out long payload_3);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
+            return n;
+        }
+
+        public static long BodySizeTyped(GlobalSettings v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => GlobalSettingsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void GlobalSettingsWriteBodyTyped(ref TableWire.Writer w, GlobalSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = GlobalSettingsTableType().Fields;
+            if (v.TickRate != 60)
+            {
+                w.Header(ids.Reference(0xa65f859b617deaf3ul), 8);
+                w.Fixed((ulong)v.TickRate, 4);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            long payload_3 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[3] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids, default, payload_3);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, GlobalSettings v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => GlobalSettingsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long GlobalSettingsSaveTyped(GlobalSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = GlobalSettingsTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!GlobalSettingsCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + GlobalSettingsBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            GlobalSettingsWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(GlobalSettings value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => GlobalSettingsSaveTyped(value, buffer, vocabulary, measure);
+
         public static long GlobalSettingsMeasure(GlobalSettings value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GlobalSettingsTableType(), Span<byte>.Empty, ids, true);
+            return GlobalSettingsSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long GlobalSettingsSave(GlobalSettings value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, GlobalSettingsTableType(), buffer, ids, false);
+            return GlobalSettingsSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict GlobalSettingsLoadVerdict(GlobalSettings value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -267,16 +497,115 @@ namespace Tabledemo
             value.ReservesCount = 0;
         }
 
+        public static bool PackConfigCollectTyped(PackConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = PackConfigTableType().Fields;
+            if (v.Version != 1 && !ids.Add(0xbb62c62c9808ea37ul)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(PackConfig v, ref TableWire.Ids ids) => PackConfigCollectTyped(v, ref ids);
+
+        public static long PackConfigBodySizeTyped(PackConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = PackConfigTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 1) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 5; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids, default, out long payload_3);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
+            scoped Span<long> elemCache_4 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[4]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_4 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[4], ref ids, elemCache_4, out long payload_4);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
+            return n;
+        }
+
+        public static long BodySizeTyped(PackConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => PackConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void PackConfigWriteBodyTyped(ref TableWire.Writer w, PackConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = PackConfigTableType().Fields;
+            int elemOffset = 0;
+            if (v.Version != 1)
+            {
+                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 8);
+                w.Fixed((ulong)v.Version, 4);
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            long payload_3 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[3] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids, default, payload_3);
+            scoped ReadOnlySpan<long> elemCache_4 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[4]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_4 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids, elemCache_4, payload_4);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, PackConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => PackConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long PackConfigSaveTyped(PackConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = PackConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!PackConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + PackConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            PackConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(PackConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => PackConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long PackConfigMeasure(PackConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, PackConfigTableType(), Span<byte>.Empty, ids, true);
+            return PackConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long PackConfigSave(PackConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, PackConfigTableType(), buffer, ids, false);
+            return PackConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict PackConfigLoadVerdict(PackConfig value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/RangesTable.cs
+++ b/testdata/golden/tables/examples-cs/RangesTable.cs
@@ -100,16 +100,187 @@ namespace Tabledemo
             value.EdgesCount = 0;
         }
 
+        public static bool RangedSignedCollectTyped(RangedSigned v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RangedSignedTableType().Fields;
+            if (v.I8Span != 0 && !ids.Add(0x48121511bf702eb5ul)) return false;
+            if (v.I8Low != 0 && !ids.Add(0x942bfe3168090f7dul)) return false;
+            if (v.I8High != 0 && !ids.Add(0xd182acd105b55dd1ul)) return false;
+            if (v.I8Inside != 0 && !ids.Add(0xef9ded23c8912a81ul)) return false;
+            if (v.I16Span != 0 && !ids.Add(0xb655574ea23760b4ul)) return false;
+            if (v.I16Low != 0 && !ids.Add(0xd217b3af8d7a2bdeul)) return false;
+            if (v.I16High != 0 && !ids.Add(0x90652f70c9127900ul)) return false;
+            if (v.I16Inside != 0 && !ids.Add(0x6a659d7c354db158ul)) return false;
+            if (v.I32Span != 0 && !ids.Add(0xe693bd88532c91d6ul)) return false;
+            if (v.I32Low != 0 && !ids.Add(0x065ee827cf99fbb4ul)) return false;
+            if (v.I32High != 0 && !ids.Add(0xc9b121c4c2a186eeul)) return false;
+            if (v.I32Inside != 0 && !ids.Add(0xd363dfa465acf27aul)) return false;
+            if (v.I64Span != 0 && !ids.Add(0x7549c70700c49d6ful)) return false;
+            if (v.I64Low != 0 && !ids.Add(0x1cce6617419771dbul)) return false;
+            if (v.I64High != 0 && !ids.Add(0x3b54fa60620b5597ul)) return false;
+            if (v.I64Inside != 0 && !ids.Add(0xd308fcb98ece5d23ul)) return false;
+            if (!TableWire.CollectField(v, fields[16], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RangedSigned v, ref TableWire.Ids ids) => RangedSignedCollectTyped(v, ref ids);
+
+        public static long RangedSignedBodySizeTyped(RangedSigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RangedSignedTableType().Fields;
+            if (v.I8Span != 0) { n += TableWire.VarSize(ids.Reference(0x48121511bf702eb5ul)) + 2; }
+            if (v.I8Low != 0) { n += TableWire.VarSize(ids.Reference(0x942bfe3168090f7dul)) + 2; }
+            if (v.I8High != 0) { n += TableWire.VarSize(ids.Reference(0xd182acd105b55dd1ul)) + 2; }
+            if (v.I8Inside != 0) { n += TableWire.VarSize(ids.Reference(0xef9ded23c8912a81ul)) + 2; }
+            if (v.I16Span != 0) { n += TableWire.VarSize(ids.Reference(0xb655574ea23760b4ul)) + 3; }
+            if (v.I16Low != 0) { n += TableWire.VarSize(ids.Reference(0xd217b3af8d7a2bdeul)) + 3; }
+            if (v.I16High != 0) { n += TableWire.VarSize(ids.Reference(0x90652f70c9127900ul)) + 3; }
+            if (v.I16Inside != 0) { n += TableWire.VarSize(ids.Reference(0x6a659d7c354db158ul)) + 3; }
+            if (v.I32Span != 0) { n += TableWire.VarSize(ids.Reference(0xe693bd88532c91d6ul)) + 5; }
+            if (v.I32Low != 0) { n += TableWire.VarSize(ids.Reference(0x065ee827cf99fbb4ul)) + 5; }
+            if (v.I32High != 0) { n += TableWire.VarSize(ids.Reference(0xc9b121c4c2a186eeul)) + 5; }
+            if (v.I32Inside != 0) { n += TableWire.VarSize(ids.Reference(0xd363dfa465acf27aul)) + 5; }
+            if (v.I64Span != 0) { n += TableWire.VarSize(ids.Reference(0x7549c70700c49d6ful)) + 9; }
+            if (v.I64Low != 0) { n += TableWire.VarSize(ids.Reference(0x1cce6617419771dbul)) + 9; }
+            if (v.I64High != 0) { n += TableWire.VarSize(ids.Reference(0x3b54fa60620b5597ul)) + 9; }
+            if (v.I64Inside != 0) { n += TableWire.VarSize(ids.Reference(0xd308fcb98ece5d23ul)) + 9; }
+            n += TableWire.BodySizeField(v, fields[16], ref ids, default, out long payload_16);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RangedSigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedSignedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RangedSignedWriteBodyTyped(ref TableWire.Writer w, RangedSigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RangedSignedTableType().Fields;
+            if (v.I8Span != 0)
+            {
+                w.Header(ids.Reference(0x48121511bf702eb5ul), 2);
+                w.Fixed((ulong)(long)v.I8Span, 1);
+            }
+            if (v.I8Low != 0)
+            {
+                w.Header(ids.Reference(0x942bfe3168090f7dul), 2);
+                w.Fixed((ulong)(long)v.I8Low, 1);
+            }
+            if (v.I8High != 0)
+            {
+                w.Header(ids.Reference(0xd182acd105b55dd1ul), 2);
+                w.Fixed((ulong)(long)v.I8High, 1);
+            }
+            if (v.I8Inside != 0)
+            {
+                w.Header(ids.Reference(0xef9ded23c8912a81ul), 2);
+                w.Fixed((ulong)(long)v.I8Inside, 1);
+            }
+            if (v.I16Span != 0)
+            {
+                w.Header(ids.Reference(0xb655574ea23760b4ul), 3);
+                w.Fixed((ulong)(long)v.I16Span, 2);
+            }
+            if (v.I16Low != 0)
+            {
+                w.Header(ids.Reference(0xd217b3af8d7a2bdeul), 3);
+                w.Fixed((ulong)(long)v.I16Low, 2);
+            }
+            if (v.I16High != 0)
+            {
+                w.Header(ids.Reference(0x90652f70c9127900ul), 3);
+                w.Fixed((ulong)(long)v.I16High, 2);
+            }
+            if (v.I16Inside != 0)
+            {
+                w.Header(ids.Reference(0x6a659d7c354db158ul), 3);
+                w.Fixed((ulong)(long)v.I16Inside, 2);
+            }
+            if (v.I32Span != 0)
+            {
+                w.Header(ids.Reference(0xe693bd88532c91d6ul), 4);
+                w.Fixed((ulong)(long)v.I32Span, 4);
+            }
+            if (v.I32Low != 0)
+            {
+                w.Header(ids.Reference(0x065ee827cf99fbb4ul), 4);
+                w.Fixed((ulong)(long)v.I32Low, 4);
+            }
+            if (v.I32High != 0)
+            {
+                w.Header(ids.Reference(0xc9b121c4c2a186eeul), 4);
+                w.Fixed((ulong)(long)v.I32High, 4);
+            }
+            if (v.I32Inside != 0)
+            {
+                w.Header(ids.Reference(0xd363dfa465acf27aul), 4);
+                w.Fixed((ulong)(long)v.I32Inside, 4);
+            }
+            if (v.I64Span != 0)
+            {
+                w.Header(ids.Reference(0x7549c70700c49d6ful), 5);
+                w.Fixed((ulong)(long)v.I64Span, 8);
+            }
+            if (v.I64Low != 0)
+            {
+                w.Header(ids.Reference(0x1cce6617419771dbul), 5);
+                w.Fixed((ulong)(long)v.I64Low, 8);
+            }
+            if (v.I64High != 0)
+            {
+                w.Header(ids.Reference(0x3b54fa60620b5597ul), 5);
+                w.Fixed((ulong)(long)v.I64High, 8);
+            }
+            if (v.I64Inside != 0)
+            {
+                w.Header(ids.Reference(0xd308fcb98ece5d23ul), 5);
+                w.Fixed((ulong)(long)v.I64Inside, 8);
+            }
+            long payload_16 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[16] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[16], ref ids, default, payload_16);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RangedSigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedSignedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RangedSignedSaveTyped(RangedSigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RangedSignedTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RangedSignedCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RangedSignedBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RangedSignedWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RangedSigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedSignedSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RangedSignedMeasure(RangedSigned value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedSignedTableType(), Span<byte>.Empty, ids, true);
+            return RangedSignedSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RangedSignedSave(RangedSigned value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedSignedTableType(), buffer, ids, false);
+            return RangedSignedSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RangedSignedLoadVerdict(RangedSigned value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -153,16 +324,187 @@ namespace Tabledemo
             value.CountsCount = 0;
         }
 
+        public static bool RangedUnsignedCollectTyped(RangedUnsigned v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RangedUnsignedTableType().Fields;
+            if (v.U8Span != 0 && !ids.Add(0x0f8897557f37c021ul)) return false;
+            if (v.U8Low != 0 && !ids.Add(0x2e17553f8200a2a1ul)) return false;
+            if (v.U8High != 1 && !ids.Add(0xa0e5c60df9301b7dul)) return false;
+            if (v.U8Inside != 1 && !ids.Add(0x1cb2c073a6f5844dul)) return false;
+            if (v.U16Span != 0 && !ids.Add(0x4ca0c150b1790960ul)) return false;
+            if (v.U16Low != 0 && !ids.Add(0xf252136836b04cb2ul)) return false;
+            if (v.U16High != 1 && !ids.Add(0x4f37e1f216e7610cul)) return false;
+            if (v.U16Inside != 1 && !ids.Add(0xd176b605978f3304ul)) return false;
+            if (v.U32Span != 0 && !ids.Add(0x200b924de7479cdaul)) return false;
+            if (v.U32Low != 0 && !ids.Add(0xa53d2f2a31b5acb0ul)) return false;
+            if (v.U32High != 1 && !ids.Add(0x9759be8ea1a4e3d2ul)) return false;
+            if (v.U32Inside != 1 && !ids.Add(0x8dc515fc082e3c0eul)) return false;
+            if (v.U64Span != 0 && !ids.Add(0xbeecef11dbdf8973ul)) return false;
+            if (v.U64Low != 0 && !ids.Add(0x0117ad66e0fff227ul)) return false;
+            if (v.U64High != 1ul && !ids.Add(0xf2b45af3b50689dbul)) return false;
+            if (v.U64Inside != 1ul && !ids.Add(0x713e12017eebcaf7ul)) return false;
+            if (!TableWire.CollectField(v, fields[16], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RangedUnsigned v, ref TableWire.Ids ids) => RangedUnsignedCollectTyped(v, ref ids);
+
+        public static long RangedUnsignedBodySizeTyped(RangedUnsigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RangedUnsignedTableType().Fields;
+            if (v.U8Span != 0) { n += TableWire.VarSize(ids.Reference(0x0f8897557f37c021ul)) + 2; }
+            if (v.U8Low != 0) { n += TableWire.VarSize(ids.Reference(0x2e17553f8200a2a1ul)) + 2; }
+            if (v.U8High != 1) { n += TableWire.VarSize(ids.Reference(0xa0e5c60df9301b7dul)) + 2; }
+            if (v.U8Inside != 1) { n += TableWire.VarSize(ids.Reference(0x1cb2c073a6f5844dul)) + 2; }
+            if (v.U16Span != 0) { n += TableWire.VarSize(ids.Reference(0x4ca0c150b1790960ul)) + 3; }
+            if (v.U16Low != 0) { n += TableWire.VarSize(ids.Reference(0xf252136836b04cb2ul)) + 3; }
+            if (v.U16High != 1) { n += TableWire.VarSize(ids.Reference(0x4f37e1f216e7610cul)) + 3; }
+            if (v.U16Inside != 1) { n += TableWire.VarSize(ids.Reference(0xd176b605978f3304ul)) + 3; }
+            if (v.U32Span != 0) { n += TableWire.VarSize(ids.Reference(0x200b924de7479cdaul)) + 5; }
+            if (v.U32Low != 0) { n += TableWire.VarSize(ids.Reference(0xa53d2f2a31b5acb0ul)) + 5; }
+            if (v.U32High != 1) { n += TableWire.VarSize(ids.Reference(0x9759be8ea1a4e3d2ul)) + 5; }
+            if (v.U32Inside != 1) { n += TableWire.VarSize(ids.Reference(0x8dc515fc082e3c0eul)) + 5; }
+            if (v.U64Span != 0) { n += TableWire.VarSize(ids.Reference(0xbeecef11dbdf8973ul)) + 9; }
+            if (v.U64Low != 0) { n += TableWire.VarSize(ids.Reference(0x0117ad66e0fff227ul)) + 9; }
+            if (v.U64High != 1ul) { n += TableWire.VarSize(ids.Reference(0xf2b45af3b50689dbul)) + 9; }
+            if (v.U64Inside != 1ul) { n += TableWire.VarSize(ids.Reference(0x713e12017eebcaf7ul)) + 9; }
+            n += TableWire.BodySizeField(v, fields[16], ref ids, default, out long payload_16);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RangedUnsigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedUnsignedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RangedUnsignedWriteBodyTyped(ref TableWire.Writer w, RangedUnsigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RangedUnsignedTableType().Fields;
+            if (v.U8Span != 0)
+            {
+                w.Header(ids.Reference(0x0f8897557f37c021ul), 6);
+                w.Fixed((ulong)v.U8Span, 1);
+            }
+            if (v.U8Low != 0)
+            {
+                w.Header(ids.Reference(0x2e17553f8200a2a1ul), 6);
+                w.Fixed((ulong)v.U8Low, 1);
+            }
+            if (v.U8High != 1)
+            {
+                w.Header(ids.Reference(0xa0e5c60df9301b7dul), 6);
+                w.Fixed((ulong)v.U8High, 1);
+            }
+            if (v.U8Inside != 1)
+            {
+                w.Header(ids.Reference(0x1cb2c073a6f5844dul), 6);
+                w.Fixed((ulong)v.U8Inside, 1);
+            }
+            if (v.U16Span != 0)
+            {
+                w.Header(ids.Reference(0x4ca0c150b1790960ul), 7);
+                w.Fixed((ulong)v.U16Span, 2);
+            }
+            if (v.U16Low != 0)
+            {
+                w.Header(ids.Reference(0xf252136836b04cb2ul), 7);
+                w.Fixed((ulong)v.U16Low, 2);
+            }
+            if (v.U16High != 1)
+            {
+                w.Header(ids.Reference(0x4f37e1f216e7610cul), 7);
+                w.Fixed((ulong)v.U16High, 2);
+            }
+            if (v.U16Inside != 1)
+            {
+                w.Header(ids.Reference(0xd176b605978f3304ul), 7);
+                w.Fixed((ulong)v.U16Inside, 2);
+            }
+            if (v.U32Span != 0)
+            {
+                w.Header(ids.Reference(0x200b924de7479cdaul), 8);
+                w.Fixed((ulong)v.U32Span, 4);
+            }
+            if (v.U32Low != 0)
+            {
+                w.Header(ids.Reference(0xa53d2f2a31b5acb0ul), 8);
+                w.Fixed((ulong)v.U32Low, 4);
+            }
+            if (v.U32High != 1)
+            {
+                w.Header(ids.Reference(0x9759be8ea1a4e3d2ul), 8);
+                w.Fixed((ulong)v.U32High, 4);
+            }
+            if (v.U32Inside != 1)
+            {
+                w.Header(ids.Reference(0x8dc515fc082e3c0eul), 8);
+                w.Fixed((ulong)v.U32Inside, 4);
+            }
+            if (v.U64Span != 0)
+            {
+                w.Header(ids.Reference(0xbeecef11dbdf8973ul), 9);
+                w.Fixed((ulong)v.U64Span, 8);
+            }
+            if (v.U64Low != 0)
+            {
+                w.Header(ids.Reference(0x0117ad66e0fff227ul), 9);
+                w.Fixed((ulong)v.U64Low, 8);
+            }
+            if (v.U64High != 1ul)
+            {
+                w.Header(ids.Reference(0xf2b45af3b50689dbul), 9);
+                w.Fixed((ulong)v.U64High, 8);
+            }
+            if (v.U64Inside != 1ul)
+            {
+                w.Header(ids.Reference(0x713e12017eebcaf7ul), 9);
+                w.Fixed((ulong)v.U64Inside, 8);
+            }
+            long payload_16 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[16] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[16], ref ids, default, payload_16);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RangedUnsigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedUnsignedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RangedUnsignedSaveTyped(RangedUnsigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RangedUnsignedTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RangedUnsignedCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RangedUnsignedBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RangedUnsignedWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RangedUnsigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedUnsignedSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RangedUnsignedMeasure(RangedUnsigned value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedUnsignedTableType(), Span<byte>.Empty, ids, true);
+            return RangedUnsignedSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RangedUnsignedSave(RangedUnsigned value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedUnsignedTableType(), buffer, ids, false);
+            return RangedUnsignedSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RangedUnsignedLoadVerdict(RangedUnsigned value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -194,16 +536,109 @@ namespace Tabledemo
             value.B48 = 0;
         }
 
+        public static bool RangedWidthsCollectTyped(RangedWidths v, ref TableWire.Ids ids)
+        {
+            if (v.B8 != 0 && !ids.Add(0x08a60c07b54d8dc7ul)) return false;
+            if (v.B16 != 0 && !ids.Add(0xff95701912ad97beul)) return false;
+            if (v.B32 != 0 && !ids.Add(0xff9c5c1912b39470ul)) return false;
+            if (v.B64 != 0 && !ids.Add(0xff92701912ab61e7ul)) return false;
+            if (v.B12 != 0 && !ids.Add(0xff95741912ad9e8aul)) return false;
+            if (v.B48 != 0 && !ids.Add(0xff8b681912a535a1ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RangedWidths v, ref TableWire.Ids ids) => RangedWidthsCollectTyped(v, ref ids);
+
+        public static long RangedWidthsBodySizeTyped(RangedWidths v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.B8 != 0) { n += TableWire.VarSize(ids.Reference(0x08a60c07b54d8dc7ul)) + 2; }
+            if (v.B16 != 0) { n += TableWire.VarSize(ids.Reference(0xff95701912ad97beul)) + 3; }
+            if (v.B32 != 0) { n += TableWire.VarSize(ids.Reference(0xff9c5c1912b39470ul)) + 5; }
+            if (v.B64 != 0) { n += TableWire.VarSize(ids.Reference(0xff92701912ab61e7ul)) + 9; }
+            if (v.B12 != 0) { n += TableWire.VarSize(ids.Reference(0xff95741912ad9e8aul)) + 3; }
+            if (v.B48 != 0) { n += TableWire.VarSize(ids.Reference(0xff8b681912a535a1ul)) + 9; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RangedWidths v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedWidthsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RangedWidthsWriteBodyTyped(ref TableWire.Writer w, RangedWidths v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.B8 != 0)
+            {
+                w.Header(ids.Reference(0x08a60c07b54d8dc7ul), 6);
+                w.Fixed((ulong)v.B8, 1);
+            }
+            if (v.B16 != 0)
+            {
+                w.Header(ids.Reference(0xff95701912ad97beul), 7);
+                w.Fixed((ulong)v.B16, 2);
+            }
+            if (v.B32 != 0)
+            {
+                w.Header(ids.Reference(0xff9c5c1912b39470ul), 8);
+                w.Fixed((ulong)v.B32, 4);
+            }
+            if (v.B64 != 0)
+            {
+                w.Header(ids.Reference(0xff92701912ab61e7ul), 9);
+                w.Fixed((ulong)v.B64, 8);
+            }
+            if (v.B12 != 0)
+            {
+                w.Header(ids.Reference(0xff95741912ad9e8aul), 7);
+                w.Fixed((ulong)v.B12, 2);
+            }
+            if (v.B48 != 0)
+            {
+                w.Header(ids.Reference(0xff8b681912a535a1ul), 9);
+                w.Fixed((ulong)v.B48, 8);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RangedWidths v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedWidthsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RangedWidthsSaveTyped(RangedWidths value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RangedWidthsTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RangedWidthsCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RangedWidthsBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RangedWidthsWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RangedWidths value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedWidthsSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RangedWidthsMeasure(RangedWidths value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedWidthsTableType(), Span<byte>.Empty, ids, true);
+            return RangedWidthsSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RangedWidthsSave(RangedWidths value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RangedWidthsTableType(), buffer, ids, false);
+            return RangedWidthsSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RangedWidthsLoadVerdict(RangedWidths value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/RangesTable.cs
+++ b/testdata/golden/tables/examples-cs/RangesTable.cs
@@ -123,8 +123,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(RangedSigned v, ref TableWire.Ids ids) => RangedSignedCollectTyped(v, ref ids);
-
         public static long RangedSignedBodySizeTyped(RangedSigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -149,8 +147,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
             return n;
         }
-
-        public static long BodySizeTyped(RangedSigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedSignedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RangedSignedWriteBodyTyped(ref TableWire.Writer w, RangedSigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -240,8 +236,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RangedSigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedSignedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RangedSignedSaveTyped(RangedSigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RangedSignedTableType();
@@ -268,8 +262,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RangedSigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedSignedSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RangedSignedMeasure(RangedSigned value)
         {
@@ -347,8 +339,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(RangedUnsigned v, ref TableWire.Ids ids) => RangedUnsignedCollectTyped(v, ref ids);
-
         public static long RangedUnsignedBodySizeTyped(RangedUnsigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -373,8 +363,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
             return n;
         }
-
-        public static long BodySizeTyped(RangedUnsigned v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedUnsignedBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RangedUnsignedWriteBodyTyped(ref TableWire.Writer w, RangedUnsigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -464,8 +452,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RangedUnsigned v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedUnsignedWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RangedUnsignedSaveTyped(RangedUnsigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RangedUnsignedTableType();
@@ -492,8 +478,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RangedUnsigned value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedUnsignedSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RangedUnsignedMeasure(RangedUnsigned value)
         {
@@ -547,8 +531,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(RangedWidths v, ref TableWire.Ids ids) => RangedWidthsCollectTyped(v, ref ids);
-
         public static long RangedWidthsBodySizeTyped(RangedWidths v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -560,8 +542,6 @@ namespace Tabledemo
             if (v.B48 != 0) { n += TableWire.VarSize(ids.Reference(0xff8b681912a535a1ul)) + 9; }
             return n;
         }
-
-        public static long BodySizeTyped(RangedWidths v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RangedWidthsBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void RangedWidthsWriteBodyTyped(ref TableWire.Writer w, RangedWidths v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -598,8 +578,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RangedWidths v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RangedWidthsWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RangedWidthsSaveTyped(RangedWidths value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RangedWidthsTableType();
@@ -626,8 +604,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RangedWidths value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RangedWidthsSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RangedWidthsMeasure(RangedWidths value)
         {

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -2645,12 +2645,12 @@ namespace Tabledemo
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2684,7 +2684,7 @@ namespace Tabledemo
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4140,7 +4140,7 @@ namespace Tabledemo
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4177,7 +4177,7 @@ namespace Tabledemo
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4397,6 +4397,44 @@ namespace Tabledemo
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -447,7 +447,16 @@ namespace Tabledemo
             if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
             if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
             if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
-            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            int count_6 = v.AttachmentsCount;
+            if (count_6 < 0 || count_6 > 8) return false;
+            if (count_6 > 0)
+            {
+                if (!ids.Add(0xf901aa0340249a41ul)) return false;
+                for (int i_6 = 0; i_6 < count_6; i_6++)
+                {
+                    if (!AttachmentCollectTyped(v.Attachments[i_6], ref ids)) return false;
+                }
+            }
             return true;
         }
 
@@ -476,16 +485,27 @@ namespace Tabledemo
             }
             n += TableWire.BodySizeField(v, fields[5], ref ids, elemCache_5, out long payload_5);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
-            scoped Span<long> elemCache_6 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_6 = v.AttachmentsCount;
+            if (count_6 > 0)
             {
-                int c = TableWire.Count(v, fields[6]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                scoped Span<long> elemCache_6 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_6, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long nChild_6 = 0;
+                for (int i_6 = 0; i_6 < count_6; i_6++)
+                {
+                    long childBody = AttachmentBodySizeTyped(v.Attachments[i_6], ref ids);
+                    if (!elemCache_6.IsEmpty && i_6 < elemCache_6.Length) { elemCache_6[i_6] = childBody; }
+                    nChild_6 += TableWire.VarSize((ulong)childBody) + childBody;
+                }
+                long payload_6 = 1 + TableWire.VarSize((ulong)count_6) + nChild_6;
+                n += TableWire.VarSize(ids.Reference(0xf901aa0340249a41ul)) + 1 + TableWire.VarSize((ulong)payload_6) + payload_6;
+                if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
             }
-            n += TableWire.BodySizeField(v, fields[6], ref ids, elemCache_6, out long payload_6);
-            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
             return n;
         }
 
@@ -513,16 +533,38 @@ namespace Tabledemo
             }
             long payload_5 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[5] : -1;
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids, elemCache_5, payload_5);
-            scoped ReadOnlySpan<long> elemCache_6 = default;
-            if (!rootElemSizes.IsEmpty)
+            int count_6 = v.AttachmentsCount;
+            if (count_6 > 0)
             {
-                int c = TableWire.Count(v, fields[6]);
-                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
-                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
-                elemOffset += take;
+                w.Header(ids.Reference(0xf901aa0340249a41ul), 14);
+                scoped ReadOnlySpan<long> elemCache_6 = default;
+                if (!rootElemSizes.IsEmpty)
+                {
+                    int take = System.Math.Min(count_6, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                    elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                    elemOffset += take;
+                }
+                long payload_6 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[6] : -1;
+                if (payload_6 < 0)
+                {
+                    long nChild_6 = 0;
+                    for (int i_6 = 0; i_6 < count_6; i_6++)
+                    {
+                        long childBody = (!elemCache_6.IsEmpty && i_6 < elemCache_6.Length) ? elemCache_6[i_6] : AttachmentBodySizeTyped(v.Attachments[i_6], ref ids);
+                        nChild_6 += TableWire.VarSize((ulong)childBody) + childBody;
+                    }
+                    payload_6 = 1 + TableWire.VarSize((ulong)count_6) + nChild_6;
+                }
+                w.Var((ulong)payload_6);
+                w.Byte(13);
+                w.Var((ulong)count_6);
+                for (int i_6 = 0; i_6 < count_6; i_6++)
+                {
+                    long childBody = (!elemCache_6.IsEmpty && i_6 < elemCache_6.Length) ? elemCache_6[i_6] : AttachmentBodySizeTyped(v.Attachments[i_6], ref ids);
+                    w.Var((ulong)childBody);
+                    AttachmentWriteBodyTyped(ref w, v.Attachments[i_6], ref ids);
+                }
             }
-            long payload_6 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[6] : -1;
-            TableWire.WriteBodyField(ref w, v, fields[6], ref ids, elemCache_6, payload_6);
             w.Var(0);
         }
 

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -161,8 +161,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(RootConfig v, ref TableWire.Ids ids) => RootConfigCollectTyped(v, ref ids);
-
         public static long RootConfigBodySizeTyped(RootConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -193,8 +191,6 @@ namespace Tabledemo
             return n;
         }
 
-        public static long BodySizeTyped(RootConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RootConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void RootConfigWriteBodyTyped(ref TableWire.Writer w, RootConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = RootConfigTableType().Fields;
@@ -224,8 +220,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, RootConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RootConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long RootConfigSaveTyped(RootConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = RootConfigTableType();
@@ -252,8 +246,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(RootConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RootConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long RootConfigMeasure(RootConfig value)
         {
@@ -308,8 +300,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(WeaponConfig v, ref TableWire.Ids ids) => WeaponConfigCollectTyped(v, ref ids);
-
         public static long WeaponConfigBodySizeTyped(WeaponConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -322,8 +312,6 @@ namespace Tabledemo
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             return n;
         }
-
-        public static long BodySizeTyped(WeaponConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => WeaponConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void WeaponConfigWriteBodyTyped(ref TableWire.Writer w, WeaponConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -357,8 +345,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, WeaponConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => WeaponConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long WeaponConfigSaveTyped(WeaponConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = WeaponConfigTableType();
@@ -385,8 +371,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(WeaponConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => WeaponConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long WeaponConfigMeasure(WeaponConfig value)
         {
@@ -460,8 +444,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(LoadoutConfig v, ref TableWire.Ids ids) => LoadoutConfigCollectTyped(v, ref ids);
-
         public static long LoadoutConfigBodySizeTyped(LoadoutConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -508,8 +490,6 @@ namespace Tabledemo
             }
             return n;
         }
-
-        public static long BodySizeTyped(LoadoutConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => LoadoutConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void LoadoutConfigWriteBodyTyped(ref TableWire.Writer w, LoadoutConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -568,8 +548,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, LoadoutConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => LoadoutConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long LoadoutConfigSaveTyped(LoadoutConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = LoadoutConfigTableType();
@@ -596,8 +574,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(LoadoutConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => LoadoutConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long LoadoutConfigMeasure(LoadoutConfig value)
         {
@@ -668,8 +644,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(ProfileConfig v, ref TableWire.Ids ids) => ProfileConfigCollectTyped(v, ref ids);
-
         public static long ProfileConfigBodySizeTyped(ProfileConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -692,8 +666,6 @@ namespace Tabledemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[12] = payload_12; }
             return n;
         }
-
-        public static long BodySizeTyped(ProfileConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ProfileConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void ProfileConfigWriteBodyTyped(ref TableWire.Writer w, ProfileConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -753,8 +725,6 @@ namespace Tabledemo
             w.Var(0);
         }
 
-        public static void WriteBodyTyped(ref TableWire.Writer w, ProfileConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ProfileConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static long ProfileConfigSaveTyped(ProfileConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
             TableTypeInfo type = ProfileConfigTableType();
@@ -781,8 +751,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(ProfileConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ProfileConfigSaveTyped(value, buffer, vocabulary, measure);
 
         public static long ProfileConfigMeasure(ProfileConfig value)
         {
@@ -828,8 +796,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(Attachment v, ref TableWire.Ids ids) => AttachmentCollectTyped(v, ref ids);
-
         public static long AttachmentBodySizeTyped(Attachment v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -837,8 +803,6 @@ namespace Tabledemo
             if (v.Power != 1.0f) { n += TableWire.VarSize(ids.Reference(0xeef9d1358ae7b4e6ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(Attachment v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => AttachmentBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void AttachmentWriteBodyTyped(ref TableWire.Writer w, Attachment v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -854,8 +818,6 @@ namespace Tabledemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Attachment v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => AttachmentWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long AttachmentSaveTyped(Attachment value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -883,8 +845,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Attachment value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => AttachmentSaveTyped(value, buffer, vocabulary, measure);
 
         public static long AttachmentMeasure(Attachment value)
         {
@@ -928,16 +888,12 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(Buff v, ref TableWire.Ids ids) => BuffCollectTyped(v, ref ids);
-
         public static long BuffBodySizeTyped(Buff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
             if (v.Multiplier != 1.0f) { n += TableWire.VarSize(ids.Reference(0x9adc623a805c87c6ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(Buff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => BuffBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void BuffWriteBodyTyped(ref TableWire.Writer w, Buff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -948,8 +904,6 @@ namespace Tabledemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Buff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => BuffWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long BuffSaveTyped(Buff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -977,8 +931,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Buff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => BuffSaveTyped(value, buffer, vocabulary, measure);
 
         public static long BuffMeasure(Buff value)
         {
@@ -1022,16 +974,12 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(Debuff v, ref TableWire.Ids ids) => DebuffCollectTyped(v, ref ids);
-
         public static long DebuffBodySizeTyped(Debuff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
             if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(Debuff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => DebuffBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void DebuffWriteBodyTyped(ref TableWire.Writer w, Debuff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -1042,8 +990,6 @@ namespace Tabledemo
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Debuff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => DebuffWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long DebuffSaveTyped(Debuff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -1071,8 +1017,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Debuff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => DebuffSaveTyped(value, buffer, vocabulary, measure);
 
         public static long DebuffMeasure(Debuff value)
         {

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -152,16 +152,119 @@ namespace Tabledemo
             value.ProfilesCount = 0;
         }
 
+        public static bool RootConfigCollectTyped(RootConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = RootConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(RootConfig v, ref TableWire.Ids ids) => RootConfigCollectTyped(v, ref ids);
+
+        public static long RootConfigBodySizeTyped(RootConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = RootConfigTableType().Fields;
+            int elemOffset = 0;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            scoped Span<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, elemCache_1, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            scoped Span<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, elemCache_2, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(RootConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => RootConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void RootConfigWriteBodyTyped(ref TableWire.Writer w, RootConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = RootConfigTableType().Fields;
+            int elemOffset = 0;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            scoped ReadOnlySpan<long> elemCache_1 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[1]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_1 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, elemCache_1, payload_1);
+            scoped ReadOnlySpan<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, elemCache_2, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, RootConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => RootConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long RootConfigSaveTyped(RootConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = RootConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!RootConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + RootConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            RootConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(RootConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => RootConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long RootConfigMeasure(RootConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RootConfigTableType(), Span<byte>.Empty, ids, true);
+            return RootConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long RootConfigSave(RootConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, RootConfigTableType(), buffer, ids, false);
+            return RootConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict RootConfigLoadVerdict(RootConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -193,16 +296,108 @@ namespace Tabledemo
             TableReset(value.Effect);
         }
 
+        public static bool WeaponConfigCollectTyped(WeaponConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = WeaponConfigTableType().Fields;
+            if (v.Damage != 21.0f && !ids.Add(0x7f6308be8ab37fc0ul)) return false;
+            if (v.Speed != 500.0f && !ids.Add(0x1733055702acb1d2ul)) return false;
+            if (v.Penetration != 1 && !ids.Add(0x4f31c5309e13e932ul)) return false;
+            if (v.Channel != 0 && !ids.Add(0xa5013e9ad5caeda4ul)) return false;
+            if (v.Homing != false && !ids.Add(0xad6587bc602e3f59ul)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(WeaponConfig v, ref TableWire.Ids ids) => WeaponConfigCollectTyped(v, ref ids);
+
+        public static long WeaponConfigBodySizeTyped(WeaponConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = WeaponConfigTableType().Fields;
+            if (v.Damage != 21.0f) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.Speed != 500.0f) { n += TableWire.VarSize(ids.Reference(0x1733055702acb1d2ul)) + 5; }
+            if (v.Penetration != 1) { n += TableWire.VarSize(ids.Reference(0x4f31c5309e13e932ul)) + 5; }
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 2; }
+            if (v.Homing != false) { n += TableWire.VarSize(ids.Reference(0xad6587bc602e3f59ul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[5], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(WeaponConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => WeaponConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void WeaponConfigWriteBodyTyped(ref TableWire.Writer w, WeaponConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = WeaponConfigTableType().Fields;
+            if (v.Damage != 21.0f)
+            {
+                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Damage)), 4);
+            }
+            if (v.Speed != 500.0f)
+            {
+                w.Header(ids.Reference(0x1733055702acb1d2ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Speed)), 4);
+            }
+            if (v.Penetration != 1)
+            {
+                w.Header(ids.Reference(0x4f31c5309e13e932ul), 4);
+                w.Fixed((ulong)(long)v.Penetration, 4);
+            }
+            if (v.Channel != 0)
+            {
+                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 6);
+                w.Fixed((ulong)v.Channel, 1);
+            }
+            if (v.Homing != false)
+            {
+                w.Header(ids.Reference(0xad6587bc602e3f59ul), 1);
+                w.Fixed(v.Homing ? 1ul : 0ul, 1);
+            }
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, WeaponConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => WeaponConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long WeaponConfigSaveTyped(WeaponConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = WeaponConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!WeaponConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + WeaponConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            WeaponConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(WeaponConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => WeaponConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long WeaponConfigMeasure(WeaponConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, WeaponConfigTableType(), Span<byte>.Empty, ids, true);
+            return WeaponConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long WeaponConfigSave(WeaponConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, WeaponConfigTableType(), buffer, ids, false);
+            return WeaponConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict WeaponConfigLoadVerdict(WeaponConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -243,16 +438,135 @@ namespace Tabledemo
             value.AttachmentsCount = 0;
         }
 
+        public static bool LoadoutConfigCollectTyped(LoadoutConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = LoadoutConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[4], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[5], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[6], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(LoadoutConfig v, ref TableWire.Ids ids) => LoadoutConfigCollectTyped(v, ref ids);
+
+        public static long LoadoutConfigBodySizeTyped(LoadoutConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = LoadoutConfigTableType().Fields;
+            int elemOffset = 0;
+            n += TableWire.BodySizeField(v, fields[0], ref ids);
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids);
+            n += TableWire.BodySizeField(v, fields[4], ref ids, default, out long payload_4);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
+            scoped Span<long> elemCache_5 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[5]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_5 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[5], ref ids, elemCache_5, out long payload_5);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[5] = payload_5; }
+            scoped Span<long> elemCache_6 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[6]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[6], ref ids, elemCache_6, out long payload_6);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
+            return n;
+        }
+
+        public static long BodySizeTyped(LoadoutConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => LoadoutConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void LoadoutConfigWriteBodyTyped(ref TableWire.Writer w, LoadoutConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = LoadoutConfigTableType().Fields;
+            int elemOffset = 0;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids);
+            long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[4], ref ids, default, payload_4);
+            scoped ReadOnlySpan<long> elemCache_5 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[5]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_5 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_5 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[5] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[5], ref ids, elemCache_5, payload_5);
+            scoped ReadOnlySpan<long> elemCache_6 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[6]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_6 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_6 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[6] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[6], ref ids, elemCache_6, payload_6);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, LoadoutConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => LoadoutConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long LoadoutConfigSaveTyped(LoadoutConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = LoadoutConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!LoadoutConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + LoadoutConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            LoadoutConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(LoadoutConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => LoadoutConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long LoadoutConfigMeasure(LoadoutConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, LoadoutConfigTableType(), Span<byte>.Empty, ids, true);
+            return LoadoutConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long LoadoutConfigSave(LoadoutConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, LoadoutConfigTableType(), buffer, ids, false);
+            return LoadoutConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict LoadoutConfigLoadVerdict(LoadoutConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -293,16 +607,151 @@ namespace Tabledemo
             TableReset(value.Loadout);
         }
 
+        public static bool ProfileConfigCollectTyped(ProfileConfig v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = ProfileConfigTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (v.Experience != 0 && !ids.Add(0xab8b6d521f80b969ul)) return false;
+            if (v.Tilt != 0 && !ids.Add(0x1e5088ef2e9bafc6ul)) return false;
+            if (v.Heading != 0 && !ids.Add(0xb128829190ca0f75ul)) return false;
+            if (v.Timestamp != 0 && !ids.Add(0x5ddc92338ef53403ul)) return false;
+            if (v.Badge != 0 && !ids.Add(0x10bda981fe095518ul)) return false;
+            if (v.Port != 0 && !ids.Add(0x8c2cdb0da8933fa6ul)) return false;
+            if (v.Epoch != 0 && !ids.Add(0xfc9697d1196e6ba6ul)) return false;
+            if (v.Precision != 0.0 && !ids.Add(0x288427f5babd05f7ul)) return false;
+            if (!TableWire.CollectField(v, fields[10], ref ids)) return false;
+            if (v.HasLoadout != false && !ids.Add(0xa06f5e0a148e253cul)) return false;
+            if (!TableWire.CollectField(v, fields[12], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(ProfileConfig v, ref TableWire.Ids ids) => ProfileConfigCollectTyped(v, ref ids);
+
+        public static long ProfileConfigBodySizeTyped(ProfileConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = ProfileConfigTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids);
+            if (v.Experience != 0) { n += TableWire.VarSize(ids.Reference(0xab8b6d521f80b969ul)) + 5; }
+            if (v.Tilt != 0) { n += TableWire.VarSize(ids.Reference(0x1e5088ef2e9bafc6ul)) + 2; }
+            if (v.Heading != 0) { n += TableWire.VarSize(ids.Reference(0xb128829190ca0f75ul)) + 3; }
+            if (v.Timestamp != 0) { n += TableWire.VarSize(ids.Reference(0x5ddc92338ef53403ul)) + 9; }
+            if (v.Badge != 0) { n += TableWire.VarSize(ids.Reference(0x10bda981fe095518ul)) + 2; }
+            if (v.Port != 0) { n += TableWire.VarSize(ids.Reference(0x8c2cdb0da8933fa6ul)) + 3; }
+            if (v.Epoch != 0) { n += TableWire.VarSize(ids.Reference(0xfc9697d1196e6ba6ul)) + 9; }
+            if (v.Precision != 0.0) { n += TableWire.VarSize(ids.Reference(0x288427f5babd05f7ul)) + 9; }
+            n += TableWire.BodySizeField(v, fields[10], ref ids, default, out long payload_10);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
+            if (v.HasLoadout != false) { n += TableWire.VarSize(ids.Reference(0xa06f5e0a148e253cul)) + 2; }
+            n += TableWire.BodySizeField(v, fields[12], ref ids, default, out long payload_12);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[12] = payload_12; }
+            return n;
+        }
+
+        public static long BodySizeTyped(ProfileConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => ProfileConfigBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void ProfileConfigWriteBodyTyped(ref TableWire.Writer w, ProfileConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = ProfileConfigTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
+            if (v.Experience != 0)
+            {
+                w.Header(ids.Reference(0xab8b6d521f80b969ul), 8);
+                w.Fixed((ulong)v.Experience, 4);
+            }
+            if (v.Tilt != 0)
+            {
+                w.Header(ids.Reference(0x1e5088ef2e9bafc6ul), 2);
+                w.Fixed((ulong)(long)v.Tilt, 1);
+            }
+            if (v.Heading != 0)
+            {
+                w.Header(ids.Reference(0xb128829190ca0f75ul), 3);
+                w.Fixed((ulong)(long)v.Heading, 2);
+            }
+            if (v.Timestamp != 0)
+            {
+                w.Header(ids.Reference(0x5ddc92338ef53403ul), 5);
+                w.Fixed((ulong)(long)v.Timestamp, 8);
+            }
+            if (v.Badge != 0)
+            {
+                w.Header(ids.Reference(0x10bda981fe095518ul), 6);
+                w.Fixed((ulong)v.Badge, 1);
+            }
+            if (v.Port != 0)
+            {
+                w.Header(ids.Reference(0x8c2cdb0da8933fa6ul), 7);
+                w.Fixed((ulong)v.Port, 2);
+            }
+            if (v.Epoch != 0)
+            {
+                w.Header(ids.Reference(0xfc9697d1196e6ba6ul), 9);
+                w.Fixed((ulong)v.Epoch, 8);
+            }
+            if (v.Precision != 0.0)
+            {
+                w.Header(ids.Reference(0x288427f5babd05f7ul), 11);
+                w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Precision)), 8);
+            }
+            long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[10], ref ids, default, payload_10);
+            if (v.HasLoadout != false)
+            {
+                w.Header(ids.Reference(0xa06f5e0a148e253cul), 1);
+                w.Fixed(v.HasLoadout ? 1ul : 0ul, 1);
+            }
+            long payload_12 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[12] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[12], ref ids, default, payload_12);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, ProfileConfig v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => ProfileConfigWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long ProfileConfigSaveTyped(ProfileConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = ProfileConfigTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!ProfileConfigCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + ProfileConfigBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            ProfileConfigWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(ProfileConfig value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => ProfileConfigSaveTyped(value, buffer, vocabulary, measure);
+
         public static long ProfileConfigMeasure(ProfileConfig value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ProfileConfigTableType(), Span<byte>.Empty, ids, true);
+            return ProfileConfigSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long ProfileConfigSave(ProfileConfig value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, ProfileConfigTableType(), buffer, ids, false);
+            return ProfileConfigSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict ProfileConfigLoadVerdict(ProfileConfig value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -330,16 +779,81 @@ namespace Tabledemo
             value.Power = 1.0f;
         }
 
+        public static bool AttachmentCollectTyped(Attachment v, ref TableWire.Ids ids)
+        {
+            if (v.Slot != 0 && !ids.Add(0x6a771618f6fe31d1ul)) return false;
+            if (v.Power != 1.0f && !ids.Add(0xeef9d1358ae7b4e6ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Attachment v, ref TableWire.Ids ids) => AttachmentCollectTyped(v, ref ids);
+
+        public static long AttachmentBodySizeTyped(Attachment v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Slot != 0) { n += TableWire.VarSize(ids.Reference(0x6a771618f6fe31d1ul)) + 5; }
+            if (v.Power != 1.0f) { n += TableWire.VarSize(ids.Reference(0xeef9d1358ae7b4e6ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Attachment v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => AttachmentBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void AttachmentWriteBodyTyped(ref TableWire.Writer w, Attachment v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Slot != 0)
+            {
+                w.Header(ids.Reference(0x6a771618f6fe31d1ul), 4);
+                w.Fixed((ulong)(long)v.Slot, 4);
+            }
+            if (v.Power != 1.0f)
+            {
+                w.Header(ids.Reference(0xeef9d1358ae7b4e6ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Power)), 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Attachment v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => AttachmentWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long AttachmentSaveTyped(Attachment value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = AttachmentTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!AttachmentCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + AttachmentBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            AttachmentWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Attachment value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => AttachmentSaveTyped(value, buffer, vocabulary, measure);
+
         public static long AttachmentMeasure(Attachment value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, AttachmentTableType(), Span<byte>.Empty, ids, true);
+            return AttachmentSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long AttachmentSave(Attachment value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, AttachmentTableType(), buffer, ids, false);
+            return AttachmentSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict AttachmentLoadVerdict(Attachment value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -366,16 +880,74 @@ namespace Tabledemo
             value.Multiplier = 1.0f;
         }
 
+        public static bool BuffCollectTyped(Buff v, ref TableWire.Ids ids)
+        {
+            if (v.Multiplier != 1.0f && !ids.Add(0x9adc623a805c87c6ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Buff v, ref TableWire.Ids ids) => BuffCollectTyped(v, ref ids);
+
+        public static long BuffBodySizeTyped(Buff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Multiplier != 1.0f) { n += TableWire.VarSize(ids.Reference(0x9adc623a805c87c6ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Buff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => BuffBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void BuffWriteBodyTyped(ref TableWire.Writer w, Buff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Multiplier != 1.0f)
+            {
+                w.Header(ids.Reference(0x9adc623a805c87c6ul), 10);
+                w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Multiplier)), 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Buff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => BuffWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long BuffSaveTyped(Buff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = BuffTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!BuffCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + BuffBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            BuffWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Buff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => BuffSaveTyped(value, buffer, vocabulary, measure);
+
         public static long BuffMeasure(Buff value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, BuffTableType(), Span<byte>.Empty, ids, true);
+            return BuffSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long BuffSave(Buff value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, BuffTableType(), buffer, ids, false);
+            return BuffSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict BuffLoadVerdict(Buff value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -402,16 +974,74 @@ namespace Tabledemo
             value.Amount = 0;
         }
 
+        public static bool DebuffCollectTyped(Debuff v, ref TableWire.Ids ids)
+        {
+            if (v.Amount != 0 && !ids.Add(0x8113fe7ea2b16969ul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Debuff v, ref TableWire.Ids ids) => DebuffCollectTyped(v, ref ids);
+
+        public static long DebuffBodySizeTyped(Debuff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Debuff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => DebuffBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void DebuffWriteBodyTyped(ref TableWire.Writer w, Debuff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            if (v.Amount != 0)
+            {
+                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.Fixed((ulong)(long)v.Amount, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Debuff v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => DebuffWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long DebuffSaveTyped(Debuff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = DebuffTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!DebuffCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + DebuffBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            DebuffWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Debuff value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => DebuffSaveTyped(value, buffer, vocabulary, measure);
+
         public static long DebuffMeasure(Debuff value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, DebuffTableType(), Span<byte>.Empty, ids, true);
+            return DebuffSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long DebuffSave(Debuff value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, DebuffTableType(), buffer, ids, false);
+            return DebuffSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict DebuffLoadVerdict(Debuff value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/tables/examples-cs/WideTable.cs
+++ b/testdata/golden/tables/examples-cs/WideTable.cs
@@ -49,8 +49,6 @@ namespace Tabledemo
             return true;
         }
 
-        public static bool CollectTyped(WideBlob v, ref TableWire.Ids ids) => WideBlobCollectTyped(v, ref ids);
-
         public static long WideBlobBodySizeTyped(WideBlob v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -63,8 +61,6 @@ namespace Tabledemo
             return n;
         }
 
-        public static long BodySizeTyped(WideBlob v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => WideBlobBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void WideBlobWriteBodyTyped(ref TableWire.Writer w, WideBlob v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = WideBlobTableType().Fields;
@@ -75,8 +71,6 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, WideBlob v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => WideBlobWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long WideBlobSaveTyped(WideBlob value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -104,8 +98,6 @@ namespace Tabledemo
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(WideBlob value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => WideBlobSaveTyped(value, buffer, vocabulary, measure);
 
         public static long WideBlobMeasure(WideBlob value)
         {

--- a/testdata/golden/tables/examples-cs/WideTable.cs
+++ b/testdata/golden/tables/examples-cs/WideTable.cs
@@ -40,16 +40,83 @@ namespace Tabledemo
             value.SamplesCount = 0;
         }
 
+        public static bool WideBlobCollectTyped(WideBlob v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = WideBlobTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(WideBlob v, ref TableWire.Ids ids) => WideBlobCollectTyped(v, ref ids);
+
+        public static long WideBlobBodySizeTyped(WideBlob v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = WideBlobTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids);
+            n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            return n;
+        }
+
+        public static long BodySizeTyped(WideBlob v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => WideBlobBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void WideBlobWriteBodyTyped(ref TableWire.Writer w, WideBlob v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = WideBlobTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, default, payload_2);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, WideBlob v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => WideBlobWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long WideBlobSaveTyped(WideBlob value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = WideBlobTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!WideBlobCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + WideBlobBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            WideBlobWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(WideBlob value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => WideBlobSaveTyped(value, buffer, vocabulary, measure);
+
         public static long WideBlobMeasure(WideBlob value)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, WideBlobTableType(), Span<byte>.Empty, ids, true);
+            return WideBlobSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long WideBlobSave(WideBlob value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[155];
-            return TableWire.Save(value, WideBlobTableType(), buffer, ids, false);
+            return WideBlobSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict WideBlobLoadVerdict(WideBlob value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/wide/cs/CaptionTable.cs
+++ b/testdata/golden/wide/cs/CaptionTable.cs
@@ -94,16 +94,106 @@ namespace Wide
             TableReset(value.Body);
         }
 
+        public static bool CaptionCollectTyped(Caption v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = CaptionTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[1], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[2], ref ids)) return false;
+            if (!TableWire.CollectField(v, fields[3], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Caption v, ref TableWire.Ids ids) => CaptionCollectTyped(v, ref ids);
+
+        public static long CaptionBodySizeTyped(Caption v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = CaptionTableType().Fields;
+            int elemOffset = 0;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
+            scoped Span<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            n += TableWire.BodySizeField(v, fields[2], ref ids, elemCache_2, out long payload_2);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
+            n += TableWire.BodySizeField(v, fields[3], ref ids);
+            return n;
+        }
+
+        public static long BodySizeTyped(Caption v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => CaptionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void CaptionWriteBodyTyped(ref TableWire.Writer w, Caption v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = CaptionTableType().Fields;
+            int elemOffset = 0;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
+            scoped ReadOnlySpan<long> elemCache_2 = default;
+            if (!rootElemSizes.IsEmpty)
+            {
+                int c = TableWire.Count(v, fields[2]);
+                int take = System.Math.Min(c, System.Math.Max(0, rootElemSizes.Length - elemOffset));
+                elemCache_2 = rootElemSizes.Slice(elemOffset, take);
+                elemOffset += take;
+            }
+            long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[2], ref ids, elemCache_2, payload_2);
+            TableWire.WriteBodyField(ref w, v, fields[3], ref ids);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Caption v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => CaptionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long CaptionSaveTyped(Caption value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = CaptionTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!CaptionCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + CaptionBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            CaptionWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Caption value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => CaptionSaveTyped(value, buffer, vocabulary, measure);
+
         public static long CaptionMeasure(Caption value)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, CaptionTableType(), Span<byte>.Empty, ids, true);
+            return CaptionSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long CaptionSave(Caption value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, CaptionTableType(), buffer, ids, false);
+            return CaptionSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict CaptionLoadVerdict(Caption value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -132,16 +222,82 @@ namespace Wide
             value.Seq = 0;
         }
 
+        public static bool StampCollectTyped(Stamp v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = StampTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            if (v.Seq != 0 && !ids.Add(0x823b8a195ce2133cul)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Stamp v, ref TableWire.Ids ids) => StampCollectTyped(v, ref ids);
+
+        public static long StampBodySizeTyped(Stamp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = StampTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            if (v.Seq != 0) { n += TableWire.VarSize(ids.Reference(0x823b8a195ce2133cul)) + 5; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Stamp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => StampBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void StampWriteBodyTyped(ref TableWire.Writer w, Stamp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = StampTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            if (v.Seq != 0)
+            {
+                w.Header(ids.Reference(0x823b8a195ce2133cul), 8);
+                w.Fixed((ulong)v.Seq, 4);
+            }
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Stamp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => StampWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long StampSaveTyped(Stamp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = StampTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!StampCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + StampBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            StampWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Stamp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => StampSaveTyped(value, buffer, vocabulary, measure);
+
         public static long StampMeasure(Stamp value)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, StampTableType(), Span<byte>.Empty, ids, true);
+            return StampSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long StampSave(Stamp value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, StampTableType(), buffer, ids, false);
+            return StampSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict StampLoadVerdict(Stamp value, ReadOnlySpan<byte> bytes, TableReport report)
@@ -169,16 +325,75 @@ namespace Wide
             value.TextLength = 0;
         }
 
+        public static bool LineCollectTyped(Line v, ref TableWire.Ids ids)
+        {
+            TableFieldInfo[] fields = LineTableType().Fields;
+            if (!TableWire.CollectField(v, fields[0], ref ids)) return false;
+            return true;
+        }
+
+        public static bool CollectTyped(Line v, ref TableWire.Ids ids) => LineCollectTyped(v, ref ids);
+
+        public static long LineBodySizeTyped(Line v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
+        {
+            long n = 1;
+            TableFieldInfo[] fields = LineTableType().Fields;
+            n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
+            if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
+            return n;
+        }
+
+        public static long BodySizeTyped(Line v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => LineBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static void LineWriteBodyTyped(ref TableWire.Writer w, Line v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
+        {
+            TableFieldInfo[] fields = LineTableType().Fields;
+            long payload_0 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[0] : -1;
+            TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
+            w.Var(0);
+        }
+
+        public static void WriteBodyTyped(ref TableWire.Writer w, Line v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => LineWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
+
+        public static long LineSaveTyped(Line value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
+        {
+            TableTypeInfo type = LineTableType();
+            int slots = 0;
+            if (vocabulary.Length <= 1024)
+            {
+                slots = 1;
+                while (slots < vocabulary.Length * 2) { slots <<= 1; }
+            }
+            Span<int> index = stackalloc int[slots];
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            if (!LineCollectTyped(value, ref ids)) { return -1; }
+            int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
+            Span<long> rootPayloadSizes = stackalloc long[cachedFields];
+            int cachedElemSlots = !measure ? type.RootElemSlots : 0;
+            Span<long> rootElemSizes = stackalloc long[cachedElemSlots];
+            long n = 1 + LineBodySizeTyped(value, ref ids, rootPayloadSizes, rootElemSizes) + 8L * ids.Count + 8;
+            if (measure) { return n; }
+            if (n > buffer.Length) { return -1; }
+            scoped TableWire.Writer w = new TableWire.Writer(buffer);
+            w.Byte(1);
+            LineWriteBodyTyped(ref w, value, ref ids, rootPayloadSizes, rootElemSizes);
+            for (int i = 0; i < ids.Count; i++) { w.Fixed(ids.Values[i], 8); }
+            w.Fixed((ulong)ids.Count, 8);
+            return w.Offset;
+        }
+
+        public static long SaveTyped(Line value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => LineSaveTyped(value, buffer, vocabulary, measure);
+
         public static long LineMeasure(Line value)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, LineTableType(), Span<byte>.Empty, ids, true);
+            return LineSaveTyped(value, Span<byte>.Empty, ids, true);
         }
 
         public static long LineSave(Line value, Span<byte> buffer)
         {
             Span<ulong> ids = stackalloc ulong[16];
-            return TableWire.Save(value, LineTableType(), buffer, ids, false);
+            return LineSaveTyped(value, buffer, ids, false);
         }
 
         public static TableWire.Verdict LineLoadVerdict(Line value, ReadOnlySpan<byte> bytes, TableReport report)

--- a/testdata/golden/wide/cs/CaptionTable.cs
+++ b/testdata/golden/wide/cs/CaptionTable.cs
@@ -104,8 +104,6 @@ namespace Wide
             return true;
         }
 
-        public static bool CollectTyped(Caption v, ref TableWire.Ids ids) => CaptionCollectTyped(v, ref ids);
-
         public static long CaptionBodySizeTyped(Caption v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -129,8 +127,6 @@ namespace Wide
             return n;
         }
 
-        public static long BodySizeTyped(Caption v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => CaptionBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void CaptionWriteBodyTyped(ref TableWire.Writer w, Caption v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = CaptionTableType().Fields;
@@ -152,8 +148,6 @@ namespace Wide
             TableWire.WriteBodyField(ref w, v, fields[3], ref ids);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Caption v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => CaptionWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long CaptionSaveTyped(Caption value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -181,8 +175,6 @@ namespace Wide
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Caption value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => CaptionSaveTyped(value, buffer, vocabulary, measure);
 
         public static long CaptionMeasure(Caption value)
         {
@@ -230,8 +222,6 @@ namespace Wide
             return true;
         }
 
-        public static bool CollectTyped(Stamp v, ref TableWire.Ids ids) => StampCollectTyped(v, ref ids);
-
         public static long StampBodySizeTyped(Stamp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -241,8 +231,6 @@ namespace Wide
             if (v.Seq != 0) { n += TableWire.VarSize(ids.Reference(0x823b8a195ce2133cul)) + 5; }
             return n;
         }
-
-        public static long BodySizeTyped(Stamp v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => StampBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static void StampWriteBodyTyped(ref TableWire.Writer w, Stamp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
@@ -256,8 +244,6 @@ namespace Wide
             }
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Stamp v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => StampWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long StampSaveTyped(Stamp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -285,8 +271,6 @@ namespace Wide
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Stamp value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => StampSaveTyped(value, buffer, vocabulary, measure);
 
         public static long StampMeasure(Stamp value)
         {
@@ -332,8 +316,6 @@ namespace Wide
             return true;
         }
 
-        public static bool CollectTyped(Line v, ref TableWire.Ids ids) => LineCollectTyped(v, ref ids);
-
         public static long LineBodySizeTyped(Line v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
@@ -343,8 +325,6 @@ namespace Wide
             return n;
         }
 
-        public static long BodySizeTyped(Line v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default) => LineBodySizeTyped(v, ref ids, rootPayloadSizes, rootElemSizes);
-
         public static void LineWriteBodyTyped(ref TableWire.Writer w, Line v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default)
         {
             TableFieldInfo[] fields = LineTableType().Fields;
@@ -352,8 +332,6 @@ namespace Wide
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             w.Var(0);
         }
-
-        public static void WriteBodyTyped(ref TableWire.Writer w, Line v, ref TableWire.Ids ids, scoped ReadOnlySpan<long> rootPayloadSizes = default, scoped ReadOnlySpan<long> rootElemSizes = default) => LineWriteBodyTyped(ref w, v, ref ids, rootPayloadSizes, rootElemSizes);
 
         public static long LineSaveTyped(Line value, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
         {
@@ -381,8 +359,6 @@ namespace Wide
             w.Fixed((ulong)ids.Count, 8);
             return w.Offset;
         }
-
-        public static long SaveTyped(Line value, Span<byte> buffer, Span<ulong> vocabulary, bool measure) => LineSaveTyped(value, buffer, vocabulary, measure);
 
         public static long LineMeasure(Line value)
         {

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -2529,12 +2529,12 @@ namespace Wide
             // One schema-bounded vocabulary lives on the caller's stack for a save.
             // Collect follows the emitted fields in order. Measuring and writing then
             // look up stable references, so a nested length never needs patching.
-            ref struct Ids
+            public ref struct Ids
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
                 public int Count;
-                public Graph Graph;
+                internal Graph Graph;
                 public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
                 public Ids(Span<ulong> values, Span<int> slots)
                 { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
@@ -2568,7 +2568,7 @@ namespace Wide
                 }
             }
 
-            ref struct Writer
+            public ref struct Writer
             {
                 public Span<byte> Buffer;
                 public int Offset;
@@ -4024,7 +4024,7 @@ namespace Wide
                     default: return 0;
                 }
             }
-            static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
+            public static int VarSize(ulong v) { int n = 1; while (v >= 128) { n++; v >>= 7; } return n; }
             static byte Kind(TableFieldInfo f) { return f.KeyId != null ? (byte)16 : f.IsArray ? (byte)14 : f.Kind; }
             static bool Named(string name) { return name != null && name != "???"; }
             static bool DefaultRaw(ulong raw, TableFieldInfo f)
@@ -4061,7 +4061,7 @@ namespace Wide
                 for (int i = 0; i < f.ArrayBound; i++) { if (!DefaultElement(value, f, i)) { return true; } }
                 return false;
             }
-            static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
+            public static int Count(object value, TableFieldInfo f) { return f.Counted ? f.GetCount(value) : f.ArrayBound; }
             static bool CollectElement(object value, TableFieldInfo f, int i, ref Ids ids)
             {
                 if (f.Kind == 13) { return Collect(f.GetChild(value, i), f.Table, ref ids); }
@@ -4281,6 +4281,44 @@ namespace Wide
                 }
                 if (root) { WriteNodes(ref w, ref ids); }
                 w.Var(0);
+            }
+            public static bool CollectField(object value, TableFieldInfo f, ref Ids ids)
+            {
+                if (f.WireGuard != null && !f.WireGuard(value)) { return true; }
+                if (f.Optional && !f.GetPresent(value)) { return true; }
+                if (f.Counted && (Count(value, f) < 0 || Count(value, f) > f.ArrayBound)) { return false; }
+                return !Rides(value, f) || (ids.Add(f.Id) && CollectPayload(value, f, ref ids));
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache, out long payload)
+            {
+                payload = 0;
+                if (!Rides(value, f)) { return 0; }
+                long n = VarSize(ids.Reference(f.Id)) + 1;
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    payload = PayloadSize(value, f, ref ids, elemCache);
+                    n += VarSize((ulong)payload) + payload;
+                }
+                else
+                {
+                    n += ElementSize(value, f, 0, ref ids, true);
+                }
+                return n;
+            }
+            public static long BodySizeField(object value, TableFieldInfo f, ref Ids ids, scoped Span<long> elemCache = default)
+            {
+                return BodySizeField(value, f, ref ids, elemCache, out _);
+            }
+            public static void WriteBodyField(ref Writer w, object value, TableFieldInfo f, ref Ids ids, scoped ReadOnlySpan<long> elemCache = default, long cachedPayload = -1)
+            {
+                if (!Rides(value, f)) { return; }
+                w.Header(ids.Reference(f.Id), Kind(f));
+                if (f.IsArray || f.Kind == 12 || f.Kind == 33 || f.Kind == 13)
+                {
+                    long payload = cachedPayload >= 0 ? cachedPayload : PayloadSize(value, f, ref ids);
+                    w.Var((ulong)payload);
+                }
+                WritePayload(ref w, value, f, ref ids, elemCache);
             }
             public static long Save(object value, TableTypeInfo type, Span<byte> buffer, Span<ulong> vocabulary, bool measure)
             {


### PR DESCRIPTION
## C# Fixed Table: Typed Child Table Array Fast Path

Addresses Rowan's review findings on `emma/cs-typed-leaf-prototype` (`1080318e` / `54a81b07`).

### Key Changes
- **Typed child scalar array delegation**: Directly delegates child struct array elements to `SaveBody` / `MeasureBody` without allocating or traversing dynamic `TableWire.Field` descriptors.
- **Guard & Optional Safety**: In `isChildScalarArray`, explicitly rejects `f.Guard != ""` and `f.Type.Optional`. Any guarded or optional child table array diverts cleanly to dynamic descriptors, evaluating `Rides(value, f)` and `GetPresent(value)` and preserving 100% wire equivalence across all presence combinations.
- **Performance Impact**: Unkeyed array `BenchMixed.stats [..80]MixedStat` is neither guarded nor optional, eliminating 890 dynamic operations per save in C# paired benchmark.
- **Linters & Cleanup**: Resolved two gocritic `ifElseChain` findings by converting to switch statements; removed 24 unused unqualified alias overloads.
- **Equivalence Testing**:
  - Unit test `TestIsChildScalarArray` (10 cases) covering non-optional/optional, non-guarded/guarded, primitive/struct.
  - End-to-end Release test `TestCsTypedVsDynamicWireEquivalence` verifying exact bit-for-bit wire equality across all 9 combinations.

### Verification
- `go test -count=1 ./internal/codegen/cstable/...`: PASS (0.210s)
- `go test -count=1 ./compiler/tablescs_test.go`: PASS (2.572s)
- `go test -count=1 ./internal/goldens`: PASS (0.584s)
- `PATH="/Users/glenn/.dotnet:$PATH" go run ./bench/paired -mode gate -langs cs`: PASS
  - Leg wire identity: packet `6b213fbfa1a03a99` / table `07c57b4fa34b2700` bit-identical across all 8 legs.

I do not merge.