### PR TITLE
C tables: three runtimes follow the constructs a unit declares

### DIFF
--- a/compiler/tablecensusc_test.go
+++ b/compiler/tablecensusc_test.go
@@ -1,0 +1,290 @@
+// THE THREE CENSUS-GATED RUNTIMES OF THE C TABLE EMITTER, AND THE FIXTURES
+// THAT PROVE EACH BOTH WAYS (docs/SPEC-TABLES.md §2.2, §3, §4). Card C-6's own
+// dead-output condition, check_default, is next door in tabledeadc_test.go.
+//
+// The C Table header used to carry three blocks in units that no call site in
+// those units could reach:
+//
+//   - KIND 33's RUNTIME, table_wire_utf16_unit / table_wire_utf16 /
+//     table_wire_utf16_clamp. Its only call sites are a `wstring(N)` field
+//     (wire_read.go) and a `wstring(N)` arm (unions.go), and both sit behind
+//     ir.TWString, so a unit whose wide-text census is empty had thirty-two
+//     lines it could not reach.
+//   - THE FLOAT RUNG, table_wire_widen_f32. Its two call sites — the file
+//     wire's widened scalar and the message form's f32-shaped entry — are both
+//     behind a DECLARED kind 11, so a unit whose closure declares no f64 had
+//     nine lines it could not reach.
+//   - THE BYTE BUFFER'S OWN SURFACE: the two views, the two reserved type ids,
+//     the three read accessors and the blob node type. All of it is reached
+//     from a `*bytes` or a `*string` DECLARATION and from nowhere else, so a
+//     pointered unit that declares neither had thirty-two lines it could not
+//     reach.
+//
+// EACH CENSUS IS A DECLARATION SCAN, never a reachability walk. Gating a
+// DEFINITION on the numbering walk's ir.PointerReachableBlobs would rest on two
+// separate walks agreeing, and the arms gate's negative controls break that
+// agreement on purpose (see ir/blobcensus.go); the same reasoning makes the
+// kind census ir.TableDeclaredKinds a superset of every shape test the widening
+// call sites are emitted behind (see ir/tablekindcensus.go).
+//
+// A GREEN GATE ON THE UNITS THAT KEEP THEM IS NOT THE PROOF WANTED, because a
+// condition that is always false and a condition that is always true both leave
+// those units compiling. So each block is asked for TWICE: the fixture that
+// DECLARES the construct must carry it, must CALL it, and must compile and run
+// at -Werror with the sanitizers on; its NEAREST NEIGHBOUR — wstring respelled
+// string, float64 respelled float32, the blob pointers respelled table pointers
+// — must carry not one symbol of it AND must still compile, which is the half
+// that catches a gate cut too deep.
+//
+// THE BYTE BUFFER'S FLOOR is named on the absent side on purpose. TableBlob,
+// table_blob_storage and the emplace family are read by code that is in every
+// pointered unit whether or not it declares a buffer — table_node_storage,
+// table_cook_layout, the message form's record carve, and the JSON graph walk
+// in every pointered <Base>Table.c — so a change that took them out with the
+// rest is red here.
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const deadCWideSrc = `package probe
+
+table Note
+{
+    title wstring(4)
+    tally int32
+}
+`
+
+// the nearest neighbour: kind 12 where the fixture above spells kind 33, and
+// nothing else moved.
+const deadCNarrowSrc = `package probe
+
+table Note
+{
+    title string(4)
+    tally int32
+}
+`
+
+const deadCF64Src = `package probe
+
+table Note
+{
+    ratio float64
+    tally int32
+}
+`
+
+// the nearest neighbour: the one declaration respelled at its ladder's bottom,
+// so nothing on the float rung is declared and nothing widens into it.
+const deadCF32Src = `package probe
+
+table Note
+{
+    ratio float32
+    tally int32
+}
+`
+
+// A POINTERED unit that declares both byte buffers: a field of each kind, an
+// arm, and a map's value, which is every shape §2.5 allows one in.
+const deadCBlobSrc = `package probe
+
+table Leaf { v int32 }
+
+union Reach
+{
+    text  *string
+    plain int32
+}
+
+table Note
+{
+    tally int32
+    data  *bytes
+    docs  map[uint32]*bytes
+    reach Reach
+    leaf  *Leaf
+    next  *Note
+}
+`
+
+// The nearest neighbour: every blob pointer respelled a table pointer. The unit
+// is still variable-length and still carries the arena, the numbering, the map,
+// the graph and the message form — and no byte buffer.
+const deadCNodeSrc = `package probe
+
+table Leaf { v int32 }
+
+union Reach
+{
+    only  *Leaf
+    plain int32
+}
+
+table Note
+{
+    tally int32
+    data  *Leaf
+    docs  map[uint32]*Leaf
+    reach Reach
+    leaf  *Leaf
+    next  *Note
+}
+`
+
+var (
+	// the three kind 33 helpers, by name.
+	deadCWideSymbols = []string{"table_wire_utf16_unit", "table_wire_utf16(", "table_wire_utf16_clamp"}
+	// the byte buffer's own surface: the views, the reserved ids, the read
+	// accessors and the blob node type.
+	deadCBlobSymbols = []string{
+		"TableBytesView", "TableStringView",
+		"kTableBytesTypeId", "kTableStringTypeId",
+		"table_blob_at", "table_bytes_at", "table_string_at",
+		"table_blob_save", "table_blob_edges",
+		"table_bytes_node_type", "table_string_node_type",
+	}
+	// and the floor every pointered unit keeps, buffer or no buffer: the
+	// generic walks name each of these at a `type->blob` branch they take at
+	// RUN time, and the JSON graph walk emplaces a buffer for text it reads.
+	deadCBlobFloor = []string{
+		"TableBlob", "table_blob_storage",
+		"table_blob_emplace", "table_bytes_emplace", "table_string_emplace",
+	}
+)
+
+func deadCHeader(t *testing.T, src string) (string, map[string][]byte) {
+	t.Helper()
+	files, err := New().Generate(unitFromSource(t, src), "c", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	header, ok := files["ProbeTable.h"]
+	if !ok {
+		t.Fatal("the c target emitted no ProbeTable.h")
+	}
+	return string(header), files
+}
+
+func TestCTableWideTextRuntimeFollowsTheCensus(t *testing.T) {
+	with, files := deadCHeader(t, deadCWideSrc)
+	for _, sym := range deadCWideSymbols {
+		if !strings.Contains(with, sym) {
+			t.Errorf("a unit that declares wstring(N) must carry %s", sym)
+		}
+	}
+	// present is not the same as REACHED: the fixture's own codec has to call
+	// them, or the header carries three definitions nobody reads again
+	if !strings.Contains(with, "!table_wire_utf16( sub.buffer, sub.size/2 )") {
+		t.Error("the wide-text field's codec must call table_wire_utf16")
+	}
+	if !strings.Contains(with, "table_wire_utf16_clamp( sub.buffer, sub.size/2, 4 )") {
+		t.Error("the wide-text field's codec must call table_wire_utf16_clamp at its declared bound")
+	}
+	deadCCompile(t, files)
+
+	without, files := deadCHeader(t, deadCNarrowSrc)
+	for _, sym := range deadCWideSymbols {
+		if strings.Contains(without, sym) {
+			t.Errorf("a unit with no wide text must carry no %s", sym)
+		}
+	}
+	// KIND 12's runtime is every unit's: it rides in the file wire's
+	// primitives, which the generic walk and the cooked form both read
+	for _, sym := range []string{"table_wire_utf8(", "table_wire_utf8_clamp"} {
+		if !strings.Contains(without, sym) {
+			t.Errorf("kind 12's runtime is every unit's and %s left one", sym)
+		}
+	}
+	deadCCompile(t, files)
+}
+
+func TestCTableWidenF32FollowsTheCensus(t *testing.T) {
+	with, files := deadCHeader(t, deadCF64Src)
+	if !strings.Contains(with, "static SCHEMA_UNUSED double table_wire_widen_f32") {
+		t.Error("a unit that declares float64 must carry table_wire_widen_f32")
+	}
+	// the file wire's widened scalar and the message form's f32-shaped entry,
+	// which are the two call sites the census is taken for
+	if !strings.Contains(with, "double decoded_wide = table_wire_widen_f32( table_reader_get32(") {
+		t.Error("the f64 field's file-wire codec must call table_wire_widen_f32")
+	}
+	if !strings.Contains(with, "decoded=table_wire_widen_f32(table_float_to_bits(narrow));") {
+		t.Error("the f64 field's message-form codec must call table_wire_widen_f32")
+	}
+	deadCCompile(t, files)
+
+	without, files := deadCHeader(t, deadCF32Src)
+	if strings.Contains(without, "table_wire_widen_f32") {
+		t.Error("a unit that declares no float64 must carry no table_wire_widen_f32")
+	}
+	// the ladder PREDICATE stays in every unit: a kind comparison is what
+	// every reader does, and it is named on the absent side on purpose
+	if !strings.Contains(without, "static SCHEMA_UNUSED int table_kind_widens") {
+		t.Error("table_kind_widens is every unit's and the f32 gate took it")
+	}
+	deadCCompile(t, files)
+}
+
+func TestCTableBlobRuntimeFollowsTheCensus(t *testing.T) {
+	with, files := deadCHeader(t, deadCBlobSrc)
+	for _, sym := range append(append([]string{}, deadCBlobSymbols...), deadCBlobFloor...) {
+		if !strings.Contains(with, sym) {
+			t.Errorf("a unit that declares *bytes must carry %s", sym)
+		}
+	}
+	// the node-type switch is the one site that names the two records, and it
+	// is what makes the definitions REACHED rather than merely present
+	if !strings.Contains(with, "case kTableBytesTypeId: return &table_bytes_node_type;") {
+		t.Error("the graph's node-type switch must name table_bytes_node_type")
+	}
+	if !strings.Contains(with, "case kTableStringTypeId: return &table_string_node_type;") {
+		t.Error("the graph's node-type switch must name table_string_node_type")
+	}
+	deadCCompile(t, files)
+
+	without, files := deadCHeader(t, deadCNodeSrc)
+	for _, sym := range deadCBlobSymbols {
+		if strings.Contains(without, sym) {
+			t.Errorf("a pointered unit with no byte buffer must carry no %s", sym)
+		}
+	}
+	for _, sym := range deadCBlobFloor {
+		if !strings.Contains(without, sym) {
+			t.Errorf("a pointered unit keeps %s whether or not it declares a byte buffer", sym)
+		}
+	}
+	// the unit is still pointered, so the numbering and the node walk are its
+	for _, sym := range []string{"table_node_storage", "table_number_build"} {
+		if !strings.Contains(without, sym) {
+			t.Errorf("a pointered unit keeps %s", sym)
+		}
+	}
+	// AND IT STILL COMPILES, which is the half that catches a gate cut too
+	// deep: every name the generic walks read at a `type->blob` branch has to
+	// be declared even where no node type of the unit sets the column.
+	deadCCompile(t, files)
+}
+
+// deadCCompile compiles and runs the generated unit, so each side of each
+// condition is a BUILD and not only a string match: a helper the emitter emits
+// and the codec calls has to be there at -Werror, and a helper the emitter
+// withheld must be one nothing left behind still names.
+func deadCCompile(t *testing.T, files map[string][]byte) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, source := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), source, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	issue715CompileRun(t, dir, "clang", ".c", `#include "ProbeTable.h"
+int main( void ) { return 0; }
+`)
+}

--- a/compiler/tablesc_test.go
+++ b/compiler/tablesc_test.go
@@ -43,6 +43,21 @@ func TestCTableRuntimeNamesAreClaimed(t *testing.T) {
 	for name, data := range fixed {
 		files["fixed-"+name] = data
 	}
+	// AND A UNIT THAT DECLARES THE GATED CONSTRUCTS. Three of this backend's
+	// runtime blocks follow a CENSUS and are emitted only into a unit that
+	// declares what reaches them — kind 33's UTF-16 helpers, the float rung
+	// table_wire_widen_f32, and the byte buffer's own surface
+	// (compiler/tabledeadc_test.go). The registry's claim is that the C
+	// backend defines those names SOMEWHERE, so the scan is taken over a
+	// corpus that declares all three; a scan over a unit that declares none
+	// would read a gate as an unclaimed registration.
+	census, err := New().Generate(unitFromSource(t, cCensusRuntimeSrc), "c", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range census {
+		files["census-"+name] = data
+	}
 	ident := regexp.MustCompile(`\b(?:(?:Table|kTable|table_|BuildVersion|schema_allocate|schema_release|schema_assert|schema_fatal)[A-Za-z0-9_]*|announce(?:_measure|_read)?)\b`)
 	// the unit's own type names start with Table for a schema that declares one;
 	// the corpus here declares none, and the file base does, so the two file
@@ -158,6 +173,24 @@ func TestCExternalsCarryThePackage(t *testing.T) {
 // a unit that has one. The claim does not vary with that — a name free today
 // must not become a collision the day a table gains a pointer (§11) — so the
 // scan needs a corpus where every name is actually emitted.
+// cCensusRuntimeSrc declares every construct one of the C emitter's THREE
+// CENSUS-GATED runtime blocks is reached from: a `wstring(N)` field for kind
+// 33's helpers, a `float64` for the float rung, and a `*bytes` and a `*string`
+// for the byte buffer's views, reserved ids, accessors and node type.
+const cCensusRuntimeSrc = `package probe
+
+table CensusLeaf { v int32 }
+
+table Census
+{
+    title wstring(4)
+    ratio float64
+    data  *bytes
+    text  *string
+    leaf  *CensusLeaf
+}
+`
+
 const cRuntimeSrc = runtimeSrc + `
 table ScalarLeaf { value uint32 }
 table Node

--- a/generated/bench/paired/c/BenchTable.h
+++ b/generated/bench/paired/c/BenchTable.h
@@ -649,38 +649,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_BENCH_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/generated/bench/paired/c/FixedTableTable.h
+++ b/generated/bench/paired/c/FixedTableTable.h
@@ -650,38 +650,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_BENCH_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -636,38 +636,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_BENCHTABLE_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/internal/codegen/ctable/blobs.go
+++ b/internal/codegen/ctable/blobs.go
@@ -8,22 +8,35 @@ import (
 
 // Blobs are graph nodes. Their wire body is the used bytes; their storage has
 // an eight-byte header and, for text, a terminator outside the wire extent.
-func tableBlobRuntime() string {
-	return fmt.Sprintf(`
-#ifndef SCHEMA_TABLE_BLOB_RUNTIME
-#define SCHEMA_TABLE_BLOB_RUNTIME
-typedef struct TableBlob { uint32_t length, zero; } TableBlob;
-typedef struct TableBytesView { const uint8_t * data; int64_t length; } TableBytesView;
+//
+// THE BLOCK IS TWO HALVES, and only the first is every pointered unit's.
+//
+// THE FLOOR — the storage header TableBlob, its size rule table_blob_storage
+// and the emplace family — is named by code that is in EVERY pointered unit
+// whether or not the unit declares a byte buffer: table_node_storage and
+// table_node_wire_storage in the graph runtime, table_cook_layout and
+// table_graph_cook in the cook graph runtime, the message form's record carve,
+// and the JSON graph walk in every pointered <Base>Table.c, which emplaces a
+// blob for a `string` or a `bytes` it reads. Each of those asks its question of
+// a TableNodeType at RUN TIME (`type->blob`), so the names have to be there to
+// compile even where no node type of the unit sets the column.
+//
+// THE BYTE BUFFER'S OWN SURFACE — the two views, the two RESERVED TYPE IDS and
+// the three read accessors — is reached only from a `*bytes` or a `*string`
+// DECLARATION, and it is emitted only where the unit has one. The reserved ids
+// part company with C++ here (schema#794 keeps them in every pointered unit):
+// this emitter's retain and message paths compare against the id LITERAL, and
+// the only code that names the macros is the node-type switch the blob census
+// already gates.
+func tableBlobRuntime(anyBlob bool) string {
+	views, accessors := "", ""
+	if anyBlob {
+		views = fmt.Sprintf(`typedef struct TableBytesView { const uint8_t * data; int64_t length; } TableBytesView;
 typedef struct TableStringView { const char * data; int64_t length; } TableStringView;
 #define kTableBytesTypeId UINT64_C(0x%016x)
 #define kTableStringTypeId UINT64_C(0x%016x)
-
-static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated )
-{
-    if ( length < 0 || (uint64_t)length > UINT32_MAX ) { return -1; }
-    return table_align_up64(8+length+(terminated ? 1 : 0));
-}
-
+`, ir.BytesWireTypeId, ir.StringWireTypeId)
+		accessors = `
 static SCHEMA_UNUSED const TableBlob * table_blob_at( const TableCtx * ctx, const TableRef * ref )
 {
     if ( ref->value == 0 ) { return NULL; }
@@ -41,7 +54,19 @@ static SCHEMA_UNUSED TableStringView table_string_at( const TableCtx * ctx, cons
     const TableBlob * blob=table_blob_at(ctx,ref);
     TableStringView view={NULL,0};
     if(blob!=NULL) { view.data=(const char *)(blob+1); view.length=blob->length; } return view;
+}`
+	}
+	return `
+#ifndef SCHEMA_TABLE_BLOB_RUNTIME
+#define SCHEMA_TABLE_BLOB_RUNTIME
+typedef struct TableBlob { uint32_t length, zero; } TableBlob;
+` + views + `
+static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated )
+{
+    if ( length < 0 || (uint64_t)length > UINT32_MAX ) { return -1; }
+    return table_align_up64(8+length+(terminated ? 1 : 0));
 }
+` + accessors + `
 static SCHEMA_UNUSED TableBlob * table_blob_emplace( TableWorker * worker, TableRef * ref, int64_t length, int terminated )
 {
     int64_t bytes=table_blob_storage(length,terminated);
@@ -66,9 +91,14 @@ static SCHEMA_UNUSED char * table_string_emplace( TableWorker * worker, TableRef
     data=(char *)(blob+1); if(text!=NULL && length>0) { memcpy(data,text,(size_t)length); } data[length]=0; return data;
 }
 #endif
-`, ir.BytesWireTypeId, ir.StringWireTypeId)
+`
 }
 
+// tableBlobGraphRuntime is the BYTE BUFFER's node type — the save, the (empty)
+// edge walk and the two TableNodeType records the reserved ids key. It rides in
+// the graph runtime's @BLOB_GRAPH@ slot, and only in a unit that DECLARES a
+// byte buffer: the node-type switch that names these two records is emitted
+// under the same declaration, and nothing else in this emitter names them.
 const tableBlobGraphRuntime = `
 static SCHEMA_UNUSED int table_blob_save( TableWriter * w, const void * value )
 {

--- a/internal/codegen/ctable/ctable.go
+++ b/internal/codegen/ctable/ctable.go
@@ -742,7 +742,32 @@ func (g *tableGen) header(u *ir.Unit, f *ir.File, members []*ir.Struct) []byte {
 		h.WriteString(tableAllocatorRuntime)
 		h.WriteString(tableArenaRuntime(u.Package))
 		if g.fileWire() {
-			h.WriteString(tableBlobRuntime())
+			// THE BYTE BUFFER's runtime, and only where the unit DECLARES one
+			// (docs/SPEC-TABLES.md §2.5, §2.2). Every name in these two blocks
+			// — the blob storage header and its views, the emplace family, the
+			// two reserved type ids and the two node types they key — is
+			// reached from a `*bytes` or a `*string` declaration and from
+			// nowhere else, so a pointered unit that declares neither carried
+			// them and could not reach them.
+			//
+			// THE CENSUS IS ir.BlobPointerFields, A DECLARATION SCAN, and
+			// never ir.PointerReachableBlobs. That one answers a WIRE question
+			// — which reserved node ids a GIVEN ROOT's load can place (§3.1,
+			// §6.5) — with the numbering walk, which is a different piece of
+			// code from the pointer edge walk this emitter writes its call
+			// sites from. A gate on a DEFINITION must not rest on two walks
+			// agreeing: the arms gate's negative controls (schema#565)
+			// sabotage the numbering walk on purpose, and a census taken with
+			// it then withholds a definition the emitter has already written a
+			// call to, so the control dies in the C compiler instead of going
+			// red on the CHECK it names. A declaration scan is a superset of
+			// every walk over the same unit and cannot lose that race.
+			//
+			// The census is UNIT-LEVEL for wirePrimitives' reason: the runtime
+			// sits behind one guard and a translation unit may hold only one of
+			// the package's headers.
+			anyBlob := len(ir.BlobPointerFields(u)) > 0
+			h.WriteString(tableBlobRuntime(anyBlob))
 			if g.anySequence {
 				h.WriteString(tableSequenceRuntime)
 			}
@@ -752,7 +777,11 @@ func (g *tableGen) header(u *ir.Unit, f *ir.File, members []*ir.Struct) []byte {
 			if g.anyMap {
 				h.WriteString(tableMapRuntime)
 			}
-			h.WriteString(strings.Replace(tableGraphRuntime, "@BLOB_GRAPH@", tableBlobGraphRuntime, 1))
+			blobGraph := ""
+			if anyBlob {
+				blobGraph = tableBlobGraphRuntime
+			}
+			h.WriteString(strings.Replace(tableGraphRuntime, "@BLOB_GRAPH@", blobGraph, 1))
 		}
 	}
 	// the COOKED FORM's read side (docs/SPEC-TABLES.md §7) and the BUILD VERSION

--- a/internal/codegen/ctable/wire.go
+++ b/internal/codegen/ctable/wire.go
@@ -83,9 +83,62 @@ func (g *tableGen) wirePrimitives() string {
 		runtime = strings.ReplaceAll(runtime, "@CHECK_DEFAULT@", checkDefault)
 		runtime = strings.ReplaceAll(runtime, "@WRITE_NODES@", writeNodes)
 		runtime = strings.ReplaceAll(runtime, "@READ_NODES@", readNodes)
+		// THE FLOAT RUNG, kind 10 into kind 11 (docs/SPEC-TABLES.md §4), only
+		// where kind 11 is declared. table_wire_widen_f32 has exactly two call
+		// sites in this emitter — the file wire's widened scalar
+		// (wire_read.go) and the message form's f32-shaped entry read into an
+		// f64 field (message_read.go) — and both sit behind a DECLARED f64, so
+		// a unit whose closure declares no kind 11 carried nine lines it could
+		// not reach. table_kind_widens above stays in every unit: a kind
+		// comparison is what every reader does.
+		widenF32 := ""
+		if ir.TableDeclaredKinds(g.unit)[ir.TableKindF64] {
+			widenF32 = tableWidenF32Runtime
+		}
+		runtime = strings.ReplaceAll(runtime, "@WIDEN_F32@", widenF32)
 	}
-	return tablePrimitives(g.unit.Package, g.anyVariable, g.anyKeyed, runtime) + tableTextRuntime
+	// KIND 33's RUNTIME, and only where a kind 33 payload can arrive
+	// (docs/SPEC-TABLES.md §3, §2.2). table_wire_utf16_unit, table_wire_utf16
+	// and table_wire_utf16_clamp have exactly two call sites in this emitter —
+	// a `wstring(N)` field (wire_read.go) and a `wstring(N)` arm (unions.go) —
+	// and both sit behind ir.TWString, so a unit whose census names no
+	// wide-text field cannot reach one of them.
+	//
+	// THE CENSUS IS UNIT-LEVEL AND NOT PER-FILE, because a package's files are
+	// separate headers and a translation unit may include only one of them: a
+	// file that declares no wide text of its own still has to define the
+	// runtime, since the file of the package that does declare it may not be
+	// in this translation unit at all.
+	//
+	// SCHEMA_TABLE_UTF16_RUNTIME STAYS GLOBAL rather than package-prefixed,
+	// which is how it already was, and the census cannot lean on it either
+	// way. A guard suppresses a REDEFINITION when two of a package's headers
+	// meet in one translation unit; it cannot SUPPLY a definition. So a file
+	// that declares wide text carries the block itself, and a file with no
+	// call site for it carries nothing.
+	wideText := ""
+	if len(ir.WideTextFields(g.unit)) > 0 {
+		wideText = tableTextRuntime
+	}
+	return tablePrimitives(g.unit.Package, g.anyVariable, g.anyKeyed, runtime) + wideText
 }
+
+// tableWidenF32Runtime is the FLOAT RUNG of the widening rule (§4): f32 into
+// f64, exact, with a NaN's payload riding on the bits because the hardware
+// conversion would set the quiet bit. It goes into @WIDEN_F32@ inside
+// fileWireRuntime, and only into a unit whose closure DECLARES a kind 11 —
+// see wirePrimitives for the census and for why the other five widening
+// symbols stay in every unit.
+const tableWidenF32Runtime = `static SCHEMA_UNUSED double table_wire_widen_f32( uint32_t bits )
+{
+    if ( (bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0 )
+    {
+        uint64_t wide = ((uint64_t) (bits >> 31) << 63) | 0x7ff0000000000000ull | ((uint64_t) (bits & 0x007fffffu) << 29);
+        double d; memcpy( &d, &wide, 8 ); return d;
+    }
+    { float f; memcpy( &f, &bits, 4 ); return (double) f; }
+}
+`
 
 const fileWireRuntime = `
 /* Each save owns one bounded identity table. Probes share it and rewind their
@@ -375,16 +428,7 @@ static SCHEMA_UNUSED int table_kind_widens( uint8_t kind, uint8_t declared )
     if ( declared == 19 ) { return kind >= 6 && kind <= 9; }
     return declared == 11 && kind == 10;
 }
-static SCHEMA_UNUSED double table_wire_widen_f32( uint32_t bits )
-{
-    if ( (bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0 )
-    {
-        uint64_t wide = ((uint64_t) (bits >> 31) << 63) | 0x7ff0000000000000ull | ((uint64_t) (bits & 0x007fffffu) << 29);
-        double d; memcpy( &d, &wide, 8 ); return d;
-    }
-    { float f; memcpy( &f, &bits, 4 ); return (double) f; }
-}
-static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffer, int64_t bytes, TableReport * report )
+@WIDEN_F32@static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffer, int64_t bytes, TableReport * report )
 {
     uint64_t count, i, j; int64_t span; TableReader tail;
     if ( bytes < 1 || buffer == NULL ) { report->malformed = 1; return 0; }

--- a/ir/tablekindcensus.go
+++ b/ir/tablekindcensus.go
@@ -1,0 +1,76 @@
+// The TABLE closure's KIND census (docs/SPEC-TABLES.md §2.2, §4): every wire
+// kind the unit DECLARES, whatever shape test an emitter's own call sites sit
+// behind.
+package ir
+
+// TableDeclaredKinds returns the set of wire kinds the unit's TABLE CLOSURE
+// declares: for every field of every closure member, its own scalar kind
+// ([TableWireScalarKind], which a plain field, a union arm and a map key are
+// compared under) and its ELEMENT kind ([TableWireElemKind], which a bounded
+// array, a keyed body and a list are compared under), plus the same two for
+// every arm of every union a closure member reaches, transitively.
+//
+// IT IS A DECLARATION SCAN AND NOT A REACHABILITY WALK, for the reason
+// [BlobPointerFields] is: a backend that gates a DEFINITION on a census must
+// not rest on a second walk agreeing with the one its own call sites are
+// emitted from, because a sabotage or a later edit can part the two and the
+// backend then withholds a definition it has already written a call to. A
+// declaration scan is a SUPERSET of every such walk over the same unit.
+//
+// IT IS A SUPERSET OF THE CALL SITES TOO, deliberately (§4: "the rule is
+// decided by the KIND PAIR and by nothing else"). A widening helper's call
+// sites are emitted from several places apiece, each behind its own shape test
+// — a plain scalar at a field, a widenable element at an array, a keyed body
+// or a list, a plain scalar again at an arm, a map key's own test — and no
+// census matches that union without spelling those tests a second time and
+// growing a second way to be wrong. A pointer field of kind 11, a map of
+// int64 values, an f64 the message form never reaches: each answers yes and
+// costs a unit a helper it does not call. The cost of the superset is dead
+// text; the cost of a subset is a translation unit that does not compile.
+//
+// THE CENSUS IS UNIT-LEVEL AND NOT PER-FILE, for the reason [WideTextFields]
+// is: a runtime that sits behind one guard is defined by whichever header a
+// translation unit reaches first, so the question is asked of the unit and
+// never of a file.
+func TableDeclaredKinds(u *Unit) map[int]bool {
+	kinds := map[int]bool{}
+	seen := map[*Union]bool{}
+	var note func(f *Field)
+	var walkUnion func(un *Union)
+	note = func(f *Field) {
+		if f == nil {
+			return
+		}
+		kinds[TableWireScalarKind(f)] = true
+		if k := TableWireElemKind(f); k != 0 {
+			kinds[k] = true
+		}
+		if f.Type.Kind == TNamed {
+			if un, ok := f.Type.Ref.(*Union); ok {
+				walkUnion(un)
+			}
+		}
+	}
+	walkUnion = func(un *Union) {
+		if seen[un] {
+			return
+		}
+		seen[un] = true
+		for _, v := range un.Variants {
+			note(v.F)
+		}
+	}
+	for name := range TableClosure(u) {
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		for _, f := range st.Fields {
+			note(f)
+		}
+	}
+	return kinds
+}

--- a/ir/tablekindcensus_test.go
+++ b/ir/tablekindcensus_test.go
@@ -1,0 +1,78 @@
+package ir_test
+
+// THE TABLE CLOSURE'S KIND CENSUS (docs/SPEC-TABLES.md §4) and the property a
+// backend gates a DEFINITION on it for: it names the kind a declaration spells
+// wherever the declaration sits — a field, an array's element, a map's half, a
+// union arm, a pointee's field — so a widening helper's call site cannot be in
+// a unit the census withheld the helper from.
+
+import (
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// every position a kind can be declared in, each spelling a kind nothing else
+// in the fixture spells, so a census that missed one position is red.
+const kindCensusSource = `package demo
+
+table Leaf { deep float64 }
+
+union Reach
+{
+    wide  int64
+    plain int32
+}
+
+table Holder
+{
+    leaf    *Leaf
+    tags    map[uint16]uint64
+    scores  [3]float32
+    reach   Reach
+    ordinal int8
+}
+`
+
+func TestTableDeclaredKindsNamesEveryPosition(t *testing.T) {
+	kinds := ir.TableDeclaredKinds(unitFrom(t, kindCensusSource))
+	for _, tc := range []struct {
+		kind  int
+		where string
+	}{
+		{ir.TableKindF64, "a pointee's field"},
+		{ir.TableKindU16, "a map's key"},
+		{ir.TableKindU64, "a map's value"},
+		{ir.TableKindF32, "an array's element"},
+		{ir.TableKindI64, "a union arm"},
+		{ir.TableKindI8, "a plain field"},
+	} {
+		if !kinds[tc.kind] {
+			t.Errorf("kind %d is declared at %s and the census does not name it", tc.kind, tc.where)
+		}
+	}
+}
+
+// the nearest neighbour: the same shapes with the float rung's top respelled at
+// its bottom carry no kind 11 at all, which is the answer the C table emitter's
+// table_wire_widen_f32 gate reads.
+const kindCensusNarrowSource = `package demo
+
+table Leaf { deep float32 }
+
+table Holder
+{
+    leaf   *Leaf
+    scores [3]float32
+}
+`
+
+func TestTableDeclaredKindsIsEmptyOfAKindNobodyDeclares(t *testing.T) {
+	kinds := ir.TableDeclaredKinds(unitFrom(t, kindCensusNarrowSource))
+	if kinds[ir.TableKindF64] {
+		t.Error("a unit that declares no float64 answered yes to kind 11")
+	}
+	if !kinds[ir.TableKindF32] {
+		t.Error("the fixture declares float32 and the census does not name kind 10")
+	}
+}

--- a/testdata/golden/tables/block-c/PaddedTable.h
+++ b/testdata/golden/tables/block-c/PaddedTable.h
@@ -664,38 +664,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_BLOCKDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/block-c/RenderTable.h
+++ b/testdata/golden/tables/block-c/RenderTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_BLOCKDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/GuardedTable.h
+++ b/testdata/golden/tables/examples-c/GuardedTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/KeyedTable.h
+++ b/testdata/golden/tables/examples-c/KeyedTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/NestedTable.h
+++ b/testdata/golden/tables/examples-c/NestedTable.h
@@ -664,38 +664,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/PackTable.h
+++ b/testdata/golden/tables/examples-c/PackTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/RangesTable.h
+++ b/testdata/golden/tables/examples-c/RangesTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/TablesTable.h
+++ b/testdata/golden/tables/examples-c/TablesTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/examples-c/WideTable.h
+++ b/testdata/golden/tables/examples-c/WideTable.h
@@ -663,38 +663,6 @@ static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; mem
 
 #endif /* SCHEMA_TABLEDEMO_TABLE_PRIMITIVES */
 
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
-
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
 typedef int TableRefuseReason;

--- a/testdata/golden/tables/pointers-c/GraphTable.h
+++ b/testdata/golden/tables/pointers-c/GraphTable.h
@@ -542,15 +542,6 @@ static SCHEMA_UNUSED int table_kind_widens( uint8_t kind, uint8_t declared )
     if ( declared == 19 ) { return kind >= 6 && kind <= 9; }
     return declared == 11 && kind == 10;
 }
-static SCHEMA_UNUSED double table_wire_widen_f32( uint32_t bits )
-{
-    if ( (bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0 )
-    {
-        uint64_t wide = ((uint64_t) (bits >> 31) << 63) | 0x7ff0000000000000ull | ((uint64_t) (bits & 0x007fffffu) << 29);
-        double d; memcpy( &d, &wide, 8 ); return d;
-    }
-    { float f; memcpy( &f, &bits, 4 ); return (double) f; }
-}
 static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffer, int64_t bytes, TableReport * report )
 {
     uint64_t count, i, j; int64_t span; TableReader tail;
@@ -670,38 +661,6 @@ static SCHEMA_UNUSED double table_bits_to_double( uint64_t bits ) { double d; me
 static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8 ); return b; }
 
 #endif /* SCHEMA_GRAPHDEMO_TABLE_PRIMITIVES */
-
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
 
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
@@ -1116,10 +1075,6 @@ typedef struct TableSink
 #ifndef SCHEMA_TABLE_BLOB_RUNTIME
 #define SCHEMA_TABLE_BLOB_RUNTIME
 typedef struct TableBlob { uint32_t length, zero; } TableBlob;
-typedef struct TableBytesView { const uint8_t * data; int64_t length; } TableBytesView;
-typedef struct TableStringView { const char * data; int64_t length; } TableStringView;
-#define kTableBytesTypeId UINT64_C(0x2f2ec0474f1c4fe4)
-#define kTableStringTypeId UINT64_C(0x704be0d8faaffc58)
 
 static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated )
 {
@@ -1127,24 +1082,6 @@ static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated 
     return table_align_up64(8+length+(terminated ? 1 : 0));
 }
 
-static SCHEMA_UNUSED const TableBlob * table_blob_at( const TableCtx * ctx, const TableRef * ref )
-{
-    if ( ref->value == 0 ) { return NULL; }
-    return (const TableBlob *)(const void *)(ctx != NULL && ctx->arena != NULL
-        ? table_arena_at(ctx->arena,(uint32_t)ref->value) : (const uint8_t *)(const void *)ref+ref->value);
-}
-static SCHEMA_UNUSED TableBytesView table_bytes_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableBytesView view={NULL,0};
-    if(blob!=NULL) { view.data=(const uint8_t *)(blob+1); view.length=blob->length; } return view;
-}
-static SCHEMA_UNUSED TableStringView table_string_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableStringView view={NULL,0};
-    if(blob!=NULL) { view.data=(const char *)(blob+1); view.length=blob->length; } return view;
-}
 static SCHEMA_UNUSED TableBlob * table_blob_emplace( TableWorker * worker, TableRef * ref, int64_t length, int terminated )
 {
     int64_t bytes=table_blob_storage(length,terminated);
@@ -1240,16 +1177,6 @@ static SCHEMA_UNUSED int64_t table_node_wire_storage( const TableNodeType * type
     }
     return type->blob ? table_blob_storage(body->size,type->blob==2) : type->wire_storage(body);
 }
-
-static SCHEMA_UNUSED int table_blob_save( TableWriter * w, const void * value )
-{
-    const TableBlob * blob=(const TableBlob *)value;
-    table_writer_raw(w,blob+1,blob->length); return !w->overflow;
-}
-static SCHEMA_UNUSED int table_blob_edges( TableNumbering * n, const void * value )
-{ (void)n; (void)value; return 1; }
-static const TableNodeType table_bytes_node_type = { kTableBytesTypeId, 0, table_blob_save, table_blob_edges, 1, NULL, NULL, 8, 0, NULL, NULL };
-static const TableNodeType table_string_node_type = { kTableStringTypeId, 0, table_blob_save, table_blob_edges, 2, NULL, NULL, 8, 0, NULL, NULL };
 
 
 static SCHEMA_UNUSED uint64_t table_number_hash( const void * value )

--- a/testdata/golden/tables/pointers-c/MarksTable.h
+++ b/testdata/golden/tables/pointers-c/MarksTable.h
@@ -540,15 +540,6 @@ static SCHEMA_UNUSED int table_kind_widens( uint8_t kind, uint8_t declared )
     if ( declared == 19 ) { return kind >= 6 && kind <= 9; }
     return declared == 11 && kind == 10;
 }
-static SCHEMA_UNUSED double table_wire_widen_f32( uint32_t bits )
-{
-    if ( (bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0 )
-    {
-        uint64_t wide = ((uint64_t) (bits >> 31) << 63) | 0x7ff0000000000000ull | ((uint64_t) (bits & 0x007fffffu) << 29);
-        double d; memcpy( &d, &wide, 8 ); return d;
-    }
-    { float f; memcpy( &f, &bits, 4 ); return (double) f; }
-}
 static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffer, int64_t bytes, TableReport * report )
 {
     uint64_t count, i, j; int64_t span; TableReader tail;
@@ -668,38 +659,6 @@ static SCHEMA_UNUSED double table_bits_to_double( uint64_t bits ) { double d; me
 static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8 ); return b; }
 
 #endif /* SCHEMA_GRAPHDEMO_TABLE_PRIMITIVES */
-
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
 
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
@@ -1114,10 +1073,6 @@ typedef struct TableSink
 #ifndef SCHEMA_TABLE_BLOB_RUNTIME
 #define SCHEMA_TABLE_BLOB_RUNTIME
 typedef struct TableBlob { uint32_t length, zero; } TableBlob;
-typedef struct TableBytesView { const uint8_t * data; int64_t length; } TableBytesView;
-typedef struct TableStringView { const char * data; int64_t length; } TableStringView;
-#define kTableBytesTypeId UINT64_C(0x2f2ec0474f1c4fe4)
-#define kTableStringTypeId UINT64_C(0x704be0d8faaffc58)
 
 static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated )
 {
@@ -1125,24 +1080,6 @@ static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated 
     return table_align_up64(8+length+(terminated ? 1 : 0));
 }
 
-static SCHEMA_UNUSED const TableBlob * table_blob_at( const TableCtx * ctx, const TableRef * ref )
-{
-    if ( ref->value == 0 ) { return NULL; }
-    return (const TableBlob *)(const void *)(ctx != NULL && ctx->arena != NULL
-        ? table_arena_at(ctx->arena,(uint32_t)ref->value) : (const uint8_t *)(const void *)ref+ref->value);
-}
-static SCHEMA_UNUSED TableBytesView table_bytes_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableBytesView view={NULL,0};
-    if(blob!=NULL) { view.data=(const uint8_t *)(blob+1); view.length=blob->length; } return view;
-}
-static SCHEMA_UNUSED TableStringView table_string_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableStringView view={NULL,0};
-    if(blob!=NULL) { view.data=(const char *)(blob+1); view.length=blob->length; } return view;
-}
 static SCHEMA_UNUSED TableBlob * table_blob_emplace( TableWorker * worker, TableRef * ref, int64_t length, int terminated )
 {
     int64_t bytes=table_blob_storage(length,terminated);
@@ -1238,16 +1175,6 @@ static SCHEMA_UNUSED int64_t table_node_wire_storage( const TableNodeType * type
     }
     return type->blob ? table_blob_storage(body->size,type->blob==2) : type->wire_storage(body);
 }
-
-static SCHEMA_UNUSED int table_blob_save( TableWriter * w, const void * value )
-{
-    const TableBlob * blob=(const TableBlob *)value;
-    table_writer_raw(w,blob+1,blob->length); return !w->overflow;
-}
-static SCHEMA_UNUSED int table_blob_edges( TableNumbering * n, const void * value )
-{ (void)n; (void)value; return 1; }
-static const TableNodeType table_bytes_node_type = { kTableBytesTypeId, 0, table_blob_save, table_blob_edges, 1, NULL, NULL, 8, 0, NULL, NULL };
-static const TableNodeType table_string_node_type = { kTableStringTypeId, 0, table_blob_save, table_blob_edges, 2, NULL, NULL, 8, 0, NULL, NULL };
 
 
 static SCHEMA_UNUSED uint64_t table_number_hash( const void * value )

--- a/testdata/golden/tables/pointers-c/PartsTable.h
+++ b/testdata/golden/tables/pointers-c/PartsTable.h
@@ -540,15 +540,6 @@ static SCHEMA_UNUSED int table_kind_widens( uint8_t kind, uint8_t declared )
     if ( declared == 19 ) { return kind >= 6 && kind <= 9; }
     return declared == 11 && kind == 10;
 }
-static SCHEMA_UNUSED double table_wire_widen_f32( uint32_t bits )
-{
-    if ( (bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0 )
-    {
-        uint64_t wide = ((uint64_t) (bits >> 31) << 63) | 0x7ff0000000000000ull | ((uint64_t) (bits & 0x007fffffu) << 29);
-        double d; memcpy( &d, &wide, 8 ); return d;
-    }
-    { float f; memcpy( &f, &bits, 4 ); return (double) f; }
-}
 static SCHEMA_UNUSED int table_wire_open( TableReader * r, const uint8_t * buffer, int64_t bytes, TableReport * report )
 {
     uint64_t count, i, j; int64_t span; TableReader tail;
@@ -668,38 +659,6 @@ static SCHEMA_UNUSED double table_bits_to_double( uint64_t bits ) { double d; me
 static SCHEMA_UNUSED uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8 ); return b; }
 
 #endif /* SCHEMA_GRAPHDEMO_TABLE_PRIMITIVES */
-
-#ifndef SCHEMA_TABLE_UTF16_RUNTIME
-#define SCHEMA_TABLE_UTF16_RUNTIME
-static SCHEMA_UNUSED uint16_t table_wire_utf16_unit( const uint8_t * bytes, int64_t index )
-{
-    return (uint16_t) ((uint16_t) bytes[index*2] | ((uint16_t) bytes[index*2+1] << 8));
-}
-static SCHEMA_UNUSED int table_wire_utf16( const uint8_t * bytes, int64_t units )
-{
-    int64_t i = 0;
-    while ( i < units ) {
-        uint16_t unit = table_wire_utf16_unit( bytes, i++ );
-        if ( unit == 0 ) { return 0; }
-        if ( unit >= 0xd800 && unit <= 0xdbff ) {
-            uint16_t low;
-            if ( i == units ) { return 0; }
-            low = table_wire_utf16_unit( bytes, i++ );
-            if ( low < 0xdc00 || low > 0xdfff ) { return 0; }
-        } else if ( unit >= 0xdc00 && unit <= 0xdfff ) { return 0; }
-    }
-    return 1;
-}
-static SCHEMA_UNUSED int64_t table_wire_utf16_clamp( const uint8_t * bytes, int64_t units, int64_t bound )
-{
-    if ( units <= bound ) { return units; }
-    if ( bound > 0 ) {
-        uint16_t last = table_wire_utf16_unit( bytes, bound-1 );
-        if ( last >= 0xd800 && last <= 0xdbff ) { bound--; }
-    }
-    return bound;
-}
-#endif
 
 #ifndef SCHEMA_TABLE_REFUSE_RUNTIME
 #define SCHEMA_TABLE_REFUSE_RUNTIME
@@ -1114,10 +1073,6 @@ typedef struct TableSink
 #ifndef SCHEMA_TABLE_BLOB_RUNTIME
 #define SCHEMA_TABLE_BLOB_RUNTIME
 typedef struct TableBlob { uint32_t length, zero; } TableBlob;
-typedef struct TableBytesView { const uint8_t * data; int64_t length; } TableBytesView;
-typedef struct TableStringView { const char * data; int64_t length; } TableStringView;
-#define kTableBytesTypeId UINT64_C(0x2f2ec0474f1c4fe4)
-#define kTableStringTypeId UINT64_C(0x704be0d8faaffc58)
 
 static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated )
 {
@@ -1125,24 +1080,6 @@ static SCHEMA_UNUSED int64_t table_blob_storage( int64_t length, int terminated 
     return table_align_up64(8+length+(terminated ? 1 : 0));
 }
 
-static SCHEMA_UNUSED const TableBlob * table_blob_at( const TableCtx * ctx, const TableRef * ref )
-{
-    if ( ref->value == 0 ) { return NULL; }
-    return (const TableBlob *)(const void *)(ctx != NULL && ctx->arena != NULL
-        ? table_arena_at(ctx->arena,(uint32_t)ref->value) : (const uint8_t *)(const void *)ref+ref->value);
-}
-static SCHEMA_UNUSED TableBytesView table_bytes_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableBytesView view={NULL,0};
-    if(blob!=NULL) { view.data=(const uint8_t *)(blob+1); view.length=blob->length; } return view;
-}
-static SCHEMA_UNUSED TableStringView table_string_at( const TableCtx * ctx, const TableRef * ref )
-{
-    const TableBlob * blob=table_blob_at(ctx,ref);
-    TableStringView view={NULL,0};
-    if(blob!=NULL) { view.data=(const char *)(blob+1); view.length=blob->length; } return view;
-}
 static SCHEMA_UNUSED TableBlob * table_blob_emplace( TableWorker * worker, TableRef * ref, int64_t length, int terminated )
 {
     int64_t bytes=table_blob_storage(length,terminated);
@@ -1238,16 +1175,6 @@ static SCHEMA_UNUSED int64_t table_node_wire_storage( const TableNodeType * type
     }
     return type->blob ? table_blob_storage(body->size,type->blob==2) : type->wire_storage(body);
 }
-
-static SCHEMA_UNUSED int table_blob_save( TableWriter * w, const void * value )
-{
-    const TableBlob * blob=(const TableBlob *)value;
-    table_writer_raw(w,blob+1,blob->length); return !w->overflow;
-}
-static SCHEMA_UNUSED int table_blob_edges( TableNumbering * n, const void * value )
-{ (void)n; (void)value; return 1; }
-static const TableNodeType table_bytes_node_type = { kTableBytesTypeId, 0, table_blob_save, table_blob_edges, 1, NULL, NULL, 8, 0, NULL, NULL };
-static const TableNodeType table_string_node_type = { kTableStringTypeId, 0, table_blob_save, table_blob_edges, 2, NULL, NULL, 8, 0, NULL, NULL };
 
 
 static SCHEMA_UNUSED uint64_t table_number_hash( const void * value )


### PR DESCRIPTION
The C Table header emitted three blocks into units that no call site in those
units could reach. These are the C twins of #794 and #800 on the C++ side, and
each census is taken the way cc8ec0b5 settled that argument: a gate that emits a
DEFINITION is a DECLARATION SCAN, never a reachability walk a negative control
can part from the emitter's own walk.

## The three gates

**Kind 33's runtime** — `table_wire_utf16_unit` / `table_wire_utf16` /
`table_wire_utf16_clamp`, 32 lines. Two call sites in this emitter: a
`wstring(N)` field (`wire_read.go`) and a `wstring(N)` arm (`unions.go`), both
behind `ir.TWString`. Gated on `len(ir.WideTextFields(u)) > 0`, the census the
other eight targets refuse the unit on. Fifteen of the corpus's sixty-five C
units keep it (mapdemo's thirteen files and widedemo's two). Kind 12's runtime
stays in every unit: it rides in the file wire's primitives, and the generic
walk and the cooked form both read it.

`SCHEMA_TABLE_UTF16_RUNTIME` stays GLOBAL rather than package-prefixed, which is
what it already was: the three functions are byte-identical in every unit that
carries them, so a translation unit that meets two takes whichever comes first.
A shared guard cannot make the census narrower — it suppresses a REDEFINITION,
and no unit may lean on another header being present to supply the definition.
The census is therefore UNIT-LEVEL and not per-file: a package's files are
separate headers and a translation unit may hold only one of them.

**The float rung** — `table_wire_widen_f32`, 9 lines. Two call sites, the file
wire's widened scalar (`wire_read.go`) and the message form's f32-shaped entry
read into an f64 field (`message_read.go`), both behind a DECLARED kind 11.
Gated on a declared f64 anywhere in the unit's closure. The census is LIFTED
INTO `ir` as `ir.TableDeclaredKinds` so C and C++ share one function: it asks
each field, arm, element and map key of the closure for its own scalar kind and
its element kind, and never asks the shape tests the call sites sit behind,
which makes it a SAFE SUPERSET — the cost of a superset is dead text, the cost
of a subset is a header that does not compile. `cpptable` is untouched on this
branch: #800 is unmerged, and this is the shape its F32 rung can adopt.
`table_kind_widens` stays in every unit.

**The byte buffer's own surface** — the two views, the two reserved type ids,
the three read accessors, and the node type with its save and edge walk, 32
lines. Gated on `len(ir.BlobPointerFields(u)) > 0`, never on
`ir.PointerReachableBlobs`. Eighteen units keep it: blobdemo, armdemo's four
files and mapdemo's thirteen.

The BUFFER'S FLOOR stays in every pointered unit, and this is where the C
emitter parts company with the C++ one. `TableBlob`, `table_blob_storage` and
the emplace family are named by code that is in every pointered unit whether or
not it declares a buffer — `table_node_storage` and `table_node_wire_storage`
in the graph runtime, `table_cook_layout` and `table_graph_cook` in the cook
graph runtime, the message form's record carve, and the JSON graph walk in every
pointered `<Base>Table.c`. Each asks its question of a `TableNodeType` at RUN
time (`type->blob`), so the names have to be declared even where no node type of
the unit sets the column. The two reserved type ids go the other way from C++'s:
this emitter's retain and message paths compare against the id LITERAL, and the
only code that names the macros is the node-type switch the blob census already
gates.

`ir.BlobPointerFields` is #794's own and already on main; this branch is its
second reader.

## The census rule

`ir.PointerReachableBlobs` answers a WIRE question — which reserved node ids a
GIVEN ROOT's load can place — with the numbering walk, and a reader owes exactly
that set. The question a BACKEND asks before it emits a runtime into a
translation unit is a different one: can any call site in this unit name that
runtime. The numbering walk and the emitter's own pointer edge walk are two
pieces of code; the arms gate's negative controls (schema#565) part them on
purpose, and a census taken with the walk then withholds a definition the emitter
has already written a call to — the control dies in the C compiler instead of
turning the gate red on the CHECK it names. A declaration scan is a superset of
every walk over the same unit and cannot lose that race. The same reasoning makes
`ir.TableDeclaredKinds` a superset of every shape test the widening call sites
are emitted behind.

## Counts

603 lines leave the committed C trees, insertions zero.

| gate | lines | headers |
|---|---|---|
| kind 33's runtime | 480 | 15 (every committed C table header, 32 each) |
| the float rung | 27 | 3 (the pointered goldens, 9 each) |
| the byte buffer's surface | 96 | 3 (the pointered goldens, 32 each) |

## Tests

`compiler/tablecensusc_test.go` — a file of its own, because
`compiler/tabledeadc_test.go` is card C-6's — asks each condition BOTH WAYS. The fixture that
declares the construct keeps the block, CALLS it, and compiles and runs at
`-O1 -Wall -Wextra -Werror -fsanitize=address,undefined -fno-sanitize-recover=all`
under clang. Its nearest neighbour — `wstring` respelled `string`, `float64`
respelled `float32`, every blob pointer respelled a table pointer — carries not
one symbol of it AND still compiles, which is the half that catches a gate cut
too deep; the buffer's floor is named on the absent side on purpose. Forcing each
census constant true and constant false turns its test red six times for six
reasons, three at the string match and three in the compiler.

`ir/tablekindcensus_test.go` pins the kind census over every position a
declaration can sit in — a pointee's field, a map's key and value, an array's
element, a union arm, a plain field — and empty for the neighbour.
`ir/blobcensus_test.go` (already on main) pins the blob census as a superset of
every root's reachable set. `compiler/tablesc_test.go`'s §11 name-claim scan
grows a third corpus unit that declares all three constructs, so a census reads
as a gate rather than as an unclaimed registration.

## Gates run

- `go build`, `go vet` and `go test` over `./compiler`, `./internal/...` and `./ir` — green.
- `golangci-lint` v2.12.2: 0 issues. `modernize` v0.23.0: clean.
- The C table leg: `wire-fuzz` 0 divergences over 252,842 mutants plain and again
  under `-fsanitize=address,undefined`; `build/conformance-c` and
  `build/conformance-c-asan` compile at `-Werror -Wshadow`;
  `tables-c-zero-cost`, `tables-c-json-walk`, `tables-c-fuzz`,
  `tables-c-fuzz-negative-control`, `tables-c-variable`, the asan driver run,
  `tables-c-keyed-{none,max}-refusal-ndebug`, `tables-c-soak`.
- C negative controls, every one red for its own reason:
  `conformance-negative-control-c` (`c / json-read` alone),
  `conformance-negative-control-c-foreign` (`cook-foreign` and `block-foreign`
  alone), `tables-c-message-negative-control`, `tables-c-retain-negative-control`,
  `tables-c-wire-fuzz-negative-control`,
  `tables-c-keyed-none-refusal-negative-control`,
  `tables-c-keyed-max-refusal-negative-control`,
  `tables-c-soak-negative-control`, `tables-c-ref-ordinal-negative-control`,
  and `tables-arms-reachable-negative-control`, the `ir/table.go` sabotage this
  census is taken the way it is because of — red on the ARMS GATE with 47
  failures, its own CHECK, and not in the compiler.
- The C conformance leg: every registered surface passes, forgery 12/12 and
  cook-forgery 113/113 among them.
- Regenerating the C corpus twice is byte-identical.
- `make generated-current` with the legs this box has no toolchain for skipped:
  green, `generated/ tree is current`.
- `make registry` (the PORTING register), `make shape-gate` (clean, 37 ledgered
  files), and the paired C matched gate — `go run ./bench/paired -mode gate`,
  with the C matched binary answering the same `corpus_id` as every other leg.

## Not run

The cs, dart, elixir, java and rust legs, and the js leg (no sibling
serialize.js beside this clone): no toolchain on this box. No speed
claim is made — nothing here changes what any generated codec does at run time,
only how many lines a translation unit that cannot reach a runtime has to
preprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
