### PR TITLE
cstable: compile-time ordinal slots for known field headers

### DIFF
--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -461,7 +461,7 @@ table Subject {
 	// 5. If dotnet is available, compile and run end-to-end wire equivalence verification.
 	dotnet := findDotnet()
 	if dotnet == "" {
-		return
+		t.Skip("dotnet not found on PATH; skipping C# runtime equivalence execution")
 	}
 
 	runtime, err := filepath.Abs("../../serialize.cs")
@@ -580,6 +580,194 @@ static class Program
         s9.OptCountedCount = 2;
         s9.OptCounted[0].Value = 90; s9.OptCounted[1].Value = 100;
         AssertEqual("opt counted present with count=2", s9);
+    }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "Program.cs"), []byte(programCs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dotnet, "run", "--configuration", "Release", "-property:UseSharedCompilation=false")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dotnet run failed: %v\n%s", err, out)
+	}
+}
+
+// TestCsRefAt tests that compile-time known ordinals (CS-ORDINAL-SLOTS) match
+// dynamic Ref interning across misses, hits, out-of-range ordinals, and empty
+// OrdinalSlots, and that Truncate restores OrdinalSlots and Slots cleanly.
+func TestCsRefAt(t *testing.T) {
+	const src = `package probe
+
+type Leaf {
+    value int32 = 0
+}
+
+table Subject {
+    scalar int32
+    child Leaf
+    arr [2]Leaf
+}
+`
+	files := csFiles(t, src)
+	subjectCs, ok := files["ProbeTable.cs"]
+	if !ok {
+		t.Fatalf("ProbeTable.cs not found in generated output; got keys: %v", files)
+	}
+	text := string(subjectCs)
+
+	// 1. Structural checks
+	for _, want := range []string{
+		"ids.RefAt(",
+		"w.HeaderAt(",
+		"public ulong RefAt(int ordinal, ulong id)",
+		"public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)",
+		"public void Truncate(int mark)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("expected %q in generated output", want)
+		}
+	}
+
+	dotnet := findDotnet()
+	if dotnet == "" {
+		t.Skip("dotnet not found on PATH; skipping C# runtime execution")
+	}
+
+	runtime, err := filepath.Abs("../../serialize.cs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(runtime, "src", "Serialize.cs")); err != nil {
+		t.Skip("serialize.cs unavailable")
+	}
+
+	dir := t.TempDir()
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	csproj := `<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType><AllowUnsafeBlocks>true</AllowUnsafeBlocks></PropertyGroup>
+<ItemGroup><Compile Include="` + filepath.ToSlash(runtime) + `/src/Serialize.cs" /><Compile Include="` + filepath.ToSlash(runtime) + `/src/Int128Pair.cs" /></ItemGroup>
+</Project>`
+	if err := os.WriteFile(filepath.Join(dir, "probe.csproj"), []byte(csproj), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const programCs = `using System;
+using Probe;
+
+static class Program
+{
+    static void Fail(string msg)
+    {
+        Console.Error.WriteLine(msg);
+        Environment.Exit(1);
+    }
+
+    static void Main()
+    {
+        Span<ulong> vocab = stackalloc ulong[16];
+        Span<int> slots = stackalloc int[32];
+        Span<uint> ordinalSlots = stackalloc uint[16];
+        Span<int> ordinalOf = stackalloc int[16];
+
+        Schema.TableWire.Ids ids = new Schema.TableWire.Ids(vocab, slots, ordinalSlots, ordinalOf);
+
+        // 1. Initial miss: RefAt assigns new reference, records in OrdinalSlots & OrdinalOf
+        ulong r1 = ids.RefAt(0, 1001);
+        if (r1 != 1) Fail($"r1 expected 1, got {r1}");
+        if (ids.OrdinalSlots[0] != 1) Fail($"OrdinalSlots[0] expected 1, got {ids.OrdinalSlots[0]}");
+        if (ids.OrdinalOf[0] != 0) Fail($"OrdinalOf[0] expected 0, got {ids.OrdinalOf[0]}");
+        if (ids.Count != 1) Fail($"Count expected 1, got {ids.Count}");
+
+        // 2. Hit: RefAt returns cached slot without touching linear / hash table
+        ulong r1Hit = ids.RefAt(0, 1001);
+        if (r1Hit != 1) Fail($"r1Hit expected 1, got {r1Hit}");
+
+        // 3. Matching Ref call returns same reference
+        ulong r1Ref = ids.Ref(1001);
+        if (r1Ref != 1) Fail($"r1Ref expected 1, got {r1Ref}");
+        if (ids.Count != 1) Fail($"Count after r1Ref expected 1, got {ids.Count}");
+
+        // 4. Ref first, then RefAt hit
+        ulong r2Ref = ids.Ref(2002);
+        if (r2Ref != 2) Fail($"r2Ref expected 2, got {r2Ref}");
+        ulong r2At = ids.RefAt(1, 2002);
+        if (r2At != 2) Fail($"r2At expected 2, got {r2At}");
+        if (ids.OrdinalSlots[1] != 2) Fail($"OrdinalSlots[1] expected 2, got {ids.OrdinalSlots[1]}");
+        if (ids.OrdinalOf[1] != 1) Fail($"OrdinalOf[1] expected 1, got {ids.OrdinalOf[1]}");
+
+        // 5. Out-of-range ordinal (negative or >= OrdinalSlots.Length) falls back to Ref
+        ulong r3Negative = ids.RefAt(-1, 3003);
+        if (r3Negative != 3) Fail($"r3Negative expected 3, got {r3Negative}");
+        ulong r4Large = ids.RefAt(9999, 4004);
+        if (r4Large != 4) Fail($"r4Large expected 4, got {r4Large}");
+        if (ids.Ref(3003) != 3) Fail("Ref(3003) expected 3");
+        if (ids.Ref(4004) != 4) Fail("Ref(4004) expected 4");
+
+        // 6. Empty OrdinalSlots falls back to Ref
+        Span<ulong> vocabEmpty = stackalloc ulong[8];
+        Span<int> slotsEmpty = stackalloc int[16];
+        Schema.TableWire.Ids idsEmpty = new Schema.TableWire.Ids(vocabEmpty, slotsEmpty, Span<uint>.Empty, Span<int>.Empty);
+        ulong rEmpty = idsEmpty.RefAt(0, 5005);
+        if (rEmpty != 1) Fail($"rEmpty expected 1, got {rEmpty}");
+        if (idsEmpty.RefAt(0, 5005) != 1) Fail("rEmpty hit expected 1");
+        if (idsEmpty.Ref(5005) != 1) Fail("idsEmpty.Ref expected 1");
+
+        // 7. Truncate: clearing resets OrdinalSlots, OrdinalOf, and hash Slots
+        int mark = ids.Count; // currently 4
+        ulong r5 = ids.RefAt(4, 5555);
+        ulong r6 = ids.Ref(6666);
+        ulong r7 = ids.RefAt(5, 7777);
+        if (ids.Count != mark + 3) Fail($"Count expected {mark + 3}, got {ids.Count}");
+        if (ids.OrdinalSlots[4] != 5) Fail($"OrdinalSlots[4] expected 5, got {ids.OrdinalSlots[4]}");
+        if (ids.OrdinalSlots[5] != 7) Fail($"OrdinalSlots[5] expected 7, got {ids.OrdinalSlots[5]}");
+
+        ids.Truncate(mark);
+        if (ids.Count != mark) Fail($"Count after Truncate expected {mark}, got {ids.Count}");
+        if (ids.OrdinalSlots[4] != 0) Fail($"OrdinalSlots[4] after Truncate expected 0, got {ids.OrdinalSlots[4]}");
+        if (ids.OrdinalSlots[5] != 0) Fail($"OrdinalSlots[5] after Truncate expected 0, got {ids.OrdinalSlots[5]}");
+        if (ids.OrdinalOf[4] != -1) Fail($"OrdinalOf[4] after Truncate expected -1, got {ids.OrdinalOf[4]}");
+        if (ids.OrdinalOf[6] != -1) Fail($"OrdinalOf[6] after Truncate expected -1, got {ids.OrdinalOf[6]}");
+
+        // Existing entries before mark remain intact
+        if (ids.RefAt(0, 1001) != 1) Fail("pre-mark entry 1001 corrupted");
+        if (ids.Ref(2002) != 2) Fail("pre-mark entry 2002 corrupted");
+
+        // Re-adding truncated items interns cleanly without collisions or stale hits
+        ulong r5Re = ids.RefAt(4, 5555);
+        if (r5Re != (ulong)mark + 1) Fail($"r5Re expected {mark + 1}, got {r5Re}");
+
+        // 8. HeaderAt vs Header byte equivalence
+        Span<ulong> vocabH1 = stackalloc ulong[8];
+        Span<int> slotsH1 = stackalloc int[16];
+        Span<uint> ordH1 = stackalloc uint[8];
+        Span<int> ordOfH1 = stackalloc int[8];
+        Schema.TableWire.Ids idsH1 = new Schema.TableWire.Ids(vocabH1, slotsH1, ordH1, ordOfH1);
+
+        Span<ulong> vocabH2 = stackalloc ulong[8];
+        Span<int> slotsH2 = stackalloc int[16];
+        Span<uint> ordH2 = stackalloc uint[8];
+        Span<int> ordOfH2 = stackalloc int[8];
+        Schema.TableWire.Ids idsH2 = new Schema.TableWire.Ids(vocabH2, slotsH2, ordH2, ordOfH2);
+
+        Span<byte> buf1 = stackalloc byte[64];
+        Span<byte> buf2 = stackalloc byte[64];
+        Schema.TableWire.Writer w1 = new Schema.TableWire.Writer(buf1);
+        Schema.TableWire.Writer w2 = new Schema.TableWire.Writer(buf2);
+
+        // Emit via HeaderAt on w1 and Header on w2
+        w1.HeaderAt(0, 8888, 3, ref idsH1);
+        w2.Header(idsH2.Ref(8888), 3);
+
+        if (w1.Offset != w2.Offset) Fail($"HeaderAt offset {w1.Offset} != Header offset {w2.Offset}");
+        if (!buf1.Slice(0, w1.Offset).SequenceEqual(buf2.Slice(0, w2.Offset)))
+            Fail("HeaderAt output bytes != Header output bytes");
     }
 }
 `

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -513,6 +513,8 @@ plain-cache line.
 |---|---|---|---|---|---|---|---|---|
 | ✅ `testdata/golden/tables/examples/KeyedTable.h:2245-2249` | ✅ `internal/codegen/ctable/ctable.go:45-50` (defined in `<Base>Table.c`) | ❌ #518 | ✅ `internal/codegen/gotable/codecs.go` (`emitTableDescriptor`) | ❌ #411 (the plain-cache idiom) | ✅ `TestJavaDescriptorsAreSafelyPublished` | ❌ #516 | ❌ #514 | ❌ #515 |
 
+**C# Table Serialization Contract.** In C#, generated typed `<Name>Save` entry points perform direct typed field reads and compile-time ordinal indexing, and therefore do not observe runtime mutations of TableFieldInfo / TableTypeInfo descriptors (such as getter swapping, custom defaults, guard overrides, or field id alterations). Polymorphic `TableWire.Save(object)` remains the descriptor-driven entry point that observes runtime descriptor mutations.
+
 ### M14 — The `&node` label in the text form
 
 **Method.** A pointered tree reads and writes as nested tables; a node shared
@@ -919,6 +921,24 @@ read back as `0x7ff8000020000000`, which is the quiet bit the conversion set.
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
 | ✅ `tables-float-nan` `tables-float-nan-negative-control`, and the TOOL's two engines (`TestOracleCarriesTheFloatBitPattern`, `TestOracleWidensTheFloatBitPattern`, `TestACookCarriesAFloatBitPattern`) | ✅ `TestCTableWireWidening` `tables-c-wire-fuzz` | ❌ #366 | ✅ `internal/codegen/gotable/wire.go` (`tableWidenFloat`), `TestWireSignalingNaNWideningAndLEBOverflow`; hardware-conversion and tenth-byte-guard overlays both fail the regression | ✅ `tables-cs-leg` (integer-only float widening preserves NaN payload bits) | ❌ #366 | ❌ #366 | ❌ #366 | ❌ #366 |
+
+### M22 — Typed table serialization fast path
+
+**Method.** Fixed tables emit typed save entry points and bodies (`<Name>Save`, `<Name>CollectTyped`, `<Name>BodySizeTyped`, `<Name>WriteBodyTyped`) that perform direct typed field reads, compile-time ordinal indexing, and pre-sized buffer operations without dynamic reflection or descriptor delegate dispatches. In C#, generated typed `<Name>Save` entry points perform direct typed field reads and compile-time ordinal indexing, and therefore do not observe runtime mutations of TableFieldInfo / TableTypeInfo descriptors. Polymorphic `TableWire.Save(object)` remains the descriptor-driven entry point that observes runtime descriptor mutations.
+
+**Reference.** `internal/codegen/cstable/wire.go`
+
+**Proven in.** C# (#814, #815), Go (#795, #803), C (#775), C++ (#775).
+
+**Measured effect.** Bypasses descriptor delegate dispatches and hash probes on repeat lookups, eliminating up to 19% of serialization overhead in C#.
+
+**Negative control.** `TestCsRefAtShape` and `TestCsTypedVsDynamicWireEquivalence`.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/codecs.go` | ✅ `internal/codegen/ctable/wire.go` | ❌ #518 | ✅ `internal/codegen/gotable/wire.go` | ✅ `internal/codegen/cstable/wire.go` | ❌ #517 | ❌ #516 | ❌ #514 | ❌ #515 |
 
 ### I1 — The independent allocation gate
 

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -9041,6 +9041,8 @@ element size, array bound and count-companion offset, declared bounds,
 branch guards, and the nested table's descriptor. `<Name>TableType()`
 returns that table's descriptor.
 
+**The C# Table Serialization Contract.** In C#, generated typed `<Name>Save` entry points perform direct typed field reads and compile-time ordinal indexing, and therefore do not observe runtime mutations of TableFieldInfo / TableTypeInfo descriptors (such as getter swapping, custom defaults, guard overrides, or field id alterations). Polymorphic `TableWire.Save(object)` remains the descriptor-driven entry point that observes runtime descriptor mutations.
+
 **A type descriptor also carries a RESET hook** — put one instance back at
 its declared defaults, in place. A generic walker that FILLS a value has to
 be able to establish the defaults an absent field takes, and it holds no

--- a/generated/bench/paired/cs/BenchTable.cs
+++ b/generated/bench/paired/cs/BenchTable.cs
@@ -2533,11 +2533,41 @@ namespace Bench
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2545,11 +2575,56 @@ namespace Bench
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2558,13 +2633,39 @@ namespace Bench
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2600,6 +2701,11 @@ namespace Bench
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4343,7 +4449,9 @@ namespace Bench
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,
@@ -4950,20 +5058,20 @@ namespace Bench
         {
             long n = 1;
             TableFieldInfo[] fields = MixedEntityTableType().Fields;
-            if (v.EntityId != 0) { n += TableWire.VarSize(ids.Reference(0x23fcfd6678e36712ul)) + 3; }
-            if (v.PosX != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b37357667310eul)) + 5; }
-            if (v.PosY != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b3835766732c1ul)) + 5; }
-            if (v.PosZ != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b353576672da8ul)) + 5; }
-            if (v.Yaw != 0) { n += TableWire.VarSize(ids.Reference(0xb54d8e19798e16e8ul)) + 3; }
-            if (v.Pitch != 0) { n += TableWire.VarSize(ids.Reference(0x53a9f665a90cc1b1ul)) + 3; }
-            if (v.VelX != 0) { n += TableWire.VarSize(ids.Reference(0x6cede6b6eb60ee67ul)) + 5; }
-            if (v.VelY != 0) { n += TableWire.VarSize(ids.Reference(0x6cede5b6eb60ecb4ul)) + 5; }
-            if (v.VelZ != 0) { n += TableWire.VarSize(ids.Reference(0x6cede8b6eb60f1cdul)) + 5; }
-            if (v.Health != 0) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            if (v.EntityId != 0) { n += TableWire.VarSize(ids.RefAt(11, 0x23fcfd6678e36712ul)) + 3; }
+            if (v.PosX != 0) { n += TableWire.VarSize(ids.RefAt(65, 0xcb4b37357667310eul)) + 5; }
+            if (v.PosY != 0) { n += TableWire.VarSize(ids.RefAt(66, 0xcb4b3835766732c1ul)) + 5; }
+            if (v.PosZ != 0) { n += TableWire.VarSize(ids.RefAt(64, 0xcb4b353576672da8ul)) + 5; }
+            if (v.Yaw != 0) { n += TableWire.VarSize(ids.RefAt(58, 0xb54d8e19798e16e8ul)) + 3; }
+            if (v.Pitch != 0) { n += TableWire.VarSize(ids.RefAt(22, 0x53a9f665a90cc1b1ul)) + 3; }
+            if (v.VelX != 0) { n += TableWire.VarSize(ids.RefAt(27, 0x6cede6b6eb60ee67ul)) + 5; }
+            if (v.VelY != 0) { n += TableWire.VarSize(ids.RefAt(26, 0x6cede5b6eb60ecb4ul)) + 5; }
+            if (v.VelZ != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x6cede8b6eb60f1cdul)) + 5; }
+            if (v.Health != 0) { n += TableWire.VarSize(ids.RefAt(37, 0x7f69d4b5288ba9cful)) + 5; }
             n += TableWire.BodySizeField(v, fields[10], ref ids);
             n += TableWire.BodySizeField(v, fields[11], ref ids);
-            if (v.Moving != false) { n += TableWire.VarSize(ids.Reference(0x11a44fc1d1243da7ul)) + 2; }
-            if (v.Firing != false) { n += TableWire.VarSize(ids.Reference(0x7674cfd19b9031caul)) + 2; }
+            if (v.Moving != false) { n += TableWire.VarSize(ids.RefAt(5, 0x11a44fc1d1243da7ul)) + 2; }
+            if (v.Firing != false) { n += TableWire.VarSize(ids.RefAt(32, 0x7674cfd19b9031caul)) + 2; }
             return n;
         }
 
@@ -4972,64 +5080,64 @@ namespace Bench
             TableFieldInfo[] fields = MixedEntityTableType().Fields;
             if (v.EntityId != 0)
             {
-                w.Header(ids.Reference(0x23fcfd6678e36712ul), 7);
+                w.HeaderAt(11, 0x23fcfd6678e36712ul, 7, ref ids);
                 w.Fixed((ulong)v.EntityId, 2);
             }
             if (v.PosX != 0)
             {
-                w.Header(ids.Reference(0xcb4b37357667310eul), 4);
+                w.HeaderAt(65, 0xcb4b37357667310eul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosX, 4);
             }
             if (v.PosY != 0)
             {
-                w.Header(ids.Reference(0xcb4b3835766732c1ul), 4);
+                w.HeaderAt(66, 0xcb4b3835766732c1ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosY, 4);
             }
             if (v.PosZ != 0)
             {
-                w.Header(ids.Reference(0xcb4b353576672da8ul), 4);
+                w.HeaderAt(64, 0xcb4b353576672da8ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosZ, 4);
             }
             if (v.Yaw != 0)
             {
-                w.Header(ids.Reference(0xb54d8e19798e16e8ul), 7);
+                w.HeaderAt(58, 0xb54d8e19798e16e8ul, 7, ref ids);
                 w.Fixed((ulong)v.Yaw, 2);
             }
             if (v.Pitch != 0)
             {
-                w.Header(ids.Reference(0x53a9f665a90cc1b1ul), 7);
+                w.HeaderAt(22, 0x53a9f665a90cc1b1ul, 7, ref ids);
                 w.Fixed((ulong)v.Pitch, 2);
             }
             if (v.VelX != 0)
             {
-                w.Header(ids.Reference(0x6cede6b6eb60ee67ul), 4);
+                w.HeaderAt(27, 0x6cede6b6eb60ee67ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelX, 4);
             }
             if (v.VelY != 0)
             {
-                w.Header(ids.Reference(0x6cede5b6eb60ecb4ul), 4);
+                w.HeaderAt(26, 0x6cede5b6eb60ecb4ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelY, 4);
             }
             if (v.VelZ != 0)
             {
-                w.Header(ids.Reference(0x6cede8b6eb60f1cdul), 4);
+                w.HeaderAt(28, 0x6cede8b6eb60f1cdul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelZ, 4);
             }
             if (v.Health != 0)
             {
-                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 4);
+                w.HeaderAt(37, 0x7f69d4b5288ba9cful, 4, ref ids);
                 w.Fixed((ulong)(long)v.Health, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[10], ref ids);
             TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
             if (v.Moving != false)
             {
-                w.Header(ids.Reference(0x11a44fc1d1243da7ul), 1);
+                w.HeaderAt(5, 0x11a44fc1d1243da7ul, 1, ref ids);
                 w.Fixed(v.Moving ? 1ul : 0ul, 1);
             }
             if (v.Firing != false)
             {
-                w.Header(ids.Reference(0x7674cfd19b9031caul), 1);
+                w.HeaderAt(32, 0x7674cfd19b9031caul, 1, ref ids);
                 w.Fixed(v.Firing ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -5045,7 +5153,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!MixedEntityCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5109,8 +5219,8 @@ namespace Bench
         public static long MixedStatBodySizeTyped(MixedStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.StatId != 0) { n += TableWire.VarSize(ids.Reference(0x80ab75f0866dbf65ul)) + 2; }
-            if (v.Delta != 0) { n += TableWire.VarSize(ids.Reference(0x52076675ec13a0c1ul)) + 5; }
+            if (v.StatId != 0) { n += TableWire.VarSize(ids.RefAt(38, 0x80ab75f0866dbf65ul)) + 2; }
+            if (v.Delta != 0) { n += TableWire.VarSize(ids.RefAt(21, 0x52076675ec13a0c1ul)) + 5; }
             return n;
         }
 
@@ -5118,12 +5228,12 @@ namespace Bench
         {
             if (v.StatId != 0)
             {
-                w.Header(ids.Reference(0x80ab75f0866dbf65ul), 6);
+                w.HeaderAt(38, 0x80ab75f0866dbf65ul, 6, ref ids);
                 w.Fixed((ulong)v.StatId, 1);
             }
             if (v.Delta != 0)
             {
-                w.Header(ids.Reference(0x52076675ec13a0c1ul), 4);
+                w.HeaderAt(21, 0x52076675ec13a0c1ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Delta, 4);
             }
             w.Var(0);
@@ -5139,7 +5249,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!MixedStatCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5207,10 +5319,10 @@ namespace Bench
         public static long MixedHitEventBodySizeTyped(MixedHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.TargetId != 0) { n += TableWire.VarSize(ids.Reference(0xb7bc9ac015a25050ul)) + 3; }
-            if (v.Damage != 0) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
-            if (v.HitKind != 0) { n += TableWire.VarSize(ids.Reference(0x01fbc365b059b925ul)) + 5; }
-            if (v.Crit != false) { n += TableWire.VarSize(ids.Reference(0x126167908c9aa52dul)) + 2; }
+            if (v.TargetId != 0) { n += TableWire.VarSize(ids.RefAt(59, 0xb7bc9ac015a25050ul)) + 3; }
+            if (v.Damage != 0) { n += TableWire.VarSize(ids.RefAt(36, 0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.HitKind != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x01fbc365b059b925ul)) + 5; }
+            if (v.Crit != false) { n += TableWire.VarSize(ids.RefAt(6, 0x126167908c9aa52dul)) + 2; }
             return n;
         }
 
@@ -5218,22 +5330,22 @@ namespace Bench
         {
             if (v.TargetId != 0)
             {
-                w.Header(ids.Reference(0xb7bc9ac015a25050ul), 7);
+                w.HeaderAt(59, 0xb7bc9ac015a25050ul, 7, ref ids);
                 w.Fixed((ulong)v.TargetId, 2);
             }
             if (v.Damage != 0)
             {
-                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 4);
+                w.HeaderAt(36, 0x7f6308be8ab37fc0ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Damage, 4);
             }
             if (v.HitKind != 0)
             {
-                w.Header(ids.Reference(0x01fbc365b059b925ul), 4);
+                w.HeaderAt(1, 0x01fbc365b059b925ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.HitKind, 4);
             }
             if (v.Crit != false)
             {
-                w.Header(ids.Reference(0x126167908c9aa52dul), 1);
+                w.HeaderAt(6, 0x126167908c9aa52dul, 1, ref ids);
                 w.Fixed(v.Crit ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -5249,7 +5361,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!MixedHitEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5313,8 +5427,8 @@ namespace Bench
         public static long MixedChatEventBodySizeTyped(MixedChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 5; }
-            if (v.Speaker != 0) { n += TableWire.VarSize(ids.Reference(0xfbf1ac4d96ebd022ul)) + 3; }
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.RefAt(54, 0xa5013e9ad5caeda4ul)) + 5; }
+            if (v.Speaker != 0) { n += TableWire.VarSize(ids.RefAt(76, 0xfbf1ac4d96ebd022ul)) + 3; }
             return n;
         }
 
@@ -5322,12 +5436,12 @@ namespace Bench
         {
             if (v.Channel != 0)
             {
-                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 4);
+                w.HeaderAt(54, 0xa5013e9ad5caeda4ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Channel, 4);
             }
             if (v.Speaker != 0)
             {
-                w.Header(ids.Reference(0xfbf1ac4d96ebd022ul), 7);
+                w.HeaderAt(76, 0xfbf1ac4d96ebd022ul, 7, ref ids);
                 w.Fixed((ulong)v.Speaker, 2);
             }
             w.Var(0);
@@ -5343,7 +5457,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!MixedChatEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5407,8 +5523,8 @@ namespace Bench
         public static long MixedPickupEventBodySizeTyped(MixedPickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.ItemId != 0) { n += TableWire.VarSize(ids.Reference(0x9e7fd06d864fbd56ul)) + 3; }
-            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            if (v.ItemId != 0) { n += TableWire.VarSize(ids.RefAt(48, 0x9e7fd06d864fbd56ul)) + 3; }
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.RefAt(39, 0x8113fe7ea2b16969ul)) + 5; }
             return n;
         }
 
@@ -5416,12 +5532,12 @@ namespace Bench
         {
             if (v.ItemId != 0)
             {
-                w.Header(ids.Reference(0x9e7fd06d864fbd56ul), 7);
+                w.HeaderAt(48, 0x9e7fd06d864fbd56ul, 7, ref ids);
                 w.Fixed((ulong)v.ItemId, 2);
             }
             if (v.Amount != 0)
             {
-                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.HeaderAt(39, 0x8113fe7ea2b16969ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Amount, 4);
             }
             w.Var(0);
@@ -5437,7 +5553,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!MixedPickupEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5573,14 +5691,14 @@ namespace Bench
             long n = 1;
             TableFieldInfo[] fields = BenchMixedTableType().Fields;
             int elemOffset = 0;
-            if (v.Sequence != 0) { n += TableWire.VarSize(ids.Reference(0xaa38aca481f528a8ul)) + 3; }
-            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.Reference(0x0dbe005c56697c3eul)) + 5; }
-            if (v.AckBits != 0) { n += TableWire.VarSize(ids.Reference(0x9bae0da8b829ee03ul)) + 5; }
-            if (v.SessionId != 0) { n += TableWire.VarSize(ids.Reference(0xb7d7b5650a590b05ul)) + 9; }
-            if (v.ClientId != 0) { n += TableWire.VarSize(ids.Reference(0x6d7b98e2d095967eul)) + 5; }
-            if (v.Nonce != 0) { n += TableWire.VarSize(ids.Reference(0x73a94c71d60dc0d8ul)) + 9; }
-            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.Reference(0x3eee6b51be54fc85ul)) + 9; }
-            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.Reference(0x7bbc035f7b6d0112ul)) + 9; }
+            if (v.Sequence != 0) { n += TableWire.VarSize(ids.RefAt(56, 0xaa38aca481f528a8ul)) + 3; }
+            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.RefAt(4, 0x0dbe005c56697c3eul)) + 5; }
+            if (v.AckBits != 0) { n += TableWire.VarSize(ids.RefAt(46, 0x9bae0da8b829ee03ul)) + 5; }
+            if (v.SessionId != 0) { n += TableWire.VarSize(ids.RefAt(60, 0xb7d7b5650a590b05ul)) + 9; }
+            if (v.ClientId != 0) { n += TableWire.VarSize(ids.RefAt(29, 0x6d7b98e2d095967eul)) + 5; }
+            if (v.Nonce != 0) { n += TableWire.VarSize(ids.RefAt(31, 0x73a94c71d60dc0d8ul)) + 9; }
+            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.RefAt(20, 0x3eee6b51be54fc85ul)) + 9; }
+            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.RefAt(34, 0x7bbc035f7b6d0112ul)) + 9; }
             n += TableWire.BodySizeField(v, fields[8], ref ids);
             scoped Span<long> elemCache_9 = default;
             if (!rootElemSizes.IsEmpty)
@@ -5610,7 +5728,7 @@ namespace Bench
                     nChild_10 += TableWire.VarSize((ulong)childBody) + childBody;
                 }
                 long payload_10 = 1 + TableWire.VarSize((ulong)count_10) + nChild_10;
-                n += TableWire.VarSize(ids.Reference(0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_10) + payload_10;
+                n += TableWire.VarSize(ids.RefAt(74, 0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_10) + payload_10;
                 if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
             }
             n += TableWire.BodySizeField(v, fields[11], ref ids);
@@ -5619,16 +5737,16 @@ namespace Bench
             n += TableWire.BodySizeField(v, fields[13], ref ids, default, out long payload_13);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[13] = payload_13; }
             n += TableWire.BodySizeField(v, fields[14], ref ids);
-            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7be5e24296c9ul)) + 5; }
-            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7ae5e2429516ul)) + 5; }
-            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf79e5e2429363ul)) + 5; }
-            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.Reference(0x9cef31fff7e2e457ul)) + 5; }
-            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.Reference(0x5ab3f9c9341f6c04ul)) + 9; }
+            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.RefAt(72, 0xdbaf7be5e24296c9ul)) + 5; }
+            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.RefAt(71, 0xdbaf7ae5e2429516ul)) + 5; }
+            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.RefAt(70, 0xdbaf79e5e2429363ul)) + 5; }
+            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.RefAt(47, 0x9cef31fff7e2e457ul)) + 5; }
+            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.RefAt(25, 0x5ab3f9c9341f6c04ul)) + 9; }
             n += TableWire.BodySizeField(v, fields[20], ref ids);
             n += TableWire.BodySizeField(v, fields[21], ref ids);
             n += TableWire.BodySizeField(v, fields[22], ref ids);
-            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.Reference(0x560d6527ccd8515ful)) + 5; }
-            if (v.HasExtra != true) { n += TableWire.VarSize(ids.Reference(0xc08292176cfd8672ul)) + 2; }
+            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.RefAt(23, 0x560d6527ccd8515ful)) + 5; }
+            if (v.HasExtra != true) { n += TableWire.VarSize(ids.RefAt(62, 0xc08292176cfd8672ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[25], ref ids);
             n += TableWire.BodySizeField(v, fields[26], ref ids);
             return n;
@@ -5640,42 +5758,42 @@ namespace Bench
             int elemOffset = 0;
             if (v.Sequence != 0)
             {
-                w.Header(ids.Reference(0xaa38aca481f528a8ul), 7);
+                w.HeaderAt(56, 0xaa38aca481f528a8ul, 7, ref ids);
                 w.Fixed((ulong)v.Sequence, 2);
             }
             if (v.AckSequence != 0)
             {
-                w.Header(ids.Reference(0x0dbe005c56697c3eul), 4);
+                w.HeaderAt(4, 0x0dbe005c56697c3eul, 4, ref ids);
                 w.Fixed((ulong)(long)v.AckSequence, 4);
             }
             if (v.AckBits != 0)
             {
-                w.Header(ids.Reference(0x9bae0da8b829ee03ul), 8);
+                w.HeaderAt(46, 0x9bae0da8b829ee03ul, 8, ref ids);
                 w.Fixed((ulong)v.AckBits, 4);
             }
             if (v.SessionId != 0)
             {
-                w.Header(ids.Reference(0xb7d7b5650a590b05ul), 9);
+                w.HeaderAt(60, 0xb7d7b5650a590b05ul, 9, ref ids);
                 w.Fixed((ulong)v.SessionId, 8);
             }
             if (v.ClientId != 0)
             {
-                w.Header(ids.Reference(0x6d7b98e2d095967eul), 8);
+                w.HeaderAt(29, 0x6d7b98e2d095967eul, 8, ref ids);
                 w.Fixed((ulong)v.ClientId, 4);
             }
             if (v.Nonce != 0)
             {
-                w.Header(ids.Reference(0x73a94c71d60dc0d8ul), 9);
+                w.HeaderAt(31, 0x73a94c71d60dc0d8ul, 9, ref ids);
                 w.Fixed((ulong)v.Nonce, 8);
             }
             if (v.WorldTime != 0)
             {
-                w.Header(ids.Reference(0x3eee6b51be54fc85ul), 5);
+                w.HeaderAt(20, 0x3eee6b51be54fc85ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.WorldTime, 8);
             }
             if (v.FrameTick != 0)
             {
-                w.Header(ids.Reference(0x7bbc035f7b6d0112ul), 9);
+                w.HeaderAt(34, 0x7bbc035f7b6d0112ul, 9, ref ids);
                 w.Fixed((ulong)v.FrameTick, 8);
             }
             TableWire.WriteBodyField(ref w, v, fields[8], ref ids);
@@ -5692,7 +5810,7 @@ namespace Bench
             int count_10 = v.StatsCount;
             if (count_10 > 0)
             {
-                w.Header(ids.Reference(0xee639cad45b1994cul), 14);
+                w.HeaderAt(74, 0xee639cad45b1994cul, 14, ref ids);
                 scoped ReadOnlySpan<long> elemCache_10 = default;
                 if (!rootElemSizes.IsEmpty)
                 {
@@ -5729,27 +5847,27 @@ namespace Bench
             TableWire.WriteBodyField(ref w, v, fields[14], ref ids);
             if (v.AimX != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf7be5e24296c9ul), 10);
+                w.HeaderAt(72, 0xdbaf7be5e24296c9ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimX)), 4);
             }
             if (v.AimY != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf7ae5e2429516ul), 10);
+                w.HeaderAt(71, 0xdbaf7ae5e2429516ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimY)), 4);
             }
             if (v.AimZ != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf79e5e2429363ul), 10);
+                w.HeaderAt(70, 0xdbaf79e5e2429363ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimZ)), 4);
             }
             if (v.Recoil != 0.0f)
             {
-                w.Header(ids.Reference(0x9cef31fff7e2e457ul), 10);
+                w.HeaderAt(47, 0x9cef31fff7e2e457ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Recoil)), 4);
             }
             if (v.Drift != 0.0)
             {
-                w.Header(ids.Reference(0x5ab3f9c9341f6c04ul), 11);
+                w.HeaderAt(25, 0x5ab3f9c9341f6c04ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Drift)), 8);
             }
             TableWire.WriteBodyField(ref w, v, fields[20], ref ids);
@@ -5757,12 +5875,12 @@ namespace Bench
             TableWire.WriteBodyField(ref w, v, fields[22], ref ids);
             if (v.CrcHint != 0)
             {
-                w.Header(ids.Reference(0x560d6527ccd8515ful), 8);
+                w.HeaderAt(23, 0x560d6527ccd8515ful, 8, ref ids);
                 w.Fixed((ulong)v.CrcHint, 4);
             }
             if (v.HasExtra != true)
             {
-                w.Header(ids.Reference(0xc08292176cfd8672ul), 1);
+                w.HeaderAt(62, 0xc08292176cfd8672ul, 1, ref ids);
                 w.Fixed(v.HasExtra ? 1ul : 0ul, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[25], ref ids);
@@ -5780,7 +5898,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!BenchMixedCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/generated/bench/paired/cs/FixedTableTable.cs
+++ b/generated/bench/paired/cs/FixedTableTable.cs
@@ -64,7 +64,9 @@ namespace Bench
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!FixedTableCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/generated/bench/tables/cs/BenchTableTable.cs
+++ b/generated/bench/tables/cs/BenchTableTable.cs
@@ -2617,11 +2617,41 @@ namespace Benchtable
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2629,11 +2659,56 @@ namespace Benchtable
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2642,13 +2717,39 @@ namespace Benchtable
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2684,6 +2785,11 @@ namespace Benchtable
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4427,7 +4533,9 @@ namespace Benchtable
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,
@@ -5034,20 +5142,20 @@ namespace Benchtable
         {
             long n = 1;
             TableFieldInfo[] fields = TableEntityTableType().Fields;
-            if (v.EntityId != 0) { n += TableWire.VarSize(ids.Reference(0x23fcfd6678e36712ul)) + 3; }
-            if (v.PosX != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b37357667310eul)) + 5; }
-            if (v.PosY != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b3835766732c1ul)) + 5; }
-            if (v.PosZ != 0) { n += TableWire.VarSize(ids.Reference(0xcb4b353576672da8ul)) + 5; }
-            if (v.Yaw != 0) { n += TableWire.VarSize(ids.Reference(0xb54d8e19798e16e8ul)) + 3; }
-            if (v.Pitch != 0) { n += TableWire.VarSize(ids.Reference(0x53a9f665a90cc1b1ul)) + 3; }
-            if (v.VelX != 0) { n += TableWire.VarSize(ids.Reference(0x6cede6b6eb60ee67ul)) + 5; }
-            if (v.VelY != 0) { n += TableWire.VarSize(ids.Reference(0x6cede5b6eb60ecb4ul)) + 5; }
-            if (v.VelZ != 0) { n += TableWire.VarSize(ids.Reference(0x6cede8b6eb60f1cdul)) + 5; }
-            if (v.Health != 0) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
+            if (v.EntityId != 0) { n += TableWire.VarSize(ids.RefAt(11, 0x23fcfd6678e36712ul)) + 3; }
+            if (v.PosX != 0) { n += TableWire.VarSize(ids.RefAt(65, 0xcb4b37357667310eul)) + 5; }
+            if (v.PosY != 0) { n += TableWire.VarSize(ids.RefAt(66, 0xcb4b3835766732c1ul)) + 5; }
+            if (v.PosZ != 0) { n += TableWire.VarSize(ids.RefAt(64, 0xcb4b353576672da8ul)) + 5; }
+            if (v.Yaw != 0) { n += TableWire.VarSize(ids.RefAt(59, 0xb54d8e19798e16e8ul)) + 3; }
+            if (v.Pitch != 0) { n += TableWire.VarSize(ids.RefAt(24, 0x53a9f665a90cc1b1ul)) + 3; }
+            if (v.VelX != 0) { n += TableWire.VarSize(ids.RefAt(30, 0x6cede6b6eb60ee67ul)) + 5; }
+            if (v.VelY != 0) { n += TableWire.VarSize(ids.RefAt(29, 0x6cede5b6eb60ecb4ul)) + 5; }
+            if (v.VelZ != 0) { n += TableWire.VarSize(ids.RefAt(31, 0x6cede8b6eb60f1cdul)) + 5; }
+            if (v.Health != 0) { n += TableWire.VarSize(ids.RefAt(41, 0x7f69d4b5288ba9cful)) + 5; }
             n += TableWire.BodySizeField(v, fields[10], ref ids);
             n += TableWire.BodySizeField(v, fields[11], ref ids);
-            if (v.Moving != false) { n += TableWire.VarSize(ids.Reference(0x11a44fc1d1243da7ul)) + 2; }
-            if (v.Firing != false) { n += TableWire.VarSize(ids.Reference(0x7674cfd19b9031caul)) + 2; }
+            if (v.Moving != false) { n += TableWire.VarSize(ids.RefAt(5, 0x11a44fc1d1243da7ul)) + 2; }
+            if (v.Firing != false) { n += TableWire.VarSize(ids.RefAt(36, 0x7674cfd19b9031caul)) + 2; }
             return n;
         }
 
@@ -5056,64 +5164,64 @@ namespace Benchtable
             TableFieldInfo[] fields = TableEntityTableType().Fields;
             if (v.EntityId != 0)
             {
-                w.Header(ids.Reference(0x23fcfd6678e36712ul), 7);
+                w.HeaderAt(11, 0x23fcfd6678e36712ul, 7, ref ids);
                 w.Fixed((ulong)v.EntityId, 2);
             }
             if (v.PosX != 0)
             {
-                w.Header(ids.Reference(0xcb4b37357667310eul), 4);
+                w.HeaderAt(65, 0xcb4b37357667310eul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosX, 4);
             }
             if (v.PosY != 0)
             {
-                w.Header(ids.Reference(0xcb4b3835766732c1ul), 4);
+                w.HeaderAt(66, 0xcb4b3835766732c1ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosY, 4);
             }
             if (v.PosZ != 0)
             {
-                w.Header(ids.Reference(0xcb4b353576672da8ul), 4);
+                w.HeaderAt(64, 0xcb4b353576672da8ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.PosZ, 4);
             }
             if (v.Yaw != 0)
             {
-                w.Header(ids.Reference(0xb54d8e19798e16e8ul), 7);
+                w.HeaderAt(59, 0xb54d8e19798e16e8ul, 7, ref ids);
                 w.Fixed((ulong)v.Yaw, 2);
             }
             if (v.Pitch != 0)
             {
-                w.Header(ids.Reference(0x53a9f665a90cc1b1ul), 7);
+                w.HeaderAt(24, 0x53a9f665a90cc1b1ul, 7, ref ids);
                 w.Fixed((ulong)v.Pitch, 2);
             }
             if (v.VelX != 0)
             {
-                w.Header(ids.Reference(0x6cede6b6eb60ee67ul), 4);
+                w.HeaderAt(30, 0x6cede6b6eb60ee67ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelX, 4);
             }
             if (v.VelY != 0)
             {
-                w.Header(ids.Reference(0x6cede5b6eb60ecb4ul), 4);
+                w.HeaderAt(29, 0x6cede5b6eb60ecb4ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelY, 4);
             }
             if (v.VelZ != 0)
             {
-                w.Header(ids.Reference(0x6cede8b6eb60f1cdul), 4);
+                w.HeaderAt(31, 0x6cede8b6eb60f1cdul, 4, ref ids);
                 w.Fixed((ulong)(long)v.VelZ, 4);
             }
             if (v.Health != 0)
             {
-                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 4);
+                w.HeaderAt(41, 0x7f69d4b5288ba9cful, 4, ref ids);
                 w.Fixed((ulong)(long)v.Health, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[10], ref ids);
             TableWire.WriteBodyField(ref w, v, fields[11], ref ids);
             if (v.Moving != false)
             {
-                w.Header(ids.Reference(0x11a44fc1d1243da7ul), 1);
+                w.HeaderAt(5, 0x11a44fc1d1243da7ul, 1, ref ids);
                 w.Fixed(v.Moving ? 1ul : 0ul, 1);
             }
             if (v.Firing != false)
             {
-                w.Header(ids.Reference(0x7674cfd19b9031caul), 1);
+                w.HeaderAt(36, 0x7674cfd19b9031caul, 1, ref ids);
                 w.Fixed(v.Firing ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -5129,7 +5237,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TableEntityCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5193,8 +5303,8 @@ namespace Benchtable
         public static long TableStatBodySizeTyped(TableStat v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.StatId != 0) { n += TableWire.VarSize(ids.Reference(0x80ab75f0866dbf65ul)) + 2; }
-            if (v.Delta != 0) { n += TableWire.VarSize(ids.Reference(0x52076675ec13a0c1ul)) + 5; }
+            if (v.StatId != 0) { n += TableWire.VarSize(ids.RefAt(42, 0x80ab75f0866dbf65ul)) + 2; }
+            if (v.Delta != 0) { n += TableWire.VarSize(ids.RefAt(23, 0x52076675ec13a0c1ul)) + 5; }
             return n;
         }
 
@@ -5202,12 +5312,12 @@ namespace Benchtable
         {
             if (v.StatId != 0)
             {
-                w.Header(ids.Reference(0x80ab75f0866dbf65ul), 6);
+                w.HeaderAt(42, 0x80ab75f0866dbf65ul, 6, ref ids);
                 w.Fixed((ulong)v.StatId, 1);
             }
             if (v.Delta != 0)
             {
-                w.Header(ids.Reference(0x52076675ec13a0c1ul), 4);
+                w.HeaderAt(23, 0x52076675ec13a0c1ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Delta, 4);
             }
             w.Var(0);
@@ -5223,7 +5333,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TableStatCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5361,16 +5473,16 @@ namespace Benchtable
             long n = 1;
             TableFieldInfo[] fields = TableMixedTableType().Fields;
             int elemOffset = 0;
-            if (v.ProtocolMagic != 0) { n += TableWire.VarSize(ids.Reference(0x6a5a70d91aa115fdul)) + 3; }
-            if (v.Sequence != 0) { n += TableWire.VarSize(ids.Reference(0xaa38aca481f528a8ul)) + 3; }
-            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.Reference(0x0dbe005c56697c3eul)) + 5; }
-            if (v.AckBits != 0) { n += TableWire.VarSize(ids.Reference(0x9bae0da8b829ee03ul)) + 5; }
-            if (v.SessionId != 0) { n += TableWire.VarSize(ids.Reference(0xb7d7b5650a590b05ul)) + 9; }
-            if (v.ClientId != 0) { n += TableWire.VarSize(ids.Reference(0x6d7b98e2d095967eul)) + 5; }
-            if (v.Nonce != 1ul) { n += TableWire.VarSize(ids.Reference(0x73a94c71d60dc0d8ul)) + 9; }
-            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.Reference(0x3eee6b51be54fc85ul)) + 9; }
-            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.Reference(0x7bbc035f7b6d0112ul)) + 9; }
-            if (v.ServerTime != 0.0f) { n += TableWire.VarSize(ids.Reference(0x3c460475f9be69c6ul)) + 5; }
+            if (v.ProtocolMagic != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x6a5a70d91aa115fdul)) + 3; }
+            if (v.Sequence != 0) { n += TableWire.VarSize(ids.RefAt(58, 0xaa38aca481f528a8ul)) + 3; }
+            if (v.AckSequence != 0) { n += TableWire.VarSize(ids.RefAt(4, 0x0dbe005c56697c3eul)) + 5; }
+            if (v.AckBits != 0) { n += TableWire.VarSize(ids.RefAt(49, 0x9bae0da8b829ee03ul)) + 5; }
+            if (v.SessionId != 0) { n += TableWire.VarSize(ids.RefAt(61, 0xb7d7b5650a590b05ul)) + 9; }
+            if (v.ClientId != 0) { n += TableWire.VarSize(ids.RefAt(32, 0x6d7b98e2d095967eul)) + 5; }
+            if (v.Nonce != 1ul) { n += TableWire.VarSize(ids.RefAt(34, 0x73a94c71d60dc0d8ul)) + 9; }
+            if (v.WorldTime != 0) { n += TableWire.VarSize(ids.RefAt(21, 0x3eee6b51be54fc85ul)) + 9; }
+            if (v.FrameTick != 0) { n += TableWire.VarSize(ids.RefAt(39, 0x7bbc035f7b6d0112ul)) + 9; }
+            if (v.ServerTime != 0.0f) { n += TableWire.VarSize(ids.RefAt(20, 0x3c460475f9be69c6ul)) + 5; }
             scoped Span<long> elemCache_10 = default;
             if (!rootElemSizes.IsEmpty)
             {
@@ -5399,7 +5511,7 @@ namespace Benchtable
                     nChild_11 += TableWire.VarSize((ulong)childBody) + childBody;
                 }
                 long payload_11 = 1 + TableWire.VarSize((ulong)count_11) + nChild_11;
-                n += TableWire.VarSize(ids.Reference(0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_11) + payload_11;
+                n += TableWire.VarSize(ids.RefAt(73, 0xee639cad45b1994cul)) + 1 + TableWire.VarSize((ulong)payload_11) + payload_11;
                 if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[11] = payload_11; }
             }
             n += TableWire.BodySizeField(v, fields[12], ref ids);
@@ -5408,16 +5520,16 @@ namespace Benchtable
             n += TableWire.BodySizeField(v, fields[14], ref ids, default, out long payload_14);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[14] = payload_14; }
             n += TableWire.BodySizeField(v, fields[15], ref ids);
-            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7be5e24296c9ul)) + 5; }
-            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf7ae5e2429516ul)) + 5; }
-            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdbaf79e5e2429363ul)) + 5; }
-            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.Reference(0x9cef31fff7e2e457ul)) + 5; }
-            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.Reference(0x5ab3f9c9341f6c04ul)) + 9; }
-            if (v.WideKey != 0) { n += TableWire.VarSize(ids.Reference(0xa3348580461faf16ul)) + 9; }
-            if (v.Flux != 0) { n += TableWire.VarSize(ids.Reference(0xd61bdd7908af2642ul)) + 9; }
-            if (v.Ping != 0.0f) { n += TableWire.VarSize(ids.Reference(0xbf30e00dc53307a9ul)) + 5; }
-            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.Reference(0x560d6527ccd8515ful)) + 5; }
-            if (v.HasExtra != false) { n += TableWire.VarSize(ids.Reference(0xc08292176cfd8672ul)) + 2; }
+            if (v.AimX != 0.0f) { n += TableWire.VarSize(ids.RefAt(72, 0xdbaf7be5e24296c9ul)) + 5; }
+            if (v.AimY != 0.0f) { n += TableWire.VarSize(ids.RefAt(71, 0xdbaf7ae5e2429516ul)) + 5; }
+            if (v.AimZ != 0.0f) { n += TableWire.VarSize(ids.RefAt(70, 0xdbaf79e5e2429363ul)) + 5; }
+            if (v.Recoil != 0.0f) { n += TableWire.VarSize(ids.RefAt(50, 0x9cef31fff7e2e457ul)) + 5; }
+            if (v.Drift != 0.0) { n += TableWire.VarSize(ids.RefAt(27, 0x5ab3f9c9341f6c04ul)) + 9; }
+            if (v.WideKey != 0) { n += TableWire.VarSize(ids.RefAt(55, 0xa3348580461faf16ul)) + 9; }
+            if (v.Flux != 0) { n += TableWire.VarSize(ids.RefAt(68, 0xd61bdd7908af2642ul)) + 9; }
+            if (v.Ping != 0.0f) { n += TableWire.VarSize(ids.RefAt(62, 0xbf30e00dc53307a9ul)) + 5; }
+            if (v.CrcHint != 0) { n += TableWire.VarSize(ids.RefAt(25, 0x560d6527ccd8515ful)) + 5; }
+            if (v.HasExtra != false) { n += TableWire.VarSize(ids.RefAt(63, 0xc08292176cfd8672ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[26], ref ids);
             n += TableWire.BodySizeField(v, fields[27], ref ids);
             return n;
@@ -5429,52 +5541,52 @@ namespace Benchtable
             int elemOffset = 0;
             if (v.ProtocolMagic != 0)
             {
-                w.Header(ids.Reference(0x6a5a70d91aa115fdul), 7);
+                w.HeaderAt(28, 0x6a5a70d91aa115fdul, 7, ref ids);
                 w.Fixed((ulong)v.ProtocolMagic, 2);
             }
             if (v.Sequence != 0)
             {
-                w.Header(ids.Reference(0xaa38aca481f528a8ul), 7);
+                w.HeaderAt(58, 0xaa38aca481f528a8ul, 7, ref ids);
                 w.Fixed((ulong)v.Sequence, 2);
             }
             if (v.AckSequence != 0)
             {
-                w.Header(ids.Reference(0x0dbe005c56697c3eul), 4);
+                w.HeaderAt(4, 0x0dbe005c56697c3eul, 4, ref ids);
                 w.Fixed((ulong)(long)v.AckSequence, 4);
             }
             if (v.AckBits != 0)
             {
-                w.Header(ids.Reference(0x9bae0da8b829ee03ul), 8);
+                w.HeaderAt(49, 0x9bae0da8b829ee03ul, 8, ref ids);
                 w.Fixed((ulong)v.AckBits, 4);
             }
             if (v.SessionId != 0)
             {
-                w.Header(ids.Reference(0xb7d7b5650a590b05ul), 9);
+                w.HeaderAt(61, 0xb7d7b5650a590b05ul, 9, ref ids);
                 w.Fixed((ulong)v.SessionId, 8);
             }
             if (v.ClientId != 0)
             {
-                w.Header(ids.Reference(0x6d7b98e2d095967eul), 8);
+                w.HeaderAt(32, 0x6d7b98e2d095967eul, 8, ref ids);
                 w.Fixed((ulong)v.ClientId, 4);
             }
             if (v.Nonce != 1ul)
             {
-                w.Header(ids.Reference(0x73a94c71d60dc0d8ul), 9);
+                w.HeaderAt(34, 0x73a94c71d60dc0d8ul, 9, ref ids);
                 w.Fixed((ulong)v.Nonce, 8);
             }
             if (v.WorldTime != 0)
             {
-                w.Header(ids.Reference(0x3eee6b51be54fc85ul), 5);
+                w.HeaderAt(21, 0x3eee6b51be54fc85ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.WorldTime, 8);
             }
             if (v.FrameTick != 0)
             {
-                w.Header(ids.Reference(0x7bbc035f7b6d0112ul), 9);
+                w.HeaderAt(39, 0x7bbc035f7b6d0112ul, 9, ref ids);
                 w.Fixed((ulong)v.FrameTick, 8);
             }
             if (v.ServerTime != 0.0f)
             {
-                w.Header(ids.Reference(0x3c460475f9be69c6ul), 10);
+                w.HeaderAt(20, 0x3c460475f9be69c6ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.ServerTime)), 4);
             }
             scoped ReadOnlySpan<long> elemCache_10 = default;
@@ -5490,7 +5602,7 @@ namespace Benchtable
             int count_11 = v.StatsCount;
             if (count_11 > 0)
             {
-                w.Header(ids.Reference(0xee639cad45b1994cul), 14);
+                w.HeaderAt(73, 0xee639cad45b1994cul, 14, ref ids);
                 scoped ReadOnlySpan<long> elemCache_11 = default;
                 if (!rootElemSizes.IsEmpty)
                 {
@@ -5527,52 +5639,52 @@ namespace Benchtable
             TableWire.WriteBodyField(ref w, v, fields[15], ref ids);
             if (v.AimX != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf7be5e24296c9ul), 10);
+                w.HeaderAt(72, 0xdbaf7be5e24296c9ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimX)), 4);
             }
             if (v.AimY != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf7ae5e2429516ul), 10);
+                w.HeaderAt(71, 0xdbaf7ae5e2429516ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimY)), 4);
             }
             if (v.AimZ != 0.0f)
             {
-                w.Header(ids.Reference(0xdbaf79e5e2429363ul), 10);
+                w.HeaderAt(70, 0xdbaf79e5e2429363ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.AimZ)), 4);
             }
             if (v.Recoil != 0.0f)
             {
-                w.Header(ids.Reference(0x9cef31fff7e2e457ul), 10);
+                w.HeaderAt(50, 0x9cef31fff7e2e457ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Recoil)), 4);
             }
             if (v.Drift != 0.0)
             {
-                w.Header(ids.Reference(0x5ab3f9c9341f6c04ul), 11);
+                w.HeaderAt(27, 0x5ab3f9c9341f6c04ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Drift)), 8);
             }
             if (v.WideKey != 0)
             {
-                w.Header(ids.Reference(0xa3348580461faf16ul), 9);
+                w.HeaderAt(55, 0xa3348580461faf16ul, 9, ref ids);
                 w.Fixed((ulong)v.WideKey, 8);
             }
             if (v.Flux != 0)
             {
-                w.Header(ids.Reference(0xd61bdd7908af2642ul), 5);
+                w.HeaderAt(68, 0xd61bdd7908af2642ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.Flux, 8);
             }
             if (v.Ping != 0.0f)
             {
-                w.Header(ids.Reference(0xbf30e00dc53307a9ul), 10);
+                w.HeaderAt(62, 0xbf30e00dc53307a9ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Ping)), 4);
             }
             if (v.CrcHint != 0)
             {
-                w.Header(ids.Reference(0x560d6527ccd8515ful), 8);
+                w.HeaderAt(25, 0x560d6527ccd8515ful, 8, ref ids);
                 w.Fixed((ulong)v.CrcHint, 4);
             }
             if (v.HasExtra != false)
             {
-                w.Header(ids.Reference(0xc08292176cfd8672ul), 1);
+                w.HeaderAt(63, 0xc08292176cfd8672ul, 1, ref ids);
                 w.Fixed(v.HasExtra ? 1ul : 0ul, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[26], ref ids);
@@ -5590,7 +5702,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TableMixedCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5658,10 +5772,10 @@ namespace Benchtable
         public static long TableHitEventBodySizeTyped(TableHitEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.TargetId != 0) { n += TableWire.VarSize(ids.Reference(0xb7bc9ac015a25050ul)) + 3; }
-            if (v.Damage != 0) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
-            if (v.HitKind != 0) { n += TableWire.VarSize(ids.Reference(0x01fbc365b059b925ul)) + 5; }
-            if (v.Crit != false) { n += TableWire.VarSize(ids.Reference(0x126167908c9aa52dul)) + 2; }
+            if (v.TargetId != 0) { n += TableWire.VarSize(ids.RefAt(60, 0xb7bc9ac015a25050ul)) + 3; }
+            if (v.Damage != 0) { n += TableWire.VarSize(ids.RefAt(40, 0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.HitKind != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x01fbc365b059b925ul)) + 5; }
+            if (v.Crit != false) { n += TableWire.VarSize(ids.RefAt(6, 0x126167908c9aa52dul)) + 2; }
             return n;
         }
 
@@ -5669,22 +5783,22 @@ namespace Benchtable
         {
             if (v.TargetId != 0)
             {
-                w.Header(ids.Reference(0xb7bc9ac015a25050ul), 7);
+                w.HeaderAt(60, 0xb7bc9ac015a25050ul, 7, ref ids);
                 w.Fixed((ulong)v.TargetId, 2);
             }
             if (v.Damage != 0)
             {
-                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 4);
+                w.HeaderAt(40, 0x7f6308be8ab37fc0ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Damage, 4);
             }
             if (v.HitKind != 0)
             {
-                w.Header(ids.Reference(0x01fbc365b059b925ul), 4);
+                w.HeaderAt(1, 0x01fbc365b059b925ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.HitKind, 4);
             }
             if (v.Crit != false)
             {
-                w.Header(ids.Reference(0x126167908c9aa52dul), 1);
+                w.HeaderAt(6, 0x126167908c9aa52dul, 1, ref ids);
                 w.Fixed(v.Crit ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -5700,7 +5814,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TableHitEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5764,8 +5880,8 @@ namespace Benchtable
         public static long TableChatEventBodySizeTyped(TableChatEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 5; }
-            if (v.Speaker != 0) { n += TableWire.VarSize(ids.Reference(0xfbf1ac4d96ebd022ul)) + 3; }
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.RefAt(56, 0xa5013e9ad5caeda4ul)) + 5; }
+            if (v.Speaker != 0) { n += TableWire.VarSize(ids.RefAt(75, 0xfbf1ac4d96ebd022ul)) + 3; }
             return n;
         }
 
@@ -5773,12 +5889,12 @@ namespace Benchtable
         {
             if (v.Channel != 0)
             {
-                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 4);
+                w.HeaderAt(56, 0xa5013e9ad5caeda4ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Channel, 4);
             }
             if (v.Speaker != 0)
             {
-                w.Header(ids.Reference(0xfbf1ac4d96ebd022ul), 7);
+                w.HeaderAt(75, 0xfbf1ac4d96ebd022ul, 7, ref ids);
                 w.Fixed((ulong)v.Speaker, 2);
             }
             w.Var(0);
@@ -5794,7 +5910,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TableChatEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -5858,8 +5976,8 @@ namespace Benchtable
         public static long TablePickupEventBodySizeTyped(TablePickupEvent v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.ItemId != 0) { n += TableWire.VarSize(ids.Reference(0x9e7fd06d864fbd56ul)) + 3; }
-            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            if (v.ItemId != 0) { n += TableWire.VarSize(ids.RefAt(51, 0x9e7fd06d864fbd56ul)) + 3; }
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.RefAt(43, 0x8113fe7ea2b16969ul)) + 5; }
             return n;
         }
 
@@ -5867,12 +5985,12 @@ namespace Benchtable
         {
             if (v.ItemId != 0)
             {
-                w.Header(ids.Reference(0x9e7fd06d864fbd56ul), 7);
+                w.HeaderAt(51, 0x9e7fd06d864fbd56ul, 7, ref ids);
                 w.Fixed((ulong)v.ItemId, 2);
             }
             if (v.Amount != 0)
             {
-                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.HeaderAt(43, 0x8113fe7ea2b16969ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Amount, 4);
             }
             w.Var(0);
@@ -5888,7 +6006,9 @@ namespace Benchtable
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TablePickupEventCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/internal/codegen/cstable/cstable.go
+++ b/internal/codegen/cstable/cstable.go
@@ -116,9 +116,24 @@ type tableGen struct {
 	home     bool       // this file carries the unit's shared table runtime
 	anyKeyed bool       // the unit declares at least one enum-keyed array
 	owner    *ir.Struct // the closure member whose codec is being emitted
+	idOrdinal map[uint64]int // compile-time slot of each id TableWireIds names
 	types    strings.Builder
 	schema   strings.Builder
 	indent   string // extra per-line indent while emitting inside a branch guard
+}
+
+func (g *tableGen) knownOrdinal(id uint64) int {
+	if g.idOrdinal == nil {
+		g.idOrdinal = make(map[uint64]int)
+		for i, known := range ir.TableWireIds(g.unit) {
+			g.idOrdinal[known] = i
+		}
+	}
+	ord, ok := g.idOrdinal[id]
+	if !ok {
+		panic(fmt.Sprintf("table id 0x%016x is not in the unit's vocabulary (ir.TableWireIds)", id))
+	}
+	return ord
 }
 
 // tf prints into the namespace-level region (storage classes).

--- a/internal/codegen/cstable/cstable.go
+++ b/internal/codegen/cstable/cstable.go
@@ -109,17 +109,17 @@ func generatedFrom(f *ir.File, u *ir.Unit) string {
 }
 
 type tableGen struct {
-	unit     *ir.Unit
-	file     *ir.File   // nil in the emitted-for-the-unit runtime file
-	outside  bool       // a view-only type has no checked wire identity
-	arm      bool       // descriptor rows inside a union
-	home     bool       // this file carries the unit's shared table runtime
-	anyKeyed bool       // the unit declares at least one enum-keyed array
-	owner    *ir.Struct // the closure member whose codec is being emitted
+	unit      *ir.Unit
+	file      *ir.File       // nil in the emitted-for-the-unit runtime file
+	outside   bool           // a view-only type has no checked wire identity
+	arm       bool           // descriptor rows inside a union
+	home      bool           // this file carries the unit's shared table runtime
+	anyKeyed  bool           // the unit declares at least one enum-keyed array
+	owner     *ir.Struct     // the closure member whose codec is being emitted
 	idOrdinal map[uint64]int // compile-time slot of each id TableWireIds names
-	types    strings.Builder
-	schema   strings.Builder
-	indent   string // extra per-line indent while emitting inside a branch guard
+	types     strings.Builder
+	schema    strings.Builder
+	indent    string // extra per-line indent while emitting inside a branch guard
 }
 
 func (g *tableGen) knownOrdinal(id uint64) int {

--- a/internal/codegen/cstable/cstable_test.go
+++ b/internal/codegen/cstable/cstable_test.go
@@ -131,6 +131,27 @@ func TestIsChildScalarArray(t *testing.T) {
 			},
 			wantOk: false,
 		},
+		{
+			name: "map field",
+			field: &ir.Field{
+				Name:       "mapField",
+				Array:      ir.ArrayFixed,
+				ArrayBound: 4,
+				MapEntry:   &ir.Struct{Name: "Entry"},
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk: false,
+		},
+		{
+			name: "list scalar array",
+			field: &ir.Field{
+				Name:       "listField",
+				Array:      ir.ArrayList,
+				ArrayBound: 4,
+				Type:       ir.FieldType{Kind: ir.TNamed, Ref: leafStruct},
+			},
+			wantOk: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/codegen/cstable/wire.go
+++ b/internal/codegen/cstable/wire.go
@@ -37,17 +37,12 @@ func isScalarLeafStruct(st *ir.Struct) bool {
 }
 
 func isChildScalarArray(f *ir.Field) (*ir.Struct, bool) {
-	if f.Array == ir.ArrayNone || f.Type.Optional || f.Guard != "" || f.KeyEnum != "" || f.Type.Pointer || f.Type.Kind != ir.TNamed {
-		return nil, false
+	if !f.IsMap() && !f.IsList() && f.KeyEnum == "" && !f.Type.Pointer && f.Guard == "" && !f.Type.Optional && (f.Array == ir.ArrayFixed || f.Array == ir.ArrayCounted) && f.Type.Kind == ir.TNamed {
+		if st, ok := f.Type.Ref.(*ir.Struct); ok && isScalarLeafStruct(st) {
+			return st, true
+		}
 	}
-	st, ok := f.Type.Ref.(*ir.Struct)
-	if !ok {
-		return nil, false
-	}
-	if !isScalarLeafStruct(st) {
-		return nil, false
-	}
-	return st, true
+	return nil, false
 }
 
 func needsElemOffset(st *ir.Struct) bool {
@@ -134,7 +129,7 @@ func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
 			cond := leafRideCondition(f)
 			kind := tableScalarKind(f)
 			width := tableKindWidth(kind)
-			g.pf("    if (%s) { n += TableWire.VarSize(ids.Reference(0x%016xul)) + %d; }\n", cond, id, 1+width)
+			g.pf("    if (%s) { n += TableWire.VarSize(ids.RefAt(%d, 0x%016xul)) + %d; }\n", cond, g.knownOrdinal(id), id, 1+width)
 		} else if childSt, ok := isChildScalarArray(f); ok {
 			prop := member(f)
 			childName := childSt.Name
@@ -156,7 +151,7 @@ func (g *tableGen) emitBodySizeTyped(st *ir.Struct) {
 			g.pf("            nChild_%d += TableWire.VarSize((ulong)childBody) + childBody;\n", i)
 			g.pf("        }\n")
 			g.pf("        long payload_%d = 1 + TableWire.VarSize((ulong)count_%d) + nChild_%d;\n", i, i, i)
-			g.pf("        n += TableWire.VarSize(ids.Reference(0x%016xul)) + 1 + TableWire.VarSize((ulong)payload_%d) + payload_%d;\n", id, i, i)
+			g.pf("        n += TableWire.VarSize(ids.RefAt(%d, 0x%016xul)) + 1 + TableWire.VarSize((ulong)payload_%d) + payload_%d;\n", g.knownOrdinal(id), id, i, i)
 			g.pf("        if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[%d] = payload_%d; }\n", i, i)
 			g.pf("    }\n")
 		} else {
@@ -198,7 +193,7 @@ func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
 			width := tableKindWidth(kind)
 			raw := csRawGet("v."+member(f), f.Type)
 			g.pf("    if (%s)\n    {\n", cond)
-			g.pf("        w.Header(ids.Reference(0x%016xul), %d);\n", id, kind)
+			g.pf("        w.HeaderAt(%d, 0x%016xul, %d, ref ids);\n", g.knownOrdinal(id), id, kind)
 			g.pf("        w.Fixed(%s, %d);\n", raw, width)
 			g.pf("    }\n")
 		} else if childSt, ok := isChildScalarArray(f); ok {
@@ -210,7 +205,7 @@ func (g *tableGen) emitWriteBodyTyped(st *ir.Struct) {
 			} else {
 				g.pf("    int count_%d = %d;\n    {\n", i, f.ArrayBound)
 			}
-			g.pf("        w.Header(ids.Reference(0x%016xul), 14);\n", id)
+			g.pf("        w.HeaderAt(%d, 0x%016xul, 14, ref ids);\n", g.knownOrdinal(id), id)
 			g.pf("        scoped ReadOnlySpan<long> elemCache_%d = default;\n", i)
 			g.pf("        if (!rootElemSizes.IsEmpty)\n        {\n")
 			g.pf("            int take = System.Math.Min(count_%d, System.Math.Max(0, rootElemSizes.Length - elemOffset));\n", i)
@@ -263,7 +258,9 @@ func (g *tableGen) emitSaveTyped(st *ir.Struct) {
 	g.pf("        slots = 1;\n")
 	g.pf("        while (slots < vocabulary.Length * 2) { slots <<= 1; }\n    }\n")
 	g.pf("    Span<int> index = stackalloc int[slots];\n")
-	g.pf("    TableWire.Ids ids = new TableWire.Ids(vocabulary, index);\n")
+	g.pf("    Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;\n")
+	g.pf("    Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;\n")
+	g.pf("    TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);\n")
 	g.pf("    if (!%sCollectTyped(value, ref ids)) { return -1; }\n", name)
 	g.pf("    int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;\n")
 	g.pf("    Span<long> rootPayloadSizes = stackalloc long[cachedFields];\n")
@@ -410,11 +407,41 @@ public static partial class TableWire
     {
         public Span<ulong> Values;
         public Span<int> Slots;
+        public Span<uint> OrdinalSlots;
+        public Span<int> OrdinalOf;
         public int Count;
         internal Graph Graph;
-        public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+        public Ids(Span<ulong> values)
+        {
+            Values = values;
+            Slots = default;
+            OrdinalSlots = default;
+            OrdinalOf = default;
+            Count = 0;
+            Graph = null;
+        }
         public Ids(Span<ulong> values, Span<int> slots)
-        { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+        {
+            Values = values;
+            Slots = slots;
+            if (!Slots.IsEmpty) { Slots.Clear(); }
+            OrdinalSlots = default;
+            OrdinalOf = default;
+            Count = 0;
+            Graph = null;
+        }
+        public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+        {
+            Values = values;
+            Slots = slots;
+            if (!Slots.IsEmpty) { Slots.Clear(); }
+            OrdinalSlots = ordinalSlots;
+            if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+            OrdinalOf = ordinalOf;
+            if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+            Count = 0;
+            Graph = null;
+        }
         int Slot(ulong id)
         {
             int mask = Slots.Length - 1;
@@ -422,11 +449,56 @@ public static partial class TableWire
             while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
             return slot;
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong Reference(ulong id)
         {
             if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
             for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
             return 0;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong Ref(ulong id)
+        {
+            if (!Slots.IsEmpty)
+            {
+                int slot = Slot(id);
+                if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                if (Count == Values.Length) { return 0; }
+                Values[Count] = id;
+                if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                Count++;
+                Slots[slot] = Count;
+                return (ulong)Count;
+            }
+            for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+            if (Count == Values.Length) { return 0; }
+            Values[Count] = id;
+            if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+            Count++;
+            return (ulong)Count;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong RefAt(int ordinal, ulong id)
+        {
+            if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+            {
+                uint s = OrdinalSlots[ordinal];
+                if (s != 0) { return (ulong)s; }
+            }
+            return RefAtMiss(ordinal, id);
+        }
+        ulong RefAtMiss(int ordinal, ulong id)
+        {
+            ulong r = Ref(id);
+            if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+            {
+                OrdinalSlots[ordinal] = (uint)r;
+                if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                {
+                    OrdinalOf[(int)(r - 1)] = ordinal;
+                }
+            }
+            return r;
         }
         public bool Add(ulong id)
         {
@@ -435,13 +507,39 @@ public static partial class TableWire
                 int slot = Slot(id);
                 if (Slots[slot] != 0) { return true; }
                 if (Count == Values.Length) { return false; }
-                Values[Count++] = id; Slots[slot] = Count;
+                Values[Count] = id;
+                if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                Count++;
+                Slots[slot] = Count;
                 return true;
             }
             if (Reference(id) != 0) { return true; }
             if (Count == Values.Length) { return false; }
-            Values[Count++] = id;
+            Values[Count] = id;
+            if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+            Count++;
             return true;
+        }
+        public void Truncate(int mark)
+        {
+            while (Count > 0 && Count > mark)
+            {
+                Count--;
+                if (!Slots.IsEmpty)
+                {
+                    int slot = Slot(Values[Count]);
+                    Slots[slot] = 0;
+                }
+                if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                {
+                    int o = OrdinalOf[Count];
+                    if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[o] = 0;
+                    }
+                    OrdinalOf[Count] = -1;
+                }
+            }
         }
     }
 
@@ -477,6 +575,11 @@ public static partial class TableWire
                 return;
             }
             Var(reference); Byte(kind);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+        {
+            Header(ids.RefAt(ordinal, id), kind);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Var(ulong v)
@@ -905,7 +1008,9 @@ public static partial class TableWire
             while (slots < vocabulary.Length * 2) { slots <<= 1; }
         }
         Span<int> index = stackalloc int[slots];
-        Ids ids = new Ids(vocabulary, index);
+        Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+        Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+        Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
         if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
         if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
         // Reuse the root's measured length prefixes while writing its fields,

--- a/testdata/golden/tables/block-cs/BlockdemoTable.cs
+++ b/testdata/golden/tables/block-cs/BlockdemoTable.cs
@@ -2649,11 +2649,41 @@ namespace Blockdemo
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2661,11 +2691,56 @@ namespace Blockdemo
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2674,13 +2749,39 @@ namespace Blockdemo
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2716,6 +2817,11 @@ namespace Blockdemo
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4459,7 +4565,9 @@ namespace Blockdemo
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,

--- a/testdata/golden/tables/block-cs/PaddedTable.cs
+++ b/testdata/golden/tables/block-cs/PaddedTable.cs
@@ -86,10 +86,10 @@ namespace Blockdemo
         {
             long n = 1;
             TableFieldInfo[] fields = PaddedRowTableType().Fields;
-            if (v.Tag != 0) { n += TableWire.VarSize(ids.Reference(0x56d7ab194448a4f3ul)) + 2; }
-            if (v.Value != 0.0) { n += TableWire.VarSize(ids.Reference(0x7ce4fd9430e80ceaul)) + 9; }
-            if (v.Flag != false) { n += TableWire.VarSize(ids.Reference(0xd5f2d079088c0b17ul)) + 2; }
-            if (v.Id != 0) { n += TableWire.VarSize(ids.Reference(0x08b72e07b55c3ac0ul)) + 5; }
+            if (v.Tag != 0) { n += TableWire.VarSize(ids.RefAt(25, 0x56d7ab194448a4f3ul)) + 2; }
+            if (v.Value != 0.0) { n += TableWire.VarSize(ids.RefAt(36, 0x7ce4fd9430e80ceaul)) + 9; }
+            if (v.Flag != false) { n += TableWire.VarSize(ids.RefAt(73, 0xd5f2d079088c0b17ul)) + 2; }
+            if (v.Id != 0) { n += TableWire.VarSize(ids.RefAt(0, 0x08b72e07b55c3ac0ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[4], ref ids, default, out long payload_4);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[4] = payload_4; }
             n += TableWire.BodySizeField(v, fields[5], ref ids, default, out long payload_5);
@@ -105,22 +105,22 @@ namespace Blockdemo
             TableFieldInfo[] fields = PaddedRowTableType().Fields;
             if (v.Tag != 0)
             {
-                w.Header(ids.Reference(0x56d7ab194448a4f3ul), 6);
+                w.HeaderAt(25, 0x56d7ab194448a4f3ul, 6, ref ids);
                 w.Fixed((ulong)v.Tag, 1);
             }
             if (v.Value != 0.0)
             {
-                w.Header(ids.Reference(0x7ce4fd9430e80ceaul), 11);
+                w.HeaderAt(36, 0x7ce4fd9430e80ceaul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Value)), 8);
             }
             if (v.Flag != false)
             {
-                w.Header(ids.Reference(0xd5f2d079088c0b17ul), 1);
+                w.HeaderAt(73, 0xd5f2d079088c0b17ul, 1, ref ids);
                 w.Fixed(v.Flag ? 1ul : 0ul, 1);
             }
             if (v.Id != 0)
             {
-                w.Header(ids.Reference(0x08b72e07b55c3ac0ul), 8);
+                w.HeaderAt(0, 0x08b72e07b55c3ac0ul, 8, ref ids);
                 w.Fixed((ulong)v.Id, 4);
             }
             long payload_4 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[4] : -1;
@@ -143,7 +143,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PaddedRowCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -219,8 +221,8 @@ namespace Blockdemo
             long n = 1;
             TableFieldInfo[] fields = PaddedFrameTableType().Fields;
             int elemOffset = 0;
-            if (v.Marker != 0) { n += TableWire.VarSize(ids.Reference(0xeddcb72b15486e77ul)) + 2; }
-            if (v.Stamp != 0) { n += TableWire.VarSize(ids.Reference(0xee7ba9ad45c64144ul)) + 9; }
+            if (v.Marker != 0) { n += TableWire.VarSize(ids.RefAt(81, 0xeddcb72b15486e77ul)) + 2; }
+            if (v.Stamp != 0) { n += TableWire.VarSize(ids.RefAt(83, 0xee7ba9ad45c64144ul)) + 9; }
             scoped Span<long> elemCache_2 = default;
             if (!rootElemSizes.IsEmpty)
             {
@@ -241,12 +243,12 @@ namespace Blockdemo
             int elemOffset = 0;
             if (v.Marker != 0)
             {
-                w.Header(ids.Reference(0xeddcb72b15486e77ul), 6);
+                w.HeaderAt(81, 0xeddcb72b15486e77ul, 6, ref ids);
                 w.Fixed((ulong)v.Marker, 1);
             }
             if (v.Stamp != 0)
             {
-                w.Header(ids.Reference(0xee7ba9ad45c64144ul), 9);
+                w.HeaderAt(83, 0xee7ba9ad45c64144ul, 9, ref ids);
                 w.Fixed((ulong)v.Stamp, 8);
             }
             scoped ReadOnlySpan<long> elemCache_2 = default;
@@ -273,7 +275,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PaddedFrameCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/block-cs/RenderTable.cs
+++ b/testdata/golden/tables/block-cs/RenderTable.cs
@@ -428,7 +428,7 @@ namespace Blockdemo
             long n = 1;
             TableFieldInfo[] fields = RenderFrameTableType().Fields;
             int elemOffset = 0;
-            if (v.Version != 0) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 9; }
+            if (v.Version != 0) { n += TableWire.VarSize(ids.RefAt(59, 0xbb62c62c9808ea37ul)) + 9; }
             scoped Span<long> elemCache_1 = default;
             if (!rootElemSizes.IsEmpty)
             {
@@ -528,7 +528,7 @@ namespace Blockdemo
             int elemOffset = 0;
             if (v.Version != 0)
             {
-                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 9);
+                w.HeaderAt(59, 0xbb62c62c9808ea37ul, 9, ref ids);
                 w.Fixed((ulong)v.Version, 8);
             }
             scoped ReadOnlySpan<long> elemCache_1 = default;
@@ -634,7 +634,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderFrameCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -712,10 +714,10 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.CameraId != 0) { n += TableWire.VarSize(ids.Reference(0x9f61700f084ab92eul)) + 5; }
-            if (v.CameraType != 0) { n += TableWire.VarSize(ids.Reference(0x336d3dc7fffd0c9bul)) + 5; }
-            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
-            if (v.Fov != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdcb27c18fed9e15cul)) + 5; }
+            if (v.CameraId != 0) { n += TableWire.VarSize(ids.RefAt(45, 0x9f61700f084ab92eul)) + 5; }
+            if (v.CameraType != 0) { n += TableWire.VarSize(ids.RefAt(15, 0x336d3dc7fffd0c9bul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.RefAt(31, 0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.Fov != 0.0f) { n += TableWire.VarSize(ids.RefAt(76, 0xdcb27c18fed9e15cul)) + 5; }
             return n;
         }
 
@@ -728,22 +730,22 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.CameraId != 0)
             {
-                w.Header(ids.Reference(0x9f61700f084ab92eul), 8);
+                w.HeaderAt(45, 0x9f61700f084ab92eul, 8, ref ids);
                 w.Fixed((ulong)v.CameraId, 4);
             }
             if (v.CameraType != 0)
             {
-                w.Header(ids.Reference(0x336d3dc7fffd0c9bul), 8);
+                w.HeaderAt(15, 0x336d3dc7fffd0c9bul, 8, ref ids);
                 w.Fixed((ulong)v.CameraType, 4);
             }
             if (v.TargetObjectId != 0)
             {
-                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.HeaderAt(31, 0x6a0c6a156952b9c2ul, 8, ref ids);
                 w.Fixed((ulong)v.TargetObjectId, 4);
             }
             if (v.Fov != 0.0f)
             {
-                w.Header(ids.Reference(0xdcb27c18fed9e15cul), 10);
+                w.HeaderAt(76, 0xdcb27c18fed9e15cul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Fov)), 4);
             }
             w.Var(0);
@@ -759,7 +761,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderCameraCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -848,14 +852,14 @@ namespace Blockdemo
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             n += TableWire.BodySizeField(v, fields[2], ref ids);
-            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
-            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
-            if (v.Thrust != 0.0f) { n += TableWire.VarSize(ids.Reference(0xcfd587cb3100cd73ul)) + 5; }
-            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x0bdab42c07f19812ul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.RefAt(31, 0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.Thrust != 0.0f) { n += TableWire.VarSize(ids.RefAt(70, 0xcfd587cb3100cd73ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x5de0015285763c46ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[7], ref ids);
             n += TableWire.BodySizeField(v, fields[8], ref ids);
-            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.Reference(0x1554fa45a1220171ul)) + 2; }
-            if (v.PredictedExplode != false) { n += TableWire.VarSize(ids.Reference(0x4d5be97ba1b9cb81ul)) + 2; }
+            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.RefAt(7, 0x1554fa45a1220171ul)) + 2; }
+            if (v.PredictedExplode != false) { n += TableWire.VarSize(ids.RefAt(22, 0x4d5be97ba1b9cb81ul)) + 2; }
             return n;
         }
 
@@ -869,34 +873,34 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[2], ref ids);
             if (v.ObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.HeaderAt(1, 0x0bdab42c07f19812ul, 8, ref ids);
                 w.Fixed((ulong)v.ObjectId, 4);
             }
             if (v.TargetObjectId != 0)
             {
-                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.HeaderAt(31, 0x6a0c6a156952b9c2ul, 8, ref ids);
                 w.Fixed((ulong)v.TargetObjectId, 4);
             }
             if (v.Thrust != 0.0f)
             {
-                w.Header(ids.Reference(0xcfd587cb3100cd73ul), 10);
+                w.HeaderAt(70, 0xcfd587cb3100cd73ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Thrust)), 4);
             }
             if (v.ObjectSequence != 0)
             {
-                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.HeaderAt(28, 0x5de0015285763c46ul, 6, ref ids);
                 w.Fixed((ulong)v.ObjectSequence, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
             TableWire.WriteBodyField(ref w, v, fields[8], ref ids);
             if (v.HasTargetLock != false)
             {
-                w.Header(ids.Reference(0x1554fa45a1220171ul), 1);
+                w.HeaderAt(7, 0x1554fa45a1220171ul, 1, ref ids);
                 w.Fixed(v.HasTargetLock ? 1ul : 0ul, 1);
             }
             if (v.PredictedExplode != false)
             {
-                w.Header(ids.Reference(0x4d5be97ba1b9cb81ul), 1);
+                w.HeaderAt(22, 0x4d5be97ba1b9cb81ul, 1, ref ids);
                 w.Fixed(v.PredictedExplode ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -912,7 +916,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderShipCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -994,14 +1000,14 @@ namespace Blockdemo
             TableFieldInfo[] fields = RenderTurretTableType().Fields;
             n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
-            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
-            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
-            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bee7b3cb4046c93ul)) + 5; }
-            if (v.TurretIndex != 0) { n += TableWire.VarSize(ids.Reference(0x88a11a6aed541f54ul)) + 5; }
-            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x6a0c6a156952b9c2ul)) + 5; }
-            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x0bdab42c07f19812ul)) + 5; }
+            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.RefAt(2, 0x0bee7b3cb4046c93ul)) + 5; }
+            if (v.TurretIndex != 0) { n += TableWire.VarSize(ids.RefAt(40, 0x88a11a6aed541f54ul)) + 5; }
+            if (v.TargetObjectId != 0) { n += TableWire.VarSize(ids.RefAt(31, 0x6a0c6a156952b9c2ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x5de0015285763c46ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[7], ref ids);
-            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.Reference(0x1554fa45a1220171ul)) + 2; }
+            if (v.HasTargetLock != false) { n += TableWire.VarSize(ids.RefAt(7, 0x1554fa45a1220171ul)) + 2; }
             return n;
         }
 
@@ -1012,38 +1018,38 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             if (v.Flags != 0)
             {
-                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.HeaderAt(8, 0x17a3a1a985f75aecul, 9, ref ids);
                 w.Fixed((ulong)v.Flags, 8);
             }
             if (v.ObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.HeaderAt(1, 0x0bdab42c07f19812ul, 8, ref ids);
                 w.Fixed((ulong)v.ObjectId, 4);
             }
             if (v.ParentObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bee7b3cb4046c93ul), 8);
+                w.HeaderAt(2, 0x0bee7b3cb4046c93ul, 8, ref ids);
                 w.Fixed((ulong)v.ParentObjectId, 4);
             }
             if (v.TurretIndex != 0)
             {
-                w.Header(ids.Reference(0x88a11a6aed541f54ul), 8);
+                w.HeaderAt(40, 0x88a11a6aed541f54ul, 8, ref ids);
                 w.Fixed((ulong)v.TurretIndex, 4);
             }
             if (v.TargetObjectId != 0)
             {
-                w.Header(ids.Reference(0x6a0c6a156952b9c2ul), 8);
+                w.HeaderAt(31, 0x6a0c6a156952b9c2ul, 8, ref ids);
                 w.Fixed((ulong)v.TargetObjectId, 4);
             }
             if (v.ObjectSequence != 0)
             {
-                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.HeaderAt(28, 0x5de0015285763c46ul, 6, ref ids);
                 w.Fixed((ulong)v.ObjectSequence, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[7], ref ids);
             if (v.HasTargetLock != false)
             {
-                w.Header(ids.Reference(0x1554fa45a1220171ul), 1);
+                w.HeaderAt(7, 0x1554fa45a1220171ul, 1, ref ids);
                 w.Fixed(v.HasTargetLock ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -1059,7 +1065,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderTurretCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1139,9 +1147,9 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
-            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
-            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x0bdab42c07f19812ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x5de0015285763c46ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
@@ -1156,17 +1164,17 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.Flags != 0)
             {
-                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.HeaderAt(8, 0x17a3a1a985f75aecul, 9, ref ids);
                 w.Fixed((ulong)v.Flags, 8);
             }
             if (v.ObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.HeaderAt(1, 0x0bdab42c07f19812ul, 8, ref ids);
                 w.Fixed((ulong)v.ObjectId, 4);
             }
             if (v.ObjectSequence != 0)
             {
-                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.HeaderAt(28, 0x5de0015285763c46ul, 6, ref ids);
                 w.Fixed((ulong)v.ObjectSequence, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
@@ -1184,7 +1192,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderMissileCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1264,9 +1274,9 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
-            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bdab42c07f19812ul)) + 5; }
-            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.Reference(0x5de0015285763c46ul)) + 2; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x17a3a1a985f75aecul)) + 9; }
+            if (v.ObjectId != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x0bdab42c07f19812ul)) + 5; }
+            if (v.ObjectSequence != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x5de0015285763c46ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
@@ -1281,17 +1291,17 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.Flags != 0)
             {
-                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.HeaderAt(8, 0x17a3a1a985f75aecul, 9, ref ids);
                 w.Fixed((ulong)v.Flags, 8);
             }
             if (v.ObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bdab42c07f19812ul), 8);
+                w.HeaderAt(1, 0x0bdab42c07f19812ul, 8, ref ids);
                 w.Fixed((ulong)v.ObjectId, 4);
             }
             if (v.ObjectSequence != 0)
             {
-                w.Header(ids.Reference(0x5de0015285763c46ul), 6);
+                w.HeaderAt(28, 0x5de0015285763c46ul, 6, ref ids);
                 w.Fixed((ulong)v.ObjectSequence, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
@@ -1309,7 +1319,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderDynamicPropCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1389,9 +1401,9 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.Reference(0x6aacb9fbb71a1d91ul)) + 9; }
-            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
-            if (v.StaticPropId != 0) { n += TableWire.VarSize(ids.Reference(0xd23da7ab574b95c3ul)) + 5; }
+            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.RefAt(32, 0x6aacb9fbb71a1d91ul)) + 9; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x17a3a1a985f75aecul)) + 9; }
+            if (v.StaticPropId != 0) { n += TableWire.VarSize(ids.RefAt(72, 0xd23da7ab574b95c3ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
@@ -1406,17 +1418,17 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.Scale != 0.0)
             {
-                w.Header(ids.Reference(0x6aacb9fbb71a1d91ul), 11);
+                w.HeaderAt(32, 0x6aacb9fbb71a1d91ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Scale)), 8);
             }
             if (v.Flags != 0)
             {
-                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.HeaderAt(8, 0x17a3a1a985f75aecul, 9, ref ids);
                 w.Fixed((ulong)v.Flags, 8);
             }
             if (v.StaticPropId != 0)
             {
-                w.Header(ids.Reference(0xd23da7ab574b95c3ul), 8);
+                w.HeaderAt(72, 0xd23da7ab574b95c3ul, 8, ref ids);
                 w.Fixed((ulong)v.StaticPropId, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
@@ -1434,7 +1446,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderStaticPropCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1516,10 +1530,10 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.Reference(0x6aacb9fbb71a1d91ul)) + 9; }
-            if (v.Flags != 0) { n += TableWire.VarSize(ids.Reference(0x17a3a1a985f75aecul)) + 9; }
-            if (v.CosmeticPropId != 0) { n += TableWire.VarSize(ids.Reference(0xb66e4449e56b2e26ul)) + 5; }
-            if (v.PropSequence != 0) { n += TableWire.VarSize(ids.Reference(0x4d7bf73bcbddc228ul)) + 2; }
+            if (v.Scale != 0.0) { n += TableWire.VarSize(ids.RefAt(32, 0x6aacb9fbb71a1d91ul)) + 9; }
+            if (v.Flags != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x17a3a1a985f75aecul)) + 9; }
+            if (v.CosmeticPropId != 0) { n += TableWire.VarSize(ids.RefAt(57, 0xb66e4449e56b2e26ul)) + 5; }
+            if (v.PropSequence != 0) { n += TableWire.VarSize(ids.RefAt(23, 0x4d7bf73bcbddc228ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             n += TableWire.BodySizeField(v, fields[7], ref ids);
             return n;
@@ -1534,22 +1548,22 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.Scale != 0.0)
             {
-                w.Header(ids.Reference(0x6aacb9fbb71a1d91ul), 11);
+                w.HeaderAt(32, 0x6aacb9fbb71a1d91ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Scale)), 8);
             }
             if (v.Flags != 0)
             {
-                w.Header(ids.Reference(0x17a3a1a985f75aecul), 9);
+                w.HeaderAt(8, 0x17a3a1a985f75aecul, 9, ref ids);
                 w.Fixed((ulong)v.Flags, 8);
             }
             if (v.CosmeticPropId != 0)
             {
-                w.Header(ids.Reference(0xb66e4449e56b2e26ul), 8);
+                w.HeaderAt(57, 0xb66e4449e56b2e26ul, 8, ref ids);
                 w.Fixed((ulong)v.CosmeticPropId, 4);
             }
             if (v.PropSequence != 0)
             {
-                w.Header(ids.Reference(0x4d7bf73bcbddc228ul), 6);
+                w.HeaderAt(23, 0x4d7bf73bcbddc228ul, 6, ref ids);
                 w.Fixed((ulong)v.PropSequence, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[6], ref ids);
@@ -1567,7 +1581,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderCosmeticPropCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1645,8 +1661,8 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.T != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63e94c860202a3ul)) + 9; }
-            if (v.LaserId != 0) { n += TableWire.VarSize(ids.Reference(0xcd29c05f390294ecul)) + 5; }
+            if (v.T != 0.0) { n += TableWire.VarSize(ids.RefAt(50, 0xaf63e94c860202a3ul)) + 9; }
+            if (v.LaserId != 0) { n += TableWire.VarSize(ids.RefAt(68, 0xcd29c05f390294ecul)) + 5; }
             n += TableWire.BodySizeField(v, fields[4], ref ids);
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             return n;
@@ -1661,12 +1677,12 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.T != 0.0)
             {
-                w.Header(ids.Reference(0xaf63e94c860202a3ul), 11);
+                w.HeaderAt(50, 0xaf63e94c860202a3ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.T)), 8);
             }
             if (v.LaserId != 0)
             {
-                w.Header(ids.Reference(0xcd29c05f390294ecul), 8);
+                w.HeaderAt(68, 0xcd29c05f390294ecul, 8, ref ids);
                 w.Fixed((ulong)v.LaserId, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[4], ref ids);
@@ -1684,7 +1700,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderLaserCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1764,9 +1782,9 @@ namespace Blockdemo
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.T != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63e94c860202a3ul)) + 9; }
-            if (v.ExplosionId != 0) { n += TableWire.VarSize(ids.Reference(0xfd7f3fa0b16ed778ul)) + 5; }
-            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.Reference(0x0bee7b3cb4046c93ul)) + 5; }
+            if (v.T != 0.0) { n += TableWire.VarSize(ids.RefAt(50, 0xaf63e94c860202a3ul)) + 9; }
+            if (v.ExplosionId != 0) { n += TableWire.VarSize(ids.RefAt(86, 0xfd7f3fa0b16ed778ul)) + 5; }
+            if (v.ParentObjectId != 0) { n += TableWire.VarSize(ids.RefAt(2, 0x0bee7b3cb4046c93ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             n += TableWire.BodySizeField(v, fields[6], ref ids);
             return n;
@@ -1781,17 +1799,17 @@ namespace Blockdemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.T != 0.0)
             {
-                w.Header(ids.Reference(0xaf63e94c860202a3ul), 11);
+                w.HeaderAt(50, 0xaf63e94c860202a3ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.T)), 8);
             }
             if (v.ExplosionId != 0)
             {
-                w.Header(ids.Reference(0xfd7f3fa0b16ed778ul), 8);
+                w.HeaderAt(86, 0xfd7f3fa0b16ed778ul, 8, ref ids);
                 w.Fixed((ulong)v.ExplosionId, 4);
             }
             if (v.ParentObjectId != 0)
             {
-                w.Header(ids.Reference(0x0bee7b3cb4046c93ul), 8);
+                w.HeaderAt(2, 0x0bee7b3cb4046c93ul, 8, ref ids);
                 w.Fixed((ulong)v.ParentObjectId, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
@@ -1809,7 +1827,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderExplosionCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1875,9 +1895,9 @@ namespace Blockdemo
         public static long RenderVector3BodySizeTyped(RenderVector3 v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.X != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f54c86021707ul)) + 9; }
-            if (v.Y != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f44c86021554ul)) + 9; }
-            if (v.Z != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f74c86021a6dul)) + 9; }
+            if (v.X != 0.0) { n += TableWire.VarSize(ids.RefAt(53, 0xaf63f54c86021707ul)) + 9; }
+            if (v.Y != 0.0) { n += TableWire.VarSize(ids.RefAt(52, 0xaf63f44c86021554ul)) + 9; }
+            if (v.Z != 0.0) { n += TableWire.VarSize(ids.RefAt(54, 0xaf63f74c86021a6dul)) + 9; }
             return n;
         }
 
@@ -1885,17 +1905,17 @@ namespace Blockdemo
         {
             if (v.X != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f54c86021707ul), 11);
+                w.HeaderAt(53, 0xaf63f54c86021707ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.X)), 8);
             }
             if (v.Y != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f44c86021554ul), 11);
+                w.HeaderAt(52, 0xaf63f44c86021554ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Y)), 8);
             }
             if (v.Z != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f74c86021a6dul), 11);
+                w.HeaderAt(54, 0xaf63f74c86021a6dul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Z)), 8);
             }
             w.Var(0);
@@ -1911,7 +1931,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderVector3CollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -1979,10 +2001,10 @@ namespace Blockdemo
         public static long RenderQuaternionBodySizeTyped(RenderQuaternion v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.X != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f54c86021707ul)) + 9; }
-            if (v.Y != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f44c86021554ul)) + 9; }
-            if (v.Z != 0.0) { n += TableWire.VarSize(ids.Reference(0xaf63f74c86021a6dul)) + 9; }
-            if (v.W != 1.0) { n += TableWire.VarSize(ids.Reference(0xaf63ea4c86020456ul)) + 9; }
+            if (v.X != 0.0) { n += TableWire.VarSize(ids.RefAt(53, 0xaf63f54c86021707ul)) + 9; }
+            if (v.Y != 0.0) { n += TableWire.VarSize(ids.RefAt(52, 0xaf63f44c86021554ul)) + 9; }
+            if (v.Z != 0.0) { n += TableWire.VarSize(ids.RefAt(54, 0xaf63f74c86021a6dul)) + 9; }
+            if (v.W != 1.0) { n += TableWire.VarSize(ids.RefAt(51, 0xaf63ea4c86020456ul)) + 9; }
             return n;
         }
 
@@ -1990,22 +2012,22 @@ namespace Blockdemo
         {
             if (v.X != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f54c86021707ul), 11);
+                w.HeaderAt(53, 0xaf63f54c86021707ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.X)), 8);
             }
             if (v.Y != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f44c86021554ul), 11);
+                w.HeaderAt(52, 0xaf63f44c86021554ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Y)), 8);
             }
             if (v.Z != 0.0)
             {
-                w.Header(ids.Reference(0xaf63f74c86021a6dul), 11);
+                w.HeaderAt(54, 0xaf63f74c86021a6dul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Z)), 8);
             }
             if (v.W != 1.0)
             {
-                w.Header(ids.Reference(0xaf63ea4c86020456ul), 11);
+                w.HeaderAt(51, 0xaf63ea4c86020456ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.W)), 8);
             }
             w.Var(0);
@@ -2021,7 +2043,9 @@ namespace Blockdemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RenderQuaternionCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
+++ b/testdata/golden/tables/blockhome-cs/BlockhomeTable.cs
@@ -2533,11 +2533,41 @@ namespace Blockhome
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2545,11 +2575,56 @@ namespace Blockhome
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2558,13 +2633,39 @@ namespace Blockhome
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2600,6 +2701,11 @@ namespace Blockhome
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4343,7 +4449,9 @@ namespace Blockhome
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -36,9 +36,9 @@ namespace Blockhome
         public static long ArmorPlateBodySizeTyped(ArmorPlate v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Thickness != 0.0) { n += TableWire.VarSize(ids.Reference(0xdbae65ca25b4f315ul)) + 9; }
-            if (v.Material != 0) { n += TableWire.VarSize(ids.Reference(0x026f7568983161e0ul)) + 5; }
-            if (v.Layer != 0) { n += TableWire.VarSize(ids.Reference(0x84e39fec29768c56ul)) + 2; }
+            if (v.Thickness != 0.0) { n += TableWire.VarSize(ids.RefAt(24, 0xdbae65ca25b4f315ul)) + 9; }
+            if (v.Material != 0) { n += TableWire.VarSize(ids.RefAt(0, 0x026f7568983161e0ul)) + 5; }
+            if (v.Layer != 0) { n += TableWire.VarSize(ids.RefAt(16, 0x84e39fec29768c56ul)) + 2; }
             return n;
         }
 
@@ -46,17 +46,17 @@ namespace Blockhome
         {
             if (v.Thickness != 0.0)
             {
-                w.Header(ids.Reference(0xdbae65ca25b4f315ul), 11);
+                w.HeaderAt(24, 0xdbae65ca25b4f315ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Thickness)), 8);
             }
             if (v.Material != 0)
             {
-                w.Header(ids.Reference(0x026f7568983161e0ul), 8);
+                w.HeaderAt(0, 0x026f7568983161e0ul, 8, ref ids);
                 w.Fixed((ulong)v.Material, 4);
             }
             if (v.Layer != 0)
             {
-                w.Header(ids.Reference(0x84e39fec29768c56ul), 6);
+                w.HeaderAt(16, 0x84e39fec29768c56ul, 6, ref ids);
                 w.Fixed((ulong)v.Layer, 1);
             }
             w.Var(0);
@@ -72,7 +72,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ArmorPlateCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -146,8 +148,8 @@ namespace Blockhome
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.Rating != 0.0f) { n += TableWire.VarSize(ids.Reference(0x4e79ecbefe5ff4d0ul)) + 5; }
-            if (v.Tier != 0) { n += TableWire.VarSize(ids.Reference(0x1e6f84ef2eb65989ul)) + 2; }
+            if (v.Rating != 0.0f) { n += TableWire.VarSize(ids.RefAt(10, 0x4e79ecbefe5ff4d0ul)) + 5; }
+            if (v.Tier != 0) { n += TableWire.VarSize(ids.RefAt(3, 0x1e6f84ef2eb65989ul)) + 2; }
             return n;
         }
 
@@ -160,12 +162,12 @@ namespace Blockhome
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.Rating != 0.0f)
             {
-                w.Header(ids.Reference(0x4e79ecbefe5ff4d0ul), 10);
+                w.HeaderAt(10, 0x4e79ecbefe5ff4d0ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Rating)), 4);
             }
             if (v.Tier != 0)
             {
-                w.Header(ids.Reference(0x1e6f84ef2eb65989ul), 6);
+                w.HeaderAt(3, 0x1e6f84ef2eb65989ul, 6, ref ids);
                 w.Fixed((ulong)v.Tier, 1);
             }
             w.Var(0);
@@ -181,7 +183,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ArmorConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -245,8 +249,8 @@ namespace Blockhome
         public static long FiringGroupBodySizeTyped(FiringGroup v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Barrel != 0) { n += TableWire.VarSize(ids.Reference(0x8ece059ad360b651ul)) + 5; }
-            if (v.Cooldown != 0.0f) { n += TableWire.VarSize(ids.Reference(0xdc2cbe6953343d48ul)) + 5; }
+            if (v.Barrel != 0) { n += TableWire.VarSize(ids.RefAt(17, 0x8ece059ad360b651ul)) + 5; }
+            if (v.Cooldown != 0.0f) { n += TableWire.VarSize(ids.RefAt(25, 0xdc2cbe6953343d48ul)) + 5; }
             return n;
         }
 
@@ -254,12 +258,12 @@ namespace Blockhome
         {
             if (v.Barrel != 0)
             {
-                w.Header(ids.Reference(0x8ece059ad360b651ul), 8);
+                w.HeaderAt(17, 0x8ece059ad360b651ul, 8, ref ids);
                 w.Fixed((ulong)v.Barrel, 4);
             }
             if (v.Cooldown != 0.0f)
             {
-                w.Header(ids.Reference(0xdc2cbe6953343d48ul), 10);
+                w.HeaderAt(25, 0xdc2cbe6953343d48ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Cooldown)), 4);
             }
             w.Var(0);
@@ -275,7 +279,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!FiringGroupCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -388,7 +394,7 @@ namespace Blockhome
                     nChild_0 += TableWire.VarSize((ulong)childBody) + childBody;
                 }
                 long payload_0 = 1 + TableWire.VarSize((ulong)count_0) + nChild_0;
-                n += TableWire.VarSize(ids.Reference(0x260b8ca6b0c3db7ful)) + 1 + TableWire.VarSize((ulong)payload_0) + payload_0;
+                n += TableWire.VarSize(ids.RefAt(4, 0x260b8ca6b0c3db7ful)) + 1 + TableWire.VarSize((ulong)payload_0) + payload_0;
                 if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             }
             int count_1 = v.MissileGroupsCount;
@@ -409,11 +415,11 @@ namespace Blockhome
                     nChild_1 += TableWire.VarSize((ulong)childBody) + childBody;
                 }
                 long payload_1 = 1 + TableWire.VarSize((ulong)count_1) + nChild_1;
-                n += TableWire.VarSize(ids.Reference(0x3c99105aa087f6bcul)) + 1 + TableWire.VarSize((ulong)payload_1) + payload_1;
+                n += TableWire.VarSize(ids.RefAt(7, 0x3c99105aa087f6bcul)) + 1 + TableWire.VarSize((ulong)payload_1) + payload_1;
                 if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             }
-            if (v.ReloadSeconds != 0.0f) { n += TableWire.VarSize(ids.Reference(0xad9b64728ea52486ul)) + 5; }
-            if (v.GunnerId != 0) { n += TableWire.VarSize(ids.Reference(0xbd9be53180256e02ul)) + 5; }
+            if (v.ReloadSeconds != 0.0f) { n += TableWire.VarSize(ids.RefAt(19, 0xad9b64728ea52486ul)) + 5; }
+            if (v.GunnerId != 0) { n += TableWire.VarSize(ids.RefAt(22, 0xbd9be53180256e02ul)) + 5; }
             return n;
         }
 
@@ -423,7 +429,7 @@ namespace Blockhome
             int count_0 = v.FiringGroupsCount;
             if (count_0 > 0)
             {
-                w.Header(ids.Reference(0x260b8ca6b0c3db7ful), 14);
+                w.HeaderAt(4, 0x260b8ca6b0c3db7ful, 14, ref ids);
                 scoped ReadOnlySpan<long> elemCache_0 = default;
                 if (!rootElemSizes.IsEmpty)
                 {
@@ -455,7 +461,7 @@ namespace Blockhome
             int count_1 = v.MissileGroupsCount;
             if (count_1 > 0)
             {
-                w.Header(ids.Reference(0x3c99105aa087f6bcul), 14);
+                w.HeaderAt(7, 0x3c99105aa087f6bcul, 14, ref ids);
                 scoped ReadOnlySpan<long> elemCache_1 = default;
                 if (!rootElemSizes.IsEmpty)
                 {
@@ -486,12 +492,12 @@ namespace Blockhome
             }
             if (v.ReloadSeconds != 0.0f)
             {
-                w.Header(ids.Reference(0xad9b64728ea52486ul), 10);
+                w.HeaderAt(19, 0xad9b64728ea52486ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.ReloadSeconds)), 4);
             }
             if (v.GunnerId != 0)
             {
-                w.Header(ids.Reference(0xbd9be53180256e02ul), 8);
+                w.HeaderAt(22, 0xbd9be53180256e02ul, 8, ref ids);
                 w.Fixed((ulong)v.GunnerId, 4);
             }
             w.Var(0);
@@ -507,7 +513,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!GunnerSettingsCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -71,8 +71,8 @@ namespace Blockhome
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
-            if (v.PartId != 0) { n += TableWire.VarSize(ids.Reference(0x04d6206b33415104ul)) + 5; }
-            if (v.Slot != 0) { n += TableWire.VarSize(ids.Reference(0x6a771618f6fe31d1ul)) + 2; }
+            if (v.PartId != 0) { n += TableWire.VarSize(ids.RefAt(1, 0x04d6206b33415104ul)) + 5; }
+            if (v.Slot != 0) { n += TableWire.VarSize(ids.RefAt(13, 0x6a771618f6fe31d1ul)) + 2; }
             return n;
         }
 
@@ -85,12 +85,12 @@ namespace Blockhome
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids, default, payload_1);
             if (v.PartId != 0)
             {
-                w.Header(ids.Reference(0x04d6206b33415104ul), 8);
+                w.HeaderAt(1, 0x04d6206b33415104ul, 8, ref ids);
                 w.Fixed((ulong)v.PartId, 4);
             }
             if (v.Slot != 0)
             {
-                w.Header(ids.Reference(0x6a771618f6fe31d1ul), 6);
+                w.HeaderAt(13, 0x6a771618f6fe31d1ul, 6, ref ids);
                 w.Fixed((ulong)v.Slot, 1);
             }
             w.Var(0);
@@ -106,7 +106,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PartRowCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -177,7 +179,7 @@ namespace Blockhome
             long n = 1;
             TableFieldInfo[] fields = PartFrameTableType().Fields;
             int elemOffset = 0;
-            if (v.Version != 0) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 9; }
+            if (v.Version != 0) { n += TableWire.VarSize(ids.RefAt(21, 0xbb62c62c9808ea37ul)) + 9; }
             scoped Span<long> elemCache_1 = default;
             if (!rootElemSizes.IsEmpty)
             {
@@ -197,7 +199,7 @@ namespace Blockhome
             int elemOffset = 0;
             if (v.Version != 0)
             {
-                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 9);
+                w.HeaderAt(21, 0xbb62c62c9808ea37ul, 9, ref ids);
                 w.Fixed((ulong)v.Version, 8);
             }
             scoped ReadOnlySpan<long> elemCache_1 = default;
@@ -223,7 +225,9 @@ namespace Blockhome
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PartFrameCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/GuardedTable.cs
+++ b/testdata/golden/tables/examples-cs/GuardedTable.cs
@@ -70,7 +70,7 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = PatrolTableType().Fields;
-            if (v.Active != false) { n += TableWire.VarSize(ids.Reference(0x6580790b036f0c6ful)) + 2; }
+            if (v.Active != false) { n += TableWire.VarSize(ids.RefAt(57, 0x6580790b036f0c6ful)) + 2; }
             n += TableWire.BodySizeField(v, fields[1], ref ids);
             n += TableWire.BodySizeField(v, fields[2], ref ids);
             n += TableWire.BodySizeField(v, fields[3], ref ids);
@@ -85,7 +85,7 @@ namespace Tabledemo
             TableFieldInfo[] fields = PatrolTableType().Fields;
             if (v.Active != false)
             {
-                w.Header(ids.Reference(0x6580790b036f0c6ful), 1);
+                w.HeaderAt(57, 0x6580790b036f0c6ful, 1, ref ids);
                 w.Fixed(v.Active ? 1ul : 0ul, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
@@ -107,7 +107,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PatrolCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/KeyedTable.cs
+++ b/testdata/golden/tables/examples-cs/KeyedTable.cs
@@ -180,7 +180,7 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = TeamConfigTableType().Fields;
-            if (v.SpawnCount != 4) { n += TableWire.VarSize(ids.Reference(0xceec99e2d65db674ul)) + 5; }
+            if (v.SpawnCount != 4) { n += TableWire.VarSize(ids.RefAt(120, 0xceec99e2d65db674ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             return n;
@@ -191,7 +191,7 @@ namespace Tabledemo
             TableFieldInfo[] fields = TeamConfigTableType().Fields;
             if (v.SpawnCount != 4)
             {
-                w.Header(ids.Reference(0xceec99e2d65db674ul), 4);
+                w.HeaderAt(120, 0xceec99e2d65db674ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.SpawnCount, 4);
             }
             long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
@@ -209,7 +209,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TeamConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -273,8 +275,8 @@ namespace Tabledemo
         public static long GunnerConfigBodySizeTyped(GunnerConfig v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.Reference(0xb75aa3662201646aul)) + 5; }
-            if (v.Tracking != false) { n += TableWire.VarSize(ids.Reference(0xa6bf719a4602b0bcul)) + 2; }
+            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.RefAt(101, 0xb75aa3662201646aul)) + 5; }
+            if (v.Tracking != false) { n += TableWire.VarSize(ids.RefAt(90, 0xa6bf719a4602b0bcul)) + 2; }
             return n;
         }
 
@@ -282,12 +284,12 @@ namespace Tabledemo
         {
             if (v.Reaction != 0.2f)
             {
-                w.Header(ids.Reference(0xb75aa3662201646aul), 10);
+                w.HeaderAt(101, 0xb75aa3662201646aul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Reaction)), 4);
             }
             if (v.Tracking != false)
             {
-                w.Header(ids.Reference(0xa6bf719a4602b0bcul), 1);
+                w.HeaderAt(90, 0xa6bf719a4602b0bcul, 1, ref ids);
                 w.Fixed(v.Tracking ? 1ul : 0ul, 1);
             }
             w.Var(0);
@@ -303,7 +305,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!GunnerConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -372,8 +376,8 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = TurretConfigTableType().Fields;
-            if (v.Damage != 10.0f) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
-            if (v.Cooldown != 0.5f) { n += TableWire.VarSize(ids.Reference(0xdc2cbe6953343d48ul)) + 5; }
+            if (v.Damage != 10.0f) { n += TableWire.VarSize(ids.RefAt(66, 0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.Cooldown != 0.5f) { n += TableWire.VarSize(ids.RefAt(133, 0xdc2cbe6953343d48ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
@@ -384,12 +388,12 @@ namespace Tabledemo
             TableFieldInfo[] fields = TurretConfigTableType().Fields;
             if (v.Damage != 10.0f)
             {
-                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 10);
+                w.HeaderAt(66, 0x7f6308be8ab37fc0ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Damage)), 4);
             }
             if (v.Cooldown != 0.5f)
             {
-                w.Header(ids.Reference(0xdc2cbe6953343d48ul), 10);
+                w.HeaderAt(133, 0xdc2cbe6953343d48ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Cooldown)), 4);
             }
             long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
@@ -407,7 +411,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!TurretConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -478,8 +484,8 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = HullConfigTableType().Fields;
-            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
-            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.Reference(0x1f3757a2ce7b0ab1ul)) + 5; }
+            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.RefAt(67, 0x7f69d4b5288ba9cful)) + 5; }
+            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.RefAt(20, 0x1f3757a2ce7b0ab1ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
@@ -490,12 +496,12 @@ namespace Tabledemo
             TableFieldInfo[] fields = HullConfigTableType().Fields;
             if (v.Health != 100.0f)
             {
-                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 10);
+                w.HeaderAt(67, 0x7f69d4b5288ba9cful, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Health)), 4);
             }
             if (v.Mass != 1.0f)
             {
-                w.Header(ids.Reference(0x1f3757a2ce7b0ab1ul), 10);
+                w.HeaderAt(20, 0x1f3757a2ce7b0ab1ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Mass)), 4);
             }
             long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
@@ -513,7 +519,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!HullConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -618,7 +626,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!KeyedConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -705,7 +715,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ScoreBoardCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/NestedTable.cs
+++ b/testdata/golden/tables/examples-cs/NestedTable.cs
@@ -46,7 +46,7 @@ namespace Tabledemo
             TableFieldInfo[] fields = ArchiveConfigTableType().Fields;
             n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
-            if (v.Count != 1) { n += TableWire.VarSize(ids.Reference(0xb1e5e28e4479a274ul)) + 5; }
+            if (v.Count != 1) { n += TableWire.VarSize(ids.RefAt(97, 0xb1e5e28e4479a274ul)) + 5; }
             return n;
         }
 
@@ -57,7 +57,7 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             if (v.Count != 1)
             {
-                w.Header(ids.Reference(0xb1e5e28e4479a274ul), 4);
+                w.HeaderAt(97, 0xb1e5e28e4479a274ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Count, 4);
             }
             w.Var(0);
@@ -73,7 +73,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ArchiveConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/PackTable.cs
+++ b/testdata/golden/tables/examples-cs/PackTable.cs
@@ -150,8 +150,8 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
-            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.Reference(0xb75aa3662201646aul)) + 5; }
-            if (v.Tracking != false) { n += TableWire.VarSize(ids.Reference(0xa6bf719a4602b0bcul)) + 2; }
+            if (v.Reaction != 0.2f) { n += TableWire.VarSize(ids.RefAt(101, 0xb75aa3662201646aul)) + 5; }
+            if (v.Tracking != false) { n += TableWire.VarSize(ids.RefAt(90, 0xa6bf719a4602b0bcul)) + 2; }
             n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
             return n;
@@ -162,12 +162,12 @@ namespace Tabledemo
             TableFieldInfo[] fields = GunnerSettingsTableType().Fields;
             if (v.Reaction != 0.2f)
             {
-                w.Header(ids.Reference(0xb75aa3662201646aul), 10);
+                w.HeaderAt(101, 0xb75aa3662201646aul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Reaction)), 4);
             }
             if (v.Tracking != false)
             {
-                w.Header(ids.Reference(0xa6bf719a4602b0bcul), 1);
+                w.HeaderAt(90, 0xa6bf719a4602b0bcul, 1, ref ids);
                 w.Fixed(v.Tracking ? 1ul : 0ul, 1);
             }
             long payload_2 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[2] : -1;
@@ -185,7 +185,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!GunnerSettingsCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -262,8 +264,8 @@ namespace Tabledemo
             TableFieldInfo[] fields = ShipEntryTableType().Fields;
             n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
-            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.Reference(0x7f69d4b5288ba9cful)) + 5; }
-            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.Reference(0x1f3757a2ce7b0ab1ul)) + 5; }
+            if (v.Health != 100.0f) { n += TableWire.VarSize(ids.RefAt(67, 0x7f69d4b5288ba9cful)) + 5; }
+            if (v.Mass != 1.0f) { n += TableWire.VarSize(ids.RefAt(20, 0x1f3757a2ce7b0ab1ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[3], ref ids, default, out long payload_3);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[3] = payload_3; }
             n += TableWire.BodySizeField(v, fields[4], ref ids, default, out long payload_4);
@@ -278,12 +280,12 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             if (v.Health != 100.0f)
             {
-                w.Header(ids.Reference(0x7f69d4b5288ba9cful), 10);
+                w.HeaderAt(67, 0x7f69d4b5288ba9cful, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Health)), 4);
             }
             if (v.Mass != 1.0f)
             {
-                w.Header(ids.Reference(0x1f3757a2ce7b0ab1ul), 10);
+                w.HeaderAt(20, 0x1f3757a2ce7b0ab1ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Mass)), 4);
             }
             long payload_3 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[3] : -1;
@@ -303,7 +305,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ShipEntryCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -374,7 +378,7 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = GlobalSettingsTableType().Fields;
-            if (v.TickRate != 60) { n += TableWire.VarSize(ids.Reference(0xa65f859b617deaf3ul)) + 5; }
+            if (v.TickRate != 60) { n += TableWire.VarSize(ids.RefAt(88, 0xa65f859b617deaf3ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[1], ref ids);
             n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[2] = payload_2; }
@@ -388,7 +392,7 @@ namespace Tabledemo
             TableFieldInfo[] fields = GlobalSettingsTableType().Fields;
             if (v.TickRate != 60)
             {
-                w.Header(ids.Reference(0xa65f859b617deaf3ul), 8);
+                w.HeaderAt(88, 0xa65f859b617deaf3ul, 8, ref ids);
                 w.Fixed((ulong)v.TickRate, 4);
             }
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
@@ -409,7 +413,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!GlobalSettingsCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -489,7 +495,7 @@ namespace Tabledemo
             long n = 1;
             TableFieldInfo[] fields = PackConfigTableType().Fields;
             int elemOffset = 0;
-            if (v.Version != 1) { n += TableWire.VarSize(ids.Reference(0xbb62c62c9808ea37ul)) + 5; }
+            if (v.Version != 1) { n += TableWire.VarSize(ids.RefAt(107, 0xbb62c62c9808ea37ul)) + 5; }
             n += TableWire.BodySizeField(v, fields[1], ref ids, default, out long payload_1);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[1] = payload_1; }
             n += TableWire.BodySizeField(v, fields[2], ref ids, default, out long payload_2);
@@ -515,7 +521,7 @@ namespace Tabledemo
             int elemOffset = 0;
             if (v.Version != 1)
             {
-                w.Header(ids.Reference(0xbb62c62c9808ea37ul), 8);
+                w.HeaderAt(107, 0xbb62c62c9808ea37ul, 8, ref ids);
                 w.Fixed((ulong)v.Version, 4);
             }
             long payload_1 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[1] : -1;
@@ -547,7 +553,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!PackConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/RangesTable.cs
+++ b/testdata/golden/tables/examples-cs/RangesTable.cs
@@ -127,22 +127,22 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = RangedSignedTableType().Fields;
-            if (v.I8Span != 0) { n += TableWire.VarSize(ids.Reference(0x48121511bf702eb5ul)) + 2; }
-            if (v.I8Low != 0) { n += TableWire.VarSize(ids.Reference(0x942bfe3168090f7dul)) + 2; }
-            if (v.I8High != 0) { n += TableWire.VarSize(ids.Reference(0xd182acd105b55dd1ul)) + 2; }
-            if (v.I8Inside != 0) { n += TableWire.VarSize(ids.Reference(0xef9ded23c8912a81ul)) + 2; }
-            if (v.I16Span != 0) { n += TableWire.VarSize(ids.Reference(0xb655574ea23760b4ul)) + 3; }
-            if (v.I16Low != 0) { n += TableWire.VarSize(ids.Reference(0xd217b3af8d7a2bdeul)) + 3; }
-            if (v.I16High != 0) { n += TableWire.VarSize(ids.Reference(0x90652f70c9127900ul)) + 3; }
-            if (v.I16Inside != 0) { n += TableWire.VarSize(ids.Reference(0x6a659d7c354db158ul)) + 3; }
-            if (v.I32Span != 0) { n += TableWire.VarSize(ids.Reference(0xe693bd88532c91d6ul)) + 5; }
-            if (v.I32Low != 0) { n += TableWire.VarSize(ids.Reference(0x065ee827cf99fbb4ul)) + 5; }
-            if (v.I32High != 0) { n += TableWire.VarSize(ids.Reference(0xc9b121c4c2a186eeul)) + 5; }
-            if (v.I32Inside != 0) { n += TableWire.VarSize(ids.Reference(0xd363dfa465acf27aul)) + 5; }
-            if (v.I64Span != 0) { n += TableWire.VarSize(ids.Reference(0x7549c70700c49d6ful)) + 9; }
-            if (v.I64Low != 0) { n += TableWire.VarSize(ids.Reference(0x1cce6617419771dbul)) + 9; }
-            if (v.I64High != 0) { n += TableWire.VarSize(ids.Reference(0x3b54fa60620b5597ul)) + 9; }
-            if (v.I64Inside != 0) { n += TableWire.VarSize(ids.Reference(0xd308fcb98ece5d23ul)) + 9; }
+            if (v.I8Span != 0) { n += TableWire.VarSize(ids.RefAt(43, 0x48121511bf702eb5ul)) + 2; }
+            if (v.I8Low != 0) { n += TableWire.VarSize(ids.RefAt(76, 0x942bfe3168090f7dul)) + 2; }
+            if (v.I8High != 0) { n += TableWire.VarSize(ids.RefAt(126, 0xd182acd105b55dd1ul)) + 2; }
+            if (v.I8Inside != 0) { n += TableWire.VarSize(ids.RefAt(141, 0xef9ded23c8912a81ul)) + 2; }
+            if (v.I16Span != 0) { n += TableWire.VarSize(ids.RefAt(100, 0xb655574ea23760b4ul)) + 3; }
+            if (v.I16Low != 0) { n += TableWire.VarSize(ids.RefAt(127, 0xd217b3af8d7a2bdeul)) + 3; }
+            if (v.I16High != 0) { n += TableWire.VarSize(ids.RefAt(75, 0x90652f70c9127900ul)) + 3; }
+            if (v.I16Inside != 0) { n += TableWire.VarSize(ids.RefAt(58, 0x6a659d7c354db158ul)) + 3; }
+            if (v.I32Span != 0) { n += TableWire.VarSize(ids.RefAt(137, 0xe693bd88532c91d6ul)) + 5; }
+            if (v.I32Low != 0) { n += TableWire.VarSize(ids.RefAt(5, 0x065ee827cf99fbb4ul)) + 5; }
+            if (v.I32High != 0) { n += TableWire.VarSize(ids.RefAt(118, 0xc9b121c4c2a186eeul)) + 5; }
+            if (v.I32Inside != 0) { n += TableWire.VarSize(ids.RefAt(129, 0xd363dfa465acf27aul)) + 5; }
+            if (v.I64Span != 0) { n += TableWire.VarSize(ids.RefAt(63, 0x7549c70700c49d6ful)) + 9; }
+            if (v.I64Low != 0) { n += TableWire.VarSize(ids.RefAt(16, 0x1cce6617419771dbul)) + 9; }
+            if (v.I64High != 0) { n += TableWire.VarSize(ids.RefAt(36, 0x3b54fa60620b5597ul)) + 9; }
+            if (v.I64Inside != 0) { n += TableWire.VarSize(ids.RefAt(128, 0xd308fcb98ece5d23ul)) + 9; }
             n += TableWire.BodySizeField(v, fields[16], ref ids, default, out long payload_16);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
             return n;
@@ -153,82 +153,82 @@ namespace Tabledemo
             TableFieldInfo[] fields = RangedSignedTableType().Fields;
             if (v.I8Span != 0)
             {
-                w.Header(ids.Reference(0x48121511bf702eb5ul), 2);
+                w.HeaderAt(43, 0x48121511bf702eb5ul, 2, ref ids);
                 w.Fixed((ulong)(long)v.I8Span, 1);
             }
             if (v.I8Low != 0)
             {
-                w.Header(ids.Reference(0x942bfe3168090f7dul), 2);
+                w.HeaderAt(76, 0x942bfe3168090f7dul, 2, ref ids);
                 w.Fixed((ulong)(long)v.I8Low, 1);
             }
             if (v.I8High != 0)
             {
-                w.Header(ids.Reference(0xd182acd105b55dd1ul), 2);
+                w.HeaderAt(126, 0xd182acd105b55dd1ul, 2, ref ids);
                 w.Fixed((ulong)(long)v.I8High, 1);
             }
             if (v.I8Inside != 0)
             {
-                w.Header(ids.Reference(0xef9ded23c8912a81ul), 2);
+                w.HeaderAt(141, 0xef9ded23c8912a81ul, 2, ref ids);
                 w.Fixed((ulong)(long)v.I8Inside, 1);
             }
             if (v.I16Span != 0)
             {
-                w.Header(ids.Reference(0xb655574ea23760b4ul), 3);
+                w.HeaderAt(100, 0xb655574ea23760b4ul, 3, ref ids);
                 w.Fixed((ulong)(long)v.I16Span, 2);
             }
             if (v.I16Low != 0)
             {
-                w.Header(ids.Reference(0xd217b3af8d7a2bdeul), 3);
+                w.HeaderAt(127, 0xd217b3af8d7a2bdeul, 3, ref ids);
                 w.Fixed((ulong)(long)v.I16Low, 2);
             }
             if (v.I16High != 0)
             {
-                w.Header(ids.Reference(0x90652f70c9127900ul), 3);
+                w.HeaderAt(75, 0x90652f70c9127900ul, 3, ref ids);
                 w.Fixed((ulong)(long)v.I16High, 2);
             }
             if (v.I16Inside != 0)
             {
-                w.Header(ids.Reference(0x6a659d7c354db158ul), 3);
+                w.HeaderAt(58, 0x6a659d7c354db158ul, 3, ref ids);
                 w.Fixed((ulong)(long)v.I16Inside, 2);
             }
             if (v.I32Span != 0)
             {
-                w.Header(ids.Reference(0xe693bd88532c91d6ul), 4);
+                w.HeaderAt(137, 0xe693bd88532c91d6ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.I32Span, 4);
             }
             if (v.I32Low != 0)
             {
-                w.Header(ids.Reference(0x065ee827cf99fbb4ul), 4);
+                w.HeaderAt(5, 0x065ee827cf99fbb4ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.I32Low, 4);
             }
             if (v.I32High != 0)
             {
-                w.Header(ids.Reference(0xc9b121c4c2a186eeul), 4);
+                w.HeaderAt(118, 0xc9b121c4c2a186eeul, 4, ref ids);
                 w.Fixed((ulong)(long)v.I32High, 4);
             }
             if (v.I32Inside != 0)
             {
-                w.Header(ids.Reference(0xd363dfa465acf27aul), 4);
+                w.HeaderAt(129, 0xd363dfa465acf27aul, 4, ref ids);
                 w.Fixed((ulong)(long)v.I32Inside, 4);
             }
             if (v.I64Span != 0)
             {
-                w.Header(ids.Reference(0x7549c70700c49d6ful), 5);
+                w.HeaderAt(63, 0x7549c70700c49d6ful, 5, ref ids);
                 w.Fixed((ulong)(long)v.I64Span, 8);
             }
             if (v.I64Low != 0)
             {
-                w.Header(ids.Reference(0x1cce6617419771dbul), 5);
+                w.HeaderAt(16, 0x1cce6617419771dbul, 5, ref ids);
                 w.Fixed((ulong)(long)v.I64Low, 8);
             }
             if (v.I64High != 0)
             {
-                w.Header(ids.Reference(0x3b54fa60620b5597ul), 5);
+                w.HeaderAt(36, 0x3b54fa60620b5597ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.I64High, 8);
             }
             if (v.I64Inside != 0)
             {
-                w.Header(ids.Reference(0xd308fcb98ece5d23ul), 5);
+                w.HeaderAt(128, 0xd308fcb98ece5d23ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.I64Inside, 8);
             }
             long payload_16 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[16] : -1;
@@ -246,7 +246,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RangedSignedCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -343,22 +345,22 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = RangedUnsignedTableType().Fields;
-            if (v.U8Span != 0) { n += TableWire.VarSize(ids.Reference(0x0f8897557f37c021ul)) + 2; }
-            if (v.U8Low != 0) { n += TableWire.VarSize(ids.Reference(0x2e17553f8200a2a1ul)) + 2; }
-            if (v.U8High != 1) { n += TableWire.VarSize(ids.Reference(0xa0e5c60df9301b7dul)) + 2; }
-            if (v.U8Inside != 1) { n += TableWire.VarSize(ids.Reference(0x1cb2c073a6f5844dul)) + 2; }
-            if (v.U16Span != 0) { n += TableWire.VarSize(ids.Reference(0x4ca0c150b1790960ul)) + 3; }
-            if (v.U16Low != 0) { n += TableWire.VarSize(ids.Reference(0xf252136836b04cb2ul)) + 3; }
-            if (v.U16High != 1) { n += TableWire.VarSize(ids.Reference(0x4f37e1f216e7610cul)) + 3; }
-            if (v.U16Inside != 1) { n += TableWire.VarSize(ids.Reference(0xd176b605978f3304ul)) + 3; }
-            if (v.U32Span != 0) { n += TableWire.VarSize(ids.Reference(0x200b924de7479cdaul)) + 5; }
-            if (v.U32Low != 0) { n += TableWire.VarSize(ids.Reference(0xa53d2f2a31b5acb0ul)) + 5; }
-            if (v.U32High != 1) { n += TableWire.VarSize(ids.Reference(0x9759be8ea1a4e3d2ul)) + 5; }
-            if (v.U32Inside != 1) { n += TableWire.VarSize(ids.Reference(0x8dc515fc082e3c0eul)) + 5; }
-            if (v.U64Span != 0) { n += TableWire.VarSize(ids.Reference(0xbeecef11dbdf8973ul)) + 9; }
-            if (v.U64Low != 0) { n += TableWire.VarSize(ids.Reference(0x0117ad66e0fff227ul)) + 9; }
-            if (v.U64High != 1ul) { n += TableWire.VarSize(ids.Reference(0xf2b45af3b50689dbul)) + 9; }
-            if (v.U64Inside != 1ul) { n += TableWire.VarSize(ids.Reference(0x713e12017eebcaf7ul)) + 9; }
+            if (v.U8Span != 0) { n += TableWire.VarSize(ids.RefAt(8, 0x0f8897557f37c021ul)) + 2; }
+            if (v.U8Low != 0) { n += TableWire.VarSize(ids.RefAt(28, 0x2e17553f8200a2a1ul)) + 2; }
+            if (v.U8High != 1) { n += TableWire.VarSize(ids.RefAt(84, 0xa0e5c60df9301b7dul)) + 2; }
+            if (v.U8Inside != 1) { n += TableWire.VarSize(ids.RefAt(15, 0x1cb2c073a6f5844dul)) + 2; }
+            if (v.U16Span != 0) { n += TableWire.VarSize(ids.RefAt(46, 0x4ca0c150b1790960ul)) + 3; }
+            if (v.U16Low != 0) { n += TableWire.VarSize(ids.RefAt(143, 0xf252136836b04cb2ul)) + 3; }
+            if (v.U16High != 1) { n += TableWire.VarSize(ids.RefAt(48, 0x4f37e1f216e7610cul)) + 3; }
+            if (v.U16Inside != 1) { n += TableWire.VarSize(ids.RefAt(125, 0xd176b605978f3304ul)) + 3; }
+            if (v.U32Span != 0) { n += TableWire.VarSize(ids.RefAt(21, 0x200b924de7479cdaul)) + 5; }
+            if (v.U32Low != 0) { n += TableWire.VarSize(ids.RefAt(87, 0xa53d2f2a31b5acb0ul)) + 5; }
+            if (v.U32High != 1) { n += TableWire.VarSize(ids.RefAt(78, 0x9759be8ea1a4e3d2ul)) + 5; }
+            if (v.U32Inside != 1) { n += TableWire.VarSize(ids.RefAt(74, 0x8dc515fc082e3c0eul)) + 5; }
+            if (v.U64Span != 0) { n += TableWire.VarSize(ids.RefAt(109, 0xbeecef11dbdf8973ul)) + 9; }
+            if (v.U64Low != 0) { n += TableWire.VarSize(ids.RefAt(0, 0x0117ad66e0fff227ul)) + 9; }
+            if (v.U64High != 1ul) { n += TableWire.VarSize(ids.RefAt(144, 0xf2b45af3b50689dbul)) + 9; }
+            if (v.U64Inside != 1ul) { n += TableWire.VarSize(ids.RefAt(62, 0x713e12017eebcaf7ul)) + 9; }
             n += TableWire.BodySizeField(v, fields[16], ref ids, default, out long payload_16);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[16] = payload_16; }
             return n;
@@ -369,82 +371,82 @@ namespace Tabledemo
             TableFieldInfo[] fields = RangedUnsignedTableType().Fields;
             if (v.U8Span != 0)
             {
-                w.Header(ids.Reference(0x0f8897557f37c021ul), 6);
+                w.HeaderAt(8, 0x0f8897557f37c021ul, 6, ref ids);
                 w.Fixed((ulong)v.U8Span, 1);
             }
             if (v.U8Low != 0)
             {
-                w.Header(ids.Reference(0x2e17553f8200a2a1ul), 6);
+                w.HeaderAt(28, 0x2e17553f8200a2a1ul, 6, ref ids);
                 w.Fixed((ulong)v.U8Low, 1);
             }
             if (v.U8High != 1)
             {
-                w.Header(ids.Reference(0xa0e5c60df9301b7dul), 6);
+                w.HeaderAt(84, 0xa0e5c60df9301b7dul, 6, ref ids);
                 w.Fixed((ulong)v.U8High, 1);
             }
             if (v.U8Inside != 1)
             {
-                w.Header(ids.Reference(0x1cb2c073a6f5844dul), 6);
+                w.HeaderAt(15, 0x1cb2c073a6f5844dul, 6, ref ids);
                 w.Fixed((ulong)v.U8Inside, 1);
             }
             if (v.U16Span != 0)
             {
-                w.Header(ids.Reference(0x4ca0c150b1790960ul), 7);
+                w.HeaderAt(46, 0x4ca0c150b1790960ul, 7, ref ids);
                 w.Fixed((ulong)v.U16Span, 2);
             }
             if (v.U16Low != 0)
             {
-                w.Header(ids.Reference(0xf252136836b04cb2ul), 7);
+                w.HeaderAt(143, 0xf252136836b04cb2ul, 7, ref ids);
                 w.Fixed((ulong)v.U16Low, 2);
             }
             if (v.U16High != 1)
             {
-                w.Header(ids.Reference(0x4f37e1f216e7610cul), 7);
+                w.HeaderAt(48, 0x4f37e1f216e7610cul, 7, ref ids);
                 w.Fixed((ulong)v.U16High, 2);
             }
             if (v.U16Inside != 1)
             {
-                w.Header(ids.Reference(0xd176b605978f3304ul), 7);
+                w.HeaderAt(125, 0xd176b605978f3304ul, 7, ref ids);
                 w.Fixed((ulong)v.U16Inside, 2);
             }
             if (v.U32Span != 0)
             {
-                w.Header(ids.Reference(0x200b924de7479cdaul), 8);
+                w.HeaderAt(21, 0x200b924de7479cdaul, 8, ref ids);
                 w.Fixed((ulong)v.U32Span, 4);
             }
             if (v.U32Low != 0)
             {
-                w.Header(ids.Reference(0xa53d2f2a31b5acb0ul), 8);
+                w.HeaderAt(87, 0xa53d2f2a31b5acb0ul, 8, ref ids);
                 w.Fixed((ulong)v.U32Low, 4);
             }
             if (v.U32High != 1)
             {
-                w.Header(ids.Reference(0x9759be8ea1a4e3d2ul), 8);
+                w.HeaderAt(78, 0x9759be8ea1a4e3d2ul, 8, ref ids);
                 w.Fixed((ulong)v.U32High, 4);
             }
             if (v.U32Inside != 1)
             {
-                w.Header(ids.Reference(0x8dc515fc082e3c0eul), 8);
+                w.HeaderAt(74, 0x8dc515fc082e3c0eul, 8, ref ids);
                 w.Fixed((ulong)v.U32Inside, 4);
             }
             if (v.U64Span != 0)
             {
-                w.Header(ids.Reference(0xbeecef11dbdf8973ul), 9);
+                w.HeaderAt(109, 0xbeecef11dbdf8973ul, 9, ref ids);
                 w.Fixed((ulong)v.U64Span, 8);
             }
             if (v.U64Low != 0)
             {
-                w.Header(ids.Reference(0x0117ad66e0fff227ul), 9);
+                w.HeaderAt(0, 0x0117ad66e0fff227ul, 9, ref ids);
                 w.Fixed((ulong)v.U64Low, 8);
             }
             if (v.U64High != 1ul)
             {
-                w.Header(ids.Reference(0xf2b45af3b50689dbul), 9);
+                w.HeaderAt(144, 0xf2b45af3b50689dbul, 9, ref ids);
                 w.Fixed((ulong)v.U64High, 8);
             }
             if (v.U64Inside != 1ul)
             {
-                w.Header(ids.Reference(0x713e12017eebcaf7ul), 9);
+                w.HeaderAt(62, 0x713e12017eebcaf7ul, 9, ref ids);
                 w.Fixed((ulong)v.U64Inside, 8);
             }
             long payload_16 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[16] : -1;
@@ -462,7 +464,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RangedUnsignedCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -534,12 +538,12 @@ namespace Tabledemo
         public static long RangedWidthsBodySizeTyped(RangedWidths v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.B8 != 0) { n += TableWire.VarSize(ids.Reference(0x08a60c07b54d8dc7ul)) + 2; }
-            if (v.B16 != 0) { n += TableWire.VarSize(ids.Reference(0xff95701912ad97beul)) + 3; }
-            if (v.B32 != 0) { n += TableWire.VarSize(ids.Reference(0xff9c5c1912b39470ul)) + 5; }
-            if (v.B64 != 0) { n += TableWire.VarSize(ids.Reference(0xff92701912ab61e7ul)) + 9; }
-            if (v.B12 != 0) { n += TableWire.VarSize(ids.Reference(0xff95741912ad9e8aul)) + 3; }
-            if (v.B48 != 0) { n += TableWire.VarSize(ids.Reference(0xff8b681912a535a1ul)) + 9; }
+            if (v.B8 != 0) { n += TableWire.VarSize(ids.RefAt(6, 0x08a60c07b54d8dc7ul)) + 2; }
+            if (v.B16 != 0) { n += TableWire.VarSize(ids.RefAt(149, 0xff95701912ad97beul)) + 3; }
+            if (v.B32 != 0) { n += TableWire.VarSize(ids.RefAt(151, 0xff9c5c1912b39470ul)) + 5; }
+            if (v.B64 != 0) { n += TableWire.VarSize(ids.RefAt(148, 0xff92701912ab61e7ul)) + 9; }
+            if (v.B12 != 0) { n += TableWire.VarSize(ids.RefAt(150, 0xff95741912ad9e8aul)) + 3; }
+            if (v.B48 != 0) { n += TableWire.VarSize(ids.RefAt(147, 0xff8b681912a535a1ul)) + 9; }
             return n;
         }
 
@@ -547,32 +551,32 @@ namespace Tabledemo
         {
             if (v.B8 != 0)
             {
-                w.Header(ids.Reference(0x08a60c07b54d8dc7ul), 6);
+                w.HeaderAt(6, 0x08a60c07b54d8dc7ul, 6, ref ids);
                 w.Fixed((ulong)v.B8, 1);
             }
             if (v.B16 != 0)
             {
-                w.Header(ids.Reference(0xff95701912ad97beul), 7);
+                w.HeaderAt(149, 0xff95701912ad97beul, 7, ref ids);
                 w.Fixed((ulong)v.B16, 2);
             }
             if (v.B32 != 0)
             {
-                w.Header(ids.Reference(0xff9c5c1912b39470ul), 8);
+                w.HeaderAt(151, 0xff9c5c1912b39470ul, 8, ref ids);
                 w.Fixed((ulong)v.B32, 4);
             }
             if (v.B64 != 0)
             {
-                w.Header(ids.Reference(0xff92701912ab61e7ul), 9);
+                w.HeaderAt(148, 0xff92701912ab61e7ul, 9, ref ids);
                 w.Fixed((ulong)v.B64, 8);
             }
             if (v.B12 != 0)
             {
-                w.Header(ids.Reference(0xff95741912ad9e8aul), 7);
+                w.HeaderAt(150, 0xff95741912ad9e8aul, 7, ref ids);
                 w.Fixed((ulong)v.B12, 2);
             }
             if (v.B48 != 0)
             {
-                w.Header(ids.Reference(0xff8b681912a535a1ul), 9);
+                w.HeaderAt(147, 0xff8b681912a535a1ul, 9, ref ids);
                 w.Fixed((ulong)v.B48, 8);
             }
             w.Var(0);
@@ -588,7 +592,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RangedWidthsCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/TabledemoTable.cs
+++ b/testdata/golden/tables/examples-cs/TabledemoTable.cs
@@ -2649,11 +2649,41 @@ namespace Tabledemo
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2661,11 +2691,56 @@ namespace Tabledemo
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2674,13 +2749,39 @@ namespace Tabledemo
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2716,6 +2817,11 @@ namespace Tabledemo
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4459,7 +4565,9 @@ namespace Tabledemo
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,

--- a/testdata/golden/tables/examples-cs/TablesTable.cs
+++ b/testdata/golden/tables/examples-cs/TablesTable.cs
@@ -230,7 +230,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!RootConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -304,11 +306,11 @@ namespace Tabledemo
         {
             long n = 1;
             TableFieldInfo[] fields = WeaponConfigTableType().Fields;
-            if (v.Damage != 21.0f) { n += TableWire.VarSize(ids.Reference(0x7f6308be8ab37fc0ul)) + 5; }
-            if (v.Speed != 500.0f) { n += TableWire.VarSize(ids.Reference(0x1733055702acb1d2ul)) + 5; }
-            if (v.Penetration != 1) { n += TableWire.VarSize(ids.Reference(0x4f31c5309e13e932ul)) + 5; }
-            if (v.Channel != 0) { n += TableWire.VarSize(ids.Reference(0xa5013e9ad5caeda4ul)) + 2; }
-            if (v.Homing != false) { n += TableWire.VarSize(ids.Reference(0xad6587bc602e3f59ul)) + 2; }
+            if (v.Damage != 21.0f) { n += TableWire.VarSize(ids.RefAt(66, 0x7f6308be8ab37fc0ul)) + 5; }
+            if (v.Speed != 500.0f) { n += TableWire.VarSize(ids.RefAt(12, 0x1733055702acb1d2ul)) + 5; }
+            if (v.Penetration != 1) { n += TableWire.VarSize(ids.RefAt(47, 0x4f31c5309e13e932ul)) + 5; }
+            if (v.Channel != 0) { n += TableWire.VarSize(ids.RefAt(86, 0xa5013e9ad5caeda4ul)) + 2; }
+            if (v.Homing != false) { n += TableWire.VarSize(ids.RefAt(94, 0xad6587bc602e3f59ul)) + 2; }
             n += TableWire.BodySizeField(v, fields[5], ref ids);
             return n;
         }
@@ -318,27 +320,27 @@ namespace Tabledemo
             TableFieldInfo[] fields = WeaponConfigTableType().Fields;
             if (v.Damage != 21.0f)
             {
-                w.Header(ids.Reference(0x7f6308be8ab37fc0ul), 10);
+                w.HeaderAt(66, 0x7f6308be8ab37fc0ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Damage)), 4);
             }
             if (v.Speed != 500.0f)
             {
-                w.Header(ids.Reference(0x1733055702acb1d2ul), 10);
+                w.HeaderAt(12, 0x1733055702acb1d2ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Speed)), 4);
             }
             if (v.Penetration != 1)
             {
-                w.Header(ids.Reference(0x4f31c5309e13e932ul), 4);
+                w.HeaderAt(47, 0x4f31c5309e13e932ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Penetration, 4);
             }
             if (v.Channel != 0)
             {
-                w.Header(ids.Reference(0xa5013e9ad5caeda4ul), 6);
+                w.HeaderAt(86, 0xa5013e9ad5caeda4ul, 6, ref ids);
                 w.Fixed((ulong)v.Channel, 1);
             }
             if (v.Homing != false)
             {
-                w.Header(ids.Reference(0xad6587bc602e3f59ul), 1);
+                w.HeaderAt(94, 0xad6587bc602e3f59ul, 1, ref ids);
                 w.Fixed(v.Homing ? 1ul : 0ul, 1);
             }
             TableWire.WriteBodyField(ref w, v, fields[5], ref ids);
@@ -355,7 +357,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!WeaponConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -485,7 +489,7 @@ namespace Tabledemo
                     nChild_6 += TableWire.VarSize((ulong)childBody) + childBody;
                 }
                 long payload_6 = 1 + TableWire.VarSize((ulong)count_6) + nChild_6;
-                n += TableWire.VarSize(ids.Reference(0xf901aa0340249a41ul)) + 1 + TableWire.VarSize((ulong)payload_6) + payload_6;
+                n += TableWire.VarSize(ids.RefAt(145, 0xf901aa0340249a41ul)) + 1 + TableWire.VarSize((ulong)payload_6) + payload_6;
                 if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[6] = payload_6; }
             }
             return n;
@@ -516,7 +520,7 @@ namespace Tabledemo
             int count_6 = v.AttachmentsCount;
             if (count_6 > 0)
             {
-                w.Header(ids.Reference(0xf901aa0340249a41ul), 14);
+                w.HeaderAt(145, 0xf901aa0340249a41ul, 14, ref ids);
                 scoped ReadOnlySpan<long> elemCache_6 = default;
                 if (!rootElemSizes.IsEmpty)
                 {
@@ -558,7 +562,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!LoadoutConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -651,17 +657,17 @@ namespace Tabledemo
             n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
             n += TableWire.BodySizeField(v, fields[1], ref ids);
-            if (v.Experience != 0) { n += TableWire.VarSize(ids.Reference(0xab8b6d521f80b969ul)) + 5; }
-            if (v.Tilt != 0) { n += TableWire.VarSize(ids.Reference(0x1e5088ef2e9bafc6ul)) + 2; }
-            if (v.Heading != 0) { n += TableWire.VarSize(ids.Reference(0xb128829190ca0f75ul)) + 3; }
-            if (v.Timestamp != 0) { n += TableWire.VarSize(ids.Reference(0x5ddc92338ef53403ul)) + 9; }
-            if (v.Badge != 0) { n += TableWire.VarSize(ids.Reference(0x10bda981fe095518ul)) + 2; }
-            if (v.Port != 0) { n += TableWire.VarSize(ids.Reference(0x8c2cdb0da8933fa6ul)) + 3; }
-            if (v.Epoch != 0) { n += TableWire.VarSize(ids.Reference(0xfc9697d1196e6ba6ul)) + 9; }
-            if (v.Precision != 0.0) { n += TableWire.VarSize(ids.Reference(0x288427f5babd05f7ul)) + 9; }
+            if (v.Experience != 0) { n += TableWire.VarSize(ids.RefAt(93, 0xab8b6d521f80b969ul)) + 5; }
+            if (v.Tilt != 0) { n += TableWire.VarSize(ids.RefAt(19, 0x1e5088ef2e9bafc6ul)) + 2; }
+            if (v.Heading != 0) { n += TableWire.VarSize(ids.RefAt(96, 0xb128829190ca0f75ul)) + 3; }
+            if (v.Timestamp != 0) { n += TableWire.VarSize(ids.RefAt(54, 0x5ddc92338ef53403ul)) + 9; }
+            if (v.Badge != 0) { n += TableWire.VarSize(ids.RefAt(9, 0x10bda981fe095518ul)) + 2; }
+            if (v.Port != 0) { n += TableWire.VarSize(ids.RefAt(73, 0x8c2cdb0da8933fa6ul)) + 3; }
+            if (v.Epoch != 0) { n += TableWire.VarSize(ids.RefAt(146, 0xfc9697d1196e6ba6ul)) + 9; }
+            if (v.Precision != 0.0) { n += TableWire.VarSize(ids.RefAt(24, 0x288427f5babd05f7ul)) + 9; }
             n += TableWire.BodySizeField(v, fields[10], ref ids, default, out long payload_10);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[10] = payload_10; }
-            if (v.HasLoadout != false) { n += TableWire.VarSize(ids.Reference(0xa06f5e0a148e253cul)) + 2; }
+            if (v.HasLoadout != false) { n += TableWire.VarSize(ids.RefAt(83, 0xa06f5e0a148e253cul)) + 2; }
             n += TableWire.BodySizeField(v, fields[12], ref ids, default, out long payload_12);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[12] = payload_12; }
             return n;
@@ -675,49 +681,49 @@ namespace Tabledemo
             TableWire.WriteBodyField(ref w, v, fields[1], ref ids);
             if (v.Experience != 0)
             {
-                w.Header(ids.Reference(0xab8b6d521f80b969ul), 8);
+                w.HeaderAt(93, 0xab8b6d521f80b969ul, 8, ref ids);
                 w.Fixed((ulong)v.Experience, 4);
             }
             if (v.Tilt != 0)
             {
-                w.Header(ids.Reference(0x1e5088ef2e9bafc6ul), 2);
+                w.HeaderAt(19, 0x1e5088ef2e9bafc6ul, 2, ref ids);
                 w.Fixed((ulong)(long)v.Tilt, 1);
             }
             if (v.Heading != 0)
             {
-                w.Header(ids.Reference(0xb128829190ca0f75ul), 3);
+                w.HeaderAt(96, 0xb128829190ca0f75ul, 3, ref ids);
                 w.Fixed((ulong)(long)v.Heading, 2);
             }
             if (v.Timestamp != 0)
             {
-                w.Header(ids.Reference(0x5ddc92338ef53403ul), 5);
+                w.HeaderAt(54, 0x5ddc92338ef53403ul, 5, ref ids);
                 w.Fixed((ulong)(long)v.Timestamp, 8);
             }
             if (v.Badge != 0)
             {
-                w.Header(ids.Reference(0x10bda981fe095518ul), 6);
+                w.HeaderAt(9, 0x10bda981fe095518ul, 6, ref ids);
                 w.Fixed((ulong)v.Badge, 1);
             }
             if (v.Port != 0)
             {
-                w.Header(ids.Reference(0x8c2cdb0da8933fa6ul), 7);
+                w.HeaderAt(73, 0x8c2cdb0da8933fa6ul, 7, ref ids);
                 w.Fixed((ulong)v.Port, 2);
             }
             if (v.Epoch != 0)
             {
-                w.Header(ids.Reference(0xfc9697d1196e6ba6ul), 9);
+                w.HeaderAt(146, 0xfc9697d1196e6ba6ul, 9, ref ids);
                 w.Fixed((ulong)v.Epoch, 8);
             }
             if (v.Precision != 0.0)
             {
-                w.Header(ids.Reference(0x288427f5babd05f7ul), 11);
+                w.HeaderAt(24, 0x288427f5babd05f7ul, 11, ref ids);
                 w.Fixed(unchecked((ulong)BitConverter.DoubleToInt64Bits(v.Precision)), 8);
             }
             long payload_10 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[10] : -1;
             TableWire.WriteBodyField(ref w, v, fields[10], ref ids, default, payload_10);
             if (v.HasLoadout != false)
             {
-                w.Header(ids.Reference(0xa06f5e0a148e253cul), 1);
+                w.HeaderAt(83, 0xa06f5e0a148e253cul, 1, ref ids);
                 w.Fixed(v.HasLoadout ? 1ul : 0ul, 1);
             }
             long payload_12 = !rootPayloadSizes.IsEmpty ? rootPayloadSizes[12] : -1;
@@ -735,7 +741,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!ProfileConfigCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -799,8 +807,8 @@ namespace Tabledemo
         public static long AttachmentBodySizeTyped(Attachment v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Slot != 0) { n += TableWire.VarSize(ids.Reference(0x6a771618f6fe31d1ul)) + 5; }
-            if (v.Power != 1.0f) { n += TableWire.VarSize(ids.Reference(0xeef9d1358ae7b4e6ul)) + 5; }
+            if (v.Slot != 0) { n += TableWire.VarSize(ids.RefAt(59, 0x6a771618f6fe31d1ul)) + 5; }
+            if (v.Power != 1.0f) { n += TableWire.VarSize(ids.RefAt(140, 0xeef9d1358ae7b4e6ul)) + 5; }
             return n;
         }
 
@@ -808,12 +816,12 @@ namespace Tabledemo
         {
             if (v.Slot != 0)
             {
-                w.Header(ids.Reference(0x6a771618f6fe31d1ul), 4);
+                w.HeaderAt(59, 0x6a771618f6fe31d1ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Slot, 4);
             }
             if (v.Power != 1.0f)
             {
-                w.Header(ids.Reference(0xeef9d1358ae7b4e6ul), 10);
+                w.HeaderAt(140, 0xeef9d1358ae7b4e6ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Power)), 4);
             }
             w.Var(0);
@@ -829,7 +837,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!AttachmentCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -891,7 +901,7 @@ namespace Tabledemo
         public static long BuffBodySizeTyped(Buff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Multiplier != 1.0f) { n += TableWire.VarSize(ids.Reference(0x9adc623a805c87c6ul)) + 5; }
+            if (v.Multiplier != 1.0f) { n += TableWire.VarSize(ids.RefAt(79, 0x9adc623a805c87c6ul)) + 5; }
             return n;
         }
 
@@ -899,7 +909,7 @@ namespace Tabledemo
         {
             if (v.Multiplier != 1.0f)
             {
-                w.Header(ids.Reference(0x9adc623a805c87c6ul), 10);
+                w.HeaderAt(79, 0x9adc623a805c87c6ul, 10, ref ids);
                 w.Fixed((ulong)unchecked((uint)BitConverter.SingleToInt32Bits(v.Multiplier)), 4);
             }
             w.Var(0);
@@ -915,7 +925,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!BuffCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -977,7 +989,7 @@ namespace Tabledemo
         public static long DebuffBodySizeTyped(Debuff v, ref TableWire.Ids ids, scoped Span<long> rootPayloadSizes = default, scoped Span<long> rootElemSizes = default)
         {
             long n = 1;
-            if (v.Amount != 0) { n += TableWire.VarSize(ids.Reference(0x8113fe7ea2b16969ul)) + 5; }
+            if (v.Amount != 0) { n += TableWire.VarSize(ids.RefAt(69, 0x8113fe7ea2b16969ul)) + 5; }
             return n;
         }
 
@@ -985,7 +997,7 @@ namespace Tabledemo
         {
             if (v.Amount != 0)
             {
-                w.Header(ids.Reference(0x8113fe7ea2b16969ul), 4);
+                w.HeaderAt(69, 0x8113fe7ea2b16969ul, 4, ref ids);
                 w.Fixed((ulong)(long)v.Amount, 4);
             }
             w.Var(0);
@@ -1001,7 +1013,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!DebuffCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/tables/examples-cs/WideTable.cs
+++ b/testdata/golden/tables/examples-cs/WideTable.cs
@@ -82,7 +82,9 @@ namespace Tabledemo
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!WideBlobCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/wide/cs/CaptionTable.cs
+++ b/testdata/golden/wide/cs/CaptionTable.cs
@@ -159,7 +159,9 @@ namespace Wide
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!CaptionCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -228,7 +230,7 @@ namespace Wide
             TableFieldInfo[] fields = StampTableType().Fields;
             n += TableWire.BodySizeField(v, fields[0], ref ids, default, out long payload_0);
             if (!rootPayloadSizes.IsEmpty) { rootPayloadSizes[0] = payload_0; }
-            if (v.Seq != 0) { n += TableWire.VarSize(ids.Reference(0x823b8a195ce2133cul)) + 5; }
+            if (v.Seq != 0) { n += TableWire.VarSize(ids.RefAt(5, 0x823b8a195ce2133cul)) + 5; }
             return n;
         }
 
@@ -239,7 +241,7 @@ namespace Wide
             TableWire.WriteBodyField(ref w, v, fields[0], ref ids, default, payload_0);
             if (v.Seq != 0)
             {
-                w.Header(ids.Reference(0x823b8a195ce2133cul), 8);
+                w.HeaderAt(5, 0x823b8a195ce2133cul, 8, ref ids);
                 w.Fixed((ulong)v.Seq, 4);
             }
             w.Var(0);
@@ -255,7 +257,9 @@ namespace Wide
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!StampCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];
@@ -343,7 +347,9 @@ namespace Wide
                 while (slots < vocabulary.Length * 2) { slots <<= 1; }
             }
             Span<int> index = stackalloc int[slots];
-            TableWire.Ids ids = new TableWire.Ids(vocabulary, index);
+            Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+            Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+            TableWire.Ids ids = new TableWire.Ids(vocabulary, index, ordinalSlots, ordinalOf);
             if (!LineCollectTyped(value, ref ids)) { return -1; }
             int cachedFields = !measure && type.Fields.Length <= 256 ? type.Fields.Length : 0;
             Span<long> rootPayloadSizes = stackalloc long[cachedFields];

--- a/testdata/golden/wide/cs/WideTable.cs
+++ b/testdata/golden/wide/cs/WideTable.cs
@@ -2533,11 +2533,41 @@ namespace Wide
             {
                 public Span<ulong> Values;
                 public Span<int> Slots;
+                public Span<uint> OrdinalSlots;
+                public Span<int> OrdinalOf;
                 public int Count;
                 internal Graph Graph;
-                public Ids(Span<ulong> values) { Values = values; Slots = default; Count = 0; Graph = null; }
+                public Ids(Span<ulong> values)
+                {
+                    Values = values;
+                    Slots = default;
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
                 public Ids(Span<ulong> values, Span<int> slots)
-                { Values = values; Slots = slots; Slots.Clear(); Count = 0; Graph = null; }
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = default;
+                    OrdinalOf = default;
+                    Count = 0;
+                    Graph = null;
+                }
+                public Ids(Span<ulong> values, Span<int> slots, Span<uint> ordinalSlots, Span<int> ordinalOf)
+                {
+                    Values = values;
+                    Slots = slots;
+                    if (!Slots.IsEmpty) { Slots.Clear(); }
+                    OrdinalSlots = ordinalSlots;
+                    if (!OrdinalSlots.IsEmpty) { OrdinalSlots.Clear(); }
+                    OrdinalOf = ordinalOf;
+                    if (!OrdinalOf.IsEmpty) { OrdinalOf.Fill(-1); }
+                    Count = 0;
+                    Graph = null;
+                }
                 int Slot(ulong id)
                 {
                     int mask = Slots.Length - 1;
@@ -2545,11 +2575,56 @@ namespace Wide
                     while (Slots[slot] != 0 && Values[Slots[slot] - 1] != id) { slot = (slot + 1) & mask; }
                     return slot;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public ulong Reference(ulong id)
                 {
                     if (!Slots.IsEmpty) { return (ulong)Slots[Slot(id)]; }
                     for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
                     return 0;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong Ref(ulong id)
+                {
+                    if (!Slots.IsEmpty)
+                    {
+                        int slot = Slot(id);
+                        if (Slots[slot] != 0) { return (ulong)Slots[slot]; }
+                        if (Count == Values.Length) { return 0; }
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
+                        return (ulong)Count;
+                    }
+                    for (int i = 0; i < Count; i++) { if (Values[i] == id) { return (ulong)i + 1; } }
+                    if (Count == Values.Length) { return 0; }
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
+                    return (ulong)Count;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public ulong RefAt(int ordinal, ulong id)
+                {
+                    if (!OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        uint s = OrdinalSlots[ordinal];
+                        if (s != 0) { return (ulong)s; }
+                    }
+                    return RefAtMiss(ordinal, id);
+                }
+                ulong RefAtMiss(int ordinal, ulong id)
+                {
+                    ulong r = Ref(id);
+                    if (r != 0 && !OrdinalSlots.IsEmpty && (uint)ordinal < (uint)OrdinalSlots.Length)
+                    {
+                        OrdinalSlots[ordinal] = (uint)r;
+                        if (!OrdinalOf.IsEmpty && (int)(r - 1) < OrdinalOf.Length)
+                        {
+                            OrdinalOf[(int)(r - 1)] = ordinal;
+                        }
+                    }
+                    return r;
                 }
                 public bool Add(ulong id)
                 {
@@ -2558,13 +2633,39 @@ namespace Wide
                         int slot = Slot(id);
                         if (Slots[slot] != 0) { return true; }
                         if (Count == Values.Length) { return false; }
-                        Values[Count++] = id; Slots[slot] = Count;
+                        Values[Count] = id;
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                        Count++;
+                        Slots[slot] = Count;
                         return true;
                     }
                     if (Reference(id) != 0) { return true; }
                     if (Count == Values.Length) { return false; }
-                    Values[Count++] = id;
+                    Values[Count] = id;
+                    if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length) { OrdinalOf[Count] = -1; }
+                    Count++;
                     return true;
+                }
+                public void Truncate(int mark)
+                {
+                    while (Count > 0 && Count > mark)
+                    {
+                        Count--;
+                        if (!Slots.IsEmpty)
+                        {
+                            int slot = Slot(Values[Count]);
+                            Slots[slot] = 0;
+                        }
+                        if (!OrdinalOf.IsEmpty && Count < OrdinalOf.Length)
+                        {
+                            int o = OrdinalOf[Count];
+                            if (o >= 0 && !OrdinalSlots.IsEmpty && (uint)o < (uint)OrdinalSlots.Length)
+                            {
+                                OrdinalSlots[o] = 0;
+                            }
+                            OrdinalOf[Count] = -1;
+                        }
+                    }
                 }
             }
 
@@ -2600,6 +2701,11 @@ namespace Wide
                         return;
                     }
                     Var(reference); Byte(kind);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)
+                {
+                    Header(ids.RefAt(ordinal, id), kind);
                 }
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public void Var(ulong v)
@@ -4343,7 +4449,9 @@ namespace Wide
                     while (slots < vocabulary.Length * 2) { slots <<= 1; }
                 }
                 Span<int> index = stackalloc int[slots];
-                Ids ids = new Ids(vocabulary, index);
+                Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;
+                Span<int> ordinalOf = vocabulary.Length <= 1024 ? stackalloc int[vocabulary.Length] : default;
+                Ids ids = new Ids(vocabulary, index, ordinalSlots, ordinalOf);
                 if (type.Variable) { ids.Graph = Number(value, type); if (ids.Graph == null) { return -1; } }
                 if (!Collect(value, type, ref ids) || !CollectNodes(ref ids)) { return -1; }
                 // Reuse the root's measured length prefixes while writing its fields,


### PR DESCRIPTION
### Summary

Implements card **CS-ORDINAL-SLOTS** and its three non-blocking follow-ups, bypassing hash table probing on known field headers during C# typed table serialization.

### Changes

1. **CS-ORDINAL-SLOTS**:
   - **`TableWire.Ids`**:
     - Added `OrdinalSlots` (`Span<uint>`) and `OrdinalOf` (`Span<int>`) tracking.
     - Added `Ref(ulong id)` (retaining full dynamic hashing semantics), `RefAt(int ordinal, ulong id)` (fast-path reading/writing `OrdinalSlots[ordinal]`), and `Truncate(int mark)` un-indexing reverse-order un-winding.
     - In `Ids` constructor, initialized `OrdinalOf.Fill(-1)` so unassigned slots are never mistaken for ordinal 0.
   - **`TableWire.Writer`**:
     - Added `[MethodImpl(MethodImplOptions.AggressiveInlining)] public void HeaderAt(int ordinal, ulong id, byte kind, ref Ids ids)`.
   - **Typed Emitter (`internal/codegen/cstable/`)**:
     - Computed schema compile-time `idOrdinal` map per struct.
     - Emitted `ids.RefAt(g.knownOrdinal(id), id)` in `emitBodySizeTyped` and `w.HeaderAt(g.knownOrdinal(id), id, kind, ref ids)` in `emitWriteBodyTyped` for clean scalar leaves and child scalar arrays.
     - Used inline ternary stack allocation (`Span<uint> ordinalSlots = vocabulary.Length <= 1024 ? stackalloc uint[vocabulary.Length] : default;`) in `emitSaveTyped` and `TableWire.Save` to satisfy C# escape analysis (CS8353).

2. **Follow-ups**:
   - **Follow-up 1**: Documented C# Table Serialization Contract in `docs/PORTING.md` (under M13) and `docs/SPEC-TABLES.md` (§8.1), and registered technique cell `M22` in `docs/PORTING.md`.
   - **Follow-up 2**: Hardened `isChildScalarArray` in `internal/codegen/cstable/wire.go` to be a strict allowlist.
   - **Follow-up 3**: Updated `compiler/tablescs_test.go` (`TestCsTypedVsDynamicWireEquivalence`) to call `t.Skip(...)` when `dotnet` is unavailable.

### Verification

- **Both-ways test**: Added `TestCsRefAt` in `compiler/tablescs_test.go` verifying miss, hit, out-of-range ordinals, empty `OrdinalSlots`, `Truncate` restoration of `OrdinalSlots` and `Slots`, and `HeaderAt` vs `Header` byte equivalence.
- **Unit & Golden Tests**:
  - `go test -count=1 ./internal/codegen/cstable/...` (PASS)
  - `go test -count=1 ./compiler -run TestCs` (PASS)
  - `go test -count=1 ./internal/goldens` (PASS)
  - Full suite `go test -count=1 ./...` (PASS)
- **Bench Gate & Throughput**:
  - `PATH="/Users/glenn/.dotnet:$PATH" go run ./bench/paired -mode gate -langs cs` (PASS)
  - Paired table benchmark write throughput: **433.7 MB/s** (up from ~366.5 MB/s on main, **+18.3%** speedup, confirming the expected ~19% gain from eliminating 895 hash table probes).
