### PR TITLE
C tables: the id trailer in one checked store, and where the rest of the write gap actually is

### DIFF
--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -399,10 +399,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -400,10 +400,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -386,10 +386,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -224,10 +224,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -389,10 +389,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -389,10 +389,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -388,10 +388,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -396,10 +396,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -394,10 +394,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -394,10 +394,44 @@ static SCHEMA_UNUSED void table_writer_rewind( const TableWriter * probe )
         o=v->ordinal_of[v->count]; if(o>=0) { v->slot[o]=-1; }
     }
 }
+/* THE TRAILER IS A CONTIGUOUS RUN OF 64-BIT LITTLE-ENDIAN WORDS
+   (docs/SPEC-TABLES.md §3): the interned entry ids followed by the entry count.
+   A SINGLE CAPACITY TEST COVERS THE ENTIRE TRAILER EXTENT instead of one test
+   per 8-byte put64, and on little-endian architectures the contiguous ids array
+   is bulk-copied in place — the same trailer the C++ TableIdsWrite writes, byte
+   for byte. NOTHING IS REMOVED: an undersized buffer still raises the overflow
+   flag and Save still answers -1; what differs is only on that failing path,
+   where a trailer that does not fit now leaves the buffer alone rather than
+   filling it entry by entry, and nothing reads those bytes. A NULL BUFFER IS
+   THE SIZING WRITER: it counts the extent and copies nothing. */
 static SCHEMA_UNUSED void table_writer_finish( TableWriter * w )
 {
-    int i; for ( i = 0; i < w->vocabulary->count; i++ ) { table_writer_put64( w, w->vocabulary->ids[i] ); }
-    table_writer_put64( w, (uint64_t) w->vocabulary->count );
+    const int64_t count = w->vocabulary->count;
+    const int64_t total_bytes = ( count + 1 ) * 8;
+    if ( w->overflow || w->offset < 0 || w->offset > w->capacity || total_bytes > w->capacity - w->offset )
+    {
+        w->overflow = 1;
+        return;
+    }
+    if ( w->buffer != NULL )
+    {
+        uint8_t * dst = w->buffer + w->offset;
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        const uint64_t n = (uint64_t) count;
+        if ( count > 0 ) { memcpy( dst, w->vocabulary->ids, (size_t) ( count * 8 ) ); }
+        memcpy( dst + count * 8, &n, 8 );
+#else
+        /* Explicit little-endian stores also cover compilers that do not expose
+           byte-order macros. Native copies require positive little-endian proof. */
+        int64_t i; int j;
+        for ( i = 0; i <= count; i++ )
+        {
+            const uint64_t v = i < count ? w->vocabulary->ids[i] : (uint64_t) count;
+            for ( j = 0; j < 8; j++ ) { dst[i * 8 + j] = (uint8_t) ( v >> ( j * 8 ) ); }
+        }
+#endif
+    }
+    w->offset += total_bytes;
 }
 
 typedef struct TableReader


### PR DESCRIPTION
Glenn asked for the C/C++ difference on the Schema Fixed Table wire to be found by
comparison and then closed. This is the comparison, and the one difference it turned up
that no card already owns.

Unit: the **paired matched** bench — `bench/tables/{c,cpp}/table_main.c{,pp}` over
`generated/bench/paired/{c,cpp}/BenchTable.h`, built exactly as `bench/paired/main.go:200-245`
builds them (clang, arm64, `-O3 -DNDEBUG -DBENCH_MATCHED`). Record: `BenchMixed` with a full
80-element `stats` array. Base `395520fe`.

**No timing is claimed anywhere.** The evidence is (a) instructions between symbol
boundaries from `objdump -d`, (b) exact function-entry counts from an
`-fprofile-instr-generate -fcoverage-mapping` build over `bench/paired/corpus`, and
(c) clang's own `-Rpass-missed=inline` remarks.

---

## The difference

The two ports write the same bytes — one wire, one corpus id `07c57b4fa34b2700`. So the
comparison reduces to one number: **how many bounded, capacity-checked stores each save
issues.** Per save, at base:

| | C | C++ | C ÷ C++ |
|---|---|---|---|
| **`table_writer_raw` / `TableWriter::raw`** | **1368.7** | **767.4** | **1.78×** |
| `put8` | 694.5 | 185.5 | 3.74× |
| `put16` | 393.7 | 26.0 | 15.1× |
| `put32` | 199.8 | 145.8 | 1.37× |
| `put64` | 76.8 | 13.0 | 5.91× |
| `leb` / `putleb` | 539.7 | 105.5 | 5.12× |
| `id_at` / `ref_at` | 236.8 | 596.3 | 0.40× |
| `id` / `ref` | 61.8 | 50.8 | 1.22× |
| `TableLebBytes` | *does not exist* | 393.2 | — |
| child save-body walks | 194.0 | 90.0 | 2.16× |
| child measure walks | 0 | 105.0, arithmetic | — |

`put16` and `id_at` invert only because the ports fuse the common header differently
(C's `table_writer_header_at` answers a warm one-byte reference with a `put16` and never
reaches `id_at`; C++'s `ref_at` is also the *sizing* call inside every `MeasureBody`).
The line that matters is the first, and it decomposes exactly:

* C's real write pass ≈ **767** stores — the same as C++'s whole save.
* C's **probe pass** ≈ **550** stores.
* the id trailer ≈ **52** stores.

### D1 — C has no arithmetic measure; it sizes by re-running the writer

C++ emits a `*MeasureBody` per struct (`internal/codegen/cpptable/codecs.go:680`, generated
at `cpp/BenchTable.h:2629`, `5822`) that walks the value doing arithmetic only —
`bytes += TableLebBytes( ids.ref_at(…) ) + 1 + 4`. C emits none.
`internal/codegen/ctable/wire.go:465-477` (`wireFrameWithProbeIDs`) sizes a frame by cloning
the writer with `buffer = NULL` and running **the full save body through it** — every branch,
every `header_at`, every `put*`, every `leb`, every bounds test — then running it again for
real (`c/BenchTable.h:5236-5242`).

| per save | C | C++ |
|---|---|---|
| `mixed_stat_save_body` / `MixedStatSaveBody` | **176.0** | **80.0** |
| `MixedStatMeasureBody` (arithmetic) | — | 96.0 |
| `mixed_entity_save_body` / `MixedEntitySaveBody` | **16.0** | **8.0** |
| `MixedEntityMeasureBody` (arithmetic) | — | 8.0 |
| `table_writer_probe` / `table_writer_rewind` | 22.0 / 20.0 | 0 / 0 |

176 = 64 cached elements × 2 walks + 16 uncached × 3. The sizing cache is 64 slots in both
emitters; C's cache *miss* costs a whole extra byte-emitting walk where C++'s costs another
126-instruction arithmetic pass.

**This is the whole remaining gap, and it is already claimed:** #806
(`codex/c-warm-id-measure`) is the beachhead — counting warm scalar reference bytes locally
during NULL-buffer sizing instead of serializing them. Extending that to struct, repeated,
union and map bodies is the continuation of that card. **Not duplicated here.**

---

## What this PR changes

One commit: **the id trailer goes down in one checked store**, the C twin of C++
`TableIdsWrite` (`internal/codegen/cpptable/cpptable.go:1044`).

`table_writer_finish` appended the trailer one `table_writer_put64` at a time — for a record
interning N ids that is N+1 capacity tests, N+1 eight-iteration byte shuffles into a stack
array and N+1 one-word `memcpy`s. The trailer is a contiguous run of 64-bit little-endian
words (docs/SPEC-TABLES.md §3), so on a target that *proves* it is little-endian the ids array
is the bytes; the other arm keeps the explicit per-byte stores behind the same guard the C++
writer carries.

Nothing is removed: an undersized buffer still raises the overflow flag and Save still answers
-1. What differs is only on that failing path — a trailer that does not fit now leaves the
buffer alone rather than filling it entry by entry, which is what the C++ writer already did.
A NULL buffer is the sizing writer: it counts the extent and copies nothing, so Measure's
answer is unchanged.

### Before / after

Dynamic, per save (the metric the gap is in):

| | before | after | C++ |
|---|---|---|---|
| `table_writer_raw` | 1368.7 | **1317.0** | 767.4 |
| `table_writer_put64` | 76.8 | **25.0** | 13.0 (trailer contributes none) |
| `table_writer_leb` | 539.7 | 539.7 | 105.5 |
| `table_writer_id_at` | 236.8 | 236.8 | 596.3 |

Static instructions, write path:

| function | before | after | C++ |
|---|---|---|---|
| `bench_mixed_save` (root, children inlined) | 2061 | **2047** | `BenchMixedSave` 6193 |
| `schema_bench_bench_mixed_wire_entities_` | 6622 | 6622 | *(inlined)* |
| `schema_bench_bench_mixed_wire_stats_` | 1427 | 1427 | *(inlined)* |
| `schema_bench_mixed_event_wire_save_` / `arm_hit_` / `arm_chat_` / `arm_pickup_` | 613 / 693 / 379 / 379 | unchanged | *(inlined)* |
| `table_writer_leb` / `table_writer_id` / `table_writer_id_at` | 29 / 101 / 56 | unchanged | *(all `always_inline`)* |
| arithmetic measure bodies | 0 — do not exist | 0 | 914 + 251 + 126 + 126 + 126 |
| **write-path total** | 12638 | **12624** | 8526 |

Read path is untouched and was already at parity: `bench_mixed_load_body` 4151 against
`BenchMixedLoadVerdict` 3111, and that residue is exactly what #807 and #809 are for.

---

## C-3 implemented, measured, and deliberately not landed

Card C-3 is `putleb`'s two properties: the stack buffer handed to `raw` once, and
`always_inline`. Both were implemented on the C emitter and measured. **Neither removes a
store**, because almost every LEB this wire spells is one byte — a reference below 128, a
small count, a short element length — and the byte-at-a-time loop already made exactly one
`table_writer_raw(…, 1)` for it. `table_writer_leb` is called 539.7 times a save before and
after; `table_writer_raw` 1317.0 before and after.

Three shapes were built on top of this commit, generated and gated (all three keep corpus id
`07c57b4fa34b2700`):

| shape | static write instrs | `raw`/save | out-of-line `leb` calls/save |
|---|---|---|---|
| **landed** (byte loop, out of line) | **12624** | 1317.0 | 539.7 |
| exact C++ mirror (stack buffer + `always_inline`) | 12653 | 1317.0 | 0 |
| mirror + a one-byte fast arm | 10484 | 1317.0 | 0 |

`always_inline` on `table_writer_id_at` as well — which is what C++ does to `ref_at` — costs
a further **+2758** write-path instructions (12653 → 15411) for no change in stores. Clang's
missed-inline remarks it removes are real — clang refuses `table_writer_id_at` 88 times and
`table_writer_leb` 32 times across this translation unit, always `cost > threshold`, where
C++'s `ref_at` and `putleb` are `always_inline` and draw no remark at all — but the remarks
are the only thing that moves. The card is better retired on these numbers than re-attempted.

---

## Left to the cards that already hold them

| | |
|---|---|
| the arithmetic measure (D1) — the whole gap | **#806** `codex/c-warm-id-measure` |
| `table_reader_get32` / `table_reader_id_at` by indexed load (C-4) | **#807** |
| matched scalar reads through `has(N)+getN` (C-7) | **#809** |
| inline demand on tolerant-wire bodies (C-5) | `c-table-inline-bodies` |
| dead `check_default` (C-6) | **#810**, merged |
| dead output (C-DEAD-1..3) | `c-table-dead-output` |
| union-arm header coalescing | merged `4b8ad632` |
| ordinal slot | merged **#787** |

Skipped by design: `table_writer_raw`'s `bytes < 0`, overflow-safe capacity and
`buffer != NULL` tests, which C++'s `raw` does not carry. They are what D1's probe model
requires — and the first is a check C++ arguably should have. They retire with D1, not before.

---

## Gates

* `make tables-c` — conformance-c and conformance-c-asan over every registered surface, the
  zero-cost gate, the generic-walk gate, `tables-c-fuzz` and its negative control,
  `tables-c-variable`, and `go test ./compiler`. Green. (Only `tables-js-leg` stops, on a
  missing pinned `dist/node-v26.7.0-darwin-arm64` in a fresh clone — no node in this
  environment, unrelated to the change.)
* wire fuzz, **0 divergences** in all four legs:
  `wire-fuzz-c` 252842 mutants, `wire-fuzz-c --retain` 183434,
  `wire-fuzz-c-asan` 252842, `wire-fuzz-c-asan --retain` 183434.
* negative controls, each red-on-sabotage as designed: `tables-c-ref-ordinal-negative-control`,
  `tables-c-soak-negative-control`, `tables-c-wire-fuzz-negative-control`,
  `tables-c-message-negative-control`, `tables-c-fuzz-negative-control`,
  `tables-c-keyed-none-refusal-negative-control`, `tables-c-keyed-max-refusal-negative-control`.
* `tables-c-keyed-none-refusal-ndebug`, `tables-c-keyed-max-refusal-ndebug`,
  `tables-c-soak SOAK_SECONDS=20`, `tables-c-collections` (C/C++ differential, 48789 mutants
  × 3 modes, identical reports, output bytes and measured sizes), `tables-c-retain`.
* `go run ./bench/paired -mode gate -langs cpp,c,go` — corpus verified, 64 identical logical
  records, **table corpus id `07c57b4fa34b2700` unchanged** in C, C++ and Go.
* goldens regenerated (`make update-goldens-c`); `generated/` regenerates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
