### PR TITLE
docs: the three wires at the top of SPEC-TABLES

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -47,19 +47,23 @@ different tables now, the type, the fixed table, the variable table"* —
   differ. Where versioning would cost more than it is worth, the type is
   the answer: *"if somebody really cares about this, they use a type
   instead (no versioning)."*
-- **FIXED TABLE — the type's speed, in table form.** *"Fixed tables are
-  meant to be the fast equivalent of types, in table form."* It is the
-  TYPE'S OWN LAYOUT with an EIGHT-BYTE HASH in front of it and a
-  VOCABULARY BLOCK beside it, declared `fixed table`. Every field is
-  BOUNDED and every field is WRITTEN AT ITS BOUND, so the body is ONE
-  CONSTANT SIZE PER TYPE and no branch is guarded: ONE read path and ONE
-  write path, whose cost DOES NOT DEPEND ON VERSION SKEW. Skew is paid for
-  whether or not the peers differ, which is the trade — *"it's more
-  honest, and predictable."* It versions by APPEND-ONLY evolution with
-  DEPRECATION IN PLACE, and that versioning is load-bearing: **we must not
-  ever break versioning in fixed tables.** Writing at the bound is why it
-  is for SMALL THINGS — *"effectively, fixed tables should only be used
-  for small things."*
+- **FIXED TABLE — the type's speed, in table form** (the FIXED FORM, form
+  byte `3`, §3.4). *"Fixed tables are meant to be the fast equivalent of
+  types, in table form."* A record is an EIGHT-BYTE HASH of the writer's
+  VOCABULARY BLOCK and then the VALUES IN DECLARED ORDER, EVERY FIELD AT
+  ITS BOUND — the type's own layout, with the block sent once beside it.
+  The class is DECLARED, `fixed table` (§2.2), and the compiler REFUSES in
+  its by-value closure anything that would make a body variable size,
+  naming the field and the table (§11): a pointer, a byte buffer at its
+  used size, a map, an unbounded array, a guarded (`if`) branch, or a
+  nested plain `table`. So the body is ONE CONSTANT SIZE PER TYPE and no
+  branch is guarded: ONE read path and ONE write path, whose cost DOES NOT
+  DEPEND ON VERSION SKEW. Skew is paid for whether or not the peers
+  differ, which is the trade — *"it's more honest, and predictable."* It
+  versions by APPEND-ONLY evolution with DEPRECATION IN PLACE, and that
+  versioning is load-bearing: **we must not ever break versioning in fixed
+  tables.** Writing at the bound is why it is for SMALL THINGS —
+  *"effectively, fixed tables should only be used for small things."*
 - **VARIABLE TABLE — the tolerant wire** (the FILE FORM, form byte `1`,
   §3). Maps, lists, pointers, per-field guards, default elision, and a
   record that DESCRIBES ITSELF every time: ids, kinds and lengths ride
@@ -67,6 +71,15 @@ different tables now, the type, the fixed table, the variable table"* —
   reported, never fatal. It pays framing bytes and, in one narrow case, an
   allocation, and it is the wire for anything LARGE, SPARSE or FREE-FORM —
   everything the other two refuse to carry.
+
+**ONE FORM BYTE PER CLASS.** Form `3` is the FIXED table's wire and form `1`
+is the VARIABLE table's, and neither reads for the other. Form `1` does not
+move: it is what §3 describes, it is what every variable table writes, and it
+is what an old file on a disk is. The form-`1` machinery a FIXED table
+currently carries — the emitted reader and writer a fixed-size table has on
+the variable wire, from the days when both classes rode form `1` — is
+SCHEDULED FOR REMOVAL once form `3` lands, so that a fixed table has one wire
+and one pair of paths and not two of each.
 
 **The variable table is the ESCAPE HATCH THAT LETS THE OTHER TWO BE
 STRICT.** A fixed table refuses what would make it variable; a type
@@ -76,7 +89,11 @@ table) is there for you."*
 
 **The MESSAGE FORM (form byte `2`, §3.3) is the fixed table on the wire
 between peers**: a BATCH of fixed tables under ONE ANNOUNCED BLOCK, each
-body packed through the type's own codec.
+body packed through the type's own codec. It is a fixed table's and nobody
+else's — a message-form request naming a plain `table` is REFUSED naming the
+table (§2.2, §11), because a message is a bitpacked body under one announced
+vocabulary and the shape has to be one the declaration fixes. The FILE form
+is every table's, and is where a variable root goes.
 
 **How to choose.**
 

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -33,6 +33,61 @@ The two contracts never mix. Flatbuffers- and protobuf-class evolution
 ideas apply here, to tables — they do not apply to `type`, whose wire is
 hardcoded under the protocol id, and nothing in this document changes that.
 
+## The three wires
+
+**There are THREE WIRES over the same struct, and each is a different
+bargain.** In the owner's words: *"I also like that there are three quite
+different tables now, the type, the fixed table, the variable table"* —
+*"they are all pretty cool and unique. the tradeoffs are clear."*
+
+- **TYPE — the fastest wire.** Bitpacked, hardcoded, and it knows only
+  itself: the bytes are ONE BUILD'S PRIVATE LAYOUT, guarded by the protocol
+  id, same-or-refuse (SPEC.md). A type is NOT VERSIONED, and that refusal
+  is the whole of what it buys — nothing is negotiated because nothing may
+  differ. Where versioning would cost more than it is worth, the type is
+  the answer: *"if somebody really cares about this, they use a type
+  instead (no versioning)."*
+- **FIXED TABLE — the type's speed, in table form.** *"Fixed tables are
+  meant to be the fast equivalent of types, in table form."* It is the
+  TYPE'S OWN LAYOUT with an EIGHT-BYTE HASH in front of it and a
+  VOCABULARY BLOCK beside it, declared `fixed table`. Every field is
+  BOUNDED and every field is WRITTEN AT ITS BOUND, so the body is ONE
+  CONSTANT SIZE PER TYPE and no branch is guarded: ONE read path and ONE
+  write path, whose cost DOES NOT DEPEND ON VERSION SKEW. Skew is paid for
+  whether or not the peers differ, which is the trade — *"it's more
+  honest, and predictable."* It versions by APPEND-ONLY evolution with
+  DEPRECATION IN PLACE, and that versioning is load-bearing: **we must not
+  ever break versioning in fixed tables.** Writing at the bound is why it
+  is for SMALL THINGS — *"effectively, fixed tables should only be used
+  for small things."*
+- **VARIABLE TABLE — the tolerant wire** (the FILE FORM, form byte `1`,
+  §3). Maps, lists, pointers, per-field guards, default elision, and a
+  record that DESCRIBES ITSELF every time: ids, kinds and lengths ride
+  with the values, so any reader reads any data and the differences are
+  reported, never fatal. It pays framing bytes and, in one narrow case, an
+  allocation, and it is the wire for anything LARGE, SPARSE or FREE-FORM —
+  everything the other two refuse to carry.
+
+**The variable table is the ESCAPE HATCH THAT LETS THE OTHER TWO BE
+STRICT.** A fixed table refuses what would make it variable; a type
+refuses to version; and neither refusal strands anyone, because —
+*"if you are ever constrained by type or fixed table, table (variable
+table) is there for you."*
+
+**The MESSAGE FORM (form byte `2`, §3.3) is the fixed table on the wire
+between peers**: a BATCH of fixed tables under ONE ANNOUNCED BLOCK, each
+body packed through the type's own codec.
+
+**How to choose.**
+
+- **One build on both ends, and speed above all** — `type`. No versioning,
+  no hash, no vocabulary; the protocol id refuses anything else.
+- **Small, dense, every field bounded, and it must cross builds** —
+  `fixed table`. A constant-size body and a skew-independent cost, versioned
+  by appending and deprecating in place.
+- **Large, sparse, free-form, or you cannot bound it** — `table`. Pay the
+  framing and keep every reader.
+
 ## The performance ladder
 
 **Tables are LESS performant than types**, and that is the trade they exist

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -48,10 +48,13 @@ different tables now, the type, the fixed table, the variable table"* —
   the answer: *"if somebody really cares about this, they use a type
   instead (no versioning)."*
 - **FIXED TABLE — the type's speed, in table form** (the FIXED FORM, form
-  byte `3`, §3.4). *"Fixed tables are meant to be the fast equivalent of
-  types, in table form."* A record is an EIGHT-BYTE HASH of the writer's
-  VOCABULARY BLOCK and then the VALUES IN DECLARED ORDER, EVERY FIELD AT
-  ITS BOUND — the type's own layout, with the block sent once beside it.
+  byte `3`, §3.4 — lands with the fixed-form batch). *"Fixed tables are
+  meant to be the fast equivalent of types, in table form."* A record is an
+  EIGHT-BYTE HASH of the writer's LAYOUT and then the VALUES IN DECLARED
+  ORDER, EVERY FIELD AT ITS BOUND — the type's own field order, with THE
+  LAYOUT sent once beside it. (The fixed form's once-per-file description
+  is THE LAYOUT; form `1`'s VOCABULARY BLOCK is a different thing and keeps
+  its name.)
   The class is DECLARED, `fixed table` (§2.2), and the compiler REFUSES in
   its by-value closure anything that would make a body variable size,
   naming the field and the table (§11): a pointer, a byte buffer at its
@@ -64,13 +67,16 @@ different tables now, the type, the fixed table, the variable table"* —
   versioning is load-bearing: **we must not ever break versioning in fixed
   tables.** Writing at the bound is why it is for SMALL THINGS —
   *"effectively, fixed tables should only be used for small things."*
-- **VARIABLE TABLE — the tolerant wire** (the FILE FORM, form byte `1`,
+- **VARIABLE TABLE — the tolerant wire** (the VARIABLE FORM, form byte `1`,
   §3). Maps, lists, pointers, per-field guards, default elision, and a
   record that DESCRIBES ITSELF every time: ids, kinds and lengths ride
   with the values, so any reader reads any data and the differences are
   reported, never fatal. It pays framing bytes and, in one narrow case, an
   allocation, and it is the wire for anything LARGE, SPARSE or FREE-FORM —
   everything the other two refuse to carry.
+
+**THE FIRST BYTE OF EVERY SCHEMA FILE IS THE FORM BYTE**, and the registry is
+three: `1` the VARIABLE FORM, `2` the MESSAGE FORM, `3` the FIXED FORM.
 
 **ONE FORM BYTE PER CLASS.** Form `3` is the FIXED table's wire and form `1`
 is the VARIABLE table's, and neither reads for the other. Form `1` does not
@@ -92,8 +98,14 @@ between peers**: a BATCH of fixed tables under ONE ANNOUNCED BLOCK, each
 body packed through the type's own codec. It is a fixed table's and nobody
 else's — a message-form request naming a plain `table` is REFUSED naming the
 table (§2.2, §11), because a message is a bitpacked body under one announced
-vocabulary and the shape has to be one the declaration fixes. The FILE form
-is every table's, and is where a variable root goes.
+vocabulary and the shape has to be one the declaration fixes.
+
+**NEITHER CLASS BORROWS THE OTHER'S FORM.** A declared `fixed table` encodes
+as form `3`, ALWAYS; a plain `table` encodes as form `1`, always; and a reader
+emitted for one REFUSES the other BY NAME. A form-`1` file handed to a fixed
+root is `previous_form` — a NAMED REFUSAL, never a slow read down the variable
+wire — exactly as a form-`3` file handed to a variable root is refused by name.
+A variable root is form `1`'s, and that is where it goes.
 
 **How to choose.**
 


### PR DESCRIPTION
Doc-only. Adds `## The three wires` to `docs/SPEC-TABLES.md` as its own subsection immediately after the document's introduction and before `## The performance ladder` — where the spec introduces tables, ahead of any wire detail. No other section is touched and no line is removed.

Content is Glenn's framing, in the spec's own voice, with his words quoted and attributed in the spec's existing "in the owner's words" style.

## The three, and the form byte each rides

**The first byte of every schema file is the FORM BYTE**, and the registry is three: `1` the VARIABLE form, `2` the MESSAGE form, `3` the FIXED form. The full first-byte rule stays the rename card's; the overview says it in one sentence.

- **TYPE** (SPEC.md) — fastest wire, bitpacked, knows only itself, not versioned: one build's private layout under the protocol id, same-or-refuse.
- **FIXED TABLE** — **the FIXED FORM, form byte `3`** (§3.4, which lands with the fixed-form batch): an eight-byte hash of the writer's **LAYOUT**, then the values in declared order, every field at its bound. The class is DECLARED, `fixed table` (§2.2), and the compiler refuses in its by-value closure a pointer, a byte buffer at its used size, a map, an unbounded array, a guarded (`if`) branch, or a nested plain `table`, naming the field and the table (§11). One constant-size body per type, one read path and one write path whose cost does not depend on version skew; versioned by append-only evolution with deprecation in place, and that versioning is load-bearing — *"we must not ever break versioning in fixed tables."* For small things.
- **VARIABLE TABLE** — **the VARIABLE FORM, form byte `1`** (§3): maps, lists, pointers, guards, default elision, self-describing on every record. For anything large, sparse or free-form.

## One form byte per class, and neither class borrows the other's

Form `3` is the fixed table's wire and form `1` is the variable table's, and neither reads for the other. **Form `1` does not move** — it is what §3 describes, it is what every variable table writes, and it is what an old file on a disk is. The **form-`1` machinery a FIXED table currently carries** — the emitted reader and writer a fixed-size table has on the variable wire, from the days when both classes rode form `1` — is **scheduled for removal once form `3` lands**, so a fixed table ends with one wire and one pair of paths and not two of each.

The overview states the encoding rule outright: a declared `fixed table` encodes as form `3` **always**, a plain `table` as form `1` **always**, and a reader emitted for one **refuses the other by name**. A form-`1` file handed to a fixed root is **`previous_form`** — a named refusal, never a slow read down the variable wire — exactly as a form-`3` file handed to a variable root is refused by name.

## The rest of the subsection

Then the escape-hatch sentence — *"if you are ever constrained by type or fixed table, table (variable table) is there for you"* — the message form (form byte `2`, §3.3) as **a fixed table's and nobody else's**, with a message-form request naming a plain `table` refused naming the table (§2.2, §11); and a three-line "how to choose".

## Johnny's read, and the four fixes (8b9b394f)

The overview got an independent read. Four things, all inside this subsection — the body sections belong to the rename card on another branch and stay untouched:

1. **form `1` was still called the FILE FORM.** Glenn: form byte `1` is **THE VARIABLE FORM**. Renamed in the VARIABLE TABLE bullet; no other use of the old name survives in the overview.
2. **"The FILE form is every table's" contradicted "neither reads for the other"** two paragraphs above it, and contradicted Glenn's rule that a form-`1` file of a declared `fixed table` is a named refusal and never a slow read. Replaced with the always/always/refuses-by-name paragraph above, naming `previous_form`.
3. **VOCABULARY BLOCK was the wrong word** for the fixed form's once-per-file description. The word is **THE LAYOUT**, said once, with the disambiguation beside it: form `1`'s vocabulary block is a different thing and keeps its name.
4. **§3.4 is not on main yet.** The citation stays and now carries **"lands with the fixed-form batch"**, so a reader of main is not sent to a section that is not there.

## Sequencing

The overview's claims about the fixed table describe work in flight on two sibling branches — `fixed-table-keyword` (the language section, draft #823) and `fixed-table-form` (the new form's wire section, §3.4). This PR is a draft and should land **with** them, not before. The §3.4 citation now says so in the spec itself.

**One point to settle with §3.4 before they merge.** §3.4 as written on `fixed-table-form` says *"THE FIXED FORM DOES NOT REPLACE FORM `1` FOR A FIXED TABLE. A generated reader for a fixed-table type accepts BOTH, by the form byte … Nothing about form `1` moves, for fixed tables or for anything else."* This overview now records the opposite decision twice over — the fixed-only form-`1` machinery **goes** once form `3` lands, and a form-`1` file handed to a fixed root is **`previous_form`**, a named refusal. Those are two different plans for the same code, and the spec should carry one of them, not both. Glenn's ruling is the one this overview carries.

## Gates

Doc-only change on top of the merge of `origin/main` (#822, #821). `make check` green. The repo has no docs lint and CI has no docs job — the spec pages are prose, referenced from code comments and the Makefile but parsed by nothing — so the gates of record are the ones the merge already carried: `go build`, `go vet`, `go test ./...` and golangci-lint v2.12.2 (`0 issues`), plus `make generated-current` with `SCHEMA_SKIP_LEGS=cs,dart,elixir,java,js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
