### PR TITLE
schema lock: fixed tables evolve append-only, and the compiler holds the line

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -6,6 +6,7 @@
 //	schema projection [dir|files...]                 print the wire shape the id hashes
 //	schema build-version [--facts] [dir|files...]    print the build version, or the cook projection it hashes
 //	schema tables-baseline [--update --reason "..."]  print or move the tables baseline
+//	schema lock       [--print] [dir|files...]       write the fixed tables' append-only lock
 //	schema fmt        [dir|files...]                 canonicalize schema files in place — the ONLY command that writes one
 //	schema pack       --root T --out F <dir>         a directory tree becomes one table's wire bytes
 //	schema unpack     --root T --in  F <dir>         the wire bytes become the tree again
@@ -68,6 +69,7 @@ func main() {
 		fs.BoolVar(&verbose, "verbose", false, "report the package and protocol id on success")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
 		c.TablesBaseline = true
+		c.SchemaLock = true
 		paths, err := compiler.GatherPaths(fs.Args())
 		if err != nil {
 			fail(err)
@@ -154,6 +156,45 @@ func main() {
 				fmt.Printf("%s is already current\n", path)
 			}
 		}
+	case "lock":
+		// THE SCHEMA LOCK (docs/SPEC-TABLES.md §2.10). Fixed tables evolve
+		// APPEND-ONLY, and this is the file that holds the compiler to it.
+		// WRITING IS THE DEFAULT here, where `tables-baseline` prints by
+		// default, because the two commands do different things: moving a
+		// baseline DECLARES a break and wants a reason, while writing a lock
+		// declares nothing — every write this command accepts is an append,
+		// and it refuses to write anything else.
+		//
+		// It does NOT run the lock check on load: this is the tool for
+		// extending a lock, and the extension is exactly what the check would
+		// be looking at.
+		fs := flag.NewFlagSet("lock", flag.ExitOnError)
+		print := fs.Bool("print", false, "print the lock this unit would write, and write nothing")
+		fs.BoolVar(&verbose, "verbose", false, "name the file written")
+		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		paths, err := compiler.GatherPaths(fs.Args())
+		if err != nil {
+			fail(err)
+		}
+		u, err := c.Load(paths)
+		if err != nil {
+			fail(err)
+		}
+		if *print {
+			fmt.Print(compiler.SchemaLockText(u))
+			break
+		}
+		path, rewrote, err := compiler.UpdateSchemaLock(u, paths)
+		if err != nil {
+			fail(err)
+		}
+		if verbose {
+			if rewrote {
+				fmt.Printf("wrote %s\n", path)
+			} else {
+				fmt.Printf("%s is already current\n", path)
+			}
+		}
 	case "fmt":
 		// THE ONE WRITER (SPEC §7.4). Every other command reads the unit and
 		// leaves it alone, so canonicalizing a tree is this command's job and
@@ -188,6 +229,7 @@ func main() {
 		fs.BoolVar(&verbose, "verbose", false, "list the files emitted")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
 		c.TablesBaseline = true
+		c.SchemaLock = true
 		unit := loadUnit(c, fs.Args())
 		files, err := c.Generate(unit, *lang, compiler.Options{})
 		if err != nil {
@@ -593,6 +635,7 @@ func usage() {
   schema projection [dir|files...]
   schema build-version [--facts] [dir|files...]
   schema tables-baseline [--update --reason "..."] [--verbose] [dir|files...]
+  schema lock       [--print] [--verbose] [dir|files...]
   schema fmt        [--verbose] [dir|files...]
   schema pack       --root <Table> --out <file> [--message [--announce <file>] [--batch <Table>=<dir>]...] [--tolerate] [--verbose] <tree-dir> [dir|files...]
   schema unpack     --root <Table> --in  <file> [--announce <file>] [--one-file] [--tolerate] [--verbose] <tree-dir> [dir|files...]

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -166,8 +166,9 @@ func main() {
 		// and it refuses to write anything else.
 		//
 		// It does NOT run the lock check on load: this is the tool for
-		// extending a lock, and the extension is exactly what the check would
-		// be looking at.
+		// extending a lock, and the extension is exactly what the check
+		// refuses — a lock the declaration has moved past is stale, and this
+		// is the command that makes it current.
 		fs := flag.NewFlagSet("lock", flag.ExitOnError)
 		print := fs.Bool("print", false, "print the lock this unit would write, and write nothing")
 		fs.BoolVar(&verbose, "verbose", false, "name the file written")

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/baseline"
 	"github.com/mas-bandwidth/schema/v2/internal/check"
 	"github.com/mas-bandwidth/schema/v2/internal/format"
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
 	"github.com/mas-bandwidth/schema/v2/internal/parser"
 	"github.com/mas-bandwidth/schema/v2/internal/version"
 	"github.com/mas-bandwidth/schema/v2/ir"
@@ -58,6 +59,16 @@ type Compiler struct {
 	// changed field kind. No file means no check. The CLI sets it for `check`
 	// and `generate`.
 	TablesBaseline bool
+
+	// SchemaLock turns on the SCHEMA LOCK check (docs/SPEC-TABLES.md §2.10):
+	// when a schema.lock sits in the unit's directory, Load compares every
+	// FIXED table's field sequence against the locked one and REFUSES
+	// anything but an append — a reorder, a removal, a changed kind or width,
+	// an un-deprecation, an insert before the end. A fixed table is a plain C
+	// record with no ids in it, so every one of those is read as garbage with
+	// no counter to fire. No file means no check. The CLI sets it for `check`
+	// and `generate`.
+	SchemaLock bool
 
 	// OnWarn, when set, receives each non-fatal report a load produced — the
 	// baseline's warn class (a shrunk bound, a removed enum variant or union
@@ -153,6 +164,11 @@ func (c *Compiler) Load(paths []string) (*ir.Unit, error) {
 		}
 		if len(berrs) > 0 {
 			return nil, Diagnostics(berrs)
+		}
+	}
+	if c.SchemaLock {
+		if lerrs := lockfile.Check(u, paths); len(lerrs) > 0 {
+			return nil, Diagnostics(lerrs)
 		}
 	}
 	return u, nil

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -62,12 +62,15 @@ type Compiler struct {
 
 	// SchemaLock turns on the SCHEMA LOCK check (docs/SPEC-TABLES.md §2.10):
 	// when a schema.lock sits in the unit's directory, Load compares every
-	// FIXED table's field sequence against the locked one and REFUSES
-	// anything but an append — a reorder, a removal, a changed kind or width,
-	// an un-deprecation, an insert before the end. A fixed table is a plain C
-	// record with no ids in it, so every one of those is read as garbage with
-	// no counter to fire. No file means no check. The CLI sets it for `check`
-	// and `generate`.
+	// FIXED table's field sequence against the locked one and REFUSES ANY
+	// DIFFERENCE. A break — a reorder, a removal, a changed kind or width, an
+	// un-deprecation, an insert before the end — is refused because a fixed
+	// table is a plain C record with no ids in it, so every one of those is
+	// read as garbage with no counter to fire. An APPEND, a new fixed table
+	// or a deprecation the file has not caught up to is refused too, and says
+	// to run `schema lock`: the committed file is the record of the layout,
+	// and a record only records what it is current with. No file means no
+	// check. The CLI sets it for `check` and `generate`.
 	SchemaLock bool
 
 	// OnWarn, when set, receives each non-fatal report a load produced — the

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -10,10 +10,13 @@ import (
 const SchemaLockFileName = lockfile.FileName
 
 // SchemaLockText renders the unit's SCHEMA LOCK (docs/SPEC-TABLES.md §2.10):
-// every FIXED table's field sequence in declared order, each entry carrying
-// the field's wire id, kind, width in the record and `deprecated` marker,
-// plus the hash of the sequence. One fact per line, stable and diffable,
-// exactly as the committed file holds it.
+// every FIXED table's field sequence in declared order — each entry carrying
+// the field's wire id, kind, width in the record, default declared or
+// implicit, declared range and resolution, `?` and `deprecated` marker — then
+// a block for every type those tables REACH: a nested `type` as a record of
+// its own, and an `enum`, a `flags` mask or a `union` as its value list in
+// declared order. Each block carries the hash of its lines. One fact per line,
+// stable and diffable, exactly as the committed file holds it.
 func SchemaLockText(u *ir.Unit) string {
 	return lockfile.Render(u).Text()
 }

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -21,7 +21,9 @@ func SchemaLockText(u *ir.Unit) string {
 // UpdateSchemaLock writes the unit's committed lock — the schema.lock beside
 // its schema files. It is the only writer of that file, and it only ever
 // appends entries, adds tables and flips `deprecated` on: it runs the check's
-// own comparison first and refuses to write a lock the check would refuse.
+// own comparison first and refuses every break the check refuses. The one
+// thing it accepts and the check does not is a declaration the lock has not
+// caught up to — writing that down is what this command is for.
 //
 // It is idempotent — when the lock is already current the file is untouched
 // and rewrote is false.

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -1,0 +1,33 @@
+package compiler
+
+import (
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// SchemaLockFileName is the lock's name in a unit directory
+// (docs/SPEC-TABLES.md §2.10).
+const SchemaLockFileName = lockfile.FileName
+
+// SchemaLockText renders the unit's SCHEMA LOCK (docs/SPEC-TABLES.md §2.10):
+// every FIXED table's field sequence in declared order, each entry carrying
+// the field's wire id, kind, width in the record and `deprecated` marker,
+// plus the hash of the sequence. One fact per line, stable and diffable,
+// exactly as the committed file holds it.
+func SchemaLockText(u *ir.Unit) string {
+	return lockfile.Render(u).Text()
+}
+
+// UpdateSchemaLock writes the unit's committed lock — the schema.lock beside
+// its schema files. It is the only writer of that file, and it only ever
+// appends entries, adds tables and flips `deprecated` on: it runs the check's
+// own comparison first and refuses to write a lock the check would refuse.
+//
+// It is idempotent — when the lock is already current the file is untouched
+// and rewrote is false.
+//
+// paths are the unit's *.schema files, as [GatherPaths] returns them; the
+// lock lives in their directory.
+func UpdateSchemaLock(u *ir.Unit, paths []string) (path string, rewrote bool, err error) {
+	return lockfile.Update(u, paths)
+}

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -12,11 +12,13 @@ const SchemaLockFileName = lockfile.FileName
 // SchemaLockText renders the unit's SCHEMA LOCK (docs/SPEC-TABLES.md §2.10):
 // every FIXED table's field sequence in declared order — each entry carrying
 // the field's wire id, kind, width in the record, default declared or
-// implicit, declared range and resolution, `?` and `deprecated` marker — then
-// a block for every type those tables REACH: a nested `type` as a record of
-// its own, and an `enum`, a `flags` mask or a `union` as its value list in
-// declared order. Each block carries the hash of its lines. One fact per line,
-// stable and diffable, exactly as the committed file holds it.
+// implicit, declared range and resolution, `?` and `deprecated` marker, the
+// nested type a kind-13/15 slot holds, and an array's element kind and width
+// — then a block for every type those tables REACH: a nested `type` as a
+// record of its own, and an `enum`, a `flags` mask or a `union` as its value
+// list in declared order, a union arm carrying its payload type. Each block
+// carries the hash of its lines. One fact per line, stable and diffable,
+// exactly as the committed file holds it.
 func SchemaLockText(u *ir.Unit) string {
 	return lockfile.Render(u).Text()
 }

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -13,7 +13,7 @@ const SchemaLockFileName = lockfile.FileName
 // every FIXED table's field sequence in declared order — each entry carrying
 // the field's wire id, kind, width in the record, default declared or
 // implicit, declared range and resolution, `?` and `deprecated` marker, the
-// nested type a kind-13/15 slot holds, and an array's element kind and width
+// named type a slot holds, and an array's element kind and width
 // — then a block for every type those tables REACH: a nested `type` as a
 // record of its own, and an `enum`, a `flags` mask or a `union` as its value
 // list in declared order, a union arm carrying its payload type. Each block

--- a/compiler/lock.go
+++ b/compiler/lock.go
@@ -13,7 +13,8 @@ const SchemaLockFileName = lockfile.FileName
 // every FIXED table's field sequence in declared order — each entry carrying
 // the field's wire id, kind, width in the record, default declared or
 // implicit, declared range and resolution, `?` and `deprecated` marker, the
-// named type a slot holds, and an array's element kind and width
+// named type a slot holds, an array's element kind and width, and the enum
+// an enum-keyed array is keyed by
 // — then a block for every type those tables REACH: a nested `type` as a
 // record of its own, and an `enum`, a `flags` mask or a `union` as its value
 // list in declared order, a union arm carrying its payload type. Each block

--- a/compiler/lockdeprecated_test.go
+++ b/compiler/lockdeprecated_test.go
@@ -1,0 +1,145 @@
+// THE `deprecated` MARKER'S GENERATED HALF (docs/SPEC-TABLES.md §2.10): the
+// slot stays. A fixed table's record is walked by offset, so deprecation has
+// to be a statement about MEANING and nothing else — and the way to prove that
+// without assuming any particular wire is to generate the SAME schema twice,
+// once with the marker and once without, and require the two outputs to differ
+// in one place only: the reflection descriptors' tags column, which is where a
+// tag is supposed to land (§8.1).
+package compiler
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+const deprecatedLive = `package depdemo
+
+table ShipConfig
+{
+    name  string(16)
+    armor uint8
+    hull  uint8
+}
+`
+
+const deprecatedMarked = `package depdemo
+
+table ShipConfig
+{
+    name  string(16)
+    armor uint8 | deprecated
+    hull  uint8
+}
+`
+
+// TestDeprecatedFieldKeepsItsSlot is the claim, measured: every generated file
+// is byte-identical but for the tags column, so the storage, the offsets, the
+// writer and the reader all still carry the field.
+func TestDeprecatedFieldKeepsItsSlot(t *testing.T) {
+	for _, lang := range []string{"cpp", "c", "go", "cs"} {
+		t.Run(lang, func(t *testing.T) {
+			live := generateSource(t, deprecatedLive, lang)
+			marked := generateSource(t, deprecatedMarked, lang)
+			if len(live) != len(marked) {
+				t.Fatalf("deprecation changed the file set: %d then %d files", len(live), len(marked))
+			}
+			for name, want := range live {
+				got, ok := marked[name]
+				if !ok {
+					t.Errorf("%s is gone from the marked output", name)
+					continue
+				}
+				for _, line := range diffLines(string(want), string(got)) {
+					if reflectionOnly(line) {
+						continue
+					}
+					t.Errorf("%s: deprecation moved something other than the tags column:\n%s", name, line)
+				}
+			}
+		})
+	}
+}
+
+// TestDeprecatedFieldStillWritesItsSlotInCpp is the same claim stated the way
+// a reader of the generated C++ would check it by hand: the member is
+// declared, it is initialized to its default, its offset assertion is
+// unchanged, and the save path still puts it.
+func TestDeprecatedFieldStillWritesItsSlotInCpp(t *testing.T) {
+	files := generateSource(t, deprecatedMarked, "cpp")
+	// unitFromSource names the unit's one file Probe.schema, and the emitted
+	// files are named after it (SPEC §7.1)
+	table := string(files["ProbeTable.h"])
+	if table == "" {
+		for name := range files {
+			t.Logf("generated %s", name)
+		}
+		t.Fatal("the table header is generated")
+	}
+	for _, want := range []string{
+		"uint8_t armor = 0;",                  // the slot, at its default
+		"value.armor = 0;",                    // and reset to it
+		"offsetof( ShipConfig, armor ) == 24", // and it has not moved
+		"static const char * const ShipConfig_armor_tags[] = { \"deprecated\" };", // and the marker reaches reflection
+	} {
+		if !strings.Contains(table, want) {
+			t.Errorf("a deprecated field keeps its slot: want %q", want)
+		}
+	}
+	if !strings.Contains(table, "value.armor") {
+		t.Error("the writer still reaches the slot")
+	}
+}
+
+// generateSource compiles a source string and emits one target.
+func generateSource(t *testing.T, src, lang string) map[string][]byte {
+	t.Helper()
+	u := unitFromSource(t, src)
+	files, err := New().Generate(u, lang, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+// reflectionOnly reports a line that belongs to the REFLECTION SURFACE and
+// nowhere else: the tag array a marker generates, or a descriptor row, which
+// every backend spells with a doc column beside its tags column (§8.1). No
+// storage declaration, offset assertion, writer or reader line carries either
+// marker, so a difference this lets through cannot be one that moved a byte.
+func reflectionOnly(line string) bool {
+	if strings.TrimSpace(strings.TrimLeft(line, "+-")) == "" {
+		return true
+	}
+	for _, marker := range []string{"TableDocNone", "TableDoc", "Tags", "tags", "deprecated"} {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// diffLines is the symmetric difference of two files' lines, counted with
+// multiplicity: the lines one has and the other does not. A positional diff
+// would cascade off a single inserted line, and the comparison here is
+// expected to come back all but empty, so a multiset is enough and pulls in no
+// diff algorithm.
+func diffLines(a, b string) []string {
+	count := map[string]int{}
+	for l := range strings.SplitSeq(a, "\n") {
+		count[l]++
+	}
+	for l := range strings.SplitSeq(b, "\n") {
+		count[l]--
+	}
+	var out []string
+	for l, n := range count {
+		if n > 0 {
+			out = append(out, "-"+l)
+		} else if n < 0 {
+			out = append(out, "+"+l)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -2970,6 +2970,207 @@ the framing and not the clamp, and the clamp is the `report` row above. Red if
 either writer's bytes differ from the pin, if either read is not silent, or if
 the two loaded values are not equal field for field.
 
+### 2.10 Evolution of fixed tables: append-only, and the lock
+
+A VARIABLE-LENGTH table rides the id-table wire, where evolution is wire
+tolerance (§4): fields may be added, removed and reordered, and the reader
+finds each one by its id. **A FIXED-SIZE table has none of that.** It is a
+plain C record (§6.1) — no ids, no terminators, no names, walked by offset —
+so the field ORDER and the field WIDTHS *are* the contract. A reordered field,
+a removed one, a widened one: every one of those is read as garbage by a
+reader holding an older record, silently, with no counter to fire and nothing
+in the bytes that could have said so.
+
+So a fixed table gets a discipline instead of a wire, and the owner ruled it:
+
+> "append only, and deprecation possibly. might keep it light weight?"
+> — Glenn Fiedler, project owner
+
+**Network Next ran this rule by hand for years** — a `uint8` version at the
+front of the struct, bumped on every change, new fields appended at the bottom,
+and hand-written upgrade paths kept alive for a limited time:
+
+> "manual stuff, and it is a footgun, but it worked."
+> — Glenn Fiedler, project owner
+
+It worked because the discipline is right. It was a footgun because nothing
+enforced it. **The rule below is that discipline with the footgun taken away:
+the compiler owns a lock file, and the check is the hand nobody has to
+remember to use.** On the mechanism itself: *"OK that sounds cool, go ahead."*
+
+**THE RULE. A fixed table evolves APPEND-ONLY.** A new field goes at the
+BOTTOM and nowhere else. A field that has outlived its use is DEPRECATED IN
+PLACE — it keeps its slot forever. Nothing is reordered, nothing is removed,
+nothing is widened, and nothing that has been deprecated comes back.
+
+#### The `deprecated` marker
+
+```
+fixed table ShipConfig
+{
+    name     string(32)
+    speed    float32
+    armor    uint8 | deprecated   // retired in place: the slot stays
+    shields  uint8                // its replacement, appended at the bottom
+}
+```
+
+`deprecated` is a TAG — a valueless qualifier in the open half of the
+qualification section (SPEC §4.2) — because there is nothing for it to take a
+value of, and it costs the grammar nothing. What it means:
+
+- **THE SLOT STAYS EXACTLY WHERE IT IS.** The record is walked by offset;
+  removing the field would slide every field after it. Deprecation is a
+  statement about MEANING, never about layout, and it moves not one byte.
+- **The writer emits the field's default.** Nothing writes a retired field, so
+  what goes into the slot is what a fresh record holds there — its specified
+  default, or zero (SPEC §5).
+- **The reader ignores it.** The slot is read like any other and the value in
+  it means nothing; a consumer that still reads it is reading what the last
+  writer that cared left behind.
+- **NEW USES ARE REFUSED**, and "new use" is deliberately small: a deprecated
+  field may not be named by a **guard** — an `if` condition is the one
+  construct in this language that reads another field's value, and branching
+  on a retired field decides the shape of a body by accident — and it may not
+  be a **key**, which the language already gives for free: a map key takes no
+  qualification at all (§2.8), so a key can never carry the marker. Everything
+  else about the field is left alone. The marker is documentation with two
+  teeth, not an access-control system.
+- **It is ONE-WAY.** A field that has been deprecated is not un-deprecated:
+  the readers were told to ignore the slot and the writers that have run since
+  left it at its default, so what would come back is not data.
+
+A `deprecated` field's id, kind and width are unchanged, and it still rides
+the id-table wire when its table is read there — deprecation is not removal in
+any form.
+
+#### Renaming is not a change
+
+`was = "old_name"` (§5) keeps a field's identity through a rename: the wire id
+stays the hash of the old name. **A rename under `was` is therefore not a
+change to a fixed table at all** — the lock records the wire name, so the file
+does not move.
+
+#### Compaction is a new table
+
+There is no mechanism for reclaiming the slots a run of deprecated fields
+holds, and there is not going to be one: **compaction is a NEW fixed table
+under a NEW name**, with the fields that are still live, and the old table
+stays exactly as it is for as long as anything holds a record written under
+it.
+
+#### The lock
+
+`schema.lock` sits beside the unit's schema files and is **written by the
+compiler only**. For every fixed table it records the field sequence IN
+DECLARED ORDER — one entry per field carrying the field's wire id, its kind,
+its WIDTH in the record and its `deprecated` marker — and the hash of that
+sequence:
+
+```
+schema-lock 1
+package fleet
+
+fixed table ShipConfig layout=0x0a301f6d45fa0b3b
+    field name id=0xc4bcadba8e631b86 kind=12 width=40
+    field speed id=0x2281498aa0200e40 kind=10 width=4
+    field armor id=0xd19988b67e699194 kind=6 width=1 deprecated
+    field shields id=0x798c587767067199 kind=6 width=1
+```
+
+The width is the field's WHOLE storage in the record — an array's elements
+together, a `string(N)`'s buffer and its length companion, an optional's value
+and its presence bool — the same measurement the block form's layout contract
+takes (§19.3), because that is the fact a reader standing at an offset is
+standing on.
+
+**The layout hash is derived and written down anyway.** It and the entries
+above it are one statement made twice, so a lock whose halves disagree has
+been edited by a hand rather than written by the compiler, and that is the
+only way this file can be caught lying.
+
+**THE CHECK runs on every compile — `schema check` and `schema generate`.**
+For every fixed table the lock carries, THE LOCKED SEQUENCE MUST BE A PREFIX
+OF THE LIVE ONE, entry for entry, with `deprecated` allowed only to turn ON.
+Anything else is a refusal naming the table and the FIRST differing entry —
+the first one is the one a person can fix, and a list of every consequence of
+a single reorder teaches nothing the first line did not:
+
+- a **reorder** or an **insert before the end**: *"fixed table ShipConfig:
+  entry 2, field speed (id=0x…), is field armor (id=0x…) in the declaration —
+  a fixed table evolves APPEND-ONLY: a field is added at the BOTTOM, never
+  inserted, moved or removed, because the record has no ids in it and a reader
+  at this offset would read one field as the other (docs/SPEC-TABLES.md
+  §2.10)"*
+  A removal from the middle lands here too, and rightly: the entry the lock
+  names now holds the field that followed it, which is exactly what a reader
+  at that offset would find.
+- a **removal from the end**: *"… is in the lock and gone from the declaration
+  — a fixed table evolves APPEND-ONLY: a field is deprecated in place, never
+  removed, because the record has no ids in it and every field after a removed
+  one slides (docs/SPEC-TABLES.md §2.10); restore it and mark it
+  `| deprecated`"*
+- a **changed width**, checked before the kind because it is the fact that
+  slides every field after it: *"… is 1 bytes wide in the lock and 4 in the
+  declaration — a field already in the lock keeps its width: a fixed record is
+  walked by offset, so widening one field moves every field after it
+  (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
+- a **changed kind** at the same width — `float32` read as `int32` moves no
+  byte and still lies: *"… is kind 10 in the lock and kind 4 in the
+  declaration — a field already in the lock keeps its type: every record
+  already written holds the old one, and nothing on the wire says which
+  (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
+- an **un-deprecation**: *"… is deprecated in the lock and live in the
+  declaration — deprecation is ONE-WAY: readers were told to ignore this slot
+  and the writers that have run since left it at its default, so what comes
+  back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead"*
+- a **table that is no longer a fixed table of this unit**: *"fixed table
+  ShipConfig is in the lock and this unit no longer declares it as a fixed
+  table — a fixed table's layout is a promise to every record already written,
+  and a promise is not withdrawn; compaction is a NEW table under a NEW name
+  (docs/SPEC-TABLES.md §2.10)"*
+- a **hand-edited lock**: *"fixed table ShipConfig: the lock records
+  layout=0x… over entries that hash to 0x… — the lock is written by the
+  compiler and a hand-edit does not hold; regenerate it with `schema lock` and
+  make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)"*
+
+**NO FILE MEANS NO CHECK.** A unit that has never been locked promises
+nothing, and a table the lock does not carry is new and passes: locking is
+what `schema lock` is for.
+
+#### `schema lock`
+
+```
+schema lock [--print] [--verbose] [dir|files...]
+```
+
+`schema lock` rewrites the file, and **it is the only thing that writes it**.
+It only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
+the check's own comparison first and **refuses to write a lock the check would
+refuse**, so the one command that moves the file cannot be the one that breaks
+the rule. It is idempotent — a lock that is already current is left untouched
+— and `--print` writes nothing at all.
+
+There is no `--reason` here and no history section, and the difference from the
+tables baseline (§18.4) is the point: moving a BASELINE declares an intentional
+break with data already written, so it wants a sentence a person reads years
+later. Writing a LOCK declares nothing — every write it accepts is an append,
+and an append breaks nothing.
+
+#### Held by test
+
+`internal/lockfile` holds the mechanism over a fixture package: an appended
+field passes the check and `schema lock` appends the entry; a reorder, a
+removal, a widening, an insert in the middle and an un-deprecation are each
+refused with the entry named; a `deprecated` marker is allowed, the lock flips
+the flag, the generated code still writes the slot, and a guard on the field is
+refused; a new table adds an entry; a `was =` rename moves no line; and a lock
+whose entries have been hand-edited away from its layout hash is refused.
+`internal/lockfile`'s corpus test regenerates every committed `schema.lock` in
+the tree and compares byte for byte, and compiles each of those units with the
+check on.
+
+
 ## 3. The wire
 
 **The wire is neutral.** It carries none of schema's packing opinions, no

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3084,7 +3084,11 @@ entry per field carrying
   flags or union's values hash). Kind 13 (nested record), kind 15 (union),
   kind 7 (enum) and kind 9 (flags) all carry it;
 - an **array**'s element kind and width, as `elem=4/4`, and `held=` beside it
-  when the element is a named type;
+  when the element is a named type — a kind-16 ENUM-KEYED array carries both
+  the same way;
+- which enum a **keyed array** is **keyed by**, as `key=Hull@0x…` — the enum's
+  wire name and its values hash. The key's variants ARE the slots, in declared
+  order, so the list is what says which slot a stored value was written into;
 
 and the hash of that sequence. Then, because a fixed record is MADE OF the
 types its fields name, it records **every type those tables reach** in a block
@@ -3112,7 +3116,7 @@ fixed table ShipConfig
 ```
 
 ```
-schema-lock 4
+schema-lock 5
 package fleet
 
 fixed table ShipConfig layout=0x7047bca71a5890be
@@ -3329,8 +3333,8 @@ at all.
 A lock written under an OLDER RENDERING VERSION is the one file this command
 will not repair. The version is the compiler's own, the file holds nothing a
 hand could carry forward, and unlike a baseline there is no history to salvage
-— so the refusal says the remedy that works: *"this lock is rendering version 3
-and this compiler writes version 4 — the rendering version is the compiler's
+— so the refusal says the remedy that works: *"this lock is rendering version 4
+and this compiler writes version 5 — the rendering version is the compiler's
 own and this file holds nothing a hand can carry forward: delete it and write
 it again with `schema lock`"*.
 
@@ -3359,9 +3363,11 @@ integer range, a moved resolution, a moved fixed-point scale at the same width,
 a `?` turned on, a `?` turned off, a kind change inside a nested `type`, a
 nested slot pointed at a different type, an optional nested slot the same way,
 a union arm's payload types swapped with the names kept, an array's element
-type, an enum slot pointed at a different type, a flags slot the same way,
-an array of enums the same way, and a reordered, renamed or removed enum variant, `flags` variant or
-union arm are each refused on the fixed half with the line named; each of them on the
+type, an enum slot pointed at a different type, a flags slot the same way, an
+array of enums the same way, a keyed array pointed at a different key enum, a
+keyed array's element respelled at the same width, and a reordered, renamed or
+removed enum variant, `flags` variant or union arm are each refused on the
+fixed half with the line named; each of them on the
 VARIABLE-LENGTH half passes in silence and moves no byte of the file, because a
 `table` with a pointer in it rides the id-table wire where those edits are what
 the wire is FOR (§4); and `schema lock` refuses every one of them with the same

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3079,9 +3079,10 @@ entry per field carrying
   fixed-point field's `frac`, which is the scale its raw integer is read at;
 - its **`?`**, as the bare token `optional`;
 - its **`deprecated`** marker;
-- which named type a kind-13 (nested record) or kind-15 (union) slot **holds**,
-  as `held=Buff@0x…` — the type's wire name and that type's layout hash (a
-  union's values hash);
+- which named type a slot **holds**, as `held=Hull@0x…` — the type's wire
+  name and that type's layout hash (a nested record's layout, an enum or
+  flags or union's values hash). Kind 13 (nested record), kind 15 (union),
+  kind 7 (enum) and kind 9 (flags) all carry it;
 - an **array**'s element kind and width, as `elem=4/4`, and `held=` beside it
   when the element is a named type;
 
@@ -3111,15 +3112,15 @@ fixed table ShipConfig
 ```
 
 ```
-schema-lock 3
+schema-lock 4
 package fleet
 
-fixed table ShipConfig layout=0xafdf97760f546da4
+fixed table ShipConfig layout=0x7047bca71a5890be
     field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
     field speed id=0x2281498aa0200e40 kind=10 width=4 default=0.0 min=0.0 max=100.0 res=0.01
     field armor id=0xd19988b67e699194 kind=6 width=1 default=0 deprecated
     field shields id=0x798c587767067199 kind=6 width=1 default=3
-    field hull id=0x80da8ccc11daadf6 kind=7 width=1 default=variant:Gunship
+    field hull id=0x80da8ccc11daadf6 kind=7 width=1 default=variant:Gunship held=Hull@0xc3cc3881c580dd9d
     field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero held=GunnerSettings@0xdd5ef1d77231ba48 optional
 
 type GunnerSettings layout=0xdd5ef1d77231ba48
@@ -3328,8 +3329,8 @@ at all.
 A lock written under an OLDER RENDERING VERSION is the one file this command
 will not repair. The version is the compiler's own, the file holds nothing a
 hand could carry forward, and unlike a baseline there is no history to salvage
-— so the refusal says the remedy that works: *"this lock is rendering version 2
-and this compiler writes version 3 — the rendering version is the compiler's
+— so the refusal says the remedy that works: *"this lock is rendering version 3
+and this compiler writes version 4 — the rendering version is the compiler's
 own and this file holds nothing a hand can carry forward: delete it and write
 it again with `schema lock`"*.
 
@@ -3358,7 +3359,8 @@ integer range, a moved resolution, a moved fixed-point scale at the same width,
 a `?` turned on, a `?` turned off, a kind change inside a nested `type`, a
 nested slot pointed at a different type, an optional nested slot the same way,
 a union arm's payload types swapped with the names kept, an array's element
-type, and a reordered, renamed or removed enum variant, `flags` variant or
+type, an enum slot pointed at a different type, a flags slot the same way,
+an array of enums the same way, and a reordered, renamed or removed enum variant, `flags` variant or
 union arm are each refused on the fixed half with the line named; each of them on the
 VARIABLE-LENGTH half passes in silence and moves no byte of the file, because a
 `table` with a pointer in it rides the id-table wire where those edits are what

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3090,8 +3090,9 @@ been edited by a hand rather than written by the compiler, and that is the
 only way this file can be caught lying.
 
 **THE CHECK runs on every compile — `schema check` and `schema generate`.**
-For every fixed table the lock carries, THE LOCKED SEQUENCE MUST BE A PREFIX
-OF THE LIVE ONE, entry for entry, with `deprecated` allowed only to turn ON.
+THE LOCK IN THE TREE IS THE LIVE SEQUENCE, entry for entry, table for table.
+The APPEND-ONLY rule says what a fixed table may BECOME; the check says the
+committed file must BE what the unit declares today.
 Anything else is a refusal naming the table and the FIRST differing entry —
 the first one is the one a person can fix, and a list of every consequence of
 a single reorder teaches nothing the first line did not:
@@ -3133,10 +3134,30 @@ a single reorder teaches nothing the first line did not:
   layout=0x… over entries that hash to 0x… — the lock is written by the
   compiler and a hand-edit does not hold; regenerate it with `schema lock` and
   make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)"*
+- a **STALE LOCK** — an appended field, a new fixed table, a `deprecated`
+  marker the file has not caught up to: *"fixed table ShipConfig: entry 4,
+  field shields (id=0x…), is in the declaration and not in the lock — the lock
+  is the committed record of a fixed table's layout, and this declaration has
+  moved past it: an append, a new table and a deprecation are the changes the
+  rule allows, and a change the rule allows is still a change the record must
+  carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`"*
+  The clause naming the difference is the only part that varies — a
+  deprecation reads *"… is deprecated in the declaration and live in the
+  lock"*, and a new table with no fields yet has no entry to name, so it reads
+  *"fixed table Marker is in the declaration and not in the lock — …"*.
 
 **NO FILE MEANS NO CHECK.** A unit that has never been locked promises
-nothing, and a table the lock does not carry is new and passes: locking is
-what `schema lock` is for.
+nothing, and `schema lock` is what makes the promise.
+
+**A UNIT THAT HAS ONE IS HELD TO IT EXACTLY.** The APPEND-ONLY rule says what
+a fixed table may become; it does not say the file may lag behind what the
+table already is. A lock the declaration has moved past — an appended field, a
+new fixed table, a `deprecated` marker not yet written down — is STALE, and a
+stale lock is refused with the sentence above, which names the table, the
+first entry the lock lacks, and the one command that fixes it. So the file in
+the tree is always the record of the layout the unit compiles today, and every
+append lands in the same commit as the schema change that made it: a change to
+a fixed table is never in the tree without the record of it.
 
 #### `schema lock`
 
@@ -3146,10 +3167,14 @@ schema lock [--print] [--verbose] [dir|files...]
 
 `schema lock` rewrites the file, and **it is the only thing that writes it**.
 It only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
-the check's own comparison first and **refuses to write a lock the check would
-refuse**, so the one command that moves the file cannot be the one that breaks
-the rule. It is idempotent — a lock that is already current is left untouched
-— and `--print` writes nothing at all.
+the check's own comparison first and **refuses everything the check refuses**
+— a reorder, a removal, a widening, a kind change, an un-deprecation, a table
+withdrawn, a hand-edited file — so the one command that moves the file cannot
+be the one that breaks the rule. The ONE difference between the two readings
+is the one this command exists for: where the check refuses a declaration the
+lock has not caught up to, this command writes it down. It is idempotent — a
+lock that is already current is left untouched — and `--print` writes nothing
+at all.
 
 There is no `--reason` here and no history section, and the difference from the
 tables baseline (§18.4) is the point: moving a BASELINE declares an intentional
@@ -3160,12 +3185,15 @@ and an append breaks nothing.
 #### Held by test
 
 `internal/lockfile` holds the mechanism over a fixture package: an appended
-field passes the check and `schema lock` appends the entry; a reorder, a
+field is refused until `schema lock` appends the entry and passes once it has,
+and so are a new table, a new table with no fields, and a `deprecated` marker;
+a reorder, a
 removal, a widening, an insert in the middle and an un-deprecation are each
-refused with the entry named; a `deprecated` marker is allowed, the lock flips
-the flag, the generated code still writes the slot, and a guard on the field is
-refused; a new table adds an entry; a `was =` rename moves no line; and a lock
-whose entries have been hand-edited away from its layout hash is refused.
+refused with the entry named, by the check and by `schema lock` alike; the
+lock flips the `deprecated` flag in place, the generated code still writes the
+slot, and a guard on the field is refused; a `was =` rename moves no line and
+is therefore no change to catch up to; and a lock whose entries have been
+hand-edited away from its layout hash is refused.
 `internal/lockfile`'s corpus test regenerates every committed `schema.lock` in
 the tree and compares byte for byte, and compiles each of those units with the
 check on.

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3079,13 +3079,20 @@ entry per field carrying
   fixed-point field's `frac`, which is the scale its raw integer is read at;
 - its **`?`**, as the bare token `optional`;
 - its **`deprecated`** marker;
+- which named type a kind-13 (nested record) or kind-15 (union) slot **holds**,
+  as `held=Buff@0x…` — the type's wire name and that type's layout hash (a
+  union's values hash);
+- an **array**'s element kind and width, as `elem=4/4`, and `held=` beside it
+  when the element is a named type;
 
 and the hash of that sequence. Then, because a fixed record is MADE OF the
 types its fields name, it records **every type those tables reach** in a block
 of its own: a nested `type` as a record like the tables above it, and an
-`enum`, a `flags` mask or a `union` as its VALUE LIST in declared order. So a
-change one level in — a variant moved, an arm inserted, a nested field
-retyped — is caught where it happens rather than not at all.
+`enum`, a `flags` mask or a `union` as its VALUE LIST in declared order, a
+union arm carrying its **payload type** beside the name (`payload=Buff@0x…`
+when the arm is a nested record). So a change one level in — a variant moved,
+an arm inserted, a nested field retyped, a slot pointed at a different type —
+is caught where it happens rather than not at all.
 
 The `ShipConfig` above, later in its life — a range on `speed`, a default on
 `shields`, an enum, and an optional block — and the whole of what the lock
@@ -3104,16 +3111,16 @@ fixed table ShipConfig
 ```
 
 ```
-schema-lock 2
+schema-lock 3
 package fleet
 
-fixed table ShipConfig layout=0x7415189c4f354006
+fixed table ShipConfig layout=0xafdf97760f546da4
     field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
     field speed id=0x2281498aa0200e40 kind=10 width=4 default=0.0 min=0.0 max=100.0 res=0.01
     field armor id=0xd19988b67e699194 kind=6 width=1 default=0 deprecated
     field shields id=0x798c587767067199 kind=6 width=1 default=3
     field hull id=0x80da8ccc11daadf6 kind=7 width=1 default=variant:Gunship
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero optional
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero held=GunnerSettings@0xdd5ef1d77231ba48 optional
 
 type GunnerSettings layout=0xdd5ef1d77231ba48
     field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
@@ -3192,6 +3199,18 @@ under a new name:
   declaration — a field already in the lock keeps its type: every record
   already written holds the old one, and nothing on the wire says which
   (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
+- a **held type** that moved at the same kind — `boost Buff` becoming
+  `boost Debuff`, or `gunner ?Buff` becoming `gunner ?Debuff`: *"… held Buff
+  in the lock and Debuff in the declaration — a field already in the lock
+  keeps the type it holds: every record already written holds the old one,
+  and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate
+  this field and append a new one"*
+- an **array element** that moved at the same field width — `[4]int32`
+  becoming `[4]float32`: *"… holds int32 elements in the lock and float32
+  elements in the declaration — a field already in the lock keeps its
+  element type: every record already written holds the old one, and nothing
+  on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field
+  and append a new one"*
 - a **moved range, resolution or fixed-point scale**, none of which moves a
   byte and all of which change what the bytes say: *"… is [1, 240] in the lock
   and [1, 480] in the declaration — a field already in the lock keeps its
@@ -3219,7 +3238,13 @@ under a new name:
   read one value as the other (docs/SPEC-TABLES.md §2.10); restore it, and add
   the new one at the END"* — and a **removed** one reads *"… is in the lock and
   gone from the declaration — … every variant keeps its place forever, because
-  a fixed record stores the PLACE and not the name …"*.
+  a fixed record stores the PLACE and not the name …"*. A **union arm whose
+  payload type moved**, names kept — `buff Buff` / `debuff Debuff` becoming
+  `buff Debuff` / `debuff Buff`: *"union Effect: arm 1, buff, held Buff in
+  the lock and Debuff in the declaration — an arm already in the lock keeps
+  the type it holds: every record already written holds the old one, and
+  nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this
+  field and append a new one"*.
 - a **table that is no longer a fixed table of this unit**: *"fixed table
   ShipConfig is in the lock and this unit no longer declares it as a fixed
   table — a fixed table's layout is a promise to every record already written,
@@ -3259,12 +3284,12 @@ entry beside it. A nested record has no bottom of its own; the bottom belongs
 to the table.
 
 **ONE CLASS OF CHANGE IS BEYOND THIS FILE.** A field that keeps its name, its
-id, its kind, its width, its default, its range and its `?` and changes only
-what it MEANS — `timeout` counted in seconds becoming `timeout` counted in
-milliseconds, an index counted from zero becoming one counted from one — moves
-no fact the lock records and no byte a reader could compare, so nothing here
-can refuse it, and the rule for it is the rule for every other break: DEPRECATE
-AND ADD.
+id, its kind, its width, its default, its range, its `?`, the type it holds
+and its element shape, and changes only what it MEANS — `timeout` counted in
+seconds becoming `timeout` counted in milliseconds, an index counted from
+zero becoming one counted from one — moves no fact the lock records and no
+byte a reader could compare, so nothing here can refuse it, and the rule for
+it is the rule for every other break: DEPRECATE AND ADD.
 
 **NO FILE MEANS NO CHECK.** A unit that has never been locked promises
 nothing, and `schema lock` is what makes the promise.
@@ -3288,10 +3313,12 @@ schema lock [--print] [--verbose] [dir|files...]
 `schema lock` rewrites the file, and **it is the only thing that writes it**.
 It only ever APPENDS entries and values, adds blocks and flips `deprecated` on:
 it runs the check's own comparison first and **refuses everything the check
-refuses** — a reorder, a removal, a widening, a kind change, a moved default, a
-moved range, a flipped `?`, a reordered value list, an un-deprecation, a table
-withdrawn, a type gone from the closure, a hand-edited file — so the one
-command that moves the file cannot be the one that breaks the rule. The ONE
+refuses** — a reorder, a removal, a widening, a kind change, a held type that
+moved, an array element that moved, a union arm's payload type that moved, a
+moved default, a moved range, a flipped `?`, a reordered value list, an
+un-deprecation, a table withdrawn, a type gone from the closure, a hand-edited
+file — so the one command that moves the file cannot be the one that breaks
+the rule. The ONE
 difference between the two readings is the one this command exists for: where
 the check refuses a declaration the lock has not caught up to, this command
 writes it down. It is idempotent — a
@@ -3301,8 +3328,8 @@ at all.
 A lock written under an OLDER RENDERING VERSION is the one file this command
 will not repair. The version is the compiler's own, the file holds nothing a
 hand could carry forward, and unlike a baseline there is no history to salvage
-— so the refusal says the remedy that works: *"this lock is rendering version 1
-and this compiler writes version 2 — the rendering version is the compiler's
+— so the refusal says the remedy that works: *"this lock is rendering version 2
+and this compiler writes version 3 — the rendering version is the compiler's
 own and this file holds nothing a hand can carry forward: delete it and write
 it again with `schema lock`"*.
 
@@ -3328,9 +3355,11 @@ Over the second — a FIXED table beside a VARIABLE-LENGTH one carrying the same
 fields, and a closure beside a closure — every fact the file gained is measured
 THREE WAYS: a moved default, a default given to a slot that had none, a widened
 integer range, a moved resolution, a moved fixed-point scale at the same width,
-a `?` turned on, a `?` turned off, a kind change inside a nested `type`, and a
-reordered, renamed or removed enum variant, `flags` variant or union arm are
-each refused on the fixed half with the line named; each of them on the
+a `?` turned on, a `?` turned off, a kind change inside a nested `type`, a
+nested slot pointed at a different type, an optional nested slot the same way,
+a union arm's payload types swapped with the names kept, an array's element
+type, and a reordered, renamed or removed enum variant, `flags` variant or
+union arm are each refused on the fixed half with the line named; each of them on the
 VARIABLE-LENGTH half passes in silence and moves no byte of the file, because a
 `table` with a pointer in it rides the id-table wire where those edits are what
 the wire is FOR (§4); and `schema lock` refuses every one of them with the same

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3040,8 +3040,8 @@ value of, and it costs the grammar nothing. What it means:
   the readers were told to ignore the slot and the writers that have run since
   left it at its default, so what would come back is not data.
 
-A `deprecated` field's id, kind and width are unchanged, and it still rides
-the id-table wire when its table is read there — deprecation is not removal in
+A `deprecated` field's id, kind, width, default and range are unchanged, and
+it still rides the id-table wire when its table is read there — deprecation is not removal in
 any form.
 
 #### Renaming is not a change
@@ -3062,40 +3062,105 @@ it.
 #### The lock
 
 `schema.lock` sits beside the unit's schema files and is **written by the
-compiler only**. For every fixed table it records the field sequence IN
-DECLARED ORDER — one entry per field carrying the field's wire id, its kind,
-its WIDTH in the record and its `deprecated` marker — and the hash of that
-sequence:
+compiler only**. It records **everything a reader of a fixed record stands
+on**, which is more than the order and the widths — and the owner's question is
+where the rest of it came from:
+
+> "Is there anything schema check cannot catch in a fixed table? Can we fix
+> that so it does?"
+> — Glenn Fiedler, project owner
+
+For every fixed table it records the field sequence IN DECLARED ORDER, one
+entry per field carrying
+
+- the field's **wire id**, its **kind**, and its **WIDTH** in the record;
+- its **DEFAULT**, declared or implicit;
+- its declared **RANGE** — `min` and `max`, a compressed float's `res`, and a
+  fixed-point field's `frac`, which is the scale its raw integer is read at;
+- its **`?`**, as the bare token `optional`;
+- its **`deprecated`** marker;
+
+and the hash of that sequence. Then, because a fixed record is MADE OF the
+types its fields name, it records **every type those tables reach** in a block
+of its own: a nested `type` as a record like the tables above it, and an
+`enum`, a `flags` mask or a `union` as its VALUE LIST in declared order. So a
+change one level in — a variant moved, an arm inserted, a nested field
+retyped — is caught where it happens rather than not at all.
+
+The `ShipConfig` above, later in its life — a range on `speed`, a default on
+`shields`, an enum, and an optional block — and the whole of what the lock
+holds for it:
 
 ```
-schema-lock 1
+fixed table ShipConfig
+{
+    name     string(32)
+    speed    float32 | min = 0, max = 100, resolution = 0.01
+    armor    uint8 | deprecated
+    shields  uint8 = 3
+    hull     Hull = Gunship
+    gunner   ?GunnerSettings
+}
+```
+
+```
+schema-lock 2
 package fleet
 
-fixed table ShipConfig layout=0x0a301f6d45fa0b3b
-    field name id=0xc4bcadba8e631b86 kind=12 width=40
-    field speed id=0x2281498aa0200e40 kind=10 width=4
-    field armor id=0xd19988b67e699194 kind=6 width=1 deprecated
-    field shields id=0x798c587767067199 kind=6 width=1
+fixed table ShipConfig layout=0x7415189c4f354006
+    field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
+    field speed id=0x2281498aa0200e40 kind=10 width=4 default=0.0 min=0.0 max=100.0 res=0.01
+    field armor id=0xd19988b67e699194 kind=6 width=1 default=0 deprecated
+    field shields id=0x798c587767067199 kind=6 width=1 default=3
+    field hull id=0x80da8ccc11daadf6 kind=7 width=1 default=variant:Gunship
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero optional
+
+type GunnerSettings layout=0xdd5ef1d77231ba48
+    field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
+    field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false
+
+enum Hull values=0xc3cc3881c580dd9d
+    variant Interceptor
+    variant Gunship
+    variant Freighter
 ```
 
 The width is the field's WHOLE storage in the record — an array's elements
 together, a `string(N)`'s buffer and its length companion, an optional's value
 and its presence bool — the same measurement the block form's layout contract
 takes (§19.3), because that is the fact a reader standing at an offset is
-standing on.
+standing on. An array's default is spelled `born:N`, the COUNT a fresh value
+carries (SPEC §4.6), since an array takes no specified default of its own; a
+nested record's and a union's is `zero`, because their own block is where their
+fresh value is recorded.
 
-**The layout hash is derived and written down anyway.** It and the entries
-above it are one statement made twice, so a lock whose halves disagree has
-been edited by a hand rather than written by the compiler, and that is the
-only way this file can be caught lying.
+**THE DEFAULT IS A WIRE FACT, and every entry carries one.** "No default
+declared" is not the absence of a fact — it is the fact that a fresh record
+holds zero in that slot (SPEC §5). A deprecated slot holds the default, an
+absent field on the id-table wire reads back as it, and a reader handed an
+older writer's record fills the missing field from it. Move it and every one of
+those records means something else.
+
+**A VALUE LIST IS A NUMBERING.** In a fixed record an enum rides as its dense
+ordinal, a `flags` variant is its bit position, and a union's tag is its arm's
+position: the list is the mapping from a stored number to a meaning. It grows
+at the END or it lies — which is the field sequence's own rule, one level in.
+
+**The layout hash is derived and written down anyway**, and so is a value
+list's `values=` hash. Each and the lines above it are one statement made
+twice, so a block whose halves disagree has been edited by a hand rather than
+written by the compiler, and that is the only way this file can be caught
+lying.
 
 **THE CHECK runs on every compile — `schema check` and `schema generate`.**
-THE LOCK IN THE TREE IS THE LIVE SEQUENCE, entry for entry, table for table.
-The APPEND-ONLY rule says what a fixed table may BECOME; the check says the
-committed file must BE what the unit declares today.
-Anything else is a refusal naming the table and the FIRST differing entry —
-the first one is the one a person can fix, and a list of every consequence of
-a single reorder teaches nothing the first line did not:
+THE LOCK IN THE TREE IS THE LIVE SEQUENCE, entry for entry, value for value,
+block for block. The APPEND-ONLY rule says what a fixed table may BECOME; the
+check says the committed file must BE what the unit declares today.
+Anything else is a refusal naming the declaration and the FIRST differing line
+— the first one is the one a person can fix, and a list of every consequence of
+a single reorder teaches nothing the first line did not — and naming the
+remedy, which is always one of three: append, deprecate and add, or a new table
+under a new name:
 
 - a **reorder** or an **insert before the end**: *"fixed table ShipConfig:
   entry 2, field speed (id=0x…), is field armor (id=0x…) in the declaration —
@@ -3111,6 +3176,12 @@ a single reorder teaches nothing the first line did not:
   removed, because the record has no ids in it and every field after a removed
   one slides (docs/SPEC-TABLES.md §2.10); restore it and mark it
   `| deprecated`"*
+- a **flipped `?`**, checked before the width because it is the more exact
+  account of the same move: *"… is plain in the lock and optional in the
+  declaration — a field already in the lock keeps its `?`: an optional carries
+  a presence bool beside its value INSIDE the record, so a reader that expects
+  one where none is written takes the next field's first byte for the answer
+  (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
 - a **changed width**, checked before the kind because it is the fact that
   slides every field after it: *"… is 1 bytes wide in the lock and 4 in the
   declaration — a field already in the lock keeps its width: a fixed record is
@@ -3121,43 +3192,92 @@ a single reorder teaches nothing the first line did not:
   declaration — a field already in the lock keeps its type: every record
   already written holds the old one, and nothing on the wire says which
   (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
+- a **moved range, resolution or fixed-point scale**, none of which moves a
+  byte and all of which change what the bytes say: *"… is [1, 240] in the lock
+  and [1, 480] in the declaration — a field already in the lock keeps its
+  range: the bounds and the resolution are the scale a stored value is read
+  back at, so moving them reads every record already written as a different
+  number (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new
+  one"* — where a compressed float reads *"is [0.0, 100.0] at resolution 0.01
+  in the lock and [0.0, 100.0] at resolution 0.001 in the declaration"* and a
+  fixed-point field reads *"is [-8, 8] at 16 fractional bits in the lock and
+  [-8, 8] at 8 fractional bits in the declaration"*, all in the one sentence.
+- a **moved default**, declared or implicit: *"… defaults to 60 in the lock and
+  90 in the declaration — a field already in the lock keeps its default: an
+  older writer's missing field is filled from this default, and a deprecated
+  slot holds it, so a record written before the change reads differently after
+  it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one"*
 - an **un-deprecation**: *"… is deprecated in the lock and live in the
   declaration — deprecation is ONE-WAY: readers were told to ignore this slot
   and the writers that have run since left it at its default, so what comes
   back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead"*
+- a **reordered, renamed or inserted enum variant, `flags` variant or union
+  arm**: *"enum Hull: variant 1, Interceptor, is Gunship in the declaration —
+  an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: a
+  new variant goes at the END, and one already in the lock is never inserted,
+  moved or renamed, because a fixed record stores the PLACE and a reader would
+  read one value as the other (docs/SPEC-TABLES.md §2.10); restore it, and add
+  the new one at the END"* — and a **removed** one reads *"… is in the lock and
+  gone from the declaration — … every variant keeps its place forever, because
+  a fixed record stores the PLACE and not the name …"*.
 - a **table that is no longer a fixed table of this unit**: *"fixed table
   ShipConfig is in the lock and this unit no longer declares it as a fixed
   table — a fixed table's layout is a promise to every record already written,
   and a promise is not withdrawn; compaction is a NEW table under a NEW name
   (docs/SPEC-TABLES.md §2.10)"*
+- a **type that has left the closure**: *"enum Hull is in the lock and this
+  unit's fixed tables no longer reach it — the lock holds every type a fixed
+  record is made of, so a type leaving the closure is a field that changed what
+  it holds; restore it, or deprecate that field and append a new one
+  (docs/SPEC-TABLES.md §2.10)"*, and a nested record reads *"type
+  GunnerSettings is in the lock and this unit's fixed tables no longer nest it
+  by value — a nested record's fields ARE the holder's bytes, …"*.
 - a **hand-edited lock**: *"fixed table ShipConfig: the lock records
   layout=0x… over entries that hash to 0x… — the lock is written by the
   compiler and a hand-edit does not hold; regenerate it with `schema lock` and
-  make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)"*
-- a **STALE LOCK** — an appended field, a new fixed table, a `deprecated`
-  marker the file has not caught up to: *"fixed table ShipConfig: entry 4,
-  field shields (id=0x…), is in the declaration and not in the lock — the lock
-  is the committed record of a fixed table's layout, and this declaration has
-  moved past it: an append, a new table and a deprecation are the changes the
-  rule allows, and a change the rule allows is still a change the record must
-  carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`"*
+  make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)"*, and
+  a value list reads *"enum Hull: the lock records values=0x… over variants
+  that hash to 0x… — …"*.
+- a **STALE LOCK** — an appended field, an appended variant or arm, a new
+  block, a `deprecated` marker the file has not caught up to: *"fixed table
+  ShipConfig: entry 4, field shields (id=0x…), is in the declaration and not in
+  the lock — the lock is the committed record of what a fixed table's readers
+  stand on, and this declaration has moved past it: an append, a new block and
+  a deprecation are the changes the rule allows, and a change the rule allows
+  is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it
+  with `schema lock`"*
   The clause naming the difference is the only part that varies — a
   deprecation reads *"… is deprecated in the declaration and live in the
-  lock"*, and a new table with no fields yet has no entry to name, so it reads
+  lock"*, and a new block with no line yet has none to name, so it reads
   *"fixed table Marker is in the declaration and not in the lock — …"*.
+
+**AN APPEND INSIDE A NESTED RECORD IS NOT AN APPEND.** A field at the bottom of
+a `type` a fixed table holds BY VALUE grows the holder's slot, which slides
+every field after it — so the compile reports both halves, the holder's width
+first because that is what a reader stands on, and the nested record's own new
+entry beside it. A nested record has no bottom of its own; the bottom belongs
+to the table.
+
+**ONE CLASS OF CHANGE IS BEYOND THIS FILE.** A field that keeps its name, its
+id, its kind, its width, its default, its range and its `?` and changes only
+what it MEANS — `timeout` counted in seconds becoming `timeout` counted in
+milliseconds, an index counted from zero becoming one counted from one — moves
+no fact the lock records and no byte a reader could compare, so nothing here
+can refuse it, and the rule for it is the rule for every other break: DEPRECATE
+AND ADD.
 
 **NO FILE MEANS NO CHECK.** A unit that has never been locked promises
 nothing, and `schema lock` is what makes the promise.
 
 **A UNIT THAT HAS ONE IS HELD TO IT EXACTLY.** The APPEND-ONLY rule says what
 a fixed table may become; it does not say the file may lag behind what the
-table already is. A lock the declaration has moved past — an appended field, a
-new fixed table, a `deprecated` marker not yet written down — is STALE, and a
-stale lock is refused with the sentence above, which names the table, the
-first entry the lock lacks, and the one command that fixes it. So the file in
-the tree is always the record of the layout the unit compiles today, and every
-append lands in the same commit as the schema change that made it: a change to
-a fixed table is never in the tree without the record of it.
+table already is. A lock the declaration has moved past — an appended field, an
+appended variant, a new block, a `deprecated` marker not yet written down — is
+STALE, and a stale lock is refused with the sentence above, which names the
+declaration, the first line the lock lacks, and the one command that fixes it.
+So the file in the tree is always the record of what the unit compiles today,
+and every append lands in the same commit as the schema change that made it: a
+change to a fixed table is never in the tree without the record of it.
 
 #### `schema lock`
 
@@ -3166,15 +3286,25 @@ schema lock [--print] [--verbose] [dir|files...]
 ```
 
 `schema lock` rewrites the file, and **it is the only thing that writes it**.
-It only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
-the check's own comparison first and **refuses everything the check refuses**
-— a reorder, a removal, a widening, a kind change, an un-deprecation, a table
-withdrawn, a hand-edited file — so the one command that moves the file cannot
-be the one that breaks the rule. The ONE difference between the two readings
-is the one this command exists for: where the check refuses a declaration the
-lock has not caught up to, this command writes it down. It is idempotent — a
+It only ever APPENDS entries and values, adds blocks and flips `deprecated` on:
+it runs the check's own comparison first and **refuses everything the check
+refuses** — a reorder, a removal, a widening, a kind change, a moved default, a
+moved range, a flipped `?`, a reordered value list, an un-deprecation, a table
+withdrawn, a type gone from the closure, a hand-edited file — so the one
+command that moves the file cannot be the one that breaks the rule. The ONE
+difference between the two readings is the one this command exists for: where
+the check refuses a declaration the lock has not caught up to, this command
+writes it down. It is idempotent — a
 lock that is already current is left untouched — and `--print` writes nothing
 at all.
+
+A lock written under an OLDER RENDERING VERSION is the one file this command
+will not repair. The version is the compiler's own, the file holds nothing a
+hand could carry forward, and unlike a baseline there is no history to salvage
+— so the refusal says the remedy that works: *"this lock is rendering version 1
+and this compiler writes version 2 — the rendering version is the compiler's
+own and this file holds nothing a hand can carry forward: delete it and write
+it again with `schema lock`"*.
 
 There is no `--reason` here and no history section, and the difference from the
 tables baseline (§18.4) is the point: moving a BASELINE declares an intentional
@@ -3184,16 +3314,35 @@ and an append breaks nothing.
 
 #### Held by test
 
-`internal/lockfile` holds the mechanism over a fixture package: an appended
-field is refused until `schema lock` appends the entry and passes once it has,
-and so are a new table, a new table with no fields, and a `deprecated` marker;
-a reorder, a
+`internal/lockfile` holds the mechanism over two fixture packages. Over the
+first: an appended field is refused until `schema lock` appends the entry and
+passes once it has, and so are a new table, a new table with no fields, and a
+`deprecated` marker; a reorder, a
 removal, a widening, an insert in the middle and an un-deprecation are each
 refused with the entry named, by the check and by `schema lock` alike; the
 lock flips the `deprecated` flag in place, the generated code still writes the
 slot, and a guard on the field is refused; a `was =` rename moves no line and
 is therefore no change to catch up to; and a lock whose entries have been
 hand-edited away from its layout hash is refused.
+Over the second — a FIXED table beside a VARIABLE-LENGTH one carrying the same
+fields, and a closure beside a closure — every fact the file gained is measured
+THREE WAYS: a moved default, a default given to a slot that had none, a widened
+integer range, a moved resolution, a moved fixed-point scale at the same width,
+a `?` turned on, a `?` turned off, a kind change inside a nested `type`, and a
+reordered, renamed or removed enum variant, `flags` variant or union arm are
+each refused on the fixed half with the line named; each of them on the
+VARIABLE-LENGTH half passes in silence and moves no byte of the file, because a
+`table` with a pointer in it rides the id-table wire where those edits are what
+the wire is FOR (§4); and `schema lock` refuses every one of them with the same
+sentence and leaves the file exactly as it sat. A variant at the end of an
+enum, of a `flags` mask and an arm at the end of a union are refused as STALE
+and then written by `schema lock`, with every line before them untouched; a
+field at the bottom of a nested `type` is refused twice, at the holder's width
+and at the nested record's own entry; a type dropped from the closure is
+refused in each of its four spellings; a hand-edited value list is caught by
+its hash; a lock from an older rendering version is refused by both verbs with
+the one remedy that works, and works once it is taken; and the widened file
+round-trips through its own parser.
 `internal/lockfile`'s corpus test regenerates every committed `schema.lock` in
 the tree and compares byte for byte, and compiles each of those units with the
 check on.

--- a/examples-wide/schema.lock
+++ b/examples-wide/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package wide
 
 fixed table Caption layout=0x4532f5365ad7bcb8

--- a/examples-wide/schema.lock
+++ b/examples-wide/schema.lock
@@ -1,11 +1,11 @@
-schema-lock 2
+schema-lock 3
 package wide
 
-fixed table Caption layout=0xdf56a387ba9e9fad
+fixed table Caption layout=0x4532f5365ad7bcb8
     field title id=0xda31296c0c1b6029 kind=33 width=20 default=bytes:
-    field line id=0xbf4ba5ad694f5907 kind=13 width=16 default=zero
-    field lines id=0x5ce3f9a9f1d5001c kind=14 width=52 default=born:0
-    field body id=0xcd4de79bc6c93295 kind=15 width=20 default=zero
+    field line id=0xbf4ba5ad694f5907 kind=13 width=16 default=zero held=Line@0x29e98794ee82dc80
+    field lines id=0x5ce3f9a9f1d5001c kind=14 width=52 default=born:0 held=Line@0x29e98794ee82dc80 elem=13/16
+    field body id=0xcd4de79bc6c93295 kind=15 width=20 default=zero held=Body@0xa032cbdb123eb700
 
 fixed table Stamp layout=0x26f593720238ea03
     field label id=0x39f7fcec8fcb623d kind=33 width=16 default=bytes:
@@ -14,7 +14,7 @@ fixed table Stamp layout=0x26f593720238ea03
 type Line layout=0x29e98794ee82dc80
     field text id=0xfa04f4ef1995407e kind=33 width=16 default=bytes:
 
-union Body values=0x2e6580b5faa71fba
-    arm wide
-    arm narrow
-    arm count
+union Body values=0xa032cbdb123eb700
+    arm wide payload=wstring(4)
+    arm narrow payload=string(4)
+    arm count payload=int32

--- a/examples-wide/schema.lock
+++ b/examples-wide/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package wide
 
 fixed table Caption layout=0x4532f5365ad7bcb8

--- a/examples-wide/schema.lock
+++ b/examples-wide/schema.lock
@@ -1,12 +1,20 @@
-schema-lock 1
+schema-lock 2
 package wide
 
-fixed table Caption layout=0x0b39b261710754bd
-    field title id=0xda31296c0c1b6029 kind=33 width=20
-    field line id=0xbf4ba5ad694f5907 kind=13 width=16
-    field lines id=0x5ce3f9a9f1d5001c kind=14 width=52
-    field body id=0xcd4de79bc6c93295 kind=15 width=20
+fixed table Caption layout=0xdf56a387ba9e9fad
+    field title id=0xda31296c0c1b6029 kind=33 width=20 default=bytes:
+    field line id=0xbf4ba5ad694f5907 kind=13 width=16 default=zero
+    field lines id=0x5ce3f9a9f1d5001c kind=14 width=52 default=born:0
+    field body id=0xcd4de79bc6c93295 kind=15 width=20 default=zero
 
-fixed table Stamp layout=0xd51d26312597dd48
-    field label id=0x39f7fcec8fcb623d kind=33 width=16
-    field seq id=0x823b8a195ce2133c kind=8 width=4
+fixed table Stamp layout=0x26f593720238ea03
+    field label id=0x39f7fcec8fcb623d kind=33 width=16 default=bytes:
+    field seq id=0x823b8a195ce2133c kind=8 width=4 default=0
+
+type Line layout=0x29e98794ee82dc80
+    field text id=0xfa04f4ef1995407e kind=33 width=16 default=bytes:
+
+union Body values=0x2e6580b5faa71fba
+    arm wide
+    arm narrow
+    arm count

--- a/examples-wide/schema.lock
+++ b/examples-wide/schema.lock
@@ -1,0 +1,12 @@
+schema-lock 1
+package wide
+
+fixed table Caption layout=0x0b39b261710754bd
+    field title id=0xda31296c0c1b6029 kind=33 width=20
+    field line id=0xbf4ba5ad694f5907 kind=13 width=16
+    field lines id=0x5ce3f9a9f1d5001c kind=14 width=52
+    field body id=0xcd4de79bc6c93295 kind=15 width=20
+
+fixed table Stamp layout=0xd51d26312597dd48
+    field label id=0x39f7fcec8fcb623d kind=33 width=16
+    field seq id=0x823b8a195ce2133c kind=8 width=4

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -689,6 +689,13 @@ var valuedKeys = map[string]bool{
 // them a given field may carry is resolveAttrs's business.
 var fieldKeys = map[string]bool{"min": true, "max": true, "resolution": true, "was": true, "json": true}
 
+// deprecatedTag is the one TAG the compiler reads (docs/SPEC-TABLES.md
+// §2.10). The valueless namespace is open by design (SPEC §4.2) and this does
+// not close it: a schema may still spell any tag it likes, and this one
+// spelling additionally sets a flag the schema lock and the new-use refusals
+// read.
+const deprecatedTag = "deprecated"
+
 // qualification reads one line's | section (SPEC §4.2). The VALUELESS entries
 // are the line's TAGS, returned in declared order. The VALUED entries are
 // returned for the caller, whose own switch decides what each means. takes
@@ -1261,10 +1268,19 @@ func (c *checker) resolveBody(owner string, body *ast.Block, inTable bool) ([]*i
 				items = append(items, &ir.FieldItem{F: f})
 			case *ast.IfItem:
 				cond := c.lookupScope(scopes, item.Cond.Text)
-				if cond == nil {
+				switch {
+				case cond == nil:
 					c.errf(item.Cond.Pos, "if condition %s must be a bool field declared earlier in the same or an enclosing block (the dominance rule, SPEC §4.5)", item.Cond.Text)
-				} else if cond.Type.Kind != ir.TBool || cond.Array != ir.ArrayNone {
+				case cond.Type.Kind != ir.TBool || cond.Array != ir.ArrayNone:
 					c.errf(item.Cond.Pos, "if condition %s must be a bool field (SPEC §4.6)", item.Cond.Text)
+				case cond.Deprecated:
+					// A NEW USE OF A DEPRECATED FIELD (docs/SPEC-TABLES.md
+					// §2.10). A guard is the one construct in the language
+					// that reads another field's VALUE, and a deprecated
+					// field's value is whatever a writer that no longer knows
+					// about it left there — so a branch taken on one decides
+					// the shape of a body by accident.
+					c.errf(item.Cond.Pos, "if condition %s names a field marked `| deprecated` — a deprecated field is retired in place: its slot stays, nothing new may name it, and a guard is a NEW USE (docs/SPEC-TABLES.md §2.10); guard on a live field, or drop the marker", item.Cond.Text)
 				}
 				// the branch condition, spelled the way the reflection
 				// descriptors spell it: at_rest, !at_rest, active &&
@@ -1898,6 +1914,17 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 	// unknown or repeated key), so nothing below meets a nil value
 	tags, valued := c.qualification("field "+f.Name, "a field", f.Attrs, fieldKeys)
 	out.Tags = tags
+	// THE `deprecated` MARKER (docs/SPEC-TABLES.md §2.10). It is a TAG, not a
+	// valued key — there is nothing for it to take a value of — so it costs
+	// the grammar nothing and reads the way every other valueless qualifier
+	// reads. It stays in Tags as well as here: a tag rides into the
+	// reflection descriptors' tags column (§8.1), and a retired field is
+	// exactly the kind of thing a tool walking those descriptors wants told.
+	for _, t := range tags {
+		if t == deprecatedTag {
+			out.Deprecated = true
+		}
+	}
 	byKey := map[string]*ast.Attr{}
 	for _, a := range valued {
 		byKey[a.Key] = a

--- a/internal/lockfile/corpus_test.go
+++ b/internal/lockfile/corpus_test.go
@@ -1,0 +1,124 @@
+// The committed locks are pinned like any other golden: every corpus unit
+// with fixed tables carries a schema.lock, and regenerating it must reproduce
+// the committed bytes exactly. A drift here means a fixed table's layout moved
+// under an unchanged corpus, which is the defect this file exists to catch.
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+)
+
+// corpora is every unit in the tree that declares a fixed table, from this
+// package's directory. A unit with none carries no lock: there is nothing for
+// the file to promise.
+var corpora = []string{
+	"../../examples-wide",
+	"../../tables/arms",
+	"../../tables/backend",
+	"../../tables/block",
+	"../../tables/blockhome",
+	"../../tables/examples",
+	"../../tables/lists",
+	"../../tables/maps",
+	"../../tables/messages",
+	"../../tables/pointers",
+	"../../tables/scalars",
+	"../../tables/stream",
+	"../../tables/vocab",
+	"../../tables/vocab9",
+	"../../test/table-base64",
+}
+
+// TestCorpusLocksAreCurrent regenerates each committed lock and compares byte
+// for byte — the idempotence `schema lock` promises, measured on the corpus
+// rather than a fixture.
+func TestCorpusLocksAreCurrent(t *testing.T) {
+	for _, dir := range corpora {
+		t.Run(strings.TrimPrefix(dir, "../../"), func(t *testing.T) {
+			path := filepath.Join(dir, lockfile.FileName)
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("this unit declares fixed tables and carries a committed lock: %v", err)
+			}
+			paths, err := compiler.GatherPaths([]string{dir})
+			if err != nil {
+				t.Fatal(err)
+			}
+			u, err := compiler.New().Load(paths)
+			if err != nil {
+				t.Fatalf("the corpus does not compile: %v", err)
+			}
+			if got := lockfile.Render(u).Text(); got != string(want) {
+				t.Errorf("%s is stale — a fixed table's layout moved:\n  ./bin/schema lock %s\n--- committed ---\n%s\n--- current ---\n%s",
+					path, dir, want, got)
+			}
+		})
+	}
+}
+
+// TestCorpusPassesItsOwnLock is the whole feature end to end over real
+// schemas: the driver's lock policy on, the committed file compared, and
+// silence.
+func TestCorpusPassesItsOwnLock(t *testing.T) {
+	for _, dir := range corpora {
+		t.Run(strings.TrimPrefix(dir, "../../"), func(t *testing.T) {
+			paths, err := compiler.GatherPaths([]string{dir})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c := compiler.New()
+			c.SchemaLock = true
+			if _, err := c.Load(paths); err != nil {
+				t.Fatalf("the corpus must pass its own lock: %v", err)
+			}
+		})
+	}
+}
+
+// TestEveryUnitWithFixedTablesIsLocked is the register kept honest: a unit
+// that grows its first fixed table and commits no lock is unguarded against
+// every edit a fixed record cannot report, and nothing else in the tree would
+// say so.
+func TestEveryUnitWithFixedTablesIsLocked(t *testing.T) {
+	locked := map[string]bool{}
+	for _, dir := range corpora {
+		locked[filepath.Clean(dir)] = true
+	}
+	// the units that are one directory each; test/tables holds many
+	// single-file units in one directory and so has no place for a lock
+	// (SPEC §3.2)
+	units := []string{
+		"../../examples", "../../examples128", "../../examples-wide",
+		"../../tables/arms", "../../tables/backend", "../../tables/blobs",
+		"../../tables/block", "../../tables/blockhome", "../../tables/examples",
+		"../../tables/lists", "../../tables/maps", "../../tables/messages",
+		"../../tables/pointers", "../../tables/scalars", "../../tables/stream",
+		"../../tables/vocab", "../../tables/vocab9",
+		"../../test/packet-text", "../../test/packet-void", "../../test/packet-wide",
+		"../../test/table-base64",
+	}
+	for _, dir := range units {
+		paths, err := compiler.GatherPaths([]string{dir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		u, err := compiler.New().Load(paths)
+		if err != nil {
+			t.Fatalf("%s does not compile: %v", dir, err)
+		}
+		fixed := len(lockfile.FixedTables(u)) > 0
+		if fixed && !locked[filepath.Clean(dir)] {
+			t.Errorf("%s declares fixed tables and carries no %s — lock it with `./bin/schema lock %s` and add it to corpora (docs/SPEC-TABLES.md §2.10)",
+				dir, lockfile.FileName, dir)
+		}
+		if !fixed && locked[filepath.Clean(dir)] {
+			t.Errorf("%s carries a %s and declares no fixed table", dir, lockfile.FileName)
+		}
+	}
+}

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -127,7 +127,7 @@ func gone(lk *Table) error {
 // CHANGE BEST: which field is at this offset; then the `?`, which is the exact
 // account of a move the width would report vaguely; then the width, the fact
 // that slides every field after it; then the kind, the held type, the array
-// element, the range and the default — the facts that move no byte and change
+// element, the enum a keyed array is keyed by, the range and the default — the facts that move no byte and change
 // what the bytes say.
 func diffTable(lk, lv *Table, policy Policy) error {
 	for i, want := range lk.Entries {
@@ -160,6 +160,10 @@ func diffTable(lk, lv *Table, policy Policy) error {
 		if want.ElemKind != got.ElemKind || want.ElemWidth != got.ElemWidth {
 			return fmt.Errorf("%s, holds %s elements in the lock and %s elements in the declaration — a field already in the lock keeps its element type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
 				where, elemWord(want.ElemKind, want.ElemWidth), elemWord(got.ElemKind, got.ElemWidth))
+		}
+		if want.KeyName != got.KeyName {
+			return fmt.Errorf("%s, is keyed by %s in the lock and %s in the declaration — a field already in the lock keeps the enum it is keyed by: the key's variants ARE the slots, in declared order, so every record already written put its values in the slots the old list numbered (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, heldName(want.KeyName), heldName(got.KeyName))
 		}
 		if !got.sameRange(want) {
 			return fmt.Errorf("%s, is %s in the lock and %s in the declaration — a field already in the lock keeps its range: the bounds and the resolution are the scale a stored value is read back at, so moving them reads every record already written as a different number (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -1,0 +1,76 @@
+// The CHECK: the locked sequence must be a PREFIX of the live one, entry for
+// entry, with `deprecated` allowed only to turn on (docs/SPEC-TABLES.md
+// §2.10).
+//
+// Every refusal here names the table and the FIRST differing entry, because
+// the first one is the one a person can fix; a list of every consequence of a
+// single reorder teaches nothing the first line did not.
+package lockfile
+
+import (
+	"fmt"
+)
+
+// Diff compares a committed lock against a live rendering. The result is the
+// refusals, in table order and one per table: the first differing entry is
+// the finding, and the entries after it are that finding's consequences.
+//
+// A live table the lock does not carry is NEW and passes: locking a table is
+// what `schema lock` does, and a table nothing has promised anything about
+// promises nothing.
+func Diff(locked, live *Unit) []error {
+	var errs []error
+	for i := range locked.Tables {
+		lk := &locked.Tables[i]
+		// THE SELF-CONSISTENCY CHECK, FIRST. The layout hash and the entries
+		// above it are one statement written twice, so a lock whose halves
+		// disagree has been edited by a hand rather than written by the
+		// compiler — and nothing below it can be trusted to mean what it
+		// says.
+		if got := LayoutHash(lk.Entries); got != lk.Layout {
+			errs = append(errs, fmt.Errorf("fixed table %s: the lock records layout=0x%016x over entries that hash to 0x%016x — the lock is written by the compiler and a hand-edit does not hold; regenerate it with `schema lock` and make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)",
+				lk.Name, lk.Layout, got))
+			continue
+		}
+		lv := live.Table(lk.Name)
+		if lv == nil {
+			errs = append(errs, fmt.Errorf("fixed table %s is in the lock and this unit no longer declares it as a fixed table — a fixed table's layout is a promise to every record already written, and a promise is not withdrawn; compaction is a NEW table under a NEW name (docs/SPEC-TABLES.md §2.10)",
+				lk.Name))
+			continue
+		}
+		if err := diffTable(lk, lv); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// diffTable is the prefix rule over one table, and it stops at the first
+// differing entry.
+func diffTable(lk, lv *Table) error {
+	for i, want := range lk.Entries {
+		where := fmt.Sprintf("fixed table %s: entry %d, field %s (id=0x%016x)", lk.Name, i+1, want.Name, want.Id)
+		if i >= len(lv.Entries) {
+			return fmt.Errorf("%s, is in the lock and gone from the declaration — a fixed table evolves APPEND-ONLY: a field is deprecated in place, never removed, because the record has no ids in it and every field after a removed one slides (docs/SPEC-TABLES.md §2.10); restore it and mark it `| deprecated`",
+				where)
+		}
+		got := lv.Entries[i]
+		if got.Id != want.Id {
+			return fmt.Errorf("%s, is field %s (id=0x%016x) in the declaration — a fixed table evolves APPEND-ONLY: a field is added at the BOTTOM, never inserted, moved or removed, because the record has no ids in it and a reader at this offset would read one field as the other (docs/SPEC-TABLES.md §2.10)",
+				where, got.Name, got.Id)
+		}
+		if got.Width != want.Width {
+			return fmt.Errorf("%s, is %d bytes wide in the lock and %d in the declaration — a field already in the lock keeps its width: a fixed record is walked by offset, so widening one field moves every field after it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, want.Width, got.Width)
+		}
+		if got.Kind != want.Kind {
+			return fmt.Errorf("%s, is kind %d in the lock and kind %d in the declaration — a field already in the lock keeps its type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, want.Kind, got.Kind)
+		}
+		if want.Deprecated && !got.Deprecated {
+			return fmt.Errorf("%s, is deprecated in the lock and live in the declaration — deprecation is ONE-WAY: readers were told to ignore this slot and the writers that have run since left it at its default, so what comes back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead",
+				where)
+		}
+	}
+	return nil
+}

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -1,18 +1,21 @@
-// The CHECK: the lock in the tree IS the live sequence, entry for entry
-// (docs/SPEC-TABLES.md §2.10) — and the one writer's own reading, where the
-// locked sequence must be a PREFIX of the live one, with `deprecated` allowed
-// only to turn on.
+// The CHECK: the lock in the tree IS the live sequence, entry for entry and
+// value for value (docs/SPEC-TABLES.md §2.10) — and the one writer's own
+// reading, where the locked sequence must be a PREFIX of the live one, with
+// `deprecated` allowed only to turn on.
 //
 // The two readings differ in ONE thing: what to make of a declaration that has
-// moved past the lock. `schema lock` must accept that — an append, a new table
-// and a deprecation flip are the changes the rule allows, and accepting them is
-// what makes the file movable. Every compile must refuse it — a lock that
-// trails the declaration is a record of a layout nobody has, and the file in
-// the tree is the record.
+// moved past the lock. `schema lock` must accept that — an append to a table,
+// an append to an enum, a new table, a new type in the closure and a
+// deprecation flip are the changes the rule allows, and accepting them is what
+// makes the file movable. Every compile must refuse it — a lock that trails
+// the declaration is a record of a layout nobody has, and the file in the tree
+// is the record.
 //
-// Every refusal here names the table and the FIRST differing entry, because
-// the first one is the one a person can fix; a list of every consequence of a
-// single reorder teaches nothing the first line did not.
+// Every refusal here names the declaration and the FIRST differing line,
+// because the first one is the one a person can fix; a list of every
+// consequence of a single reorder teaches nothing the first line did not. And
+// every refusal names its remedy, which is always one of three: append,
+// deprecate and add, or a new table under a new name.
 package lockfile
 
 import (
@@ -32,20 +35,20 @@ const (
 
 	// Appendable is `schema lock`'s own reading: the locked sequence must be a
 	// PREFIX of the live one. It is what lets the ONE WRITER move the file —
-	// it accepts an append, a new table and a deprecation flip, and it refuses
+	// it accepts an append, a new block and a deprecation flip, and it refuses
 	// everything the check refuses, so the command that moves the lock cannot
 	// be the one that breaks the rule.
 	Appendable
 )
 
 // Diff compares a committed lock against a live rendering. The result is the
-// refusals, in table order and one per table: the first differing entry is
-// the finding, and the entries after it are that finding's consequences.
+// refusals, in block order and one per block: the first differing line is the
+// finding, and the lines after it are that finding's consequences.
 //
-// Under [Appendable] a live table the lock does not carry is NEW and passes:
-// locking a table is what `schema lock` does, and a table nothing has promised
-// anything about promises nothing. Under [Current] it is a stale lock, like
-// any other drift.
+// Under [Appendable] a live block the lock does not carry is NEW and passes:
+// locking a table, a nested record, an enum, a flags mask or a union is what
+// `schema lock` does, and a declaration nothing has promised anything about
+// promises nothing. Under [Current] it is a stale lock, like any other drift.
 func Diff(locked, live *Unit, policy Policy) []error {
 	var errs []error
 	for i := range locked.Tables {
@@ -56,38 +59,77 @@ func Diff(locked, live *Unit, policy Policy) []error {
 		// compiler — and nothing below it can be trusted to mean what it
 		// says.
 		if got := LayoutHash(lk.Entries); got != lk.Layout {
-			errs = append(errs, fmt.Errorf("fixed table %s: the lock records layout=0x%016x over entries that hash to 0x%016x — the lock is written by the compiler and a hand-edit does not hold; regenerate it with `schema lock` and make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)",
-				lk.Name, lk.Layout, got))
+			errs = append(errs, fmt.Errorf("%s %s: the lock records layout=0x%016x over entries that hash to 0x%016x — the lock is written by the compiler and a hand-edit does not hold; regenerate it with `schema lock` and make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)",
+				lk.Decl, lk.Name, lk.Layout, got))
 			continue
 		}
 		lv := live.Table(lk.Name)
-		if lv == nil {
-			errs = append(errs, fmt.Errorf("fixed table %s is in the lock and this unit no longer declares it as a fixed table — a fixed table's layout is a promise to every record already written, and a promise is not withdrawn; compaction is a NEW table under a NEW name (docs/SPEC-TABLES.md §2.10)",
-				lk.Name))
+		if lv == nil || lv.Decl != lk.Decl {
+			errs = append(errs, gone(lk))
 			continue
 		}
 		if err := diffTable(lk, lv, policy); err != nil {
 			errs = append(errs, err)
 		}
 	}
+	for i := range locked.Values {
+		lk := &locked.Values[i]
+		if got := ValuesHash(lk); got != lk.Hash {
+			errs = append(errs, fmt.Errorf("%s %s: the lock records values=0x%016x over %ss that hash to 0x%016x — the lock is written by the compiler and a hand-edit does not hold; regenerate it with `schema lock` and make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)",
+				lk.Decl, lk.Name, lk.Hash, lk.Child(), got))
+			continue
+		}
+		lv := live.List(lk.Name)
+		if lv == nil || lv.Decl != lk.Decl {
+			errs = append(errs, fmt.Errorf("%s %s is in the lock and this unit's fixed tables no longer reach it — the lock holds every type a fixed record is made of, so a type leaving the closure is a field that changed what it holds; restore it, or deprecate that field and append a new one (docs/SPEC-TABLES.md §2.10)",
+				lk.Decl, lk.Name))
+			continue
+		}
+		if err := diffValues(lk, lv, policy); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	if policy == Current {
-		// a whole table the lock has not caught up to, reported at its first
-		// entry for the same reason every other finding is
+		// a whole block the lock has not caught up to, reported at its first
+		// line for the same reason every other finding is
 		for i := range live.Tables {
 			lv := &live.Tables[i]
-			if locked.Table(lv.Name) == nil {
-				errs = append(errs, stale(lv, 0, "in the declaration and not in the lock"))
+			if lk := locked.Table(lv.Name); lk == nil || lk.Decl != lv.Decl {
+				errs = append(errs, stale(lv.Decl, lv.Name, entryName(lv, 0), "in the declaration and not in the lock"))
+			}
+		}
+		for i := range live.Values {
+			lv := &live.Values[i]
+			if lk := locked.List(lv.Name); lk == nil || lk.Decl != lv.Decl {
+				errs = append(errs, stale(lv.Decl, lv.Name, valueName(lv, 0), "in the declaration and not in the lock"))
 			}
 		}
 	}
 	return errs
 }
 
-// diffTable is the rule over one table, and it stops at the first differing
-// entry.
+// gone is the refusal for a locked block the unit no longer declares. A fixed
+// table's layout is a promise to every record already written; a `type`, an
+// enum, a flags mask or a union leaving the closure is a field that changed
+// what it holds, which is the same promise broken one level in.
+func gone(lk *Table) error {
+	if lk.Decl == DeclFixedTable {
+		return fmt.Errorf("fixed table %s is in the lock and this unit no longer declares it as a fixed table — a fixed table's layout is a promise to every record already written, and a promise is not withdrawn; compaction is a NEW table under a NEW name (docs/SPEC-TABLES.md §2.10)",
+			lk.Name)
+	}
+	return fmt.Errorf("type %s is in the lock and this unit's fixed tables no longer nest it by value — a nested record's fields ARE the holder's bytes, so a type leaving the closure is a field that changed what it holds; restore it, or deprecate that field and append a new one (docs/SPEC-TABLES.md §2.10)",
+		lk.Name)
+}
+
+// diffTable is the rule over one record, and it stops at the first differing
+// entry. THE ORDER THE FACTS ARE COMPARED IN IS THE ORDER THAT NAMES THE
+// CHANGE BEST: which field is at this offset; then the `?`, which is the exact
+// account of a move the width would report vaguely; then the width, the fact
+// that slides every field after it; then the kind, the range and the default —
+// the three that move no byte and change what the bytes say.
 func diffTable(lk, lv *Table, policy Policy) error {
 	for i, want := range lk.Entries {
-		where := fmt.Sprintf("fixed table %s: entry %d, field %s (id=0x%016x)", lk.Name, i+1, want.Name, want.Id)
+		where := fmt.Sprintf("%s %s: entry %d, field %s (id=0x%016x)", lk.Decl, lk.Name, i+1, want.Name, want.Id)
 		if i >= len(lv.Entries) {
 			return fmt.Errorf("%s, is in the lock and gone from the declaration — a fixed table evolves APPEND-ONLY: a field is deprecated in place, never removed, because the record has no ids in it and every field after a removed one slides (docs/SPEC-TABLES.md §2.10); restore it and mark it `| deprecated`",
 				where)
@@ -97,6 +139,10 @@ func diffTable(lk, lv *Table, policy Policy) error {
 			return fmt.Errorf("%s, is field %s (id=0x%016x) in the declaration — a fixed table evolves APPEND-ONLY: a field is added at the BOTTOM, never inserted, moved or removed, because the record has no ids in it and a reader at this offset would read one field as the other (docs/SPEC-TABLES.md §2.10)",
 				where, got.Name, got.Id)
 		}
+		if got.Optional != want.Optional {
+			return fmt.Errorf("%s, is %s in the lock and %s in the declaration — a field already in the lock keeps its `?`: an optional carries a presence bool beside its value INSIDE the record, so a reader that expects one where none is written takes the next field's first byte for the answer (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, optionalText(want.Optional), optionalText(got.Optional))
+		}
 		if got.Width != want.Width {
 			return fmt.Errorf("%s, is %d bytes wide in the lock and %d in the declaration — a field already in the lock keeps its width: a fixed record is walked by offset, so widening one field moves every field after it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
 				where, want.Width, got.Width)
@@ -105,6 +151,14 @@ func diffTable(lk, lv *Table, policy Policy) error {
 			return fmt.Errorf("%s, is kind %d in the lock and kind %d in the declaration — a field already in the lock keeps its type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
 				where, want.Kind, got.Kind)
 		}
+		if !got.sameRange(want) {
+			return fmt.Errorf("%s, is %s in the lock and %s in the declaration — a field already in the lock keeps its range: the bounds and the resolution are the scale a stored value is read back at, so moving them reads every record already written as a different number (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, want.rangeText(), got.rangeText())
+		}
+		if got.Default != want.Default {
+			return fmt.Errorf("%s, defaults to %s in the lock and %s in the declaration — a field already in the lock keeps its default: an older writer's missing field is filled from this default, and a deprecated slot holds it, so a record written before the change reads differently after it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, want.Default, got.Default)
+		}
 		if want.Deprecated && !got.Deprecated {
 			return fmt.Errorf("%s, is deprecated in the lock and live in the declaration — deprecation is ONE-WAY: readers were told to ignore this slot and the writers that have run since left it at its default, so what comes back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead",
 				where)
@@ -112,28 +166,77 @@ func diffTable(lk, lv *Table, policy Policy) error {
 		// the marker turned ON: the change the rule allows, and the check
 		// still wants it written down
 		if policy == Current && !want.Deprecated && got.Deprecated {
-			return stale(lv, i, "deprecated in the declaration and live in the lock")
+			return stale(lv.Decl, lv.Name, entryName(lv, i), "deprecated in the declaration and live in the lock")
 		}
 	}
 	if policy == Current && len(lv.Entries) > len(lk.Entries) {
-		return stale(lv, len(lk.Entries), "in the declaration and not in the lock")
+		return stale(lv.Decl, lv.Name, entryName(lv, len(lk.Entries)), "in the declaration and not in the lock")
 	}
 	return nil
 }
 
+func optionalText(optional bool) string {
+	if optional {
+		return "optional"
+	}
+	return "plain"
+}
+
+// diffValues is the same rule over an enum, a flags mask or a union. THE LIST
+// IS A NUMBERING: in a fixed record an enum rides as its dense ordinal, a
+// flags variant is its bit position, and a union's tag is its arm's position —
+// so a value's PLACE in this list is what a stored number means, and the list
+// grows at the end or it lies.
+func diffValues(lk, lv *ValueList, policy Policy) error {
+	for i, want := range lk.Values {
+		where := fmt.Sprintf("%s %s: %s %d, %s", lk.Decl, lk.Name, lk.Child(), i+1, want)
+		if i >= len(lv.Values) {
+			return fmt.Errorf("%s, is in the lock and gone from the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: every %s keeps its place forever, because a fixed record stores the PLACE and not the name (docs/SPEC-TABLES.md §2.10); restore it, and add the new one at the END",
+				where, lk.Child())
+		}
+		if lv.Values[i] != want {
+			return fmt.Errorf("%s, is %s in the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: a new %s goes at the END, and one already in the lock is never inserted, moved or renamed, because a fixed record stores the PLACE and a reader would read one value as the other (docs/SPEC-TABLES.md §2.10); restore it, and add the new one at the END",
+				where, lv.Values[i], lk.Child())
+		}
+	}
+	if policy == Current && len(lv.Values) > len(lk.Values) {
+		return stale(lv.Decl, lv.Name, valueName(lv, len(lk.Values)), "in the declaration and not in the lock")
+	}
+	return nil
+}
+
+// entryName names a record's i'th entry the way a refusal names it, and "" for
+// a record with no such entry — a table with no fields yet has nothing to name.
+func entryName(lv *Table, i int) string {
+	if i >= len(lv.Entries) {
+		return ""
+	}
+	e := lv.Entries[i]
+	return fmt.Sprintf("entry %d, field %s (id=0x%016x)", i+1, e.Name, e.Id)
+}
+
+// valueName is [entryName] for a value list.
+func valueName(lv *ValueList, i int) string {
+	if i >= len(lv.Values) {
+		return ""
+	}
+	return fmt.Sprintf("%s %d, %s", lv.Child(), i+1, lv.Values[i])
+}
+
 // stale is THE ONE REFUSAL for a lock the declaration has moved past: an
-// append, a new table, a deprecation flip. Each of those is a change the
-// append-only rule ALLOWS, and every one of them still has to be written down,
-// so the sentence is one sentence and the remedy is one command.
+// appended field, an appended variant or arm, a new block, a deprecation flip.
+// Each of those is a change the append-only rule ALLOWS, and every one of them
+// still has to be written down, so the sentence is one sentence and the remedy
+// is one command.
 //
 // what is the clause naming the difference; the rest is why a lock is only
-// ever current, and it does not vary.
-func stale(lv *Table, i int, what string) error {
-	subject := fmt.Sprintf("fixed table %s is", lv.Name)
-	if i < len(lv.Entries) {
-		e := lv.Entries[i]
-		subject = fmt.Sprintf("fixed table %s: entry %d, field %s (id=0x%016x), is", lv.Name, i+1, e.Name, e.Id)
+// ever current, and it does not vary. line is the block-local position, and is
+// empty on a block that has no line to name yet.
+func stale(decl, name, line, what string) error {
+	subject := fmt.Sprintf("%s %s is", decl, name)
+	if line != "" {
+		subject = fmt.Sprintf("%s %s: %s, is", decl, name, line)
 	}
-	return fmt.Errorf("%s %s — the lock is the committed record of a fixed table's layout, and this declaration has moved past it: an append, a new table and a deprecation are the changes the rule allows, and a change the rule allows is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`",
+	return fmt.Errorf("%s %s — the lock is the committed record of what a fixed table's readers stand on, and this declaration has moved past it: an append, a new block and a deprecation are the changes the rule allows, and a change the rule allows is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`",
 		subject, what)
 }

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -1,6 +1,14 @@
-// The CHECK: the locked sequence must be a PREFIX of the live one, entry for
-// entry, with `deprecated` allowed only to turn on (docs/SPEC-TABLES.md
-// §2.10).
+// The CHECK: the lock in the tree IS the live sequence, entry for entry
+// (docs/SPEC-TABLES.md §2.10) — and the one writer's own reading, where the
+// locked sequence must be a PREFIX of the live one, with `deprecated` allowed
+// only to turn on.
+//
+// The two readings differ in ONE thing: what to make of a declaration that has
+// moved past the lock. `schema lock` must accept that — an append, a new table
+// and a deprecation flip are the changes the rule allows, and accepting them is
+// what makes the file movable. Every compile must refuse it — a lock that
+// trails the declaration is a record of a layout nobody has, and the file in
+// the tree is the record.
 //
 // Every refusal here names the table and the FIRST differing entry, because
 // the first one is the one a person can fix; a list of every consequence of a
@@ -11,14 +19,34 @@ import (
 	"fmt"
 )
 
+// A Policy is which of the two readings a comparison takes.
+type Policy int
+
+const (
+	// Current is the CHECK's reading, on every compile (`schema check`,
+	// `schema generate`): the lock must be the live sequence exactly. A
+	// declaration the lock has not caught up to is a refusal that says to run
+	// `schema lock`, because the committed file is the record and a record
+	// only records what it is current with.
+	Current Policy = iota
+
+	// Appendable is `schema lock`'s own reading: the locked sequence must be a
+	// PREFIX of the live one. It is what lets the ONE WRITER move the file —
+	// it accepts an append, a new table and a deprecation flip, and it refuses
+	// everything the check refuses, so the command that moves the lock cannot
+	// be the one that breaks the rule.
+	Appendable
+)
+
 // Diff compares a committed lock against a live rendering. The result is the
 // refusals, in table order and one per table: the first differing entry is
 // the finding, and the entries after it are that finding's consequences.
 //
-// A live table the lock does not carry is NEW and passes: locking a table is
-// what `schema lock` does, and a table nothing has promised anything about
-// promises nothing.
-func Diff(locked, live *Unit) []error {
+// Under [Appendable] a live table the lock does not carry is NEW and passes:
+// locking a table is what `schema lock` does, and a table nothing has promised
+// anything about promises nothing. Under [Current] it is a stale lock, like
+// any other drift.
+func Diff(locked, live *Unit, policy Policy) []error {
 	var errs []error
 	for i := range locked.Tables {
 		lk := &locked.Tables[i]
@@ -38,16 +66,26 @@ func Diff(locked, live *Unit) []error {
 				lk.Name))
 			continue
 		}
-		if err := diffTable(lk, lv); err != nil {
+		if err := diffTable(lk, lv, policy); err != nil {
 			errs = append(errs, err)
+		}
+	}
+	if policy == Current {
+		// a whole table the lock has not caught up to, reported at its first
+		// entry for the same reason every other finding is
+		for i := range live.Tables {
+			lv := &live.Tables[i]
+			if locked.Table(lv.Name) == nil {
+				errs = append(errs, stale(lv, 0, "in the declaration and not in the lock"))
+			}
 		}
 	}
 	return errs
 }
 
-// diffTable is the prefix rule over one table, and it stops at the first
-// differing entry.
-func diffTable(lk, lv *Table) error {
+// diffTable is the rule over one table, and it stops at the first differing
+// entry.
+func diffTable(lk, lv *Table, policy Policy) error {
 	for i, want := range lk.Entries {
 		where := fmt.Sprintf("fixed table %s: entry %d, field %s (id=0x%016x)", lk.Name, i+1, want.Name, want.Id)
 		if i >= len(lv.Entries) {
@@ -71,6 +109,31 @@ func diffTable(lk, lv *Table) error {
 			return fmt.Errorf("%s, is deprecated in the lock and live in the declaration — deprecation is ONE-WAY: readers were told to ignore this slot and the writers that have run since left it at its default, so what comes back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead",
 				where)
 		}
+		// the marker turned ON: the change the rule allows, and the check
+		// still wants it written down
+		if policy == Current && !want.Deprecated && got.Deprecated {
+			return stale(lv, i, "deprecated in the declaration and live in the lock")
+		}
+	}
+	if policy == Current && len(lv.Entries) > len(lk.Entries) {
+		return stale(lv, len(lk.Entries), "in the declaration and not in the lock")
 	}
 	return nil
+}
+
+// stale is THE ONE REFUSAL for a lock the declaration has moved past: an
+// append, a new table, a deprecation flip. Each of those is a change the
+// append-only rule ALLOWS, and every one of them still has to be written down,
+// so the sentence is one sentence and the remedy is one command.
+//
+// what is the clause naming the difference; the rest is why a lock is only
+// ever current, and it does not vary.
+func stale(lv *Table, i int, what string) error {
+	subject := fmt.Sprintf("fixed table %s is", lv.Name)
+	if i < len(lv.Entries) {
+		e := lv.Entries[i]
+		subject = fmt.Sprintf("fixed table %s: entry %d, field %s (id=0x%016x), is", lv.Name, i+1, e.Name, e.Id)
+	}
+	return fmt.Errorf("%s %s — the lock is the committed record of a fixed table's layout, and this declaration has moved past it: an append, a new table and a deprecation are the changes the rule allows, and a change the rule allows is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`",
+		subject, what)
 }

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -20,6 +20,7 @@ package lockfile
 
 import (
 	"fmt"
+	"strings"
 )
 
 // A Policy is which of the two readings a comparison takes.
@@ -125,8 +126,9 @@ func gone(lk *Table) error {
 // entry. THE ORDER THE FACTS ARE COMPARED IN IS THE ORDER THAT NAMES THE
 // CHANGE BEST: which field is at this offset; then the `?`, which is the exact
 // account of a move the width would report vaguely; then the width, the fact
-// that slides every field after it; then the kind, the range and the default —
-// the three that move no byte and change what the bytes say.
+// that slides every field after it; then the kind, the held type, the array
+// element, the range and the default — the facts that move no byte and change
+// what the bytes say.
 func diffTable(lk, lv *Table, policy Policy) error {
 	for i, want := range lk.Entries {
 		where := fmt.Sprintf("%s %s: entry %d, field %s (id=0x%016x)", lk.Decl, lk.Name, i+1, want.Name, want.Id)
@@ -150,6 +152,14 @@ func diffTable(lk, lv *Table, policy Policy) error {
 		if got.Kind != want.Kind {
 			return fmt.Errorf("%s, is kind %d in the lock and kind %d in the declaration — a field already in the lock keeps its type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
 				where, want.Kind, got.Kind)
+		}
+		if want.HeldName != got.HeldName {
+			return fmt.Errorf("%s, held %s in the lock and %s in the declaration — a field already in the lock keeps the type it holds: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, heldName(want.HeldName), heldName(got.HeldName))
+		}
+		if want.ElemKind != got.ElemKind || want.ElemWidth != got.ElemWidth {
+			return fmt.Errorf("%s, holds %s elements in the lock and %s elements in the declaration — a field already in the lock keeps its element type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+				where, elemWord(want.ElemKind, want.ElemWidth), elemWord(got.ElemKind, got.ElemWidth))
 		}
 		if !got.sameRange(want) {
 			return fmt.Errorf("%s, is %s in the lock and %s in the declaration — a field already in the lock keeps its range: the bounds and the resolution are the scale a stored value is read back at, so moving them reads every record already written as a different number (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
@@ -182,6 +192,63 @@ func optionalText(optional bool) string {
 	return "plain"
 }
 
+func heldName(name string) string {
+	if name == "" {
+		return "nothing"
+	}
+	return name
+}
+
+func payloadTypeName(p string) string {
+	name, _, ok := strings.Cut(p, "@")
+	if ok {
+		return name
+	}
+	return p
+}
+
+func elemWord(kind int, width int64) string {
+	if kind == 0 && width == 0 {
+		return "nothing"
+	}
+	if w := kindWord(kind); w != "" {
+		return w
+	}
+	return fmt.Sprintf("kind %d width %d", kind, width)
+}
+
+func kindWord(kind int) string {
+	switch kind {
+	case 1:
+		return "bool"
+	case 2:
+		return "int8"
+	case 3:
+		return "int16"
+	case 4:
+		return "int32"
+	case 5:
+		return "int64"
+	case 6:
+		return "uint8"
+	case 7:
+		return "uint16"
+	case 8:
+		return "uint32"
+	case 9:
+		return "uint64"
+	case 10:
+		return "float32"
+	case 11:
+		return "float64"
+	case 13:
+		return "table"
+	case 15:
+		return "union"
+	}
+	return ""
+}
+
 // diffValues is the same rule over an enum, a flags mask or a union. THE LIST
 // IS A NUMBERING: in a fixed record an enum rides as its dense ordinal, a
 // flags variant is its bit position, and a union's tag is its arm's position —
@@ -197,6 +264,14 @@ func diffValues(lk, lv *ValueList, policy Policy) error {
 		if lv.Values[i] != want {
 			return fmt.Errorf("%s, is %s in the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: a new %s goes at the END, and one already in the lock is never inserted, moved or renamed, because a fixed record stores the PLACE and a reader would read one value as the other (docs/SPEC-TABLES.md §2.10); restore it, and add the new one at the END",
 				where, lv.Values[i], lk.Child())
+		}
+		if lk.Decl == DeclUnion {
+			wantP := payloadTypeName(valuePayload(lk, i))
+			gotP := payloadTypeName(valuePayload(lv, i))
+			if wantP != gotP {
+				return fmt.Errorf("%s, held %s in the lock and %s in the declaration — an arm already in the lock keeps the type it holds: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
+					where, heldName(wantP), heldName(gotP))
+			}
 		}
 	}
 	if policy == Current && len(lv.Values) > len(lk.Values) {

--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -127,8 +127,8 @@ func gone(lk *Table) error {
 // CHANGE BEST: which field is at this offset; then the `?`, which is the exact
 // account of a move the width would report vaguely; then the width, the fact
 // that slides every field after it; then the kind, the held type, the array
-// element, the enum a keyed array is keyed by, the range and the default — the facts that move no byte and change
-// what the bytes say.
+// element, the enum a keyed array is keyed by, the range and the default —
+// the facts that move no byte and change what the bytes say.
 func diffTable(lk, lv *Table, policy Policy) error {
 	for i, want := range lk.Entries {
 		where := fmt.Sprintf("%s %s: entry %d, field %s (id=0x%016x)", lk.Decl, lk.Name, i+1, want.Name, want.Id)

--- a/internal/lockfile/file.go
+++ b/internal/lockfile/file.go
@@ -52,8 +52,8 @@ func Locate(paths []string) (path string, ok bool, err error) {
 	}
 }
 
-// Check compares a checked unit's fixed tables against its committed lock,
-// when it has one. No file means no check: a unit that has never been locked
+// Check compares a checked unit's fixed tables — and every type they reach —
+// against its committed lock, when it has one. No file means no check: a unit that has never been locked
 // promises nothing, and `schema lock` is what makes the promise.
 //
 // A unit that HAS one is held to it exactly ([Current]): a lock the
@@ -96,8 +96,8 @@ func Check(u *ir.Unit, paths []string) []error {
 }
 
 // Update writes the unit's lock. It is the ONLY writer of this file, and it
-// only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
-// the same comparison [Check] runs, under [Appendable] rather than [Current],
+// only ever APPENDS entries and values, adds blocks and flips `deprecated` on:
+// it runs the same comparison [Check] runs, under [Appendable] rather than [Current],
 // and refuses everything the check refuses, so the one command that moves the
 // file cannot be the one that breaks the rule. The one thing it accepts and
 // the check does not is a declaration that has moved past the lock — which is

--- a/internal/lockfile/file.go
+++ b/internal/lockfile/file.go
@@ -1,0 +1,148 @@
+// The FILE side: where the lock lives, when the check runs, and how `schema
+// lock` moves it (docs/SPEC-TABLES.md §2.10).
+package lockfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Locate finds the unit's lock file from the unit's source paths. A unit is
+// one directory (SPEC §3.2), so the answer is normally that directory's
+// schema.lock.
+//
+// Two honest answers besides a path, on the tables baseline's terms (§18.1):
+// when the paths span several directories and NONE of them holds a lock there
+// is nothing to check and ok is false, and when several of them do the unit
+// has no single lock and that is an error rather than a silent pick.
+func Locate(paths []string) (path string, ok bool, err error) {
+	seen := map[string]bool{}
+	var dirs []string
+	for _, p := range paths {
+		d := filepath.Dir(p)
+		if !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	sort.Strings(dirs)
+	if len(dirs) == 1 {
+		return filepath.Join(dirs[0], FileName), true, nil
+	}
+	var found []string
+	for _, d := range dirs {
+		p := filepath.Join(d, FileName)
+		if _, statErr := os.Stat(p); statErr == nil {
+			found = append(found, p)
+		}
+	}
+	switch len(found) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return found[0], true, nil
+	default:
+		return "", false, fmt.Errorf("this unit's files span %d directories and %d of them hold a %s (%s) — a unit has one lock; compile the unit as one directory (SPEC §3.2)",
+			len(dirs), len(found), FileName, strings.Join(found, ", "))
+	}
+}
+
+// Check compares a checked unit's fixed tables against its committed lock,
+// when it has one. No file means no check: a unit that has never been locked
+// promises nothing, and `schema lock` is what makes the promise.
+//
+// Every finding is a refusal — a fixed record has no tolerant class, so there
+// is nothing here for a warning to be.
+func Check(u *ir.Unit, paths []string) []error {
+	path, ok, err := Locate(paths)
+	if err != nil {
+		return []error{err}
+	}
+	if !ok {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return []error{err}
+	}
+	locked, err := Parse(path, data)
+	if err != nil {
+		// EVERY parse refusal names the remedy, in one place, and the remedy
+		// works: `schema lock` writes the file from the unit and needs
+		// nothing out of the old one.
+		return []error{fmt.Errorf("%w — the compiler owns this file; write it with: schema lock (docs/SPEC-TABLES.md §2.10)", err)}
+	}
+	if locked.Package != u.Package {
+		return []error{fmt.Errorf("%s: lock is for package %s, this unit is package %s — the lock belongs to the unit it sits beside", path, locked.Package, u.Package)}
+	}
+	var errs []error
+	for _, e := range Diff(locked, Render(u)) {
+		errs = append(errs, fmt.Errorf("%s: %w", path, e))
+	}
+	return errs
+}
+
+// Update writes the unit's lock. It is the ONLY writer of this file, and it
+// only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
+// [Check]'s own comparison first and refuses to write a lock the check would
+// refuse, so the one command that moves the file cannot be the one that
+// breaks the rule.
+//
+// It is idempotent: when the lock is already current, the file is left
+// exactly as it sits and rewrote is false.
+//
+// There is no `--reason` here and no history section, and the difference from
+// the tables baseline (§18.4) is the point: moving a baseline DECLARES a break
+// with data already written, so it wants a sentence a person reads years
+// later. Writing a lock declares nothing — every write it accepts is an
+// append, and an append breaks nothing.
+func Update(u *ir.Unit, paths []string) (path string, rewrote bool, err error) {
+	dirs := map[string]bool{}
+	var dir string
+	for _, p := range paths {
+		dir = filepath.Dir(p)
+		dirs[dir] = true
+	}
+	if len(dirs) != 1 {
+		return "", false, fmt.Errorf("this unit's files span %d directories — a lock belongs to one unit directory (SPEC §3.2); compile the unit as one directory", len(dirs))
+	}
+	path = filepath.Join(dir, FileName)
+
+	live := Render(u)
+	data, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil:
+		locked, perr := Parse(path, data)
+		if perr != nil {
+			return "", false, fmt.Errorf("%w — repair it by hand or delete it; this command will not write over a lock it cannot read, because it cannot tell an append from a break without one (docs/SPEC-TABLES.md §2.10)", perr)
+		}
+		if locked.Package != u.Package {
+			return "", false, fmt.Errorf("%s: lock is for package %s, this unit is package %s — the lock belongs to the unit it sits beside", path, locked.Package, u.Package)
+		}
+		if errs := Diff(locked, live); len(errs) > 0 {
+			return "", false, fmt.Errorf("%s: %w — `schema lock` appends, and this is not an append; the lock is not a way to make the refusal go away (docs/SPEC-TABLES.md §2.10)", path, errs[0])
+		}
+		if live.Text() == string(data) {
+			return path, false, nil
+		}
+	case os.IsNotExist(readErr):
+		// the first lock over this unit: everything already written under
+		// these tables predates the promise, and nothing here can say
+		// otherwise
+	default:
+		return "", false, readErr
+	}
+
+	if err := os.WriteFile(path, []byte(live.Text()), 0o644); err != nil {
+		return "", false, err
+	}
+	return path, true, nil
+}

--- a/internal/lockfile/file.go
+++ b/internal/lockfile/file.go
@@ -56,6 +56,11 @@ func Locate(paths []string) (path string, ok bool, err error) {
 // when it has one. No file means no check: a unit that has never been locked
 // promises nothing, and `schema lock` is what makes the promise.
 //
+// A unit that HAS one is held to it exactly ([Current]): a lock the
+// declaration has moved past — an append, a new fixed table, a deprecation
+// not written down — is refused like any other drift, because the file in the
+// tree is the record and a record is current or it is nothing.
+//
 // Every finding is a refusal — a fixed record has no tolerant class, so there
 // is nothing here for a warning to be.
 func Check(u *ir.Unit, paths []string) []error {
@@ -84,7 +89,7 @@ func Check(u *ir.Unit, paths []string) []error {
 		return []error{fmt.Errorf("%s: lock is for package %s, this unit is package %s — the lock belongs to the unit it sits beside", path, locked.Package, u.Package)}
 	}
 	var errs []error
-	for _, e := range Diff(locked, Render(u)) {
+	for _, e := range Diff(locked, Render(u), Current) {
 		errs = append(errs, fmt.Errorf("%s: %w", path, e))
 	}
 	return errs
@@ -92,9 +97,11 @@ func Check(u *ir.Unit, paths []string) []error {
 
 // Update writes the unit's lock. It is the ONLY writer of this file, and it
 // only ever APPENDS entries, adds tables and flips `deprecated` on: it runs
-// [Check]'s own comparison first and refuses to write a lock the check would
-// refuse, so the one command that moves the file cannot be the one that
-// breaks the rule.
+// the same comparison [Check] runs, under [Appendable] rather than [Current],
+// and refuses everything the check refuses, so the one command that moves the
+// file cannot be the one that breaks the rule. The one thing it accepts and
+// the check does not is a declaration that has moved past the lock — which is
+// the whole reason this command exists.
 //
 // It is idempotent: when the lock is already current, the file is left
 // exactly as it sits and rewrote is false.
@@ -127,7 +134,7 @@ func Update(u *ir.Unit, paths []string) (path string, rewrote bool, err error) {
 		if locked.Package != u.Package {
 			return "", false, fmt.Errorf("%s: lock is for package %s, this unit is package %s — the lock belongs to the unit it sits beside", path, locked.Package, u.Package)
 		}
-		if errs := Diff(locked, live); len(errs) > 0 {
+		if errs := Diff(locked, live, Appendable); len(errs) > 0 {
 			return "", false, fmt.Errorf("%s: %w — `schema lock` appends, and this is not an append; the lock is not a way to make the refusal go away (docs/SPEC-TABLES.md §2.10)", path, errs[0])
 		}
 		if live.Text() == string(data) {

--- a/internal/lockfile/lockclosure_test.go
+++ b/internal/lockfile/lockclosure_test.go
@@ -5,15 +5,17 @@
 // Order and width were the whole of the old file, and they are not the whole
 // of what a reader stands on. This file is the rest of it — the default, the
 // range, the fixed-point scale, the `?`, which type a nested slot holds, which
-// enum or flags type a slot holds, an array's element, a union arm's payload,
-// and every enum, flags mask, union and nested record a fixed table reaches —
-// and every case is measured three ways:
+// enum or flags type a slot holds, an array's element, the enum a keyed array
+// is keyed by, a union arm's payload, and every enum, flags mask, union and
+// nested record a fixed table reaches — and every case is measured three ways:
 // the edit is REFUSED on the fixed table, the SAME edit on a plain
 // variable-length `table` is not the lock's business, and `schema lock` will
 // not write the break either.
 package lockfile_test
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,6 +67,39 @@ enum Stow
     Liquid
 }
 
+// Bay keys a slot array and Deck is what it is repointed at; Carton and Rack
+// are their twins on Bag's half. No other row edits their variants, so no
+// other row's edit moves the width of the slot array they size — and both
+// halves' pairs sit in Manifest and Invoice, so a repointed key is the ONE
+// thing the swap changes and not a type leaving the closure as well.
+enum Bay
+{
+    Fore
+    Mid
+    Aft
+}
+
+enum Deck
+{
+    Upper
+    Lower
+    Hold
+}
+
+enum Carton
+{
+    Small
+    Medium
+    Large
+}
+
+enum Rack
+{
+    Low
+    High
+    Top
+}
+
 flags Honors { Medal, Star }
 
 flags Tackle { Hook, Line }
@@ -75,6 +110,8 @@ type Manifest
     rank   Rank
     kit    Perks
     medal  Honors
+    bay    Bay
+    deck   Deck
 }
 
 type Invoice
@@ -83,6 +120,8 @@ type Invoice
     stow   Stow
     kit    Rigging
     medal  Tackle
+    carton Carton
+    rack   Rack
 }
 
 type Buff
@@ -130,6 +169,7 @@ table Config
     lanes     [4]int32
     manifest  Manifest
     ranks     [4]Hull
+    slots     [Bay]int32
 }
 
 table Bag
@@ -145,6 +185,7 @@ table Bag
     lanes   [4]int32
     invoice Invoice
     holds   [4]Cargo
+    bins    [Carton]int32
     tail    *Bag
 }
 `
@@ -184,8 +225,8 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 	lk := lockfile.Render(load(t, paths))
 	text := lk.Text()
 
-	if lk.Version != 4 {
-		t.Errorf("the widened rendering is version 4, got %d", lk.Version)
+	if lk.Version != 5 {
+		t.Errorf("the widened rendering is version 5, got %d", lk.Version)
 	}
 	for _, want := range []string{
 		"fixed table Config layout=0x",
@@ -215,6 +256,8 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 		"elem=4/4",                             // kind 14 names its element
 		"held=Hull@",                           // hull, Manifest.kind, ranks
 		"elem=7/1",                             // an array of enums
+		"elem=4/4 key=Bay@",                    // a keyed array's element and its key
+		"enum Bay values=0x",                   // a key is reached like anything else
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("the lock must carry %q:\n%s", want, text)
@@ -222,7 +265,7 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 	}
 	for _, absent := range []string{
 		"Bag", "Ballast", "Trim", "Cargo", "Rigging", "Stowage",
-		"Invoice", "Stow", "Tackle",
+		"Invoice", "Stow", "Tackle", "Carton", "Rack",
 	} {
 		if strings.Contains(text, absent) {
 			t.Errorf("a VARIABLE-LENGTH table and what only it reaches are not in the lock, found %q:\n%s", absent, text)
@@ -404,6 +447,27 @@ var closureBreaks = []struct {
 		want: []string{"fixed table Config", "entry 11, field ranks",
 			"held Hull in the lock and Rank in the declaration",
 			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	// kind 16 is an array too, and its key is a fact of its own: Hull and
+	// Rank have the same number of variants, so the slot is the same width
+	// and every other line of the entry is unmoved.
+	{
+		name:      "an enum-keyed array keyed by a different enum",
+		fixedFrom: "    slots     [Bay]int32\n", fixed: "    slots     [Deck]int32\n",
+		varFrom: "    bins    [Carton]int32\n", varTo: "    bins    [Rack]int32\n",
+		want: []string{"fixed table Config", "entry 12, field slots",
+			"is keyed by Bay in the lock and Deck in the declaration",
+			"keeps the enum it is keyed by",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an enum-keyed array's element respelled at the same width",
+		fixedFrom: "    slots     [Bay]int32\n", fixed: "    slots     [Bay]float32\n",
+		varFrom: "    bins    [Carton]int32\n", varTo: "    bins    [Carton]float32\n",
+		want: []string{"fixed table Config", "entry 12, field slots",
+			"holds int32 elements in the lock and float32 elements in the declaration",
+			"keeps its element type",
 			"deprecate this field and append a new one"},
 	},
 }
@@ -700,7 +764,7 @@ func TestALockFromAnOlderRenderingSaysWhatToDo(t *testing.T) {
 		t.Fatal(err)
 	}
 	refuses(t, lockfile.Check(load(t, paths), paths),
-		"rendering version 1 and this compiler writes version 4",
+		"rendering version 1 and this compiler writes version 5",
 		"delete it and write it again with `schema lock`")
 	_, rewrote, err := lockfile.Update(load(t, paths), paths)
 	if err == nil || rewrote {
@@ -715,6 +779,60 @@ func TestALockFromAnOlderRenderingSaysWhatToDo(t *testing.T) {
 	}
 	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
 		t.Fatalf("the remedy works: rewrote=%v err=%v", rewrote, err)
+	}
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the written lock checks clean: %v", errs)
+	}
+}
+
+// TestALockFromTheRenderingJustBeforeThisOneSaysTheSameThing is the case a
+// person actually meets: not a two-line stub, but a WHOLE well-formed lock
+// this compiler wrote one version ago. The version sits on the first line and
+// is read before any of the body, so a file that parses perfectly still gets
+// the one remedy that works — and `schema lock`, the command that remedy names,
+// must not send the user around a loop by refusing to write it either.
+func TestALockFromTheRenderingJustBeforeThisOneSaysTheSameThing(t *testing.T) {
+	dir, paths := fixture(t, closureBase)
+	path := filepath.Join(dir, lockfile.FileName)
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+		t.Fatalf("lock the unit first: rewrote=%v err=%v", rewrote, err)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := fmt.Sprintf("schema-lock %d\n", lockfile.Version)
+	if !bytes.HasPrefix(current, []byte(head)) {
+		t.Fatalf("the lock opens with %q:\n%s", head, current)
+	}
+	// the same file, one rendering back: every other line still parses
+	previous := append([]byte(fmt.Sprintf("schema-lock %d\n", lockfile.Version-1)), current[len(head):]...)
+	if err := os.WriteFile(path, previous, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refuses(t, lockfile.Check(load(t, paths), paths),
+		fmt.Sprintf("rendering version %d and this compiler writes version %d", lockfile.Version-1, lockfile.Version),
+		"holds nothing a hand can carry forward",
+		"delete it and write it again with `schema lock`")
+	_, rewrote, err := lockfile.Update(load(t, paths), paths)
+	if err == nil || rewrote {
+		t.Fatalf("`schema lock` does not write over a lock it cannot read: rewrote=%v err=%v", rewrote, err)
+	}
+	if !strings.Contains(err.Error(), "delete it and write it again with `schema lock`") {
+		t.Errorf("the one writer names the same remedy: %v", err)
+	}
+	if got, _ := os.ReadFile(path); !bytes.Equal(got, previous) {
+		t.Errorf("a refused lock writes nothing:\n--- was ---\n%s\n--- now ---\n%s", previous, got)
+	}
+	// the remedy works, and it writes THIS rendering back
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+		t.Fatalf("the remedy works: rewrote=%v err=%v", rewrote, err)
+	}
+	if got, _ := os.ReadFile(path); !bytes.Equal(got, current) {
+		t.Errorf("the rewritten lock is this rendering, byte for byte:\n--- want ---\n%s\n--- got ---\n%s", current, got)
 	}
 	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
 		t.Errorf("the written lock checks clean: %v", errs)

--- a/internal/lockfile/lockclosure_test.go
+++ b/internal/lockfile/lockclosure_test.go
@@ -4,9 +4,10 @@
 //
 // Order and width were the whole of the old file, and they are not the whole
 // of what a reader stands on. This file is the rest of it — the default, the
-// range, the fixed-point scale, the `?`, which type a nested slot holds, an
-// array's element, a union arm's payload, and every enum, flags mask, union
-// and nested record a fixed table reaches — and every case is measured three ways:
+// range, the fixed-point scale, the `?`, which type a nested slot holds, which
+// enum or flags type a slot holds, an array's element, a union arm's payload,
+// and every enum, flags mask, union and nested record a fixed table reaches —
+// and every case is measured three ways:
 // the edit is REFUSED on the fixed table, the SAME edit on a plain
 // variable-length `table` is not the lock's business, and `schema lock` will
 // not write the break either.
@@ -49,6 +50,40 @@ enum Cargo
 flags Perks { Shielded, Cloaked }
 
 flags Rigging { Sail, Mast }
+
+enum Rank
+{
+    Scout
+    Wing
+    Leader
+}
+
+enum Stow
+{
+    Dry
+    Frozen
+    Liquid
+}
+
+flags Honors { Medal, Star }
+
+flags Tackle { Hook, Line }
+
+type Manifest
+{
+    kind   Hull
+    rank   Rank
+    kit    Perks
+    medal  Honors
+}
+
+type Invoice
+{
+    kind   Cargo
+    stow   Stow
+    kit    Rigging
+    medal  Tackle
+}
 
 type Buff
 {
@@ -93,6 +128,8 @@ table Config
     gunner    ?Buff
     effect    Effect
     lanes     [4]int32
+    manifest  Manifest
+    ranks     [4]Hull
 }
 
 table Bag
@@ -106,6 +143,8 @@ table Bag
     spare   ?Ballast
     stowage Stowage
     lanes   [4]int32
+    invoice Invoice
+    holds   [4]Cargo
     tail    *Bag
 }
 `
@@ -145,16 +184,19 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 	lk := lockfile.Render(load(t, paths))
 	text := lk.Text()
 
-	if lk.Version != 3 {
-		t.Errorf("the widened rendering is version 3, got %d", lk.Version)
+	if lk.Version != 4 {
+		t.Errorf("the widened rendering is version 4, got %d", lk.Version)
 	}
 	for _, want := range []string{
 		"fixed table Config layout=0x",
 		// the closure, each in its own block
 		"type Buff layout=0x",
 		"type Debuff layout=0x",
+		"type Manifest layout=0x",
 		"enum Hull values=0x",
+		"enum Rank values=0x",
 		"flags Perks values=0x",
+		"flags Honors values=0x",
 		"union Effect values=0x",
 		// the value lists, in declared order — a union arm names its payload
 		"    variant Interceptor\n    variant Gunship\n    variant Freighter\n",
@@ -165,12 +207,14 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 		"field tick_rate id=0x", "default=60 min=1 max=240",
 		"default=0 min=-8 max=8 frac=16",       // the fixed-point scale
 		"default=0.0 min=0.0 max=1.0 res=0.01", // the compressed float
-		"default=variant:Gunship",              // an enum's named default
-		"default=mask:0",                       // a flags field's fresh mask
+		"default=variant:Gunship held=Hull@",   // an enum slot names what it holds
+		"default=mask:0 held=Perks@",           // a flags slot names what it holds
 		"default=zero held=Buff@",              // kind 13 names what it holds
 		"held=Buff@",                           // boost and gunner both
 		" optional",                            // the `?` still sits on gunner
 		"elem=4/4",                             // kind 14 names its element
+		"held=Hull@",                           // hull, Manifest.kind, ranks
+		"elem=7/1",                             // an array of enums
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("the lock must carry %q:\n%s", want, text)
@@ -178,6 +222,7 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 	}
 	for _, absent := range []string{
 		"Bag", "Ballast", "Trim", "Cargo", "Rigging", "Stowage",
+		"Invoice", "Stow", "Tackle",
 	} {
 		if strings.Contains(text, absent) {
 			t.Errorf("a VARIABLE-LENGTH table and what only it reaches are not in the lock, found %q:\n%s", absent, text)
@@ -332,6 +377,33 @@ var closureBreaks = []struct {
 		want: []string{"fixed table Config", "entry 9, field lanes",
 			"holds int32 elements in the lock and float32 elements in the declaration",
 			"keeps its element type",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an enum slot holding a different type",
+		fixedFrom: "    hull      Hull = Gunship\n", fixed: "    hull      Rank = Scout\n",
+		varFrom: "    cargo   Cargo = Ore\n", varTo: "    cargo   Stow = Dry\n",
+		want: []string{"fixed table Config", "entry 4, field hull",
+			"held Hull in the lock and Rank in the declaration",
+			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "a flags slot holding a different type",
+		fixedFrom: "    perks     Perks\n", fixed: "    perks     Honors\n",
+		varFrom: "    rigging Rigging\n", varTo: "    rigging Tackle\n",
+		want: []string{"fixed table Config", "entry 5, field perks",
+			"held Perks in the lock and Honors in the declaration",
+			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an array of enums holding a different type",
+		fixedFrom: "    ranks     [4]Hull\n", fixed: "    ranks     [4]Rank\n",
+		varFrom: "    holds   [4]Cargo\n", varTo: "    holds   [4]Stow\n",
+		want: []string{"fixed table Config", "entry 11, field ranks",
+			"held Hull in the lock and Rank in the declaration",
+			"keeps the type it holds",
 			"deprecate this field and append a new one"},
 	},
 }
@@ -628,7 +700,7 @@ func TestALockFromAnOlderRenderingSaysWhatToDo(t *testing.T) {
 		t.Fatal(err)
 	}
 	refuses(t, lockfile.Check(load(t, paths), paths),
-		"rendering version 1 and this compiler writes version 3",
+		"rendering version 1 and this compiler writes version 4",
 		"delete it and write it again with `schema lock`")
 	_, rewrote, err := lockfile.Update(load(t, paths), paths)
 	if err == nil || rewrote {

--- a/internal/lockfile/lockclosure_test.go
+++ b/internal/lockfile/lockclosure_test.go
@@ -1,0 +1,607 @@
+// THE OWNER'S QUESTION, answered both ways (docs/SPEC-TABLES.md §2.10):
+// "is there anything schema check cannot catch in a fixed table? can we fix
+// that so it does?"
+//
+// Order and width were the whole of the old file, and they are not the whole
+// of what a reader stands on. This file is the rest of it — the default, the
+// range, the fixed-point scale, the `?`, and every enum, flags mask, union and
+// nested record a fixed table reaches — and every case is measured three ways:
+// the edit is REFUSED on the fixed table, the SAME edit on a plain
+// variable-length `table` is not the lock's business, and `schema lock` will
+// not write the break either.
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+)
+
+// closureBase is the fixture, and it is built in TWO HALVES that mirror each
+// other field for field.
+//
+// `Config` is FIXED, and everything it reaches — Buff, Debuff, Hull, Perks,
+// Effect — is in the lock with it. `Bag` holds a `*Bag`, which makes it
+// VARIABLE-LENGTH (§2.2), and everything only IT reaches — Ballast, Trim,
+// Cargo, Rigging, Freight — is in no lock at all. So every edit below can be
+// made twice, once on each half, and the difference in what the compiler says
+// is the whole of what this file measures.
+const closureBase = `package closuredemo
+
+enum Hull
+{
+    Interceptor
+    Gunship
+    Freighter
+}
+
+enum Cargo
+{
+    Ore
+    Ice
+    Fuel
+}
+
+flags Perks { Shielded, Cloaked }
+
+flags Rigging { Sail, Mast }
+
+type Buff
+{
+    multiplier float32 = 1.0
+}
+
+type Debuff
+{
+    amount int32 = 0 | min = 0, max = 100
+}
+
+type Ballast
+{
+    weight float32 = 1.0
+}
+
+type Trim
+{
+    amount int32 = 0 | min = 0, max = 100
+}
+
+union Effect
+{
+    buff   Buff
+    debuff Debuff
+}
+
+union Stowage
+{
+    ballast Ballast
+    trim    Trim
+}
+
+table Config
+{
+    tick_rate int32 = 60 | min = 1, max = 240
+    scale     fixed(16, 16) | min = -8, max = 8
+    reaction  float32 | min = 0, max = 1, resolution = 0.01
+    hull      Hull = Gunship
+    perks     Perks
+    boost     Buff
+    gunner    ?Buff
+    effect    Effect
+}
+
+table Bag
+{
+    rate    int32 = 60 | min = 1, max = 240
+    pitch   fixed(16, 16) | min = -8, max = 8
+    lag     float32 | min = 0, max = 1, resolution = 0.01
+    cargo   Cargo = Ore
+    rigging Rigging
+    keel    Ballast
+    spare   ?Ballast
+    stowage Stowage
+    tail    *Bag
+}
+`
+
+// lockedFrom writes before, locks it, rewrites the schema to after, and
+// returns the refusals the check produces over the committed lock.
+func lockedFrom(t *testing.T, before, after string) (dir string, paths []string, errs []error) {
+	t.Helper()
+	dir, paths = fixture(t, before)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatalf("locking the fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(after), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, paths, lockfile.Check(load(t, paths), paths)
+}
+
+// edit is one substitution into closureBase, and it must land.
+func edit(t *testing.T, src, from, to string) string {
+	t.Helper()
+	out := strings.Replace(src, from, to, 1)
+	if out == src {
+		t.Fatalf("the fixture does not carry %q", from)
+	}
+	return out
+}
+
+// ---- what the lock holds now ----
+
+// TestLockHoldsTheWholeClosure is the widened file's shape: the fixed table's
+// entries carry every fact a reader of the record assumes, and every type the
+// record is MADE of has a block of its own — while the variable-length table
+// beside it and everything only it reaches are absent, as they were.
+func TestLockHoldsTheWholeClosure(t *testing.T) {
+	_, paths := fixture(t, closureBase)
+	lk := lockfile.Render(load(t, paths))
+	text := lk.Text()
+
+	if lk.Version != 2 {
+		t.Errorf("the widened rendering is version 2, got %d", lk.Version)
+	}
+	for _, want := range []string{
+		"fixed table Config layout=0x",
+		// the closure, each in its own block
+		"type Buff layout=0x",
+		"type Debuff layout=0x",
+		"enum Hull values=0x",
+		"flags Perks values=0x",
+		"union Effect values=0x",
+		// the value lists, in declared order
+		"    variant Interceptor\n    variant Gunship\n    variant Freighter\n",
+		"    variant Shielded\n    variant Cloaked\n",
+		"    arm buff\n    arm debuff\n",
+		// and the facts on the entries
+		"field tick_rate id=0x", "default=60 min=1 max=240",
+		"default=0 min=-8 max=8 frac=16",       // the fixed-point scale
+		"default=0.0 min=0.0 max=1.0 res=0.01", // the compressed float
+		"default=variant:Gunship",              // an enum's named default
+		"default=mask:0",                       // a flags field's fresh mask
+		"default=zero optional",                // the `?`
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the lock must carry %q:\n%s", want, text)
+		}
+	}
+	for _, absent := range []string{
+		"Bag", "Ballast", "Trim", "Cargo", "Rigging", "Stowage",
+	} {
+		if strings.Contains(text, absent) {
+			t.Errorf("a VARIABLE-LENGTH table and what only it reaches are not in the lock, found %q:\n%s", absent, text)
+		}
+	}
+}
+
+// ---- every new refusal, three ways ----
+
+// closureBreaks is the table of edits the widened lock now catches. Each row
+// is ONE change spelled twice: once on the FIXED half, where it is refused,
+// and once on the VARIABLE-LENGTH half, where it is nobody's business but the
+// id-table wire's.
+var closureBreaks = []struct {
+	name             string
+	fixedFrom, fixed string // the edit on Config's half
+	varFrom, varTo   string // the same edit on Bag's half
+	want             []string
+}{
+	{
+		name:      "a moved default",
+		fixedFrom: "    tick_rate int32 = 60 |", fixed: "    tick_rate int32 = 90 |",
+		varFrom: "    rate    int32 = 60 |", varTo: "    rate    int32 = 90 |",
+		want: []string{"fixed table Config", "entry 1, field tick_rate",
+			"defaults to 60 in the lock and 90 in the declaration",
+			"an older writer's missing field is filled from this default",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an implicit default given a value",
+		fixedFrom: "    reaction  float32 |", fixed: "    reaction  float32 = 0.5 |",
+		varFrom: "    lag     float32 |", varTo: "    lag     float32 = 0.5 |",
+		want: []string{"fixed table Config", "entry 3, field reaction",
+			"defaults to 0.0 in the lock and 0.5 in the declaration"},
+	},
+	{
+		name:      "a widened integer range",
+		fixedFrom: "    tick_rate int32 = 60 | min = 1, max = 240", fixed: "    tick_rate int32 = 60 | min = 1, max = 480",
+		varFrom: "    rate    int32 = 60 | min = 1, max = 240", varTo: "    rate    int32 = 60 | min = 1, max = 480",
+		want: []string{"fixed table Config", "entry 1, field tick_rate",
+			"is [1, 240] in the lock and [1, 480] in the declaration",
+			"keeps its range", "deprecate this field and append a new one"},
+	},
+	{
+		name:      "a moved resolution",
+		fixedFrom: "    reaction  float32 | min = 0, max = 1, resolution = 0.01", fixed: "    reaction  float32 | min = 0, max = 1, resolution = 0.001",
+		varFrom: "    lag     float32 | min = 0, max = 1, resolution = 0.01", varTo: "    lag     float32 | min = 0, max = 1, resolution = 0.001",
+		want: []string{"fixed table Config", "entry 3, field reaction",
+			"resolution 0.01 in the lock", "resolution 0.001 in the declaration",
+			"keeps its range"},
+	},
+	{
+		name:      "a moved fixed-point scale at the same width",
+		fixedFrom: "    scale     fixed(16, 16) |", fixed: "    scale     fixed(24, 8) |",
+		varFrom: "    pitch   fixed(16, 16) |", varTo: "    pitch   fixed(24, 8) |",
+		want: []string{"fixed table Config", "entry 2, field scale",
+			"16 fractional bits in the lock", "8 fractional bits in the declaration",
+			"keeps its range"},
+	},
+	{
+		name:      "an optional turned on",
+		fixedFrom: "    boost     Buff\n", fixed: "    boost     ?Buff\n",
+		varFrom: "    keel    Ballast\n", varTo: "    keel    ?Ballast\n",
+		want: []string{"fixed table Config", "entry 6, field boost",
+			"is plain in the lock and optional in the declaration",
+			"presence bool beside its value INSIDE the record",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an optional turned off",
+		fixedFrom: "    gunner    ?Buff\n", fixed: "    gunner    Buff\n",
+		varFrom: "    spare   ?Ballast\n", varTo: "    spare   Ballast\n",
+		want: []string{"fixed table Config", "entry 7, field gunner",
+			"is optional in the lock and plain in the declaration"},
+	},
+	{
+		name:      "a change inside a nested record",
+		fixedFrom: "type Buff\n{\n    multiplier float32 = 1.0\n}", fixed: "type Buff\n{\n    multiplier int32 = 1\n}",
+		varFrom: "type Ballast\n{\n    weight float32 = 1.0\n}", varTo: "type Ballast\n{\n    weight int32 = 1\n}",
+		want: []string{"type Buff", "entry 1, field multiplier",
+			"in the lock and kind", "keeps its type",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "a reordered enum",
+		fixedFrom: "enum Hull\n{\n    Interceptor\n    Gunship\n", fixed: "enum Hull\n{\n    Gunship\n    Interceptor\n",
+		varFrom: "enum Cargo\n{\n    Ore\n    Ice\n", varTo: "enum Cargo\n{\n    Ice\n    Ore\n",
+		want: []string{"enum Hull", "variant 1, Interceptor", "is Gunship in the declaration",
+			"APPEND-ONLY", "a new variant goes at the END", "never inserted, moved or renamed",
+			"restore it, and add the new one at the END"},
+	},
+	{
+		name:      "a removed enum variant",
+		fixedFrom: "    Gunship\n    Freighter\n", fixed: "    Gunship\n",
+		varFrom: "    Ice\n    Fuel\n", varTo: "    Ice\n",
+		want: []string{"enum Hull", "variant 3, Freighter",
+			"is in the lock and gone from the declaration",
+			"keeps its place forever", "restore it, and add the new one at the END"},
+	},
+	{
+		name:      "a renamed enum variant",
+		fixedFrom: "    Freighter\n", fixed: "    Hauler\n",
+		varFrom: "    Fuel\n", varTo: "    Coal\n",
+		want: []string{"enum Hull", "variant 3, Freighter", "is Hauler in the declaration",
+			"never inserted, moved or renamed"},
+	},
+	{
+		name:      "a reordered flags mask",
+		fixedFrom: "flags Perks { Shielded, Cloaked }", fixed: "flags Perks { Cloaked, Shielded }",
+		varFrom: "flags Rigging { Sail, Mast }", varTo: "flags Rigging { Mast, Sail }",
+		want: []string{"flags Perks", "variant 1, Shielded", "is Cloaked in the declaration",
+			"a fixed record stores the PLACE"},
+	},
+	{
+		name:      "a reordered union",
+		fixedFrom: "union Effect\n{\n    buff   Buff\n    debuff Debuff\n}", fixed: "union Effect\n{\n    debuff Debuff\n    buff   Buff\n}",
+		varFrom: "union Stowage\n{\n    ballast Ballast\n    trim    Trim\n}", varTo: "union Stowage\n{\n    trim    Trim\n    ballast Ballast\n}",
+		want: []string{"union Effect", "arm 1, buff", "is debuff in the declaration",
+			"a new arm goes at the END"},
+	},
+}
+
+// TestClosureBreakRefused is the first of the three ways: the edit lands on the
+// FIXED half and the compile refuses, naming the declaration, the line, the
+// reason and the remedy.
+func TestClosureBreakRefused(t *testing.T) {
+	for _, tc := range closureBreaks {
+		t.Run(tc.name, func(t *testing.T) {
+			after := edit(t, closureBase, tc.fixedFrom, tc.fixed)
+			_, _, errs := lockedFrom(t, closureBase, after)
+			refuses(t, errs, tc.want...)
+		})
+	}
+}
+
+// TestClosureBreakOnAVariableTableIsNotTheLocksBusiness is the second: the
+// SAME edit on the VARIABLE-LENGTH half passes in silence and moves no line of
+// the file. A `table` with a pointer in it rides the id-table wire, where a
+// moved default, a widened range and a reordered enum are what the wire is FOR
+// (§4) — the lock has no opinion, and this is the proof it has none.
+func TestClosureBreakOnAVariableTableIsNotTheLocksBusiness(t *testing.T) {
+	for _, tc := range closureBreaks {
+		t.Run(tc.name, func(t *testing.T) {
+			after := edit(t, closureBase, tc.varFrom, tc.varTo)
+			dir, paths, errs := lockedFrom(t, closureBase, after)
+			if len(errs) != 0 {
+				t.Fatalf("a variable-length table's evolution is the wire's business, not the lock's: %v", errs)
+			}
+			path := filepath.Join(dir, lockfile.FileName)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
+				t.Errorf("the file does not move: rewrote=%v err=%v", rewrote, err)
+			}
+			if got, _ := os.ReadFile(path); string(got) != string(before) {
+				t.Errorf("the file moved:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+			}
+		})
+	}
+}
+
+// TestClosureBreakRefusedByLockToo is the third: `schema lock` is not the way
+// to make one of these refusals go away. It runs the check's own comparison
+// first, refuses with the same sentence, and leaves the file exactly as it sat.
+func TestClosureBreakRefusedByLockToo(t *testing.T) {
+	for _, tc := range closureBreaks {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, paths := fixture(t, closureBase)
+			if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, lockfile.FileName)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			after := edit(t, closureBase, tc.fixedFrom, tc.fixed)
+			if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(after), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, rewrote, err := lockfile.Update(load(t, paths), paths)
+			if err == nil || rewrote {
+				t.Fatalf("`schema lock` appends, and this is not an append: rewrote=%v err=%v", rewrote, err)
+			}
+			if !strings.Contains(err.Error(), tc.want[len(tc.want)-1]) || !strings.Contains(err.Error(), "not an append") {
+				t.Errorf("the refusal says which break and why: %v", err)
+			}
+			if got, _ := os.ReadFile(path); string(got) != string(before) {
+				t.Errorf("a refused lock writes nothing:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+			}
+		})
+	}
+}
+
+// ---- the appends the rule allows, recorded ----
+
+// closureAppends are the changes the APPEND-ONLY rule permits over the widened
+// file: a value at the END of an enum, of a flags mask, of a union, and a field
+// at the bottom of a nested record. Each is a CHANGE, so the compile before the
+// lock is written is refused as stale — and `schema lock` then writes exactly
+// it, with every line before it untouched.
+var closureAppends = []struct {
+	name     string
+	from, to string
+	stale    []string
+	recorded string
+}{
+	{
+		name: "a variant at the end of an enum",
+		from: "    Freighter\n}", to: "    Freighter\n    Tanker\n}",
+		stale:    []string{"enum Hull", "variant 4, Tanker", "in the declaration and not in the lock", "write it with `schema lock`"},
+		recorded: "    variant Tanker\n",
+	},
+	{
+		name: "a variant at the end of a flags mask",
+		from: "flags Perks { Shielded, Cloaked }", to: "flags Perks { Shielded, Cloaked, Turbo }",
+		stale:    []string{"flags Perks", "variant 3, Turbo", "in the declaration and not in the lock"},
+		recorded: "    variant Turbo\n",
+	},
+	{
+		name: "an arm at the end of a union",
+		from: "    debuff Debuff\n}", to: "    debuff Debuff\n    stun   Buff\n}",
+		stale:    []string{"union Effect", "arm 3, stun", "in the declaration and not in the lock"},
+		recorded: "    arm stun\n",
+	},
+}
+
+// TestClosureAppendRefusedUntilLocked is the STRICT reading over the widened
+// file: an append to anything the lock holds is allowed by the rule and still
+// refused until the record of it is in the tree, and `schema lock` writes it
+// with every line before it left where it was.
+func TestClosureAppendRefusedUntilLocked(t *testing.T) {
+	for _, tc := range closureAppends {
+		t.Run(tc.name, func(t *testing.T) {
+			after := edit(t, closureBase, tc.from, tc.to)
+			dir, paths, errs := lockedFrom(t, closureBase, after)
+			refuses(t, errs, tc.stale...)
+
+			path := filepath.Join(dir, lockfile.FileName)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+				t.Fatalf("`schema lock` writes an append: rewrote=%v err=%v", rewrote, err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(got), tc.recorded) {
+				t.Errorf("the append is recorded (%q):\n%s", tc.recorded, got)
+			}
+			// and with it written, the same compile passes and the file is
+			// left alone the next time
+			if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+				t.Errorf("the written lock checks clean: %v", errs)
+			}
+			if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
+				t.Errorf("a current lock is left alone: rewrote=%v err=%v", rewrote, err)
+			}
+			if len(before) >= len(got) {
+				t.Errorf("an append grows the file: %d then %d bytes", len(before), len(got))
+			}
+		})
+	}
+}
+
+// ---- the closure narrowing ----
+
+// TestTypeLeavingTheClosureRefused is the block-level twin of a withdrawn
+// table: a `type`, an enum, a flags mask or a union the lock holds and the
+// declaration no longer reaches. A fixed record is MADE of those, so one
+// leaving means a field changed what it holds — and the refusal says so and
+// names the remedy, rather than letting the block quietly vanish from the file.
+func TestTypeLeavingTheClosureRefused(t *testing.T) {
+	_, paths := fixture(t, closureBase)
+	locked := lockfile.Render(load(t, paths))
+
+	for _, tc := range []struct {
+		name string
+		drop string
+		want []string
+	}{
+		{"a nested record", "Buff", []string{"type Buff is in the lock", "no longer nest it by value",
+			"a nested record's fields ARE the holder's bytes", "deprecate that field and append a new one"}},
+		{"an enum", "Hull", []string{"enum Hull is in the lock", "no longer reach it",
+			"every type a fixed record is made of", "deprecate that field and append a new one"}},
+		{"a flags mask", "Perks", []string{"flags Perks is in the lock", "no longer reach it"}},
+		{"a union", "Effect", []string{"union Effect is in the lock", "no longer reach it"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			live := lockfile.Render(load(t, paths))
+			live.Tables = dropTable(live.Tables, tc.drop)
+			live.Values = dropList(live.Values, tc.drop)
+			refuses(t, lockfile.Diff(locked, live, lockfile.Current), tc.want...)
+		})
+	}
+}
+
+func dropTable(in []lockfile.Table, name string) []lockfile.Table {
+	var out []lockfile.Table
+	for _, t := range in {
+		if t.Name != name {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func dropList(in []lockfile.ValueList, name string) []lockfile.ValueList {
+	var out []lockfile.ValueList
+	for _, v := range in {
+		if v.Name != name {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// ---- the file caught lying, on its new half ----
+
+// TestHandEditedValueListRefused is the hand-edit check over a value list: the
+// values and the hash beside them are one statement made twice, exactly as a
+// record's entries and its layout hash are.
+func TestHandEditedValueListRefused(t *testing.T) {
+	dir, paths := fixture(t, closureBase)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lie := strings.Replace(string(data), "    variant Interceptor\n    variant Gunship\n", "    variant Gunship\n    variant Interceptor\n", 1)
+	if lie == string(data) {
+		t.Fatal("the fixture's Hull block is not what this test edits")
+	}
+	if err := os.WriteFile(path, []byte(lie), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refuses(t, lockfile.Check(load(t, paths), paths),
+		"enum Hull", "variants that hash to", "a hand-edit does not hold", "schema lock")
+}
+
+// TestValueListRoundTrips is the widened format read back as what it wrote:
+// the value lists, the nested records and every new fact on an entry line
+// survive a parse, or the file the compiler writes is not the file it reads.
+func TestValueListRoundTrips(t *testing.T) {
+	_, paths := fixture(t, closureBase)
+	want := lockfile.Render(load(t, paths))
+	got, err := lockfile.Parse("schema.lock", []byte(want.Text()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Text() != want.Text() {
+		t.Errorf("round trip:\n--- wrote ---\n%s\n--- read back ---\n%s", want.Text(), got.Text())
+	}
+	if len(got.Values) != len(want.Values) || len(got.Values) == 0 {
+		t.Fatalf("the value lists survive: %d then %d", len(want.Values), len(got.Values))
+	}
+	if hull := got.List("Hull"); hull == nil || strings.Join(hull.Values, ",") != "Interceptor,Gunship,Freighter" {
+		t.Errorf("Hull reads back in declared order: %+v", hull)
+	}
+}
+
+// TestNestedRecordAppendSlidesTheHolder is the difference between a fixed
+// table's own bottom and a nested record's, and it is not a nicety: a field
+// appended to a `type` a fixed table holds BY VALUE grows the holder's slot,
+// which slides every field after it. So the change the rule allows at the
+// bottom of a table is a BREAK one level in, and the compiler says both halves
+// — the holder's width first, because that is what a reader stands on, and the
+// nested record's own new entry beside it.
+func TestNestedRecordAppendSlidesTheHolder(t *testing.T) {
+	after := edit(t, closureBase,
+		"    multiplier float32 = 1.0\n}", "    multiplier float32 = 1.0\n    stacks     uint8\n}")
+	dir, paths, errs := lockedFrom(t, closureBase, after)
+	if len(errs) != 2 {
+		t.Fatalf("want the holder's width and the nested record's entry, got %d: %v", len(errs), errs)
+	}
+	first := errs[0].Error()
+	for _, w := range []string{"fixed table Config", "entry 6, field boost",
+		"4 bytes wide in the lock and 8 in the declaration", "walked by offset"} {
+		if !strings.Contains(first, w) {
+			t.Errorf("the holder's refusal must name %q:\n%s", w, first)
+		}
+	}
+	if second := errs[1].Error(); !strings.Contains(second, "type Buff") || !strings.Contains(second, "field stacks") {
+		t.Errorf("the nested record's own finding names it:\n%s", second)
+	}
+	// and `schema lock` will not write it away either
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err == nil || rewrote {
+		t.Fatalf("`schema lock` appends, and this is not an append: rewrote=%v err=%v", rewrote, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, lockfile.FileName)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestALockFromAnOlderRenderingSaysWhatToDo is the one parse refusal that is
+// not a hand-edit, and the version bump that widened this file made it live: a
+// lock written under an older rendering holds nothing a person can carry
+// forward, so both verbs name the remedy that works rather than sending the
+// user around a loop.
+func TestALockFromAnOlderRenderingSaysWhatToDo(t *testing.T) {
+	dir, paths := fixture(t, closureBase)
+	path := filepath.Join(dir, lockfile.FileName)
+	if err := os.WriteFile(path, []byte("schema-lock 1\npackage closuredemo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refuses(t, lockfile.Check(load(t, paths), paths),
+		"rendering version 1 and this compiler writes version 2",
+		"delete it and write it again with `schema lock`")
+	_, rewrote, err := lockfile.Update(load(t, paths), paths)
+	if err == nil || rewrote {
+		t.Fatalf("`schema lock` does not write over a lock it cannot read: rewrote=%v err=%v", rewrote, err)
+	}
+	if !strings.Contains(err.Error(), "delete it and write it again with `schema lock`") {
+		t.Errorf("the one writer names the same remedy: %v", err)
+	}
+	// and once it IS gone, the command locks the unit
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+		t.Fatalf("the remedy works: rewrote=%v err=%v", rewrote, err)
+	}
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the written lock checks clean: %v", errs)
+	}
+}

--- a/internal/lockfile/lockclosure_test.go
+++ b/internal/lockfile/lockclosure_test.go
@@ -4,8 +4,9 @@
 //
 // Order and width were the whole of the old file, and they are not the whole
 // of what a reader stands on. This file is the rest of it — the default, the
-// range, the fixed-point scale, the `?`, and every enum, flags mask, union and
-// nested record a fixed table reaches — and every case is measured three ways:
+// range, the fixed-point scale, the `?`, which type a nested slot holds, an
+// array's element, a union arm's payload, and every enum, flags mask, union
+// and nested record a fixed table reaches — and every case is measured three ways:
 // the edit is REFUSED on the fixed table, the SAME edit on a plain
 // variable-length `table` is not the lock's business, and `schema lock` will
 // not write the break either.
@@ -91,6 +92,7 @@ table Config
     boost     Buff
     gunner    ?Buff
     effect    Effect
+    lanes     [4]int32
 }
 
 table Bag
@@ -103,6 +105,7 @@ table Bag
     keel    Ballast
     spare   ?Ballast
     stowage Stowage
+    lanes   [4]int32
     tail    *Bag
 }
 `
@@ -142,8 +145,8 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 	lk := lockfile.Render(load(t, paths))
 	text := lk.Text()
 
-	if lk.Version != 2 {
-		t.Errorf("the widened rendering is version 2, got %d", lk.Version)
+	if lk.Version != 3 {
+		t.Errorf("the widened rendering is version 3, got %d", lk.Version)
 	}
 	for _, want := range []string{
 		"fixed table Config layout=0x",
@@ -153,17 +156,21 @@ func TestLockHoldsTheWholeClosure(t *testing.T) {
 		"enum Hull values=0x",
 		"flags Perks values=0x",
 		"union Effect values=0x",
-		// the value lists, in declared order
+		// the value lists, in declared order — a union arm names its payload
 		"    variant Interceptor\n    variant Gunship\n    variant Freighter\n",
 		"    variant Shielded\n    variant Cloaked\n",
-		"    arm buff\n    arm debuff\n",
+		"    arm buff payload=Buff@",
+		"    arm debuff payload=Debuff@",
 		// and the facts on the entries
 		"field tick_rate id=0x", "default=60 min=1 max=240",
 		"default=0 min=-8 max=8 frac=16",       // the fixed-point scale
 		"default=0.0 min=0.0 max=1.0 res=0.01", // the compressed float
 		"default=variant:Gunship",              // an enum's named default
 		"default=mask:0",                       // a flags field's fresh mask
-		"default=zero optional",                // the `?`
+		"default=zero held=Buff@",              // kind 13 names what it holds
+		"held=Buff@",                           // boost and gunner both
+		" optional",                            // the `?` still sits on gunner
+		"elem=4/4",                             // kind 14 names its element
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("the lock must carry %q:\n%s", want, text)
@@ -291,6 +298,42 @@ var closureBreaks = []struct {
 		want: []string{"union Effect", "arm 1, buff", "is debuff in the declaration",
 			"a new arm goes at the END"},
 	},
+	{
+		name:      "a nested slot holding a different type",
+		fixedFrom: "    boost     Buff\n", fixed: "    boost     Debuff\n",
+		varFrom: "    keel    Ballast\n", varTo: "    keel    Trim\n",
+		want: []string{"fixed table Config", "entry 6, field boost",
+			"held Buff in the lock and Debuff in the declaration",
+			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an optional nested slot holding a different type",
+		fixedFrom: "    gunner    ?Buff\n", fixed: "    gunner    ?Debuff\n",
+		varFrom: "    spare   ?Ballast\n", varTo: "    spare   ?Trim\n",
+		want: []string{"fixed table Config", "entry 7, field gunner",
+			"held Buff in the lock and Debuff in the declaration",
+			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "a union arm's payload type swapped, names kept",
+		fixedFrom: "union Effect\n{\n    buff   Buff\n    debuff Debuff\n}", fixed: "union Effect\n{\n    buff   Debuff\n    debuff Buff\n}",
+		varFrom: "union Stowage\n{\n    ballast Ballast\n    trim    Trim\n}", varTo: "union Stowage\n{\n    ballast Trim\n    trim    Ballast\n}",
+		want: []string{"union Effect", "arm 1, buff",
+			"held Buff in the lock and Debuff in the declaration",
+			"keeps the type it holds",
+			"deprecate this field and append a new one"},
+	},
+	{
+		name:      "an array's element type",
+		fixedFrom: "    lanes     [4]int32\n", fixed: "    lanes     [4]float32\n",
+		varFrom: "    lanes   [4]int32\n", varTo: "    lanes   [4]float32\n",
+		want: []string{"fixed table Config", "entry 9, field lanes",
+			"holds int32 elements in the lock and float32 elements in the declaration",
+			"keeps its element type",
+			"deprecate this field and append a new one"},
+	},
 }
 
 // TestClosureBreakRefused is the first of the three ways: the edit lands on the
@@ -396,7 +439,7 @@ var closureAppends = []struct {
 		name: "an arm at the end of a union",
 		from: "    debuff Debuff\n}", to: "    debuff Debuff\n    stun   Buff\n}",
 		stale:    []string{"union Effect", "arm 3, stun", "in the declaration and not in the lock"},
-		recorded: "    arm stun\n",
+		recorded: "    arm stun payload=Buff@",
 	},
 }
 
@@ -585,7 +628,7 @@ func TestALockFromAnOlderRenderingSaysWhatToDo(t *testing.T) {
 		t.Fatal(err)
 	}
 	refuses(t, lockfile.Check(load(t, paths), paths),
-		"rendering version 1 and this compiler writes version 2",
+		"rendering version 1 and this compiler writes version 3",
 		"delete it and write it again with `schema lock`")
 	_, rewrote, err := lockfile.Update(load(t, paths), paths)
 	if err == nil || rewrote {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,0 +1,336 @@
+// Package lockfile is the SCHEMA LOCK (docs/SPEC-TABLES.md §2.10): the
+// committed record of every FIXED table's field sequence, and the check that
+// refuses every edit to it but an append.
+//
+// # WHY IT EXISTS
+//
+// A fixed-size table is a plain C record (§6.1). Its bytes carry no ids, no
+// terminators and no names: a reader finds a field by walking to its offset,
+// so the field ORDER and the field WIDTHS are the whole contract. Everything
+// the id-table wire absorbs — a reordered field, a removed one, a widened one
+// — a fixed table reads as garbage, silently, with no counter to fire. The
+// tables baseline (§18) guards what the table wire cannot report; this guards
+// what the fixed record cannot report, which is more.
+//
+// The owner ruled the discipline rather than the mechanism, and the mechanism
+// follows from it: fixed tables evolve APPEND-ONLY — "append only, and
+// deprecation possibly. might keep it light weight?" Network Next ran the
+// same rule by hand for years, a version byte at the front and new fields at
+// the bottom: "manual stuff, and it is a footgun, but it worked." The lock is
+// that footgun taken away — the compiler owns the file, and the check is the
+// hand nobody has to remember to use.
+//
+// # THE SHAPE OF THE ANSWER
+//
+// One entry per field, in DECLARED ORDER, carrying the four facts a fixed
+// record's layout is made of: the field's wire id, its kind, its WIDTH in the
+// record, and whether it is deprecated. Per table, the hash of that sequence.
+// The check is then one sentence: THE LOCKED SEQUENCE IS A PREFIX OF THE
+// LIVE ONE, entry for entry, with `deprecated` allowed only to turn on.
+package lockfile
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Version is the lock RENDERING's own version, on the file's first line — the
+// discipline ir.ProjectionVersion keeps for the protocol id and
+// baseline.Version keeps for the baseline. Bumping it makes every committed
+// lock stale at once, deliberately and visibly.
+//
+// THE RULE FOR BUMPING IT: any new fact on an entry line, or any change to
+// what the layout hash digests. Both would make every committed hash
+// disagree with its own entries, which is the refusal that catches a
+// hand-edit — so the version is what tells the two apart.
+const Version = 1
+
+// FileName is the lock's name beside the unit's schema files. Unlike the
+// tables baseline, its presence is not what turns the check on for a unit
+// that HAS one: a unit with fixed tables and no lock is unlocked, and `schema
+// lock` is what locks it.
+const FileName = "schema.lock"
+
+const magic = "schema-lock"
+
+// A Unit is one lock file: every fixed table of a unit, in name order.
+type Unit struct {
+	Version int
+	Package string
+	Tables  []Table
+}
+
+// A Table is one FIXED table's locked field sequence.
+type Table struct {
+	// Name is the table's WIRE name (§5): the `was` alias of a renamed table,
+	// else its declared name. A rename keeps the identity, so it moves no
+	// line in this file.
+	Name string
+
+	// Layout is the hash of Entries as [LayoutHash] takes it. It is derived,
+	// and it is written down anyway: a lock whose entries have been edited by
+	// hand no longer hashes to the number beside them, and that is the only
+	// way this file can be caught lying.
+	Layout uint64
+
+	Entries []Entry
+}
+
+// An Entry is one field of a fixed table, and it is the unit the check
+// compares. Everything a fixed record's layout is made of is here and nothing
+// else: the record has no ids in it, so a field's POSITION is its identity,
+// and the id, kind and width are what a reader at that position assumes.
+type Entry struct {
+	// Name is the field's WIRE name (§5) — its `was` alias where one is
+	// declared — for the same reason the table's is: a `was =` rename is not
+	// a change, so it must move no byte of this file.
+	Name string
+
+	// Id is the field's table-wire id (§5). It is recorded and compared: two
+	// fields of the same kind and width at one position are still two
+	// different fields, and the id is what says so.
+	Id uint64
+
+	// Kind is the field's table-wire kind (§3).
+	Kind int
+
+	// Width is the field's WHOLE storage in the record, in bytes — an array's
+	// elements together, a string's buffer AND its length companion, an
+	// optional's value AND its presence bool, exactly as ir.FieldLayout
+	// measures it (§19.3). It is the fact a fixed reader is standing on.
+	Width int64
+
+	// Deprecated is the field's `| deprecated` marker (§2.10). It may turn
+	// on and it may never turn off: the slot stays where it is, nothing new
+	// may name the field, and a reader ignores what it finds there.
+	Deprecated bool
+}
+
+// FixedTables names the unit's FIXED tables — the ones this file locks — in
+// name order.
+//
+// THIS IS THE ONE PLACE THE SET IS DECIDED. Today it is derived: a table is
+// fixed when it is not variable-length (ir.VariableTables, §2.2), because
+// that is the only answer the language can give. The sibling work adding the
+// `fixed table` keyword makes the flag DECLARED, and when it lands this
+// function's body is the one line that changes.
+//
+// TODO(fixed-table-keyword): read the declared flag — `st.IsFixedTable` on
+// the `fixed table` keyword branch — instead of deriving the answer here.
+func FixedTables(u *ir.Unit) []string {
+	variable := ir.VariableTables(u)
+	var out []string
+	for name, st := range u.Tables {
+		if st.IsMapEntry() {
+			// a generated map entry is not a declaration anybody wrote, and
+			// its holder is variable by construction (§2.8)
+			continue
+		}
+		if variable[name] {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Render projects a checked unit's fixed tables. The result is exactly what
+// [Unit.Text] writes and what the check compares against.
+func Render(u *ir.Unit) *Unit {
+	out := &Unit{Version: Version, Package: u.Package}
+	for _, name := range FixedTables(u) {
+		st := u.Tables[name]
+		out.Tables = append(out.Tables, renderTable(u, st))
+	}
+	return out
+}
+
+func renderTable(u *ir.Unit, st *ir.Struct) Table {
+	t := Table{Name: st.WireName()}
+	layout := ir.RecordLayout(u, st)
+	for _, f := range st.Fields {
+		e := Entry{
+			Name:       fieldWireName(f),
+			Id:         ir.TableFieldWireId(f),
+			Kind:       ir.TableFieldKind(f),
+			Deprecated: f.Deprecated,
+		}
+		if fl := layout.FieldByName(f.Name); fl != nil {
+			e.Width = fl.Size
+		}
+		t.Entries = append(t.Entries, e)
+	}
+	t.Layout = LayoutHash(t.Entries)
+	return t
+}
+
+// fieldWireName is the name this file records: the `was` alias where one is
+// declared, so a rename moves nothing (§5).
+func fieldWireName(f *ir.Field) string {
+	if f.WasName != "" {
+		return f.WasName
+	}
+	return f.Name
+}
+
+// LayoutHash digests an entry sequence with the wire's own hash — one hash in
+// this tree, and this file has no reason to be the second (§5).
+//
+// It digests the ENTRY LINES as they are written, so the number in the file
+// and the entries above it are the same statement twice; that is what makes a
+// hand-edit of either half visible.
+func LayoutHash(entries []Entry) uint64 {
+	var b strings.Builder
+	for _, e := range entries {
+		b.WriteString(e.line())
+		b.WriteByte('\n')
+	}
+	return ir.TableWireId(b.String())
+}
+
+// line is one entry's text, and the unit the layout hash digests.
+func (e Entry) line() string {
+	s := fmt.Sprintf("field %s id=0x%016x kind=%d width=%d", e.Name, e.Id, e.Kind, e.Width)
+	if e.Deprecated {
+		s += " deprecated"
+	}
+	return s
+}
+
+// Text renders the lock as the committed file.
+func (u *Unit) Text() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %d\n", magic, u.Version)
+	fmt.Fprintf(&b, "package %s\n", u.Package)
+	for _, t := range u.Tables {
+		fmt.Fprintf(&b, "\nfixed table %s layout=0x%016x\n", t.Name, t.Layout)
+		for _, e := range t.Entries {
+			fmt.Fprintf(&b, "    %s\n", e.line())
+		}
+	}
+	return b.String()
+}
+
+// Table returns one locked table by wire name.
+func (u *Unit) Table(name string) *Table {
+	for i := range u.Tables {
+		if u.Tables[i].Name == name {
+			return &u.Tables[i]
+		}
+	}
+	return nil
+}
+
+// Parse reads a committed lock. Every refusal names the file and the line, and
+// the remedy is always the same one command.
+func Parse(path string, data []byte) (*Unit, error) {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	u := &Unit{}
+	var cur *Table
+	for n, raw := range lines {
+		where := fmt.Sprintf("%s:%d", path, n+1)
+		line := strings.TrimRight(raw, " \t")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		switch {
+		case n == 0:
+			if len(fields) != 2 || fields[0] != magic {
+				return nil, fmt.Errorf("%s: a %s begins with %q and its rendering version", where, FileName, magic)
+			}
+			v, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return nil, fmt.Errorf("%s: %q is not a rendering version", where, fields[1])
+			}
+			if v != Version {
+				return nil, fmt.Errorf("%s: this lock is rendering version %d and this compiler writes version %d", where, v, Version)
+			}
+			u.Version = v
+		case fields[0] == "package":
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("%s: the package line names one package", where)
+			}
+			u.Package = fields[1]
+		case fields[0] == "fixed" && len(fields) > 1 && fields[1] == "table":
+			if len(fields) != 4 {
+				return nil, fmt.Errorf("%s: a table line is `fixed table <Name> layout=0x...`", where)
+			}
+			h, err := parseHex(fields[3], "layout")
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", where, err)
+			}
+			u.Tables = append(u.Tables, Table{Name: fields[2], Layout: h})
+			cur = &u.Tables[len(u.Tables)-1]
+		case fields[0] == "field":
+			if cur == nil {
+				return nil, fmt.Errorf("%s: a field line before any `fixed table` line", where)
+			}
+			e, err := parseEntry(fields)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", where, err)
+			}
+			cur.Entries = append(cur.Entries, e)
+		default:
+			return nil, fmt.Errorf("%s: %q is not a line a %s carries", where, fields[0], FileName)
+		}
+	}
+	if u.Version == 0 {
+		return nil, fmt.Errorf("%s: empty — a %s begins with %q and its rendering version", path, FileName, magic)
+	}
+	return u, nil
+}
+
+func parseEntry(fields []string) (Entry, error) {
+	if len(fields) < 5 {
+		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N [deprecated]`")
+	}
+	e := Entry{Name: fields[1]}
+	for _, tok := range fields[2:] {
+		key, val, valued := strings.Cut(tok, "=")
+		switch {
+		case !valued && key == "deprecated":
+			e.Deprecated = true
+		case !valued:
+			return Entry{}, fmt.Errorf("%q is not a fact a field line carries", tok)
+		case key == "id":
+			h, err := parseHex(tok, "id")
+			if err != nil {
+				return Entry{}, err
+			}
+			e.Id = h
+		case key == "kind":
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				return Entry{}, fmt.Errorf("kind=%q is not a number", val)
+			}
+			e.Kind = n
+		case key == "width":
+			n, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return Entry{}, fmt.Errorf("width=%q is not a number", val)
+			}
+			e.Width = n
+		default:
+			return Entry{}, fmt.Errorf("%q is not a fact a field line carries", key)
+		}
+	}
+	return e, nil
+}
+
+func parseHex(tok, key string) (uint64, error) {
+	_, val, ok := strings.Cut(tok, "=")
+	if !ok {
+		return 0, fmt.Errorf("%s takes a hex value, written %s=0x0000000000000000", key, key)
+	}
+	v, err := strconv.ParseUint(strings.TrimPrefix(val, "0x"), 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q is not a 64-bit hex value", key, val)
+	}
+	return v, nil
+}

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1001,11 +1001,11 @@ func parseHex(tok, key string) (uint64, error) {
 func parseHeld(val string) (string, uint64, error) {
 	name, rest, ok := strings.Cut(val, "@")
 	if !ok || name == "" {
-		return "", 0, fmt.Errorf("held=%q is not Name@0x...", val)
+		return "", 0, fmt.Errorf("held=%q is not Name@0x plus a hash", val)
 	}
 	h, err := strconv.ParseUint(strings.TrimPrefix(rest, "0x"), 16, 64)
 	if err != nil {
-		return "", 0, fmt.Errorf("held=%q is not Name@0x...", val)
+		return "", 0, fmt.Errorf("held=%q is not Name@0x plus a hash", val)
 	}
 	return name, h, nil
 }

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -31,8 +31,8 @@
 //   - one entry per field, in DECLARED ORDER, carrying the field's wire id,
 //     its kind, its WIDTH in the record, its DEFAULT declared or implicit, its
 //     declared RANGE and resolution, its `?` and its `deprecated` marker,
-//     which named type a kind-13/15 slot holds (name and that type's layout
-//     hash), and an array's element kind and width;
+//     which named type a slot holds (name and that type's layout hash), and
+//     an array's element kind and width;
 //   - one block per TYPE the fixed tables reach — a nested `type` record, an
 //     `enum`, a `flags` mask, a `union` — because a fixed record is made of
 //     those and a change inside one moves the root's bytes without moving one
@@ -79,7 +79,11 @@ import (
 // array's element kind and width (`elem=4/4`), and a union arm's payload
 // type beside the name. Those are new facts on the hashed lines, so a v2
 // lock is deleted and rewritten, the same sentence v1 took.
-const Version = 3
+// 4 records which enum or flags type a slot holds (`held=Hull@0x...`), the
+// same fact kind 13/15 already carried; an array of enum or flags carries
+// held= beside elem=. v3 locks are deleted and rewritten, the same sentence
+// v1 took.
+const Version = 4
 
 // FileName is the lock's name beside the unit's schema files. Unlike the
 // tables baseline, its presence is not what turns the check on for a unit
@@ -186,10 +190,11 @@ type Entry struct {
 	// may name the field, and a reader ignores what it finds there.
 	Deprecated bool
 
-	// HeldName and HeldHash are the nested type a kind-13 (table) or kind-15
-	// (union) slot holds — the type's wire name and that type's layout hash
-	// (a union's values hash), spelled `held=Buff@0x...`. A kind-14 array of
-	// a named type carries the same pair for its element. Empty on a scalar.
+	// HeldName and HeldHash are the named type a slot holds — a kind-13
+	// table, a kind-15 union, a kind-7 enum, a kind-9 flags mask, or a
+	// kind-14 array of any of those — the type's wire name and that type's
+	// layout hash (an enum, flags or union's values hash), spelled
+	// `held=Hull@0x...`. Empty on a scalar.
 	HeldName string
 	HeldHash uint64
 
@@ -391,9 +396,9 @@ func Render(u *ir.Unit) *Unit {
 	return out
 }
 
-// renderer fills held hashes from the nested type's own block, so a kind-13
-// slot and the `type` it names agree on the number, and a union arm's
-// payload= agrees with the nested record it points at.
+// renderer fills held hashes from the nested type's own block, so a slot
+// and the `type`, enum, flags or union it names agree on the number, and a
+// union arm's payload= agrees with the nested record it points at.
 type renderer struct {
 	u      *ir.Unit
 	tables map[*ir.Struct]Table
@@ -450,6 +455,8 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 			e.ElemKind = ir.TableElemKind(f)
 			e.ElemWidth = elemSize(r.u, f)
 			e.HeldName, e.HeldHash = r.held(f)
+		default:
+			e.HeldName, e.HeldHash = r.held(f)
 		}
 		t.Entries = append(t.Entries, e)
 	}
@@ -471,6 +478,12 @@ func (r *renderer) held(f *ir.Field) (string, uint64) {
 		return t.Name, t.Layout
 	case *ir.Union:
 		v := r.unionList(ref)
+		return v.Name, v.Hash
+	case *ir.Enum:
+		v := r.enumList(ref)
+		return v.Name, v.Hash
+	case *ir.Flags:
+		v := r.flagsList(ref)
 		return v.Name, v.Hash
 	default:
 		return "", 0

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,6 +1,6 @@
 // Package lockfile is the SCHEMA LOCK (docs/SPEC-TABLES.md §2.10): the
-// committed record of every FIXED table's field sequence, and the check that
-// refuses every edit to it but an append.
+// committed record of everything a FIXED table's reader stands on, and the
+// check that refuses every edit to it but an append.
 //
 // # WHY IT EXISTS
 //
@@ -22,17 +22,35 @@
 //
 // # THE SHAPE OF THE ANSWER
 //
-// One entry per field, in DECLARED ORDER, carrying the four facts a fixed
-// record's layout is made of: the field's wire id, its kind, its WIDTH in the
-// record, and whether it is deprecated. Per table, the hash of that sequence.
+// ORDER AND WIDTH ARE NOT THE WHOLE OF WHAT A READER STANDS ON, so they are
+// not the whole of the file. The owner's question — "is there anything schema
+// check cannot catch in a fixed table? can we fix that so it does?" — is
+// answered by recording every fact a reader assumes and the declaration can
+// move underneath it:
+//
+//   - one entry per field, in DECLARED ORDER, carrying the field's wire id,
+//     its kind, its WIDTH in the record, its DEFAULT declared or implicit, its
+//     declared RANGE and resolution, its `?` and its `deprecated` marker;
+//   - one block per TYPE the fixed tables reach — a nested `type` record, an
+//     `enum`, a `flags` mask, a `union` — because a fixed record is made of
+//     those and a change inside one moves the root's bytes without moving one
+//     line of the root's own entries;
+//   - per block, the hash of its lines.
+//
 // The check is then one sentence: THE LOCK IS THE LIVE SEQUENCE, entry for
-// entry. The APPEND-ONLY rule — the locked sequence is a PREFIX of the live
-// one, with `deprecated` allowed only to turn on — is what `schema lock` will
-// write, and what it refuses to write is what every compile refuses too. The
-// two readings are [Current] and [Appendable].
+// entry and value for value. The APPEND-ONLY rule — the locked sequence is a
+// PREFIX of the live one, with `deprecated` allowed only to turn on — is what
+// `schema lock` will write, and what it refuses to write is what every compile
+// refuses too. The two readings are [Current] and [Appendable].
+//
+// ONE CLASS IS BEYOND THE FILE, and §2.10 says so: a field that keeps its
+// name, its id, its kind, its width, its default, its range and its `?` and
+// changes only what it MEANS. Nothing recorded here moves, so nothing here can
+// refuse it; the rule for that change is deprecate and add.
 package lockfile
 
 import (
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
@@ -46,11 +64,14 @@ import (
 // baseline.Version keeps for the baseline. Bumping it makes every committed
 // lock stale at once, deliberately and visibly.
 //
-// THE RULE FOR BUMPING IT: any new fact on an entry line, or any change to
-// what the layout hash digests. Both would make every committed hash
-// disagree with its own entries, which is the refusal that catches a
-// hand-edit — so the version is what tells the two apart.
-const Version = 1
+// THE RULE FOR BUMPING IT: any new fact on an entry line, any new block, or
+// any change to what a hash digests. All three would make every committed hash
+// disagree with its own lines, which is the refusal that catches a hand-edit —
+// so the version is what tells the two apart.
+//
+// 2 is the owner's widening: the default, the range, the `?`, and a block per
+// enum, flags mask, union and nested record the fixed tables reach.
+const Version = 2
 
 // FileName is the lock's name beside the unit's schema files. Unlike the
 // tables baseline, its presence is not what turns the check on for a unit
@@ -60,16 +81,35 @@ const FileName = "schema.lock"
 
 const magic = "schema-lock"
 
-// A Unit is one lock file: every fixed table of a unit, in name order.
+// The four block keywords. A block's keyword is the DECLARATION'S OWN WORD, so
+// a refusal reads as the schema reads: `fixed table Config`, `type Vec3`,
+// `enum Hull`, `flags Perm`, `union Payload`.
+const (
+	DeclFixedTable = "fixed table" // a locked table: the root of a record
+	DeclType       = "type"        // a `type` a fixed record nests by value
+	DeclEnum       = "enum"
+	DeclFlags      = "flags"
+	DeclUnion      = "union"
+)
+
+// A Unit is one lock file: every fixed table of a unit and every nested record
+// its fields reach, then every enum, flags mask and union they reach — each
+// group in name order.
 type Unit struct {
 	Version int
 	Package string
 	Tables  []Table
+	Values  []ValueList
 }
 
-// A Table is one FIXED table's locked field sequence.
+// A Table is one RECORD's locked field sequence: a FIXED table, or a `type`
+// one of them nests by value.
 type Table struct {
-	// Name is the table's WIRE name (§5): the `was` alias of a renamed table,
+	// Decl is [DeclFixedTable] or [DeclType] — the word the declaration uses,
+	// and the word the refusal uses.
+	Decl string
+
+	// Name is the record's WIRE name (§5): the `was` alias of a renamed table,
 	// else its declared name. A rename keeps the identity, so it moves no
 	// line in this file.
 	Name string
@@ -83,13 +123,13 @@ type Table struct {
 	Entries []Entry
 }
 
-// An Entry is one field of a fixed table, and it is the unit the check
-// compares. Everything a fixed record's layout is made of is here and nothing
-// else: the record has no ids in it, so a field's POSITION is its identity,
-// and the id, kind and width are what a reader at that position assumes.
+// An Entry is one field of a locked record, and it is the unit the check
+// compares. EVERY FACT A READER OF THIS RECORD ASSUMES IS HERE: the record has
+// no ids in it, so a field's POSITION is its identity, and everything below is
+// what a reader standing at that position takes the bytes to be.
 type Entry struct {
 	// Name is the field's WIRE name (§5) — its `was` alias where one is
-	// declared — for the same reason the table's is: a `was =` rename is not
+	// declared — for the same reason the record's is: a `was =` rename is not
 	// a change, so it must move no byte of this file.
 	Name string
 
@@ -107,13 +147,67 @@ type Entry struct {
 	// measures it (§19.3). It is the fact a fixed reader is standing on.
 	Width int64
 
+	// Default is the field's FRESH VALUE — its specified default where one is
+	// declared, and the implicit zero otherwise (SPEC §5), rendered as exact
+	// canonical text. It is a WIRE FACT, not a convenience: a deprecated slot
+	// holds it, an absent field on the id-table wire reads back as it, and a
+	// reader given an older writer's record fills the missing field from it.
+	// Move it and every such record means something else.
+	Default string
+
+	// Min and Max are the field's DECLARED range, "" when it declares none,
+	// and Res is the compressed-float resolution beside them, "" on an integer
+	// range. A stored value is read back against these bounds, so moving them
+	// reads every record already written at a different scale.
+	Min, Max, Res string
+
+	// Frac is a fixed-point field's RESOLUTION, spelled as the fractional bits
+	// its raw integer is scaled by, and -1 on every field that is not
+	// fixed-point. The kind fixes the width and the signedness and says
+	// nothing about F, so a moved F reads a stored raw value as a different
+	// number with no counter to fire (§4.3).
+	Frac int
+
+	// Optional is the field's `?` (§2.3): a presence bool beside the value,
+	// inside the record. A reader that expects one where none is written
+	// stands on the next field's first byte.
+	Optional bool
+
 	// Deprecated is the field's `| deprecated` marker (§2.10). It may turn
 	// on and it may never turn off: the slot stays where it is, nothing new
 	// may name the field, and a reader ignores what it finds there.
 	Deprecated bool
 }
 
-// FixedTables names the unit's FIXED tables — the ones this file locks — in
+// A ValueList is one enum, flags mask or union a fixed table reaches: its
+// values in DECLARED ORDER, which is the order the storage is numbered by. In
+// a fixed record an enum rides as its dense ordinal, a flags bit is its
+// position, and a union's tag is its arm's position — so the list IS the
+// mapping from a stored number to a meaning, and it evolves append-only for
+// exactly the reason a field sequence does.
+type ValueList struct {
+	// Decl is [DeclEnum], [DeclFlags] or [DeclUnion].
+	Decl string
+	// Name is the declaration's name.
+	Name string
+	// Hash is the hash of Values as [ValuesHash] takes it — the same statement
+	// twice that a record's layout hash is.
+	Hash uint64
+	// Values are the variant or arm WIRE names in declared order (§5), so a
+	// `was` rename moves no line here either.
+	Values []string
+}
+
+// Child is the word one value of this list is called: a union has ARMS and an
+// enum or a flags mask has VARIANTS.
+func (v *ValueList) Child() string {
+	if v.Decl == DeclUnion {
+		return "arm"
+	}
+	return "variant"
+}
+
+// FixedTables names the unit's FIXED tables — the roots this file locks — in
 // name order.
 //
 // THIS IS THE ONE PLACE THE SET IS DECIDED. Today it is derived: a table is
@@ -142,26 +236,163 @@ func FixedTables(u *ir.Unit) []string {
 	return out
 }
 
-// Render projects a checked unit's fixed tables. The result is exactly what
-// [Unit.Text] writes and what the check compares against.
+// closure is everything the unit's FIXED tables REACH, which is everything
+// their records are made of. The root alone is not the layout: a `type` nested
+// by value contributes its own fields' bytes, an enum contributes the meaning
+// of a stored ordinal, a flags mask the meaning of a bit, a union the meaning
+// of a tag. A change inside any of them moves what a reader of the ROOT gets
+// back without moving one line of the root's entries, so each is locked in its
+// own block.
+type closure struct {
+	structs []*ir.Struct // the `type` records — the tables are roots already
+	enums   []*ir.Enum
+	flags   []*ir.Flags
+	unions  []*ir.Union
+}
+
+// reach walks the fixed tables' by-value edges. A pointer edge cannot appear
+// here at all — a pointer is what makes its owner VARIABLE-LENGTH
+// (ir.VariableTables) — so every edge this walk crosses is one whose bytes are
+// inside the root's own record.
+func reach(u *ir.Unit) *closure {
+	c := &closure{}
+	seenStruct := map[*ir.Struct]bool{}
+	seenEnum := map[*ir.Enum]bool{}
+	seenFlags := map[*ir.Flags]bool{}
+	seenUnion := map[*ir.Union]bool{}
+
+	var walkFields func(fields []*ir.Field)
+	var walkStruct func(st *ir.Struct)
+	var walkUnion func(un *ir.Union)
+
+	walkStruct = func(st *ir.Struct) {
+		if st == nil || seenStruct[st] {
+			return
+		}
+		seenStruct[st] = true
+		// a nested `table` is a fixed table of this unit and already a root
+		// (FixedTables lists every one of them); only a `type` needs a block
+		// of its own
+		if !st.IsTable {
+			c.structs = append(c.structs, st)
+		}
+		walkFields(st.Fields)
+	}
+	walkUnion = func(un *ir.Union) {
+		if un == nil || seenUnion[un] {
+			return
+		}
+		seenUnion[un] = true
+		c.unions = append(c.unions, un)
+		for _, v := range un.Variants {
+			if v.F != nil {
+				walkFields([]*ir.Field{v.F})
+			}
+		}
+	}
+	walkFields = func(fields []*ir.Field) {
+		for _, f := range fields {
+			// an enum-keyed array's KEY reaches the enum as surely as a field
+			// of that type does (§2.4), and its Max is the array's length
+			if f.KeyEnumRef != nil && !seenEnum[f.KeyEnumRef] {
+				seenEnum[f.KeyEnumRef] = true
+				c.enums = append(c.enums, f.KeyEnumRef)
+			}
+			if f.IsMap() {
+				walkStruct(f.MapEntry)
+				continue
+			}
+			if f.Type.Kind != ir.TNamed {
+				continue
+			}
+			switch ref := f.Type.Ref.(type) {
+			case *ir.Struct:
+				walkStruct(ref)
+			case *ir.Enum:
+				if !seenEnum[ref] {
+					seenEnum[ref] = true
+					c.enums = append(c.enums, ref)
+				}
+			case *ir.Flags:
+				if !seenFlags[ref] {
+					seenFlags[ref] = true
+					c.flags = append(c.flags, ref)
+				}
+			case *ir.Union:
+				walkUnion(ref)
+			}
+		}
+	}
+
+	for _, name := range FixedTables(u) {
+		walkStruct(u.Tables[name])
+	}
+	sort.Slice(c.structs, func(i, j int) bool { return c.structs[i].Name < c.structs[j].Name })
+	sort.Slice(c.enums, func(i, j int) bool { return c.enums[i].Name < c.enums[j].Name })
+	sort.Slice(c.flags, func(i, j int) bool { return c.flags[i].Name < c.flags[j].Name })
+	sort.Slice(c.unions, func(i, j int) bool { return c.unions[i].Name < c.unions[j].Name })
+	return c
+}
+
+// Render projects a checked unit's fixed tables and their whole closure. The
+// result is exactly what [Unit.Text] writes and what the check compares
+// against.
 func Render(u *ir.Unit) *Unit {
 	out := &Unit{Version: Version, Package: u.Package}
 	for _, name := range FixedTables(u) {
-		st := u.Tables[name]
-		out.Tables = append(out.Tables, renderTable(u, st))
+		out.Tables = append(out.Tables, renderTable(u, DeclFixedTable, u.Tables[name]))
+	}
+	c := reach(u)
+	for _, st := range c.structs {
+		out.Tables = append(out.Tables, renderTable(u, DeclType, st))
+	}
+	for _, e := range c.enums {
+		vals := make([]string, len(e.Variants))
+		for i := range e.Variants {
+			vals[i] = e.VariantWireName(i)
+		}
+		out.Values = append(out.Values, newValueList(DeclEnum, e.Name, vals))
+	}
+	for _, fl := range c.flags {
+		out.Values = append(out.Values, newValueList(DeclFlags, fl.Name, append([]string(nil), fl.Variants...)))
+	}
+	for _, un := range c.unions {
+		vals := make([]string, len(un.Variants))
+		for i, v := range un.Variants {
+			vals[i] = v.WireName()
+		}
+		out.Values = append(out.Values, newValueList(DeclUnion, un.Name, vals))
 	}
 	return out
 }
 
-func renderTable(u *ir.Unit, st *ir.Struct) Table {
-	t := Table{Name: st.WireName()}
+func newValueList(decl, name string, values []string) ValueList {
+	v := ValueList{Decl: decl, Name: name, Values: values}
+	v.Hash = ValuesHash(&v)
+	return v
+}
+
+func renderTable(u *ir.Unit, decl string, st *ir.Struct) Table {
+	t := Table{Decl: decl, Name: st.WireName()}
 	layout := ir.RecordLayout(u, st)
 	for _, f := range st.Fields {
 		e := Entry{
 			Name:       fieldWireName(f),
 			Id:         ir.TableFieldWireId(f),
 			Kind:       ir.TableFieldKind(f),
+			Default:    defaultText(f),
+			Frac:       -1,
+			Optional:   f.Type.Optional,
 			Deprecated: f.Deprecated,
+		}
+		switch {
+		case f.HasIntRange && f.IntMin != nil && f.IntMax != nil:
+			e.Min, e.Max = f.IntMin.String(), f.IntMax.String()
+		case f.HasFloatRange:
+			e.Min, e.Max, e.Res = floatText(f.FMin), floatText(f.FMax), floatText(f.Resolution)
+		}
+		if f.Type.Kind == ir.TFixed {
+			e.Frac = f.Type.FracBits
 		}
 		if fl := layout.FieldByName(f.Name); fl != nil {
 			e.Width = fl.Size
@@ -181,6 +412,77 @@ func fieldWireName(f *ir.Field) string {
 	return f.Name
 }
 
+// defaultText is the field's FRESH VALUE as exact canonical text — the
+// specified default where one is declared, and the implicit zero otherwise
+// (SPEC §5). It is the EVALUATED value and never the author's spelling, so a
+// constant that moved through an expression into a default shows up as the
+// value it now produces.
+//
+// Every field renders something: "no default declared" is not the absence of a
+// fact, it is the fact that a fresh record holds zero there, and a declaration
+// that gives that slot a value later has changed what an older writer's
+// missing field reads back as.
+func defaultText(f *ir.Field) string {
+	if f.IsMap() || f.Array != ir.ArrayNone {
+		// an array takes no specified default; its one birth value is the
+		// COUNT a fresh value carries, the declared minimum (SPEC §4.6)
+		return "born:" + strconv.FormatInt(f.BornCount(), 10)
+	}
+	switch f.Type.Kind {
+	case ir.TBool:
+		return strconv.FormatBool(f.HasDefault && f.DefBool)
+	case ir.TFloat32, ir.TFloat64:
+		if f.HasDefault {
+			return floatText(f.DefFloat)
+		}
+		return floatText(0)
+	case ir.TString, ir.TWString, ir.TBytes:
+		// the bytes themselves, hex-spelled so a space in a default cannot
+		// split the token (SPEC §4.2)
+		if f.HasDefault {
+			return "bytes:" + hex.EncodeToString(f.DefBytes)
+		}
+		return "bytes:"
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			// the implicit None at 0 is what a fresh enum field holds, and a
+			// named default records the variant's WIRE name so a rename moves
+			// no line (§5)
+			if f.HasDefault && f.DefVariant != "" {
+				return "variant:" + ref.VariantWireNameOf(f.DefVariant)
+			}
+			return "variant:None"
+		case *ir.Flags:
+			return "mask:" + intText(f)
+		}
+		// a nested record and a union hold their own fresh value, and their
+		// own block is where it is recorded
+		return "zero"
+	default:
+		// TInt, TBits and TFixed — a fixed field's RAW value
+		return intText(f)
+	}
+}
+
+func intText(f *ir.Field) string {
+	if f.HasDefault && f.DefInt != nil {
+		return f.DefInt.String()
+	}
+	return "0"
+}
+
+// floatText is the shortest round-tripping form of a float fact: exact, and
+// stable across builds. The trailing ".0" is put back on a whole number so a
+// float never reads as an integer one.
+func floatText(v float64) string {
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eEnN") {
+		s += ".0"
+	}
+	return s
+}
+
 // LayoutHash digests an entry sequence with the wire's own hash — one hash in
 // this tree, and this file has no reason to be the second (§5).
 //
@@ -196,13 +498,62 @@ func LayoutHash(entries []Entry) uint64 {
 	return ir.TableWireId(b.String())
 }
 
+// ValuesHash is [LayoutHash] for a value list, over the same lines the file
+// carries and for the same reason.
+func ValuesHash(v *ValueList) uint64 {
+	var b strings.Builder
+	for _, s := range v.Values {
+		b.WriteString(v.Child())
+		b.WriteByte(' ')
+		b.WriteString(s)
+		b.WriteByte('\n')
+	}
+	return ir.TableWireId(b.String())
+}
+
 // line is one entry's text, and the unit the layout hash digests.
 func (e Entry) line() string {
-	s := fmt.Sprintf("field %s id=0x%016x kind=%d width=%d", e.Name, e.Id, e.Kind, e.Width)
+	s := fmt.Sprintf("field %s id=0x%016x kind=%d width=%d default=%s", e.Name, e.Id, e.Kind, e.Width, e.Default)
+	if e.Min != "" || e.Max != "" {
+		s += " min=" + e.Min + " max=" + e.Max
+	}
+	if e.Res != "" {
+		s += " res=" + e.Res
+	}
+	if e.Frac >= 0 {
+		s += " frac=" + strconv.Itoa(e.Frac)
+	}
+	if e.Optional {
+		s += " optional"
+	}
 	if e.Deprecated {
 		s += " deprecated"
 	}
 	return s
+}
+
+// rangeText is an entry's range as a refusal says it, and "unranged" when the
+// field declares none.
+func (e Entry) rangeText() string {
+	var parts []string
+	if e.Min != "" || e.Max != "" {
+		parts = append(parts, "["+e.Min+", "+e.Max+"]")
+	}
+	if e.Res != "" {
+		parts = append(parts, "resolution "+e.Res)
+	}
+	if e.Frac >= 0 {
+		parts = append(parts, strconv.Itoa(e.Frac)+" fractional bits")
+	}
+	if len(parts) == 0 {
+		return "unranged"
+	}
+	return strings.Join(parts, " at ")
+}
+
+// sameRange reports whether two entries agree on every bound and every scale.
+func (e Entry) sameRange(o Entry) bool {
+	return e.Min == o.Min && e.Max == o.Max && e.Res == o.Res && e.Frac == o.Frac
 }
 
 // Text renders the lock as the committed file.
@@ -211,19 +562,35 @@ func (u *Unit) Text() string {
 	fmt.Fprintf(&b, "%s %d\n", magic, u.Version)
 	fmt.Fprintf(&b, "package %s\n", u.Package)
 	for _, t := range u.Tables {
-		fmt.Fprintf(&b, "\nfixed table %s layout=0x%016x\n", t.Name, t.Layout)
+		fmt.Fprintf(&b, "\n%s %s layout=0x%016x\n", t.Decl, t.Name, t.Layout)
 		for _, e := range t.Entries {
 			fmt.Fprintf(&b, "    %s\n", e.line())
+		}
+	}
+	for _, v := range u.Values {
+		fmt.Fprintf(&b, "\n%s %s values=0x%016x\n", v.Decl, v.Name, v.Hash)
+		for _, s := range v.Values {
+			fmt.Fprintf(&b, "    %s %s\n", v.Child(), s)
 		}
 	}
 	return b.String()
 }
 
-// Table returns one locked table by wire name.
+// Table returns one locked record by name.
 func (u *Unit) Table(name string) *Table {
 	for i := range u.Tables {
 		if u.Tables[i].Name == name {
 			return &u.Tables[i]
+		}
+	}
+	return nil
+}
+
+// List returns one locked enum, flags mask or union by name.
+func (u *Unit) List(name string) *ValueList {
+	for i := range u.Values {
+		if u.Values[i].Name == name {
+			return &u.Values[i]
 		}
 	}
 	return nil
@@ -235,6 +602,7 @@ func Parse(path string, data []byte) (*Unit, error) {
 	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
 	u := &Unit{}
 	var cur *Table
+	var curList *ValueList
 	for n, raw := range lines {
 		where := fmt.Sprintf("%s:%d", path, n+1)
 		line := strings.TrimRight(raw, " \t")
@@ -252,7 +620,15 @@ func Parse(path string, data []byte) (*Unit, error) {
 				return nil, fmt.Errorf("%s: %q is not a rendering version", where, fields[1])
 			}
 			if v != Version {
-				return nil, fmt.Errorf("%s: this lock is rendering version %d and this compiler writes version %d", where, v, Version)
+				// THE ONE PARSE REFUSAL THAT IS NOT A HAND-EDIT. The
+				// rendering version is the compiler's own, so there is
+				// nothing here for a person to repair: the file is
+				// regenerated from the declaration and nothing in it is
+				// salvage. Say the remedy that works, because the wrappers
+				// around this error say "write it with `schema lock`" and
+				// this is the one case where that command needs the old file
+				// gone first.
+				return nil, fmt.Errorf("%s: this lock is rendering version %d and this compiler writes version %d — the rendering version is the compiler's own and this file holds nothing a hand can carry forward: delete it and write it again with `schema lock`", where, v, Version)
 			}
 			u.Version = v
 		case fields[0] == "package":
@@ -268,17 +644,48 @@ func Parse(path string, data []byte) (*Unit, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", where, err)
 			}
-			u.Tables = append(u.Tables, Table{Name: fields[2], Layout: h})
-			cur = &u.Tables[len(u.Tables)-1]
+			u.Tables = append(u.Tables, Table{Decl: DeclFixedTable, Name: fields[2], Layout: h})
+			cur, curList = &u.Tables[len(u.Tables)-1], nil
+		case fields[0] == DeclType:
+			if len(fields) != 3 {
+				return nil, fmt.Errorf("%s: a nested record line is `type <Name> layout=0x...`", where)
+			}
+			h, err := parseHex(fields[2], "layout")
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", where, err)
+			}
+			u.Tables = append(u.Tables, Table{Decl: DeclType, Name: fields[1], Layout: h})
+			cur, curList = &u.Tables[len(u.Tables)-1], nil
+		case fields[0] == DeclEnum, fields[0] == DeclFlags, fields[0] == DeclUnion:
+			if len(fields) != 3 {
+				return nil, fmt.Errorf("%s: a value-list line is `%s <Name> values=0x...`", where, fields[0])
+			}
+			h, err := parseHex(fields[2], "values")
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", where, err)
+			}
+			u.Values = append(u.Values, ValueList{Decl: fields[0], Name: fields[1], Hash: h})
+			cur, curList = nil, &u.Values[len(u.Values)-1]
 		case fields[0] == "field":
 			if cur == nil {
-				return nil, fmt.Errorf("%s: a field line before any `fixed table` line", where)
+				return nil, fmt.Errorf("%s: a field line before any record line", where)
 			}
 			e, err := parseEntry(fields)
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", where, err)
 			}
 			cur.Entries = append(cur.Entries, e)
+		case fields[0] == "variant", fields[0] == "arm":
+			if curList == nil {
+				return nil, fmt.Errorf("%s: a %s line before any `enum`, `flags` or `union` line", where, fields[0])
+			}
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("%s: a %s line names one value", where, fields[0])
+			}
+			if fields[0] != curList.Child() {
+				return nil, fmt.Errorf("%s: a %s carries %s lines, not %s lines", where, curList.Decl, curList.Child(), fields[0])
+			}
+			curList.Values = append(curList.Values, fields[1])
 		default:
 			return nil, fmt.Errorf("%s: %q is not a line a %s carries", where, fields[0], FileName)
 		}
@@ -290,13 +697,15 @@ func Parse(path string, data []byte) (*Unit, error) {
 }
 
 func parseEntry(fields []string) (Entry, error) {
-	if len(fields) < 5 {
-		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N [deprecated]`")
+	if len(fields) < 6 {
+		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N default=V [min=V max=V] [res=V] [frac=N] [optional] [deprecated]`")
 	}
-	e := Entry{Name: fields[1]}
+	e := Entry{Name: fields[1], Frac: -1}
 	for _, tok := range fields[2:] {
 		key, val, valued := strings.Cut(tok, "=")
 		switch {
+		case !valued && key == "optional":
+			e.Optional = true
 		case !valued && key == "deprecated":
 			e.Deprecated = true
 		case !valued:
@@ -319,6 +728,20 @@ func parseEntry(fields []string) (Entry, error) {
 				return Entry{}, fmt.Errorf("width=%q is not a number", val)
 			}
 			e.Width = n
+		case key == "default":
+			e.Default = val
+		case key == "min":
+			e.Min = val
+		case key == "max":
+			e.Max = val
+		case key == "res":
+			e.Res = val
+		case key == "frac":
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				return Entry{}, fmt.Errorf("frac=%q is not a count of fractional bits", val)
+			}
+			e.Frac = n
 		default:
 			return Entry{}, fmt.Errorf("%q is not a fact a field line carries", key)
 		}

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -25,8 +25,11 @@
 // One entry per field, in DECLARED ORDER, carrying the four facts a fixed
 // record's layout is made of: the field's wire id, its kind, its WIDTH in the
 // record, and whether it is deprecated. Per table, the hash of that sequence.
-// The check is then one sentence: THE LOCKED SEQUENCE IS A PREFIX OF THE
-// LIVE ONE, entry for entry, with `deprecated` allowed only to turn on.
+// The check is then one sentence: THE LOCK IS THE LIVE SEQUENCE, entry for
+// entry. The APPEND-ONLY rule — the locked sequence is a PREFIX of the live
+// one, with `deprecated` allowed only to turn on — is what `schema lock` will
+// write, and what it refuses to write is what every compile refuses too. The
+// two readings are [Current] and [Appendable].
 package lockfile
 
 import (

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -30,11 +30,14 @@
 //
 //   - one entry per field, in DECLARED ORDER, carrying the field's wire id,
 //     its kind, its WIDTH in the record, its DEFAULT declared or implicit, its
-//     declared RANGE and resolution, its `?` and its `deprecated` marker;
+//     declared RANGE and resolution, its `?` and its `deprecated` marker,
+//     which named type a kind-13/15 slot holds (name and that type's layout
+//     hash), and an array's element kind and width;
 //   - one block per TYPE the fixed tables reach — a nested `type` record, an
 //     `enum`, a `flags` mask, a `union` — because a fixed record is made of
 //     those and a change inside one moves the root's bytes without moving one
-//     line of the root's own entries;
+//     line of the root's own entries; a union arm carries its payload type
+//     beside the name;
 //   - per block, the hash of its lines.
 //
 // The check is then one sentence: THE LOCK IS THE LIVE SEQUENCE, entry for
@@ -44,9 +47,10 @@
 // refuses too. The two readings are [Current] and [Appendable].
 //
 // ONE CLASS IS BEYOND THE FILE, and §2.10 says so: a field that keeps its
-// name, its id, its kind, its width, its default, its range and its `?` and
-// changes only what it MEANS. Nothing recorded here moves, so nothing here can
-// refuse it; the rule for that change is deprecate and add.
+// name, its id, its kind, its width, its default, its range, its `?`, the
+// type it holds and its element shape, and changes only what it MEANS.
+// Nothing recorded here moves, so nothing here can refuse it; the rule for
+// that change is deprecate and add.
 package lockfile
 
 import (
@@ -71,7 +75,11 @@ import (
 //
 // 2 is the owner's widening: the default, the range, the `?`, and a block per
 // enum, flags mask, union and nested record the fixed tables reach.
-const Version = 2
+// 3 records which type a kind-13/15 slot holds (`held=Buff@0x...`), an
+// array's element kind and width (`elem=4/4`), and a union arm's payload
+// type beside the name. Those are new facts on the hashed lines, so a v2
+// lock is deleted and rewritten, the same sentence v1 took.
+const Version = 3
 
 // FileName is the lock's name beside the unit's schema files. Unlike the
 // tables baseline, its presence is not what turns the check on for a unit
@@ -177,6 +185,19 @@ type Entry struct {
 	// on and it may never turn off: the slot stays where it is, nothing new
 	// may name the field, and a reader ignores what it finds there.
 	Deprecated bool
+
+	// HeldName and HeldHash are the nested type a kind-13 (table) or kind-15
+	// (union) slot holds — the type's wire name and that type's layout hash
+	// (a union's values hash), spelled `held=Buff@0x...`. A kind-14 array of
+	// a named type carries the same pair for its element. Empty on a scalar.
+	HeldName string
+	HeldHash uint64
+
+	// ElemKind and ElemWidth are a kind-14 (array) slot's element: the
+	// element's table-wire kind and its width in bytes, spelled `elem=4/4`.
+	// Zero on every other kind.
+	ElemKind  int
+	ElemWidth int64
 }
 
 // A ValueList is one enum, flags mask or union a fixed table reaches: its
@@ -196,6 +217,11 @@ type ValueList struct {
 	// Values are the variant or arm WIRE names in declared order (§5), so a
 	// `was` rename moves no line here either.
 	Values []string
+
+	// Payloads are a union's arm payload types, parallel to Values: the
+	// nested record's `Name@0xhash`, or a scalar arm's type spelling, or
+	// "" on a payload-free arm. Nil on an enum or a flags mask.
+	Payloads []string
 }
 
 // Child is the word one value of this list is called: a union has ARMS and an
@@ -338,43 +364,63 @@ func reach(u *ir.Unit) *closure {
 // result is exactly what [Unit.Text] writes and what the check compares
 // against.
 func Render(u *ir.Unit) *Unit {
+	r := &renderer{
+		u:      u,
+		tables: map[*ir.Struct]Table{},
+		enums:  map[*ir.Enum]ValueList{},
+		flags:  map[*ir.Flags]ValueList{},
+		unions: map[*ir.Union]ValueList{},
+	}
 	out := &Unit{Version: Version, Package: u.Package}
 	for _, name := range FixedTables(u) {
-		out.Tables = append(out.Tables, renderTable(u, DeclFixedTable, u.Tables[name]))
+		out.Tables = append(out.Tables, r.table(DeclFixedTable, u.Tables[name]))
 	}
 	c := reach(u)
 	for _, st := range c.structs {
-		out.Tables = append(out.Tables, renderTable(u, DeclType, st))
+		out.Tables = append(out.Tables, r.table(DeclType, st))
 	}
 	for _, e := range c.enums {
-		vals := make([]string, len(e.Variants))
-		for i := range e.Variants {
-			vals[i] = e.VariantWireName(i)
-		}
-		out.Values = append(out.Values, newValueList(DeclEnum, e.Name, vals))
+		out.Values = append(out.Values, r.enumList(e))
 	}
 	for _, fl := range c.flags {
-		out.Values = append(out.Values, newValueList(DeclFlags, fl.Name, append([]string(nil), fl.Variants...)))
+		out.Values = append(out.Values, r.flagsList(fl))
 	}
 	for _, un := range c.unions {
-		vals := make([]string, len(un.Variants))
-		for i, v := range un.Variants {
-			vals[i] = v.WireName()
-		}
-		out.Values = append(out.Values, newValueList(DeclUnion, un.Name, vals))
+		out.Values = append(out.Values, r.unionList(un))
 	}
 	return out
 }
 
-func newValueList(decl, name string, values []string) ValueList {
-	v := ValueList{Decl: decl, Name: name, Values: values}
-	v.Hash = ValuesHash(&v)
-	return v
+// renderer fills held hashes from the nested type's own block, so a kind-13
+// slot and the `type` it names agree on the number, and a union arm's
+// payload= agrees with the nested record it points at.
+type renderer struct {
+	u      *ir.Unit
+	tables map[*ir.Struct]Table
+	enums  map[*ir.Enum]ValueList
+	flags  map[*ir.Flags]ValueList
+	unions map[*ir.Union]ValueList
 }
 
-func renderTable(u *ir.Unit, decl string, st *ir.Struct) Table {
+func structDecl(st *ir.Struct) string {
+	if st.IsTable {
+		return DeclFixedTable
+	}
+	return DeclType
+}
+
+func (r *renderer) table(decl string, st *ir.Struct) Table {
+	if t, ok := r.tables[st]; ok {
+		return t
+	}
+	t := r.renderTable(decl, st)
+	r.tables[st] = t
+	return t
+}
+
+func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 	t := Table{Decl: decl, Name: st.WireName()}
-	layout := ir.RecordLayout(u, st)
+	layout := ir.RecordLayout(r.u, st)
 	for _, f := range st.Fields {
 		e := Entry{
 			Name:       fieldWireName(f),
@@ -397,10 +443,146 @@ func renderTable(u *ir.Unit, decl string, st *ir.Struct) Table {
 		if fl := layout.FieldByName(f.Name); fl != nil {
 			e.Width = fl.Size
 		}
+		switch e.Kind {
+		case ir.TableKindTable, ir.TableKindUnion:
+			e.HeldName, e.HeldHash = r.held(f)
+		case ir.TableKindArray:
+			e.ElemKind = ir.TableElemKind(f)
+			e.ElemWidth = elemSize(r.u, f)
+			e.HeldName, e.HeldHash = r.held(f)
+		}
 		t.Entries = append(t.Entries, e)
 	}
 	t.Layout = LayoutHash(t.Entries)
 	return t
+}
+
+func (r *renderer) held(f *ir.Field) (string, uint64) {
+	if f.IsMap() && f.MapEntry != nil {
+		t := r.table(DeclFixedTable, f.MapEntry)
+		return t.Name, t.Layout
+	}
+	if f.Type.Kind != ir.TNamed {
+		return "", 0
+	}
+	switch ref := f.Type.Ref.(type) {
+	case *ir.Struct:
+		t := r.table(structDecl(ref), ref)
+		return t.Name, t.Layout
+	case *ir.Union:
+		v := r.unionList(ref)
+		return v.Name, v.Hash
+	default:
+		return "", 0
+	}
+}
+
+func (r *renderer) enumList(e *ir.Enum) ValueList {
+	if v, ok := r.enums[e]; ok {
+		return v
+	}
+	vals := make([]string, len(e.Variants))
+	for i := range e.Variants {
+		vals[i] = e.VariantWireName(i)
+	}
+	v := newValueList(DeclEnum, e.Name, vals, nil)
+	r.enums[e] = v
+	return v
+}
+
+func (r *renderer) flagsList(fl *ir.Flags) ValueList {
+	if v, ok := r.flags[fl]; ok {
+		return v
+	}
+	v := newValueList(DeclFlags, fl.Name, append([]string(nil), fl.Variants...), nil)
+	r.flags[fl] = v
+	return v
+}
+
+func (r *renderer) unionList(un *ir.Union) ValueList {
+	if v, ok := r.unions[un]; ok {
+		return v
+	}
+	vals := make([]string, len(un.Variants))
+	payloads := make([]string, len(un.Variants))
+	for i, arm := range un.Variants {
+		vals[i] = arm.WireName()
+		payloads[i] = r.armPayload(arm)
+	}
+	v := newValueList(DeclUnion, un.Name, vals, payloads)
+	r.unions[un] = v
+	return v
+}
+
+func (r *renderer) armPayload(arm ir.UnionVariant) string {
+	if arm.F == nil {
+		return ""
+	}
+	if name, hash := r.held(arm.F); name != "" {
+		return heldText(name, hash)
+	}
+	return ir.FieldTypeSpelling(arm.F)
+}
+
+func heldText(name string, hash uint64) string {
+	if name == "" {
+		return ""
+	}
+	if hash == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s@0x%016x", name, hash)
+}
+
+func newValueList(decl, name string, values, payloads []string) ValueList {
+	v := ValueList{Decl: decl, Name: name, Values: values, Payloads: payloads}
+	v.Hash = ValuesHash(&v)
+	return v
+}
+
+// elemSize is one VALUE of a field's declared type, in bytes — the array
+// element a kind-14 slot is made of. It follows ir.elementPiece so a nested
+// record, an enum's storage width and a scalar all agree with the layout.
+func elemSize(u *ir.Unit, f *ir.Field) int64 {
+	if f.IsMap() && f.MapEntry != nil {
+		return ir.RecordLayout(u, f.MapEntry).Size
+	}
+	if f.Type.Pointer {
+		return 8
+	}
+	switch f.Type.Kind {
+	case ir.TBool:
+		return 1
+	case ir.TFloat32:
+		return 4
+	case ir.TFloat64:
+		return 8
+	case ir.TInt, ir.TFixed:
+		return int64(f.Type.Width) / 8
+	case ir.TBits:
+		if f.Type.Width <= 32 {
+			return 4
+		}
+		return 8
+	case ir.TBytes:
+		return 1
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			return int64(ir.StorageBitsFor(ref.Max)) / 8
+		case *ir.Flags:
+			return 8
+		case *ir.Struct:
+			return ir.RecordLayout(u, ref).Size
+		case *ir.Union:
+			size, _, _, _ := ir.UnionLayout(u, ref)
+			return size
+		}
+	}
+	if w := ir.TableKindWidth(ir.TableElemKind(f)); w > 0 {
+		return int64(w)
+	}
+	return 0
 }
 
 // fieldWireName is the name this file records: the `was` alias where one is
@@ -502,13 +684,24 @@ func LayoutHash(entries []Entry) uint64 {
 // carries and for the same reason.
 func ValuesHash(v *ValueList) uint64 {
 	var b strings.Builder
-	for _, s := range v.Values {
+	for i, s := range v.Values {
 		b.WriteString(v.Child())
 		b.WriteByte(' ')
 		b.WriteString(s)
+		if payload := valuePayload(v, i); payload != "" {
+			b.WriteString(" payload=")
+			b.WriteString(payload)
+		}
 		b.WriteByte('\n')
 	}
 	return ir.TableWireId(b.String())
+}
+
+func valuePayload(v *ValueList, i int) string {
+	if i < 0 || i >= len(v.Payloads) {
+		return ""
+	}
+	return v.Payloads[i]
 }
 
 // line is one entry's text, and the unit the layout hash digests.
@@ -522,6 +715,12 @@ func (e Entry) line() string {
 	}
 	if e.Frac >= 0 {
 		s += " frac=" + strconv.Itoa(e.Frac)
+	}
+	if e.HeldName != "" {
+		s += " held=" + heldText(e.HeldName, e.HeldHash)
+	}
+	if e.ElemKind != 0 || e.ElemWidth != 0 {
+		s += fmt.Sprintf(" elem=%d/%d", e.ElemKind, e.ElemWidth)
 	}
 	if e.Optional {
 		s += " optional"
@@ -569,8 +768,12 @@ func (u *Unit) Text() string {
 	}
 	for _, v := range u.Values {
 		fmt.Fprintf(&b, "\n%s %s values=0x%016x\n", v.Decl, v.Name, v.Hash)
-		for _, s := range v.Values {
-			fmt.Fprintf(&b, "    %s %s\n", v.Child(), s)
+		for i, s := range v.Values {
+			if payload := valuePayload(&v, i); payload != "" {
+				fmt.Fprintf(&b, "    %s %s payload=%s\n", v.Child(), s, payload)
+			} else {
+				fmt.Fprintf(&b, "    %s %s\n", v.Child(), s)
+			}
 		}
 	}
 	return b.String()
@@ -679,13 +882,27 @@ func Parse(path string, data []byte) (*Unit, error) {
 			if curList == nil {
 				return nil, fmt.Errorf("%s: a %s line before any `enum`, `flags` or `union` line", where, fields[0])
 			}
-			if len(fields) != 2 {
+			if len(fields) < 2 {
 				return nil, fmt.Errorf("%s: a %s line names one value", where, fields[0])
 			}
 			if fields[0] != curList.Child() {
 				return nil, fmt.Errorf("%s: a %s carries %s lines, not %s lines", where, curList.Decl, curList.Child(), fields[0])
 			}
+			payload := ""
+			for _, tok := range fields[2:] {
+				key, val, valued := strings.Cut(tok, "=")
+				if !valued || key != "payload" {
+					return nil, fmt.Errorf("%s: %q is not a fact a %s line carries", where, tok, fields[0])
+				}
+				payload = val
+			}
+			if fields[0] == "variant" && payload != "" {
+				return nil, fmt.Errorf("%s: a variant line names one value", where)
+			}
 			curList.Values = append(curList.Values, fields[1])
+			if curList.Decl == DeclUnion {
+				curList.Payloads = append(curList.Payloads, payload)
+			}
 		default:
 			return nil, fmt.Errorf("%s: %q is not a line a %s carries", where, fields[0], FileName)
 		}
@@ -698,7 +915,7 @@ func Parse(path string, data []byte) (*Unit, error) {
 
 func parseEntry(fields []string) (Entry, error) {
 	if len(fields) < 6 {
-		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N default=V [min=V max=V] [res=V] [frac=N] [optional] [deprecated]`")
+		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N default=V [min=V max=V] [res=V] [frac=N] [held=Name@0x...] [elem=K/W] [optional] [deprecated]`")
 	}
 	e := Entry{Name: fields[1], Frac: -1}
 	for _, tok := range fields[2:] {
@@ -742,6 +959,26 @@ func parseEntry(fields []string) (Entry, error) {
 				return Entry{}, fmt.Errorf("frac=%q is not a count of fractional bits", val)
 			}
 			e.Frac = n
+		case key == "held":
+			name, hash, err := parseHeld(val)
+			if err != nil {
+				return Entry{}, err
+			}
+			e.HeldName, e.HeldHash = name, hash
+		case key == "elem":
+			ks, ws, ok := strings.Cut(val, "/")
+			if !ok {
+				return Entry{}, fmt.Errorf("elem=%q is not kind/width", val)
+			}
+			ek, err := strconv.Atoi(ks)
+			if err != nil {
+				return Entry{}, fmt.Errorf("elem=%q is not kind/width", val)
+			}
+			ew, err := strconv.ParseInt(ws, 10, 64)
+			if err != nil {
+				return Entry{}, fmt.Errorf("elem=%q is not kind/width", val)
+			}
+			e.ElemKind, e.ElemWidth = ek, ew
 		default:
 			return Entry{}, fmt.Errorf("%q is not a fact a field line carries", key)
 		}
@@ -759,4 +996,16 @@ func parseHex(tok, key string) (uint64, error) {
 		return 0, fmt.Errorf("%s=%q is not a 64-bit hex value", key, val)
 	}
 	return v, nil
+}
+
+func parseHeld(val string) (string, uint64, error) {
+	name, rest, ok := strings.Cut(val, "@")
+	if !ok || name == "" {
+		return "", 0, fmt.Errorf("held=%q is not Name@0x...", val)
+	}
+	h, err := strconv.ParseUint(strings.TrimPrefix(rest, "0x"), 16, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("held=%q is not Name@0x...", val)
+	}
+	return name, h, nil
 }

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -31,8 +31,9 @@
 //   - one entry per field, in DECLARED ORDER, carrying the field's wire id,
 //     its kind, its WIDTH in the record, its DEFAULT declared or implicit, its
 //     declared RANGE and resolution, its `?` and its `deprecated` marker,
-//     which named type a slot holds (name and that type's layout hash), and
-//     an array's element kind and width;
+//     which named type a slot holds (name and that type's layout hash), an
+//     array's element kind and width, and the enum an enum-keyed array is
+//     keyed by;
 //   - one block per TYPE the fixed tables reach — a nested `type` record, an
 //     `enum`, a `flags` mask, a `union` — because a fixed record is made of
 //     those and a change inside one moves the root's bytes without moving one
@@ -83,7 +84,11 @@ import (
 // same fact kind 13/15 already carried; an array of enum or flags carries
 // held= beside elem=. v3 locks are deleted and rewritten, the same sentence
 // v1 took.
-const Version = 4
+// 5 finishes that sweep at kind 16: an ENUM-KEYED array records the enum it
+// is keyed by (`key=Hull@0x...`) and its element beside it (`elem=4/4`), the
+// two facts every other array already carried. v4 locks are deleted and
+// rewritten, the same sentence v1 took.
+const Version = 5
 
 // FileName is the lock's name beside the unit's schema files. Unlike the
 // tables baseline, its presence is not what turns the check on for a unit
@@ -198,11 +203,19 @@ type Entry struct {
 	HeldName string
 	HeldHash uint64
 
-	// ElemKind and ElemWidth are a kind-14 (array) slot's element: the
-	// element's table-wire kind and its width in bytes, spelled `elem=4/4`.
-	// Zero on every other kind.
+	// ElemKind and ElemWidth are a kind-14 (array) or kind-16 (enum-keyed
+	// array) slot's element: the element's table-wire kind and its width in
+	// bytes, spelled `elem=4/4`. Zero on every other kind.
 	ElemKind  int
 	ElemWidth int64
+
+	// KeyName and KeyHash are the enum a kind-16 slot is KEYED BY — the
+	// enum's wire name and its values hash, spelled `key=Hull@0x...`. The
+	// key's variants ARE the slots, in declared order, so the list is what
+	// says which slot a stored value was written into. Empty on every other
+	// kind.
+	KeyName string
+	KeyHash uint64
 }
 
 // A ValueList is one enum, flags mask or union a fixed table reaches: its
@@ -448,15 +461,17 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 		if fl := layout.FieldByName(f.Name); fl != nil {
 			e.Width = fl.Size
 		}
-		switch e.Kind {
-		case ir.TableKindTable, ir.TableKindUnion:
-			e.HeldName, e.HeldHash = r.held(f)
-		case ir.TableKindArray:
+		// held= is taken for EVERY kind, so a named type in a slot is never
+		// silent for want of an arm here; held() is what knows which kinds
+		// name one.
+		e.HeldName, e.HeldHash = r.held(f)
+		if e.Kind == ir.TableKindArray || e.Kind == ir.TableKindKeyed {
 			e.ElemKind = ir.TableElemKind(f)
 			e.ElemWidth = elemSize(r.u, f)
-			e.HeldName, e.HeldHash = r.held(f)
-		default:
-			e.HeldName, e.HeldHash = r.held(f)
+		}
+		if f.KeyEnumRef != nil {
+			v := r.enumList(f.KeyEnumRef)
+			e.KeyName, e.KeyHash = v.Name, v.Hash
 		}
 		t.Entries = append(t.Entries, e)
 	}
@@ -735,6 +750,9 @@ func (e Entry) line() string {
 	if e.ElemKind != 0 || e.ElemWidth != 0 {
 		s += fmt.Sprintf(" elem=%d/%d", e.ElemKind, e.ElemWidth)
 	}
+	if e.KeyName != "" {
+		s += " key=" + heldText(e.KeyName, e.KeyHash)
+	}
 	if e.Optional {
 		s += " optional"
 	}
@@ -928,7 +946,7 @@ func Parse(path string, data []byte) (*Unit, error) {
 
 func parseEntry(fields []string) (Entry, error) {
 	if len(fields) < 6 {
-		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N default=V [min=V max=V] [res=V] [frac=N] [held=Name@0x...] [elem=K/W] [optional] [deprecated]`")
+		return Entry{}, fmt.Errorf("a field line is `field <name> id=0x... kind=N width=N default=V [min=V max=V] [res=V] [frac=N] [held=Name@0x...] [elem=K/W] [key=Name@0x...] [optional] [deprecated]`")
 	}
 	e := Entry{Name: fields[1], Frac: -1}
 	for _, tok := range fields[2:] {
@@ -973,11 +991,17 @@ func parseEntry(fields []string) (Entry, error) {
 			}
 			e.Frac = n
 		case key == "held":
-			name, hash, err := parseHeld(val)
+			name, hash, err := parseHeld("held", val)
 			if err != nil {
 				return Entry{}, err
 			}
 			e.HeldName, e.HeldHash = name, hash
+		case key == "key":
+			name, hash, err := parseHeld("key", val)
+			if err != nil {
+				return Entry{}, err
+			}
+			e.KeyName, e.KeyHash = name, hash
 		case key == "elem":
 			ks, ws, ok := strings.Cut(val, "/")
 			if !ok {
@@ -1011,14 +1035,16 @@ func parseHex(tok, key string) (uint64, error) {
 	return v, nil
 }
 
-func parseHeld(val string) (string, uint64, error) {
+// parseHeld reads the `Name@0xhash` pair both held= and key= are spelled as,
+// and names the one it was given in the refusal.
+func parseHeld(key, val string) (string, uint64, error) {
 	name, rest, ok := strings.Cut(val, "@")
 	if !ok || name == "" {
-		return "", 0, fmt.Errorf("held=%q is not Name@0x plus a hash", val)
+		return "", 0, fmt.Errorf("%s=%q is not Name@0x plus a hash", key, val)
 	}
 	h, err := strconv.ParseUint(strings.TrimPrefix(rest, "0x"), 16, 64)
 	if err != nil {
-		return "", 0, fmt.Errorf("held=%q is not Name@0x plus a hash", val)
+		return "", 0, fmt.Errorf("%s=%q is not Name@0x plus a hash", key, val)
 	}
 	return name, h, nil
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,6 +1,7 @@
 // The SCHEMA LOCK, both ways (docs/SPEC-TABLES.md §2.10): every edit the rule
-// allows passes and moves the file, and every edit it forbids is refused with
-// the entry named.
+// allows moves the file and passes ONCE THE LOCK IS WRITTEN, and every edit it
+// forbids is refused with the entry named — by the check and by `schema lock`
+// alike.
 //
 // The fixture is one package with a lock, edited in a temp directory, so each
 // case is the whole path a user takes — schema on disk, lock beside it, the
@@ -162,17 +163,23 @@ func TestTextRoundTrips(t *testing.T) {
 	}
 }
 
-// ---- the edits the rule allows ----
+// ---- the edits the rule allows, and the lock that has to catch up ----
+//
+// Each of these is an append in the rule's sense, so `schema lock` writes it —
+// and each of them is a CHANGE, so the compile before that write is refused.
+// The lock in the tree is the record, and a record is current or it is
+// nothing.
 
-// TestAppendPasses is the whole point of the rule: a field at the BOTTOM
-// passes the check against the older lock, and `schema lock` extends the file
-// by exactly that entry.
-func TestAppendPasses(t *testing.T) {
+// TestAppendRefusedUntilLocked is the whole point of the rule and the STRICT
+// reading of it in one test: a field at the BOTTOM is the change the rule
+// allows, so `schema lock` extends the file by exactly that entry — and until
+// it does, the compile is refused, naming the entry the lock lacks and the
+// command that writes it.
+func TestAppendRefusedUntilLocked(t *testing.T) {
 	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint8\n    shields uint8\n", 1)
 	dir, paths, errs := locked(t, after)
-	if len(errs) != 0 {
-		t.Fatalf("an append passes: %v", errs)
-	}
+	refuses(t, errs, "fixed table ShipConfig", "entry 4", "field shields",
+		"in the declaration and not in the lock", "write it with `schema lock`")
 	before := readLock(t, filepath.Join(dir, lockfile.FileName))
 	path, rewrote, err := lockfile.Update(load(t, paths), paths)
 	if err != nil {
@@ -196,20 +203,24 @@ func TestAppendPasses(t *testing.T) {
 	if now[len(old)].Name != "shields" {
 		t.Errorf("the appended field is the last entry: %+v", now[len(old)])
 	}
+	// and with the lock written, the same compile passes
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the written lock checks clean: %v", errs)
+	}
 	// and the extended lock is idempotent
 	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
 		t.Errorf("a current lock is left alone: rewrote=%v err=%v", rewrote, err)
 	}
 }
 
-// TestNewTablePasses: a table the lock does not carry has promised nothing,
-// so it passes and `schema lock` adds its entry.
-func TestNewTablePasses(t *testing.T) {
+// TestNewTableRefusedUntilLocked: a table the lock does not carry has promised
+// nothing, so `schema lock` adds it — and until it has, the lock is behind the
+// unit and the compile is refused at the table's first entry.
+func TestNewTableRefusedUntilLocked(t *testing.T) {
 	after := base + "\ntable Beacon\n{\n    hz uint8\n}\n"
 	dir, paths, errs := locked(t, after)
-	if len(errs) != 0 {
-		t.Fatalf("a new table passes: %v", errs)
-	}
+	refuses(t, errs, "fixed table Beacon", "entry 1", "field hz",
+		"in the declaration and not in the lock", "write it with `schema lock`")
 	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
 		t.Fatal(err)
 	}
@@ -219,6 +230,28 @@ func TestNewTablePasses(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "fixed table Beacon ") {
 		t.Errorf("the new table is in the lock:\n%s", got)
+	}
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the written lock checks clean: %v", errs)
+	}
+}
+
+// TestNewFieldlessTableRefusedUntilLocked is the same finding with no entry to
+// name: a table with no fields is still a table the lock does not carry, and
+// the refusal names the table alone rather than inventing an entry for it.
+func TestNewFieldlessTableRefusedUntilLocked(t *testing.T) {
+	after := base + "\ntable Marker\n{\n}\n"
+	_, paths, errs := locked(t, after)
+	refuses(t, errs, "fixed table Marker is in the declaration and not in the lock",
+		"write it with `schema lock`")
+	if strings.Contains(errs[0].Error(), "entry ") {
+		t.Errorf("there is no entry to name: %v", errs[0])
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the written lock checks clean: %v", errs)
 	}
 }
 
@@ -246,15 +279,15 @@ func TestWasRenameIsNotAChange(t *testing.T) {
 	}
 }
 
-// TestDeprecateIsAllowed: the marker turns on, the check passes, and
-// `schema lock` flips the flag in place — the entry keeps its position, its id
-// and its width, because deprecation is about meaning and never about layout.
-func TestDeprecateIsAllowed(t *testing.T) {
+// TestDeprecateIsAllowedOnceLocked: the marker turns on and `schema lock`
+// flips the flag in place — the entry keeps its position, its id and its
+// width, because deprecation is about meaning and never about layout. It is a
+// change all the same, so the compile before the flip is written is refused.
+func TestDeprecateIsAllowedOnceLocked(t *testing.T) {
 	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint8 | deprecated\n", 1)
 	dir, paths, errs := locked(t, after)
-	if len(errs) != 0 {
-		t.Fatalf("deprecating a field is allowed: %v", errs)
-	}
+	refuses(t, errs, "fixed table ShipConfig", "entry 3", "field armor",
+		"deprecated in the declaration and live in the lock", "write it with `schema lock`")
 	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
 		t.Fatalf("the lock flips the flag: rewrote=%v err=%v", rewrote, err)
 	}
@@ -303,8 +336,9 @@ func TestDeprecatedFieldStillHasItsSlot(t *testing.T) {
 
 // ---- the edits the rule refuses ----
 
-func TestReorderRefused(t *testing.T) {
-	after := `package lockdemo
+// reordered is the fixture with speed and armor swapped — the break both
+// verbs refuse.
+const reordered = `package lockdemo
 
 table ShipConfig
 {
@@ -324,7 +358,9 @@ table Chain
     next *Chain
 }
 `
-	_, _, errs := locked(t, after)
+
+func TestReorderRefused(t *testing.T) {
+	_, _, errs := locked(t, reordered)
 	refuses(t, errs, "fixed table ShipConfig", "entry 2", "field speed", "APPEND-ONLY", "never inserted, moved or removed")
 }
 
@@ -460,6 +496,46 @@ func TestLockRefusesToWriteABreak(t *testing.T) {
 	got, _ := os.ReadFile(path)
 	if string(got) != string(before) {
 		t.Errorf("the file was left alone:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+	}
+}
+
+// TestLockRefusesWhatTheCheckRefuses: the two verbs part company on ONE
+// reading — a declaration the lock has not caught up to, which is the whole
+// reason this command exists — and on nothing else. A reorder, a removal and
+// a kind change are refused by both, and none of them moves the file.
+func TestLockRefusesWhatTheCheckRefuses(t *testing.T) {
+	for _, tc := range []struct{ name, after, want string }{
+		{"reorder", reordered, "never inserted, moved or removed"},
+		{"removal from the end", strings.Replace(base, "    armor   uint8\n", "", 1), "gone from the declaration"},
+		{"kind change", strings.Replace(base, "    speed   float32\n", "    speed   int32\n", 1), "keeps its type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, paths := fixture(t, base)
+			if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, lockfile.FileName)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(tc.after), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			// the check refuses it
+			refuses(t, lockfile.Check(load(t, paths), paths), tc.want)
+			// and so does the one writer, with the file left alone
+			_, rewrote, err := lockfile.Update(load(t, paths), paths)
+			if err == nil || rewrote {
+				t.Fatalf("`schema lock` appends, and this is not an append: rewrote=%v err=%v", rewrote, err)
+			}
+			if !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), "not an append") {
+				t.Errorf("the refusal says which break and why: %v", err)
+			}
+			if got, _ := os.ReadFile(path); string(got) != string(before) {
+				t.Errorf("a refused lock writes nothing:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+			}
+		})
 	}
 }
 

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,0 +1,530 @@
+// The SCHEMA LOCK, both ways (docs/SPEC-TABLES.md §2.10): every edit the rule
+// allows passes and moves the file, and every edit it forbids is refused with
+// the entry named.
+//
+// The fixture is one package with a lock, edited in a temp directory, so each
+// case is the whole path a user takes — schema on disk, lock beside it, the
+// driver's check on load, `schema lock` to move it.
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// base is the fixture package: two FIXED tables, one of them holding a
+// deprecated field already, and a VARIABLE-LENGTH one beside them that the
+// lock must not carry.
+const base = `package lockdemo
+
+table ShipConfig
+{
+    name    string(32)
+    speed   float32
+    armor   uint8
+}
+
+table Slot
+{
+    index uint16
+    live  bool
+}
+
+table Chain
+{
+    next *Chain
+}
+`
+
+// fixture writes a schema into a fresh directory and returns the directory and
+// the unit's paths.
+func fixture(t *testing.T, src string) (dir string, paths []string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	paths, err := compiler.GatherPaths([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, paths
+}
+
+// load compiles the fixture with no lock check, which is what `schema lock`
+// itself does.
+func load(t *testing.T, paths []string) *ir.Unit {
+	t.Helper()
+	u, err := compiler.New().Load(paths)
+	if err != nil {
+		t.Fatalf("the fixture does not compile: %v", err)
+	}
+	return u
+}
+
+// locked writes the fixture, locks it, then rewrites the schema to after and
+// returns the refusals the check produces over the committed lock.
+func locked(t *testing.T, after string) (dir string, paths []string, errs []error) {
+	t.Helper()
+	dir, paths = fixture(t, base)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatalf("locking the fixture: %v", err)
+	}
+	if after != "" {
+		if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(after), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir, paths, lockfile.Check(load(t, paths), paths)
+}
+
+// readLock reads and parses a committed lock.
+func readLock(t *testing.T, path string) *lockfile.Unit {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lk, err := lockfile.Parse(path, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lk
+}
+
+// refuses is the shape every negative case takes: exactly one refusal, naming
+// the table, the entry and the field.
+func refuses(t *testing.T, errs []error, want ...string) {
+	t.Helper()
+	if len(errs) != 1 {
+		t.Fatalf("want one refusal, got %d: %v", len(errs), errs)
+	}
+	got := errs[0].Error()
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("the refusal must name %q:\n%s", w, got)
+		}
+	}
+	if !strings.Contains(got, "docs/SPEC-TABLES.md §2.10") {
+		t.Errorf("every refusal cites the spec:\n%s", got)
+	}
+}
+
+// ---- what the lock holds ----
+
+// TestLockHoldsFixedTablesOnly is the set the file covers: the fixed tables
+// and not the variable-length one beside them, whose evolution the id-table
+// wire handles on its own (§2.2, §4).
+func TestLockHoldsFixedTablesOnly(t *testing.T) {
+	_, paths := fixture(t, base)
+	lk := lockfile.Render(load(t, paths))
+	if lk.Package != "lockdemo" {
+		t.Errorf("package = %q", lk.Package)
+	}
+	var names []string
+	for _, tb := range lk.Tables {
+		names = append(names, tb.Name)
+	}
+	if strings.Join(names, ",") != "ShipConfig,Slot" {
+		t.Errorf("the lock holds the FIXED tables in name order, got %v", names)
+	}
+	ship := lk.Table("ShipConfig")
+	if len(ship.Entries) != 3 {
+		t.Fatalf("ShipConfig has three entries, got %d", len(ship.Entries))
+	}
+	if ship.Entries[0].Name != "name" || ship.Entries[0].Width != 40 {
+		// a string(32) is its whole storage — the character buffer AND the
+		// int32 used length beside it, padding included (§19.3)
+		t.Errorf("entry 1 is the whole storage of name, got %+v", ship.Entries[0])
+	}
+	if ship.Layout != lockfile.LayoutHash(ship.Entries) {
+		t.Errorf("the layout hash is the hash of the entries")
+	}
+}
+
+// TestTextRoundTrips is the file the compiler writes read back as what it
+// wrote: the parse and the render are one format, not two.
+func TestTextRoundTrips(t *testing.T) {
+	_, paths := fixture(t, base)
+	want := lockfile.Render(load(t, paths))
+	got, err := lockfile.Parse("schema.lock", []byte(want.Text()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Text() != want.Text() {
+		t.Errorf("round trip:\n--- wrote ---\n%s\n--- read back ---\n%s", want.Text(), got.Text())
+	}
+}
+
+// ---- the edits the rule allows ----
+
+// TestAppendPasses is the whole point of the rule: a field at the BOTTOM
+// passes the check against the older lock, and `schema lock` extends the file
+// by exactly that entry.
+func TestAppendPasses(t *testing.T) {
+	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint8\n    shields uint8\n", 1)
+	dir, paths, errs := locked(t, after)
+	if len(errs) != 0 {
+		t.Fatalf("an append passes: %v", errs)
+	}
+	before := readLock(t, filepath.Join(dir, lockfile.FileName))
+	path, rewrote, err := lockfile.Update(load(t, paths), paths)
+	if err != nil {
+		t.Fatalf("schema lock appends: %v", err)
+	}
+	if !rewrote {
+		t.Fatalf("the lock moved and %s was not rewritten", path)
+	}
+	after2 := readLock(t, path)
+	// the old entries are a PREFIX of the new ones, entry for entry: that is
+	// the whole rule, and it is what `schema lock` is allowed to write
+	old, now := before.Table("ShipConfig").Entries, after2.Table("ShipConfig").Entries
+	if len(now) != len(old)+1 {
+		t.Fatalf("the lock grew by one entry: %d then %d", len(old), len(now))
+	}
+	for i := range old {
+		if old[i] != now[i] {
+			t.Errorf("entry %d moved: %+v then %+v", i+1, old[i], now[i])
+		}
+	}
+	if now[len(old)].Name != "shields" {
+		t.Errorf("the appended field is the last entry: %+v", now[len(old)])
+	}
+	// and the extended lock is idempotent
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
+		t.Errorf("a current lock is left alone: rewrote=%v err=%v", rewrote, err)
+	}
+}
+
+// TestNewTablePasses: a table the lock does not carry has promised nothing,
+// so it passes and `schema lock` adds its entry.
+func TestNewTablePasses(t *testing.T) {
+	after := base + "\ntable Beacon\n{\n    hz uint8\n}\n"
+	dir, paths, errs := locked(t, after)
+	if len(errs) != 0 {
+		t.Fatalf("a new table passes: %v", errs)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, lockfile.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "fixed table Beacon ") {
+		t.Errorf("the new table is in the lock:\n%s", got)
+	}
+}
+
+// TestWasRenameIsNotAChange: `was` keeps the wire id, and the lock records
+// wire names — so a rename moves not one line of the file (§5).
+func TestWasRenameIsNotAChange(t *testing.T) {
+	after := strings.Replace(base, "    speed   float32\n", "    velocity float32 | was = \"speed\"\n", 1)
+	dir, paths, errs := locked(t, after)
+	if len(errs) != 0 {
+		t.Fatalf("a was rename is not a change: %v", errs)
+	}
+	before, err := os.ReadFile(filepath.Join(dir, lockfile.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
+		t.Errorf("a rename moves no line: rewrote=%v err=%v", rewrote, err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, lockfile.FileName))
+	if string(got) != string(before) {
+		t.Errorf("the file moved:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+	}
+	if !strings.Contains(string(got), "field speed ") {
+		t.Errorf("the lock records the WIRE name:\n%s", got)
+	}
+}
+
+// TestDeprecateIsAllowed: the marker turns on, the check passes, and
+// `schema lock` flips the flag in place — the entry keeps its position, its id
+// and its width, because deprecation is about meaning and never about layout.
+func TestDeprecateIsAllowed(t *testing.T) {
+	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint8 | deprecated\n", 1)
+	dir, paths, errs := locked(t, after)
+	if len(errs) != 0 {
+		t.Fatalf("deprecating a field is allowed: %v", errs)
+	}
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+		t.Fatalf("the lock flips the flag: rewrote=%v err=%v", rewrote, err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, lockfile.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lk, err := lockfile.Parse("schema.lock", got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	armor := lk.Table("ShipConfig").Entries[2]
+	if armor.Name != "armor" || !armor.Deprecated {
+		t.Errorf("entry 3 is armor, deprecated: %+v", armor)
+	}
+	if armor.Width != 1 || armor.Kind == 0 {
+		t.Errorf("deprecation moves no byte and changes no kind: %+v", armor)
+	}
+	// and the lock still checks clean against itself
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("the flipped lock checks clean: %v", errs)
+	}
+}
+
+// TestDeprecatedFieldStillHasItsSlot is the layout claim the marker makes,
+// measured rather than asserted: the record's size and every offset in it are
+// what they were before the marker.
+func TestDeprecatedFieldStillHasItsSlot(t *testing.T) {
+	_, livePaths := fixture(t, base)
+	live := ir.RecordLayout(load(t, livePaths), load(t, livePaths).Tables["ShipConfig"])
+	_, depPaths := fixture(t, strings.Replace(base, "    armor   uint8\n", "    armor   uint8 | deprecated\n", 1))
+	du := load(t, depPaths)
+	dep := ir.RecordLayout(du, du.Tables["ShipConfig"])
+	if live.Size != dep.Size || len(live.Fields) != len(dep.Fields) {
+		t.Fatalf("deprecation moved the record: %d/%d fields, %d/%d bytes", len(live.Fields), len(dep.Fields), live.Size, dep.Size)
+	}
+	for i := range live.Fields {
+		if live.Fields[i].Offset != dep.Fields[i].Offset || live.Fields[i].Size != dep.Fields[i].Size {
+			t.Errorf("field %s moved: %+v then %+v", live.Fields[i].Field.Name, live.Fields[i], dep.Fields[i])
+		}
+	}
+	if !du.Tables["ShipConfig"].Fields[2].Deprecated {
+		t.Errorf("the marker reaches the IR")
+	}
+}
+
+// ---- the edits the rule refuses ----
+
+func TestReorderRefused(t *testing.T) {
+	after := `package lockdemo
+
+table ShipConfig
+{
+    name    string(32)
+    armor   uint8
+    speed   float32
+}
+
+table Slot
+{
+    index uint16
+    live  bool
+}
+
+table Chain
+{
+    next *Chain
+}
+`
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 2", "field speed", "APPEND-ONLY", "never inserted, moved or removed")
+}
+
+// TestRemovalRefused: a field taken out of the MIDDLE is caught at its own
+// entry, where the declaration now holds the field that followed it — which is
+// exactly what a reader at that offset would find.
+func TestRemovalRefused(t *testing.T) {
+	after := strings.Replace(base, "    speed   float32\n", "", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 2", "field speed", "is field armor", "never inserted, moved or removed")
+}
+
+func TestRemovalOfTheLastFieldRefused(t *testing.T) {
+	after := strings.Replace(base, "    armor   uint8\n", "", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 3", "field armor", "gone from the declaration")
+}
+
+// TestWidenRefused grows a bound rather than swapping a scalar, so the KIND is
+// untouched and the width is the only fact that moved.
+func TestWidenRefused(t *testing.T) {
+	after := strings.Replace(base, "    name    string(32)\n", "    name    string(64)\n", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 1", "field name", "40 bytes wide in the lock and 72", "walked by offset")
+}
+
+// TestWidenScalarRefused is the same rule over a scalar swap, where the width
+// is still what is named: it is the fact that slides every field after it.
+func TestWidenScalarRefused(t *testing.T) {
+	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint32\n", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 3", "field armor", "1 bytes wide in the lock and 4")
+}
+
+// TestKindChangeRefused is the edit that moves no byte and still lies: float32
+// and int32 are four bytes each, so only the KIND says the stored bits are
+// being read as something else.
+func TestKindChangeRefused(t *testing.T) {
+	after := strings.Replace(base, "    speed   float32\n", "    speed   int32\n", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 2", "field speed", "in the lock and kind", "keeps its type")
+}
+
+func TestInsertInTheMiddleRefused(t *testing.T) {
+	after := strings.Replace(base, "    speed   float32\n", "    hull    uint8\n    speed   float32\n", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table ShipConfig", "entry 2", "field speed", "is field hull", "added at the BOTTOM")
+}
+
+// TestUnDeprecateRefused: the marker goes on and never comes off.
+func TestUnDeprecateRefused(t *testing.T) {
+	dir, paths := fixture(t, strings.Replace(base, "    armor   uint8\n", "    armor   uint8 | deprecated\n", 1))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(base), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refuses(t, lockfile.Check(load(t, paths), paths),
+		"fixed table ShipConfig", "entry 3", "field armor", "deprecated in the lock and live in the declaration", "ONE-WAY")
+}
+
+// TestTableGoneRefused: a fixed table's layout is a promise, and a promise is
+// not withdrawn — compaction is a new table under a new name.
+func TestTableGoneRefused(t *testing.T) {
+	after := strings.Replace(base, "table Slot\n{\n    index uint16\n    live  bool\n}\n", "", 1)
+	_, _, errs := locked(t, after)
+	refuses(t, errs, "fixed table Slot", "no longer declares it as a fixed table", "NEW table under a NEW name")
+}
+
+// TestHandEditedLockRefused is the file caught lying: the entries and the
+// layout hash beside them are one statement made twice, so a hand that edits
+// one half and not the other is visible.
+func TestHandEditedLockRefused(t *testing.T) {
+	dir, paths := fixture(t, base)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the lie a widening tempts: edit the width in the lock to match the
+	// schema you are about to write
+	lines := strings.Split(string(data), "\n")
+	edited := false
+	for i, line := range lines {
+		if strings.Contains(line, "field armor ") {
+			lines[i] = strings.Replace(line, "width=1", "width=4", 1)
+			edited = lines[i] != line
+		}
+	}
+	if !edited {
+		t.Fatal("the fixture's armor entry is not what this test edits")
+	}
+	lie := strings.Join(lines, "\n")
+	if err := os.WriteFile(path, []byte(lie), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refuses(t, lockfile.Check(load(t, paths), paths),
+		"fixed table ShipConfig", "entries that hash to", "a hand-edit does not hold", "schema lock")
+}
+
+// ---- the command's own refusal ----
+
+// TestLockRefusesToWriteABreak: `schema lock` is not the way to make a refusal
+// go away. It runs the check's comparison first and leaves the file alone.
+func TestLockRefusesToWriteABreak(t *testing.T) {
+	dir, paths := fixture(t, base)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, lockfile.FileName)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint32\n", 1)
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(after), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, rewrote, err := lockfile.Update(load(t, paths), paths)
+	if err == nil {
+		t.Fatal("schema lock appends, and a widening is not an append")
+	}
+	if rewrote {
+		t.Error("a refused lock writes nothing")
+	}
+	if !strings.Contains(err.Error(), "not an append") {
+		t.Errorf("the refusal says why: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(before) {
+		t.Errorf("the file was left alone:\n--- was ---\n%s\n--- now ---\n%s", before, got)
+	}
+}
+
+// TestNoLockNoCheck: a unit that has never been locked promises nothing.
+func TestNoLockNoCheck(t *testing.T) {
+	_, paths := fixture(t, strings.Replace(base, "    armor   uint8\n", "    armor   uint32\n", 1))
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Errorf("no file, no check: %v", errs)
+	}
+}
+
+// TestDriverRefusesOnLoad is the check where a user meets it: the driver's
+// policy on, the committed lock read, and the load refusing.
+func TestDriverRefusesOnLoad(t *testing.T) {
+	dir, paths := fixture(t, base)
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	after := strings.Replace(base, "    armor   uint8\n", "    armor   uint32\n", 1)
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(after), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := compiler.New()
+	c.SchemaLock = true
+	if _, err := c.Load(paths); err == nil {
+		t.Fatal("the check runs on load")
+	} else if !strings.Contains(err.Error(), "docs/SPEC-TABLES.md §2.10") {
+		t.Errorf("the refusal reaches the caller intact: %v", err)
+	}
+	// and with the policy off, the same unit loads
+	if _, err := compiler.New().Load(paths); err != nil {
+		t.Errorf("the check is the driver's policy, not the checker's: %v", err)
+	}
+}
+
+// TestGuardOnDeprecatedFieldRefused is the one NEW USE the compiler refuses
+// (§2.10): a guard is the only construct that reads another field's value, and
+// a retired field's value is whatever the last writer that cared left behind.
+func TestGuardOnDeprecatedFieldRefused(t *testing.T) {
+	src := `package lockdemo
+
+table Body
+{
+    active bool | deprecated
+    if active
+    {
+        hp uint8
+    }
+}
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	paths, err := compiler.GatherPaths([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = compiler.New().Load(paths)
+	if err == nil {
+		t.Fatal("a guard on a deprecated field is a new use")
+	}
+	for _, w := range []string{"if condition active", "| deprecated", "NEW USE", "docs/SPEC-TABLES.md §2.10"} {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("the refusal must name %q: %v", w, err)
+		}
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -356,6 +356,14 @@ type Field struct {
 	// ids are the wire's.
 	JsonKey string
 
+	// Deprecated is the `| deprecated` marker (docs/SPEC-TABLES.md §2.10): the
+	// field is RETIRED IN PLACE. Its slot stays exactly where it is — a fixed
+	// table's record is walked by offset, so removing the field would slide
+	// every field after it — nothing new may name it, and a reader ignores
+	// what it finds there. The marker is one-way: the schema lock refuses to
+	// see it turn off.
+	Deprecated bool
+
 	Array      ArrayKind
 	ArrayBound int64
 	ArrayExpr  Expr  // the declared bound expression, for rendering

--- a/tables/arms/schema.lock
+++ b/tables/arms/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package armdemo
 
 fixed table Node layout=0x3157106757693e8a

--- a/tables/arms/schema.lock
+++ b/tables/arms/schema.lock
@@ -1,0 +1,8 @@
+schema-lock 1
+package armdemo
+
+fixed table Node layout=0x4c160b6acc8ee562
+    field v id=0xaf63eb4c86020609 kind=4 width=4
+
+fixed table Only layout=0xdd4a2fb00ae58fee
+    field w id=0xaf63ea4c86020456 kind=4 width=4

--- a/tables/arms/schema.lock
+++ b/tables/arms/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package armdemo
 
 fixed table Node layout=0x3157106757693e8a

--- a/tables/arms/schema.lock
+++ b/tables/arms/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package armdemo
 
 fixed table Node layout=0x3157106757693e8a

--- a/tables/arms/schema.lock
+++ b/tables/arms/schema.lock
@@ -1,8 +1,8 @@
-schema-lock 1
+schema-lock 2
 package armdemo
 
-fixed table Node layout=0x4c160b6acc8ee562
-    field v id=0xaf63eb4c86020609 kind=4 width=4
+fixed table Node layout=0x3157106757693e8a
+    field v id=0xaf63eb4c86020609 kind=4 width=4 default=0
 
-fixed table Only layout=0xdd4a2fb00ae58fee
-    field w id=0xaf63ea4c86020456 kind=4 width=4
+fixed table Only layout=0x4593a4b74e06f09e
+    field w id=0xaf63ea4c86020456 kind=4 width=4 default=0

--- a/tables/backend/schema.lock
+++ b/tables/backend/schema.lock
@@ -1,14 +1,14 @@
-schema-lock 3
+schema-lock 4
 package backenddemo
 
-fixed table Envelope layout=0x48afa68f5294513f
-    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176 default=zero held=Payload@0xcfe090b40861806a
+fixed table Envelope layout=0x077ac066017f41c9
+    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176 default=zero held=Payload@0xb48f66556c573f94
 
-fixed table LoginRequest layout=0x8cc33d2fe825b64e
+fixed table LoginRequest layout=0x0a38315ac8ffb08d
     field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
     field session_token id=0x26860f8b6834fa0d kind=14 width=36 default=bytes: elem=6/1
     field client_build id=0xb865d537bd0b08f9 kind=8 width=4 default=0
-    field region id=0xc755a623f50a24dd kind=7 width=1 default=variant:None
+    field region id=0xc755a623f50a24dd kind=7 width=1 default=variant:None held=Region@0xc06757fb8ef01643
 
 fixed table MatchResult layout=0xa3114890cbd24e07
     field match_id id=0xf336e379ba146826 kind=9 width=8 default=0
@@ -19,12 +19,12 @@ fixed table PlayerRow layout=0x2b7e49e62ce171dd
     field score id=0xc10e63fbe7f624f5 kind=4 width=4 default=0 min=0 max=100000
     field placement id=0x98a3024830754a20 kind=6 width=1 default=1 min=1 max=10
 
-fixed table StorePurchase layout=0x02bc096258c7960b
+fixed table StorePurchase layout=0xcef54ea9fbe1e15a
     field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
     field sku id=0x82429a195ce84d1a kind=12 width=40 default=bytes:
     field quantity id=0xa3768bf56b809718 kind=6 width=1 default=1 min=1 max=99
     field price_minor id=0xa745885cff2a8840 kind=8 width=4 default=0
-    field currency id=0x75a5fb9b890ad416 kind=7 width=1 default=variant:None
+    field currency id=0x75a5fb9b890ad416 kind=7 width=1 default=variant:None held=Currency@0x9869f7d0d2752133
 
 enum Currency values=0x9869f7d0d2752133
     variant USD
@@ -38,7 +38,7 @@ enum Region values=0xc06757fb8ef01643
     variant APAC
     variant SA
 
-union Payload values=0xcfe090b40861806a
-    arm login payload=LoginRequest@0x8cc33d2fe825b64e
+union Payload values=0xb48f66556c573f94
+    arm login payload=LoginRequest@0x0a38315ac8ffb08d
     arm result payload=MatchResult@0xa3114890cbd24e07
-    arm purchase payload=StorePurchase@0x02bc096258c7960b
+    arm purchase payload=StorePurchase@0xcef54ea9fbe1e15a

--- a/tables/backend/schema.lock
+++ b/tables/backend/schema.lock
@@ -1,0 +1,27 @@
+schema-lock 1
+package backenddemo
+
+fixed table Envelope layout=0xa1d09d7092cc56a0
+    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176
+
+fixed table LoginRequest layout=0x76c57c3551a974ee
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
+    field session_token id=0x26860f8b6834fa0d kind=14 width=36
+    field client_build id=0xb865d537bd0b08f9 kind=8 width=4
+    field region id=0xc755a623f50a24dd kind=7 width=1
+
+fixed table MatchResult layout=0xb8d1169575f46f54
+    field match_id id=0xf336e379ba146826 kind=9 width=8
+    field players id=0x98e3ac7518558b29 kind=14 width=160
+
+fixed table PlayerRow layout=0x4c657e43185f33a7
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
+    field score id=0xc10e63fbe7f624f5 kind=4 width=4
+    field placement id=0x98a3024830754a20 kind=6 width=1
+
+fixed table StorePurchase layout=0xa6be627f9f933339
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
+    field sku id=0x82429a195ce84d1a kind=12 width=40
+    field quantity id=0xa3768bf56b809718 kind=6 width=1
+    field price_minor id=0xa745885cff2a8840 kind=8 width=4
+    field currency id=0x75a5fb9b890ad416 kind=7 width=1

--- a/tables/backend/schema.lock
+++ b/tables/backend/schema.lock
@@ -1,27 +1,44 @@
-schema-lock 1
+schema-lock 2
 package backenddemo
 
-fixed table Envelope layout=0xa1d09d7092cc56a0
-    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176
+fixed table Envelope layout=0x35194e8ba69691e6
+    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176 default=zero
 
-fixed table LoginRequest layout=0x76c57c3551a974ee
-    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
-    field session_token id=0x26860f8b6834fa0d kind=14 width=36
-    field client_build id=0xb865d537bd0b08f9 kind=8 width=4
-    field region id=0xc755a623f50a24dd kind=7 width=1
+fixed table LoginRequest layout=0x338c20379a69d172
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
+    field session_token id=0x26860f8b6834fa0d kind=14 width=36 default=bytes:
+    field client_build id=0xb865d537bd0b08f9 kind=8 width=4 default=0
+    field region id=0xc755a623f50a24dd kind=7 width=1 default=variant:None
 
-fixed table MatchResult layout=0xb8d1169575f46f54
-    field match_id id=0xf336e379ba146826 kind=9 width=8
-    field players id=0x98e3ac7518558b29 kind=14 width=160
+fixed table MatchResult layout=0xa06db399a76c88c3
+    field match_id id=0xf336e379ba146826 kind=9 width=8 default=0
+    field players id=0x98e3ac7518558b29 kind=14 width=160 default=born:0
 
-fixed table PlayerRow layout=0x4c657e43185f33a7
-    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
-    field score id=0xc10e63fbe7f624f5 kind=4 width=4
-    field placement id=0x98a3024830754a20 kind=6 width=1
+fixed table PlayerRow layout=0x2b7e49e62ce171dd
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
+    field score id=0xc10e63fbe7f624f5 kind=4 width=4 default=0 min=0 max=100000
+    field placement id=0x98a3024830754a20 kind=6 width=1 default=1 min=1 max=10
 
-fixed table StorePurchase layout=0xa6be627f9f933339
-    field player_id id=0xc14ae3ff748dc438 kind=9 width=8
-    field sku id=0x82429a195ce84d1a kind=12 width=40
-    field quantity id=0xa3768bf56b809718 kind=6 width=1
-    field price_minor id=0xa745885cff2a8840 kind=8 width=4
-    field currency id=0x75a5fb9b890ad416 kind=7 width=1
+fixed table StorePurchase layout=0x02bc096258c7960b
+    field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
+    field sku id=0x82429a195ce84d1a kind=12 width=40 default=bytes:
+    field quantity id=0xa3768bf56b809718 kind=6 width=1 default=1 min=1 max=99
+    field price_minor id=0xa745885cff2a8840 kind=8 width=4 default=0
+    field currency id=0x75a5fb9b890ad416 kind=7 width=1 default=variant:None
+
+enum Currency values=0x9869f7d0d2752133
+    variant USD
+    variant EUR
+    variant GBP
+    variant JPY
+
+enum Region values=0xc06757fb8ef01643
+    variant NA
+    variant EU
+    variant APAC
+    variant SA
+
+union Payload values=0x4344d822b00cb72e
+    arm login
+    arm result
+    arm purchase

--- a/tables/backend/schema.lock
+++ b/tables/backend/schema.lock
@@ -1,18 +1,18 @@
-schema-lock 2
+schema-lock 3
 package backenddemo
 
-fixed table Envelope layout=0x35194e8ba69691e6
-    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176 default=zero
+fixed table Envelope layout=0x48afa68f5294513f
+    field payload id=0xcfb8a9d063b5e9e5 kind=15 width=176 default=zero held=Payload@0xcfe090b40861806a
 
-fixed table LoginRequest layout=0x338c20379a69d172
+fixed table LoginRequest layout=0x8cc33d2fe825b64e
     field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
-    field session_token id=0x26860f8b6834fa0d kind=14 width=36 default=bytes:
+    field session_token id=0x26860f8b6834fa0d kind=14 width=36 default=bytes: elem=6/1
     field client_build id=0xb865d537bd0b08f9 kind=8 width=4 default=0
     field region id=0xc755a623f50a24dd kind=7 width=1 default=variant:None
 
-fixed table MatchResult layout=0xa06db399a76c88c3
+fixed table MatchResult layout=0xa3114890cbd24e07
     field match_id id=0xf336e379ba146826 kind=9 width=8 default=0
-    field players id=0x98e3ac7518558b29 kind=14 width=160 default=born:0
+    field players id=0x98e3ac7518558b29 kind=14 width=160 default=born:0 held=PlayerRow@0x2b7e49e62ce171dd elem=13/16
 
 fixed table PlayerRow layout=0x2b7e49e62ce171dd
     field player_id id=0xc14ae3ff748dc438 kind=9 width=8 default=0
@@ -38,7 +38,7 @@ enum Region values=0xc06757fb8ef01643
     variant APAC
     variant SA
 
-union Payload values=0x4344d822b00cb72e
-    arm login
-    arm result
-    arm purchase
+union Payload values=0xcfe090b40861806a
+    arm login payload=LoginRequest@0x8cc33d2fe825b64e
+    arm result payload=MatchResult@0xa3114890cbd24e07
+    arm purchase payload=StorePurchase@0x02bc096258c7960b

--- a/tables/backend/schema.lock
+++ b/tables/backend/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package backenddemo
 
 fixed table Envelope layout=0x077ac066017f41c9

--- a/tables/block/schema.lock
+++ b/tables/block/schema.lock
@@ -1,20 +1,20 @@
-schema-lock 4
+schema-lock 5
 package blockdemo
 
-fixed table PaddedFrame layout=0x3ad30b4696945e69
+fixed table PaddedFrame layout=0xb3bbce6e031522fd
     field marker id=0xeddcb72b15486e77 kind=6 width=1 default=0
     field stamp id=0xee7ba9ad45c64144 kind=9 width=8 default=0
-    field rows id=0xa3a7061ff10a8138 kind=14 width=4100 default=born:0 held=PaddedRow@0x9020be3c7b98758c elem=13/64
+    field rows id=0xa3a7061ff10a8138 kind=14 width=4100 default=born:0 held=PaddedRow@0xf4bbd54ffd1ff205 elem=13/64
     field blob id=0xc573b39bc29148ca kind=14 width=16 default=bytes: elem=6/1
 
-fixed table PaddedRow layout=0x9020be3c7b98758c
+fixed table PaddedRow layout=0xf4bbd54ffd1ff205
     field tag id=0x56d7ab194448a4f3 kind=6 width=1 default=0
     field value id=0x7ce4fd9430e80cea kind=11 width=8 default=0.0
     field flag id=0xd5f2d079088c0b17 kind=1 width=1 default=false
     field id id=0x08b72e07b55c3ac0 kind=8 width=4 default=0
     field label id=0x39f7fcec8fcb623d kind=12 width=20 default=bytes:
     field slots id=0xe68c2e6bb1ee5646 kind=14 width=8 default=born:0 elem=7/2
-    field teams id=0xbaaeb048a5a8fa6d kind=16 width=4 default=born:0
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=4 default=born:0 elem=6/1 key=Team@0x8eb91b0f4cfa397d
     field counter id=0x77976c7416517c63 kind=4 width=5 default=0 optional
 
 fixed table RenderCamera layout=0xbc6d7a94c6456443

--- a/tables/block/schema.lock
+++ b/tables/block/schema.lock
@@ -1,0 +1,116 @@
+schema-lock 1
+package blockdemo
+
+fixed table PaddedFrame layout=0x3e16de206eaceb11
+    field marker id=0xeddcb72b15486e77 kind=6 width=1
+    field stamp id=0xee7ba9ad45c64144 kind=9 width=8
+    field rows id=0xa3a7061ff10a8138 kind=14 width=4100
+    field blob id=0xc573b39bc29148ca kind=14 width=16
+
+fixed table PaddedRow layout=0x92c3e1e32115ac36
+    field tag id=0x56d7ab194448a4f3 kind=6 width=1
+    field value id=0x7ce4fd9430e80cea kind=11 width=8
+    field flag id=0xd5f2d079088c0b17 kind=1 width=1
+    field id id=0x08b72e07b55c3ac0 kind=8 width=4
+    field label id=0x39f7fcec8fcb623d kind=12 width=20
+    field slots id=0xe68c2e6bb1ee5646 kind=14 width=8
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=4
+    field counter id=0x77976c7416517c63 kind=4 width=5
+
+fixed table RenderCamera layout=0x5135ec9bc09e1c89
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field camera_id id=0x9f61700f084ab92e kind=8 width=4
+    field camera_type id=0x336d3dc7fffd0c9b kind=8 width=4
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
+    field fov id=0xdcb27c18fed9e15c kind=10 width=4
+
+fixed table RenderCosmeticProp layout=0xbb6b0402b267fb06
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field cosmetic_prop_id id=0xb66e4449e56b2e26 kind=8 width=4
+    field prop_sequence id=0x4d7bf73bcbddc228 kind=6 width=1
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderDynamicProp layout=0x480b7589ab2c4282
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderExplosion layout=0xebb74ee8f9757870
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field t id=0xaf63e94c860202a3 kind=11 width=8
+    field explosion_id id=0xfd7f3fa0b16ed778 kind=8 width=4
+    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4
+    field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderFrame layout=0xc92991345f5c941f
+    field version id=0xbb62c62c9808ea37 kind=9 width=8
+    field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76
+    field ships id=0x294a5c4913e1ad44 kind=14 width=360452
+    field turrets id=0x84f8260bc283608c kind=14 width=65540
+    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916
+    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916
+    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004
+    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364
+    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004
+    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004
+
+fixed table RenderLaser layout=0x14782736664261d6
+    field start id=0xee5d97ad45ad251f kind=13 width=24
+    field finish id=0x6917a5bab91540f2 kind=13 width=24
+    field t id=0xaf63e94c860202a3 kind=11 width=8
+    field laser_id id=0xcd29c05f390294ec kind=8 width=4
+    field laser_type id=0x96b593c242133841 kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderMissile layout=0xa5e8035ea1404856
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1
+    field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderShip layout=0xb628e00cc9b80da2
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
+    field thrust id=0xcfd587cb3100cd73 kind=10 width=4
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1
+    field ship_type id=0x1f7d2e86a2e77268 kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1
+    field predicted_explode id=0x4d5be97ba1b9cb81 kind=1 width=1
+
+fixed table RenderStaticProp layout=0xbd09161254294f5f
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field static_prop_id id=0xd23da7ab574b95c3 kind=8 width=4
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+
+fixed table RenderTurret layout=0x5f8cdd5879267e20
+    field rotation id=0xb51afb05cd34709f kind=13 width=32
+    field flags id=0x17a3a1a985f75aec kind=9 width=8
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4
+    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4
+    field turret_index id=0x88a11a6aed541f54 kind=8 width=4
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1
+    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1

--- a/tables/block/schema.lock
+++ b/tables/block/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package blockdemo
 
 fixed table PaddedFrame layout=0x3ad30b4696945e69
@@ -25,86 +25,86 @@ fixed table RenderCamera layout=0xbc6d7a94c6456443
     field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
     field fov id=0xdcb27c18fed9e15c kind=10 width=4 default=0.0
 
-fixed table RenderCosmeticProp layout=0x3fee9fcc767a59f0
+fixed table RenderCosmeticProp layout=0x166dd4b3667d5956
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field cosmetic_prop_id id=0xb66e4449e56b2e26 kind=8 width=4 default=0
     field prop_sequence id=0x4d7bf73bcbddc228 kind=6 width=1 default=0
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None held=PropType@0x3b1763ed728049d9
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderDynamicProp layout=0x6c9d8733bd2633ce
+fixed table RenderDynamicProp layout=0x4d9e74bf20f7abb4
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None held=PropType@0x3b1763ed728049d9
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderExplosion layout=0x6125a84373f1884a
+fixed table RenderExplosion layout=0x03659e6208adc3eb
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
     field explosion_id id=0xfd7f3fa0b16ed778 kind=8 width=4 default=0
     field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4 default=0
-    field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1 default=variant:None held=ExplosionType@0x551b0cc9b76d47b1
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderFrame layout=0xa8b62c87a8033b12
+fixed table RenderFrame layout=0x15914feff26e99af
     field version id=0xbb62c62c9808ea37 kind=9 width=8 default=0
     field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76 default=born:0 held=RenderCamera@0xbc6d7a94c6456443 elem=13/72
-    field ships id=0x294a5c4913e1ad44 kind=14 width=360452 default=born:0 held=RenderShip@0xe675979306e57f6e elem=13/88
-    field turrets id=0x84f8260bc283608c kind=14 width=65540 default=born:0 held=RenderTurret@0xf828a57e1fb64685 elem=13/64
-    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916 default=born:0 held=RenderMissile@0x0c11d87f35a5964a elem=13/72
-    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916 default=born:0 held=RenderDynamicProp@0x6c9d8733bd2633ce elem=13/72
-    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004 default=born:0 held=RenderStaticProp@0x9cd76a335a730e55 elem=13/80
-    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364 default=born:0 held=RenderCosmeticProp@0x3fee9fcc767a59f0 elem=13/80
-    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004 default=born:0 held=RenderLaser@0x1057e9f2a4e5dd76 elem=13/64
-    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004 default=born:0 held=RenderExplosion@0x6125a84373f1884a elem=13/80
+    field ships id=0x294a5c4913e1ad44 kind=14 width=360452 default=born:0 held=RenderShip@0x5adf9bdf3466ad50 elem=13/88
+    field turrets id=0x84f8260bc283608c kind=14 width=65540 default=born:0 held=RenderTurret@0xf5e2df000b75fb78 elem=13/64
+    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916 default=born:0 held=RenderMissile@0xbea2e7b5ad141600 elem=13/72
+    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916 default=born:0 held=RenderDynamicProp@0x4d9e74bf20f7abb4 elem=13/72
+    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004 default=born:0 held=RenderStaticProp@0xdf27489ae411d7d3 elem=13/80
+    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364 default=born:0 held=RenderCosmeticProp@0x166dd4b3667d5956 elem=13/80
+    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004 default=born:0 held=RenderLaser@0xbad5e7c97ded7d8a elem=13/64
+    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004 default=born:0 held=RenderExplosion@0x03659e6208adc3eb elem=13/80
 
-fixed table RenderLaser layout=0x1057e9f2a4e5dd76
+fixed table RenderLaser layout=0xbad5e7c97ded7d8a
     field start id=0xee5d97ad45ad251f kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field finish id=0x6917a5bab91540f2 kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
     field laser_id id=0xcd29c05f390294ec kind=8 width=4 default=0
-    field laser_type id=0x96b593c242133841 kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field laser_type id=0x96b593c242133841 kind=7 width=1 default=variant:None held=LaserType@0xfd9b1629ddecc8db
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderMissile layout=0x0c11d87f35a5964a
+fixed table RenderMissile layout=0xbea2e7b5ad141600
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
-    field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1 default=variant:None held=MissileType@0x80f6fa8d3c86ef2c
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderShip layout=0xe675979306e57f6e
+fixed table RenderShip layout=0x5adf9bdf3466ad50
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
-    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=mask:0
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=mask:0 held=ShipFlags@0x08ed14a23bc4def7
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
     field thrust id=0xcfd587cb3100cd73 kind=10 width=4 default=0.0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
-    field ship_type id=0x1f7d2e86a2e77268 kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field ship_type id=0x1f7d2e86a2e77268 kind=7 width=1 default=variant:None held=ShipType@0x54489ce6ef530b62
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
     field has_target_lock id=0x1554fa45a1220171 kind=1 width=1 default=false
     field predicted_explode id=0x4d5be97ba1b9cb81 kind=1 width=1 default=false
 
-fixed table RenderStaticProp layout=0x9cd76a335a730e55
+fixed table RenderStaticProp layout=0xdf27489ae411d7d3
     field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field static_prop_id id=0xd23da7ab574b95c3 kind=8 width=4 default=0
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None held=PropType@0x3b1763ed728049d9
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
 
-fixed table RenderTurret layout=0xf828a57e1fb64685
+fixed table RenderTurret layout=0xf5e2df000b75fb78
     field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
@@ -112,7 +112,7 @@ fixed table RenderTurret layout=0xf828a57e1fb64685
     field turret_index id=0x88a11a6aed541f54 kind=8 width=4 default=0
     field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
-    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None held=Team@0x8eb91b0f4cfa397d
     field has_target_lock id=0x1554fa45a1220171 kind=1 width=1 default=false
 
 type RenderQuaternion layout=0x23322f19f5b78111

--- a/tables/block/schema.lock
+++ b/tables/block/schema.lock
@@ -1,33 +1,33 @@
-schema-lock 2
+schema-lock 3
 package blockdemo
 
-fixed table PaddedFrame layout=0x15684f7c1f001a61
+fixed table PaddedFrame layout=0x3ad30b4696945e69
     field marker id=0xeddcb72b15486e77 kind=6 width=1 default=0
     field stamp id=0xee7ba9ad45c64144 kind=9 width=8 default=0
-    field rows id=0xa3a7061ff10a8138 kind=14 width=4100 default=born:0
-    field blob id=0xc573b39bc29148ca kind=14 width=16 default=bytes:
+    field rows id=0xa3a7061ff10a8138 kind=14 width=4100 default=born:0 held=PaddedRow@0x9020be3c7b98758c elem=13/64
+    field blob id=0xc573b39bc29148ca kind=14 width=16 default=bytes: elem=6/1
 
-fixed table PaddedRow layout=0xff8e8027f63afd7e
+fixed table PaddedRow layout=0x9020be3c7b98758c
     field tag id=0x56d7ab194448a4f3 kind=6 width=1 default=0
     field value id=0x7ce4fd9430e80cea kind=11 width=8 default=0.0
     field flag id=0xd5f2d079088c0b17 kind=1 width=1 default=false
     field id id=0x08b72e07b55c3ac0 kind=8 width=4 default=0
     field label id=0x39f7fcec8fcb623d kind=12 width=20 default=bytes:
-    field slots id=0xe68c2e6bb1ee5646 kind=14 width=8 default=born:0
+    field slots id=0xe68c2e6bb1ee5646 kind=14 width=8 default=born:0 elem=7/2
     field teams id=0xbaaeb048a5a8fa6d kind=16 width=4 default=born:0
     field counter id=0x77976c7416517c63 kind=4 width=5 default=0 optional
 
-fixed table RenderCamera layout=0x062a5291bb3c3d45
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderCamera layout=0xbc6d7a94c6456443
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field camera_id id=0x9f61700f084ab92e kind=8 width=4 default=0
     field camera_type id=0x336d3dc7fffd0c9b kind=8 width=4 default=0
     field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
     field fov id=0xdcb27c18fed9e15c kind=10 width=4 default=0.0
 
-fixed table RenderCosmeticProp layout=0xec86d7d79410791a
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderCosmeticProp layout=0x3fee9fcc767a59f0
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field cosmetic_prop_id id=0xb66e4449e56b2e26 kind=8 width=4 default=0
@@ -35,56 +35,56 @@ fixed table RenderCosmeticProp layout=0xec86d7d79410791a
     field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderDynamicProp layout=0x140d4e03d39953c0
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderDynamicProp layout=0x6c9d8733bd2633ce
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
     field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderExplosion layout=0xe71646e319b09bd0
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderExplosion layout=0x6125a84373f1884a
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
     field explosion_id id=0xfd7f3fa0b16ed778 kind=8 width=4 default=0
     field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4 default=0
     field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderFrame layout=0x4219ed0c600fca44
+fixed table RenderFrame layout=0xa8b62c87a8033b12
     field version id=0xbb62c62c9808ea37 kind=9 width=8 default=0
-    field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76 default=born:0
-    field ships id=0x294a5c4913e1ad44 kind=14 width=360452 default=born:0
-    field turrets id=0x84f8260bc283608c kind=14 width=65540 default=born:0
-    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916 default=born:0
-    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916 default=born:0
-    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004 default=born:0
-    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364 default=born:0
-    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004 default=born:0
-    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004 default=born:0
+    field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76 default=born:0 held=RenderCamera@0xbc6d7a94c6456443 elem=13/72
+    field ships id=0x294a5c4913e1ad44 kind=14 width=360452 default=born:0 held=RenderShip@0xe675979306e57f6e elem=13/88
+    field turrets id=0x84f8260bc283608c kind=14 width=65540 default=born:0 held=RenderTurret@0xf828a57e1fb64685 elem=13/64
+    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916 default=born:0 held=RenderMissile@0x0c11d87f35a5964a elem=13/72
+    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916 default=born:0 held=RenderDynamicProp@0x6c9d8733bd2633ce elem=13/72
+    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004 default=born:0 held=RenderStaticProp@0x9cd76a335a730e55 elem=13/80
+    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364 default=born:0 held=RenderCosmeticProp@0x3fee9fcc767a59f0 elem=13/80
+    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004 default=born:0 held=RenderLaser@0x1057e9f2a4e5dd76 elem=13/64
+    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004 default=born:0 held=RenderExplosion@0x6125a84373f1884a elem=13/80
 
-fixed table RenderLaser layout=0xb018ee3b2d2555dc
-    field start id=0xee5d97ad45ad251f kind=13 width=24 default=zero
-    field finish id=0x6917a5bab91540f2 kind=13 width=24 default=zero
+fixed table RenderLaser layout=0x1057e9f2a4e5dd76
+    field start id=0xee5d97ad45ad251f kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field finish id=0x6917a5bab91540f2 kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
     field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
     field laser_id id=0xcd29c05f390294ec kind=8 width=4 default=0
     field laser_type id=0x96b593c242133841 kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderMissile layout=0xa2c1c31f863fef5c
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderMissile layout=0x0c11d87f35a5964a
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
     field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderShip layout=0x257d2692c9b5e640
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderShip layout=0xe675979306e57f6e
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=mask:0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
@@ -95,17 +95,17 @@ fixed table RenderShip layout=0x257d2692c9b5e640
     field has_target_lock id=0x1554fa45a1220171 kind=1 width=1 default=false
     field predicted_explode id=0x4d5be97ba1b9cb81 kind=1 width=1 default=false
 
-fixed table RenderStaticProp layout=0xd9e313b912df6b8b
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderStaticProp layout=0x9cd76a335a730e55
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero held=RenderVector3@0xd77965e30412b51d
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field static_prop_id id=0xd23da7ab574b95c3 kind=8 width=4 default=0
     field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
     field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderTurret layout=0x3b03b34ca5dcc5fc
-    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+fixed table RenderTurret layout=0xf828a57e1fb64685
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero held=RenderQuaternion@0x23322f19f5b78111
     field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
     field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
     field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4 default=0

--- a/tables/block/schema.lock
+++ b/tables/block/schema.lock
@@ -1,116 +1,161 @@
-schema-lock 1
+schema-lock 2
 package blockdemo
 
-fixed table PaddedFrame layout=0x3e16de206eaceb11
-    field marker id=0xeddcb72b15486e77 kind=6 width=1
-    field stamp id=0xee7ba9ad45c64144 kind=9 width=8
-    field rows id=0xa3a7061ff10a8138 kind=14 width=4100
-    field blob id=0xc573b39bc29148ca kind=14 width=16
+fixed table PaddedFrame layout=0x15684f7c1f001a61
+    field marker id=0xeddcb72b15486e77 kind=6 width=1 default=0
+    field stamp id=0xee7ba9ad45c64144 kind=9 width=8 default=0
+    field rows id=0xa3a7061ff10a8138 kind=14 width=4100 default=born:0
+    field blob id=0xc573b39bc29148ca kind=14 width=16 default=bytes:
 
-fixed table PaddedRow layout=0x92c3e1e32115ac36
-    field tag id=0x56d7ab194448a4f3 kind=6 width=1
-    field value id=0x7ce4fd9430e80cea kind=11 width=8
-    field flag id=0xd5f2d079088c0b17 kind=1 width=1
-    field id id=0x08b72e07b55c3ac0 kind=8 width=4
-    field label id=0x39f7fcec8fcb623d kind=12 width=20
-    field slots id=0xe68c2e6bb1ee5646 kind=14 width=8
-    field teams id=0xbaaeb048a5a8fa6d kind=16 width=4
-    field counter id=0x77976c7416517c63 kind=4 width=5
+fixed table PaddedRow layout=0xff8e8027f63afd7e
+    field tag id=0x56d7ab194448a4f3 kind=6 width=1 default=0
+    field value id=0x7ce4fd9430e80cea kind=11 width=8 default=0.0
+    field flag id=0xd5f2d079088c0b17 kind=1 width=1 default=false
+    field id id=0x08b72e07b55c3ac0 kind=8 width=4 default=0
+    field label id=0x39f7fcec8fcb623d kind=12 width=20 default=bytes:
+    field slots id=0xe68c2e6bb1ee5646 kind=14 width=8 default=born:0
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=4 default=born:0
+    field counter id=0x77976c7416517c63 kind=4 width=5 default=0 optional
 
-fixed table RenderCamera layout=0x5135ec9bc09e1c89
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field camera_id id=0x9f61700f084ab92e kind=8 width=4
-    field camera_type id=0x336d3dc7fffd0c9b kind=8 width=4
-    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
-    field fov id=0xdcb27c18fed9e15c kind=10 width=4
+fixed table RenderCamera layout=0x062a5291bb3c3d45
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field camera_id id=0x9f61700f084ab92e kind=8 width=4 default=0
+    field camera_type id=0x336d3dc7fffd0c9b kind=8 width=4 default=0
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
+    field fov id=0xdcb27c18fed9e15c kind=10 width=4 default=0.0
 
-fixed table RenderCosmeticProp layout=0xbb6b0402b267fb06
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field cosmetic_prop_id id=0xb66e4449e56b2e26 kind=8 width=4
-    field prop_sequence id=0x4d7bf73bcbddc228 kind=6 width=1
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderCosmeticProp layout=0xec86d7d79410791a
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
+    field cosmetic_prop_id id=0xb66e4449e56b2e26 kind=8 width=4 default=0
+    field prop_sequence id=0x4d7bf73bcbddc228 kind=6 width=1 default=0
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderDynamicProp layout=0x480b7589ab2c4282
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field object_id id=0x0bdab42c07f19812 kind=8 width=4
-    field object_sequence id=0x5de0015285763c46 kind=6 width=1
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderDynamicProp layout=0x140d4e03d39953c0
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderExplosion layout=0xebb74ee8f9757870
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field t id=0xaf63e94c860202a3 kind=11 width=8
-    field explosion_id id=0xfd7f3fa0b16ed778 kind=8 width=4
-    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4
-    field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderExplosion layout=0xe71646e319b09bd0
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
+    field explosion_id id=0xfd7f3fa0b16ed778 kind=8 width=4 default=0
+    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4 default=0
+    field explosion_type id=0xdc89eb9cd3393be5 kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderFrame layout=0xc92991345f5c941f
-    field version id=0xbb62c62c9808ea37 kind=9 width=8
-    field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76
-    field ships id=0x294a5c4913e1ad44 kind=14 width=360452
-    field turrets id=0x84f8260bc283608c kind=14 width=65540
-    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916
-    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916
-    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004
-    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364
-    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004
-    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004
+fixed table RenderFrame layout=0x4219ed0c600fca44
+    field version id=0xbb62c62c9808ea37 kind=9 width=8 default=0
+    field cameras id=0x0f9222d2ba7aa2a7 kind=14 width=76 default=born:0
+    field ships id=0x294a5c4913e1ad44 kind=14 width=360452 default=born:0
+    field turrets id=0x84f8260bc283608c kind=14 width=65540 default=born:0
+    field missiles id=0x1c3027194b1ba4d0 kind=14 width=294916 default=born:0
+    field dynamic_props id=0x43125398a9903d27 kind=14 width=294916 default=born:0
+    field static_props id=0xc1f8d7edff7fcfd2 kind=14 width=1600004 default=born:0
+    field cosmetic_props id=0x33408e39f5f480ff kind=14 width=655364 default=born:0
+    field lasers id=0xd982b77b3e92d16d kind=14 width=2048004 default=born:0
+    field explosions id=0x876a8c1a85806a69 kind=14 width=2560004 default=born:0
 
-fixed table RenderLaser layout=0x14782736664261d6
-    field start id=0xee5d97ad45ad251f kind=13 width=24
-    field finish id=0x6917a5bab91540f2 kind=13 width=24
-    field t id=0xaf63e94c860202a3 kind=11 width=8
-    field laser_id id=0xcd29c05f390294ec kind=8 width=4
-    field laser_type id=0x96b593c242133841 kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderLaser layout=0xb018ee3b2d2555dc
+    field start id=0xee5d97ad45ad251f kind=13 width=24 default=zero
+    field finish id=0x6917a5bab91540f2 kind=13 width=24 default=zero
+    field t id=0xaf63e94c860202a3 kind=11 width=8 default=0.0
+    field laser_id id=0xcd29c05f390294ec kind=8 width=4 default=0
+    field laser_type id=0x96b593c242133841 kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderMissile layout=0xa5e8035ea1404856
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field object_id id=0x0bdab42c07f19812 kind=8 width=4
-    field object_sequence id=0x5de0015285763c46 kind=6 width=1
-    field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderMissile layout=0xa2c1c31f863fef5c
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
+    field missile_type id=0x151b2a0e2c07b4bc kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderShip layout=0xb628e00cc9b80da2
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field object_id id=0x0bdab42c07f19812 kind=8 width=4
-    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
-    field thrust id=0xcfd587cb3100cd73 kind=10 width=4
-    field object_sequence id=0x5de0015285763c46 kind=6 width=1
-    field ship_type id=0x1f7d2e86a2e77268 kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
-    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1
-    field predicted_explode id=0x4d5be97ba1b9cb81 kind=1 width=1
+fixed table RenderShip layout=0x257d2692c9b5e640
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=mask:0
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
+    field thrust id=0xcfd587cb3100cd73 kind=10 width=4 default=0.0
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
+    field ship_type id=0x1f7d2e86a2e77268 kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1 default=false
+    field predicted_explode id=0x4d5be97ba1b9cb81 kind=1 width=1 default=false
 
-fixed table RenderStaticProp layout=0xbd09161254294f5f
-    field position id=0x4cbf3a26fca1d74a kind=13 width=24
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field static_prop_id id=0xd23da7ab574b95c3 kind=8 width=4
-    field prop_type id=0xe5626f155e4c5dad kind=7 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
+fixed table RenderStaticProp layout=0xd9e313b912df6b8b
+    field position id=0x4cbf3a26fca1d74a kind=13 width=24 default=zero
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field scale id=0x6aacb9fbb71a1d91 kind=11 width=8 default=0.0
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
+    field static_prop_id id=0xd23da7ab574b95c3 kind=8 width=4 default=0
+    field prop_type id=0xe5626f155e4c5dad kind=7 width=1 default=variant:None
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
 
-fixed table RenderTurret layout=0x5f8cdd5879267e20
-    field rotation id=0xb51afb05cd34709f kind=13 width=32
-    field flags id=0x17a3a1a985f75aec kind=9 width=8
-    field object_id id=0x0bdab42c07f19812 kind=8 width=4
-    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4
-    field turret_index id=0x88a11a6aed541f54 kind=8 width=4
-    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4
-    field object_sequence id=0x5de0015285763c46 kind=6 width=1
-    field team id=0xfa23d9ef19afc32c kind=7 width=1
-    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1
+fixed table RenderTurret layout=0x3b03b34ca5dcc5fc
+    field rotation id=0xb51afb05cd34709f kind=13 width=32 default=zero
+    field flags id=0x17a3a1a985f75aec kind=9 width=8 default=0
+    field object_id id=0x0bdab42c07f19812 kind=8 width=4 default=0
+    field parent_object_id id=0x0bee7b3cb4046c93 kind=8 width=4 default=0
+    field turret_index id=0x88a11a6aed541f54 kind=8 width=4 default=0
+    field target_object_id id=0x6a0c6a156952b9c2 kind=8 width=4 default=0
+    field object_sequence id=0x5de0015285763c46 kind=6 width=1 default=0
+    field team id=0xfa23d9ef19afc32c kind=7 width=1 default=variant:None
+    field has_target_lock id=0x1554fa45a1220171 kind=1 width=1 default=false
+
+type RenderQuaternion layout=0x23322f19f5b78111
+    field x id=0xaf63f54c86021707 kind=11 width=8 default=0.0
+    field y id=0xaf63f44c86021554 kind=11 width=8 default=0.0
+    field z id=0xaf63f74c86021a6d kind=11 width=8 default=0.0
+    field w id=0xaf63ea4c86020456 kind=11 width=8 default=1.0
+
+type RenderVector3 layout=0xd77965e30412b51d
+    field x id=0xaf63f54c86021707 kind=11 width=8 default=0.0
+    field y id=0xaf63f44c86021554 kind=11 width=8 default=0.0
+    field z id=0xaf63f74c86021a6d kind=11 width=8 default=0.0
+
+enum ExplosionType values=0x551b0cc9b76d47b1
+    variant Small
+    variant Large
+
+enum LaserType values=0xfd9b1629ddecc8db
+    variant Pulse
+    variant Beam
+
+enum MissileType values=0x80f6fa8d3c86ef2c
+    variant Seeker
+    variant Dumb
+
+enum PropType values=0x3b1763ed728049d9
+    variant Rock
+    variant Station
+    variant Beacon
+
+enum ShipType values=0x54489ce6ef530b62
+    variant Fighter
+    variant Bomber
+    variant Freighter
+
+enum Team values=0x8eb91b0f4cfa397d
+    variant Red
+    variant Blue
+    variant Green
+    variant Gold
+
+flags ShipFlags values=0x08ed14a23bc4def7
+    variant FiringLaser
+    variant Boosting
+    variant Braking
+    variant Aiming

--- a/tables/blockhome/schema.lock
+++ b/tables/blockhome/schema.lock
@@ -1,0 +1,12 @@
+schema-lock 1
+package blockhome
+
+fixed table PartFrame layout=0x72e97f7a51d19218
+    field version id=0xbb62c62c9808ea37 kind=9 width=8
+    field parts id=0x0c519da7a1f958c5 kind=14 width=11268
+
+fixed table PartRow layout=0xd3b3439a67da02c5
+    field armor id=0xd19988b67e699194 kind=13 width=40
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=304
+    field part_id id=0x04d6206b33415104 kind=8 width=4
+    field slot id=0x6a771618f6fe31d1 kind=6 width=1

--- a/tables/blockhome/schema.lock
+++ b/tables/blockhome/schema.lock
@@ -1,12 +1,33 @@
-schema-lock 1
+schema-lock 2
 package blockhome
 
-fixed table PartFrame layout=0x72e97f7a51d19218
-    field version id=0xbb62c62c9808ea37 kind=9 width=8
-    field parts id=0x0c519da7a1f958c5 kind=14 width=11268
+fixed table PartFrame layout=0xcd1ebd8a344addf3
+    field version id=0xbb62c62c9808ea37 kind=9 width=8 default=0
+    field parts id=0x0c519da7a1f958c5 kind=14 width=11268 default=born:0
 
-fixed table PartRow layout=0xd3b3439a67da02c5
-    field armor id=0xd19988b67e699194 kind=13 width=40
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=304
-    field part_id id=0x04d6206b33415104 kind=8 width=4
-    field slot id=0x6a771618f6fe31d1 kind=6 width=1
+fixed table PartRow layout=0x3ec22d2f140c8061
+    field armor id=0xd19988b67e699194 kind=13 width=40 default=zero
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=304 default=zero
+    field part_id id=0x04d6206b33415104 kind=8 width=4 default=0
+    field slot id=0x6a771618f6fe31d1 kind=6 width=1 default=0
+
+type ArmorConfig layout=0x0c3e09a68740dd9b
+    field front id=0x538b8c566e9e4b38 kind=13 width=16 default=zero
+    field rear id=0x4ce65d1fbfdde703 kind=13 width=16 default=zero
+    field rating id=0x4e79ecbefe5ff4d0 kind=10 width=4 default=0.0
+    field tier id=0x1e6f84ef2eb65989 kind=6 width=1 default=0
+
+type ArmorPlate layout=0x79850006eca65f5b
+    field thickness id=0xdbae65ca25b4f315 kind=11 width=8 default=0.0
+    field material id=0x026f7568983161e0 kind=8 width=4 default=0
+    field layer id=0x84e39fec29768c56 kind=6 width=1 default=0
+
+type FiringGroup layout=0x1a0b7db98e965100
+    field barrel id=0x8ece059ad360b651 kind=8 width=4 default=0
+    field cooldown id=0xdc2cbe6953343d48 kind=10 width=4 default=0.0
+
+type GunnerSettings layout=0x08d7f3cea1150e12
+    field firing_groups id=0x260b8ca6b0c3db7f kind=14 width=260 default=born:0
+    field missile_groups id=0x3c99105aa087f6bc kind=14 width=36 default=born:0
+    field reload_seconds id=0xad9b64728ea52486 kind=10 width=4 default=0.0
+    field gunner_id id=0xbd9be53180256e02 kind=8 width=4 default=0

--- a/tables/blockhome/schema.lock
+++ b/tables/blockhome/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package blockhome
 
 fixed table PartFrame layout=0x01a3a6535b4f1d64

--- a/tables/blockhome/schema.lock
+++ b/tables/blockhome/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package blockhome
 
 fixed table PartFrame layout=0x01a3a6535b4f1d64

--- a/tables/blockhome/schema.lock
+++ b/tables/blockhome/schema.lock
@@ -1,19 +1,19 @@
-schema-lock 2
+schema-lock 3
 package blockhome
 
-fixed table PartFrame layout=0xcd1ebd8a344addf3
+fixed table PartFrame layout=0x01a3a6535b4f1d64
     field version id=0xbb62c62c9808ea37 kind=9 width=8 default=0
-    field parts id=0x0c519da7a1f958c5 kind=14 width=11268 default=born:0
+    field parts id=0x0c519da7a1f958c5 kind=14 width=11268 default=born:0 held=PartRow@0x769a008d08bceea2 elem=13/352
 
-fixed table PartRow layout=0x3ec22d2f140c8061
-    field armor id=0xd19988b67e699194 kind=13 width=40 default=zero
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=304 default=zero
+fixed table PartRow layout=0x769a008d08bceea2
+    field armor id=0xd19988b67e699194 kind=13 width=40 default=zero held=ArmorConfig@0xde232a6687ea65a3
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=304 default=zero held=GunnerSettings@0x679f84faa6f0ae14
     field part_id id=0x04d6206b33415104 kind=8 width=4 default=0
     field slot id=0x6a771618f6fe31d1 kind=6 width=1 default=0
 
-type ArmorConfig layout=0x0c3e09a68740dd9b
-    field front id=0x538b8c566e9e4b38 kind=13 width=16 default=zero
-    field rear id=0x4ce65d1fbfdde703 kind=13 width=16 default=zero
+type ArmorConfig layout=0xde232a6687ea65a3
+    field front id=0x538b8c566e9e4b38 kind=13 width=16 default=zero held=ArmorPlate@0x79850006eca65f5b
+    field rear id=0x4ce65d1fbfdde703 kind=13 width=16 default=zero held=ArmorPlate@0x79850006eca65f5b
     field rating id=0x4e79ecbefe5ff4d0 kind=10 width=4 default=0.0
     field tier id=0x1e6f84ef2eb65989 kind=6 width=1 default=0
 
@@ -26,8 +26,8 @@ type FiringGroup layout=0x1a0b7db98e965100
     field barrel id=0x8ece059ad360b651 kind=8 width=4 default=0
     field cooldown id=0xdc2cbe6953343d48 kind=10 width=4 default=0.0
 
-type GunnerSettings layout=0x08d7f3cea1150e12
-    field firing_groups id=0x260b8ca6b0c3db7f kind=14 width=260 default=born:0
-    field missile_groups id=0x3c99105aa087f6bc kind=14 width=36 default=born:0
+type GunnerSettings layout=0x679f84faa6f0ae14
+    field firing_groups id=0x260b8ca6b0c3db7f kind=14 width=260 default=born:0 held=FiringGroup@0x1a0b7db98e965100 elem=13/8
+    field missile_groups id=0x3c99105aa087f6bc kind=14 width=36 default=born:0 held=FiringGroup@0x1a0b7db98e965100 elem=13/8
     field reload_seconds id=0xad9b64728ea52486 kind=10 width=4 default=0.0
     field gunner_id id=0xbd9be53180256e02 kind=8 width=4 default=0

--- a/tables/examples/schema.lock
+++ b/tables/examples/schema.lock
@@ -1,150 +1,202 @@
-schema-lock 1
+schema-lock 2
 package tabledemo
 
-fixed table ArchiveConfig layout=0x0504584a27e89ec6
-    field root id=0xa354fd1ff0c467c5 kind=13 width=1480
-    field count id=0xb1e5e28e4479a274 kind=4 width=4
+fixed table ArchiveConfig layout=0x2a490501945fcf4e
+    field root id=0xa354fd1ff0c467c5 kind=13 width=1480 default=zero
+    field count id=0xb1e5e28e4479a274 kind=4 width=4 default=1 min=0 max=100
 
-fixed table GlobalSettings layout=0xbe2b4b4dcd3340a5
-    field tick_rate id=0xa65f859b617deaf3 kind=8 width=4
-    field difficulty id=0x467f35a74c6e4a70 kind=7 width=1
-    field build_note id=0x14ec921cc2549d60 kind=12 width=55
-    field spawn_delays id=0x09ae5613b0051271 kind=14 width=12
+fixed table GlobalSettings layout=0xd10142c396a60776
+    field tick_rate id=0xa65f859b617deaf3 kind=8 width=4 default=60 min=1 max=240
+    field difficulty id=0x467f35a74c6e4a70 kind=7 width=1 default=variant:Normal
+    field build_note id=0x14ec921cc2549d60 kind=12 width=55 default=bytes:
+    field spawn_delays id=0x09ae5613b0051271 kind=14 width=12 default=born:0
 
-fixed table GunnerConfig layout=0x8ff20b5071239e4d
-    field reaction id=0xb75aa3662201646a kind=10 width=4
-    field tracking id=0xa6bf719a4602b0bc kind=1 width=1
+fixed table GunnerConfig layout=0xdd5ef1d77231ba48
+    field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
+    field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false
 
-fixed table GunnerSettings layout=0xfd060839982f983c
-    field reaction id=0xb75aa3662201646a kind=10 width=4
-    field tracking id=0xa6bf719a4602b0bc kind=1 width=1
-    field callsign id=0x5bc44627b9848818 kind=12 width=31
+fixed table GunnerSettings layout=0x4d7299bf23b53716
+    field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
+    field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false
+    field callsign id=0x5bc44627b9848818 kind=12 width=31 default=bytes:
 
-fixed table HullConfig layout=0xfd3c9c2f7dedb5a7
-    field health id=0x7f69d4b5288ba9cf kind=10 width=4
-    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4
-    field turrets id=0x84f8260bc283608c kind=16 width=60
+fixed table HullConfig layout=0x7f5975fb9fddcaa4
+    field health id=0x7f69d4b5288ba9cf kind=10 width=4 default=100.0
+    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
+    field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0
 
-fixed table KeyedConfig layout=0x95a65b04f31448cf
-    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84
-    field hulls id=0xce0ac3c25694d8ff kind=16 width=204
-    field scores id=0x01986b0b27400fb2 kind=13 width=12
+fixed table KeyedConfig layout=0x15ddae216e2d83f3
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0
+    field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0
+    field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero
 
-fixed table LoadoutConfig layout=0xe2ca51a5b31f71c6
-    field grade id=0x32a89b2977c48ad4 kind=7 width=1
-    field grades id=0xd90a4e7682f799c5 kind=14 width=11
-    field podium id=0xb46ff45a23d72549 kind=14 width=3
-    field perks id=0x4b06f5847096e54a kind=9 width=8
-    field primary id=0xbf31137ff783e939 kind=13 width=28
-    field backups id=0xde28f0f5118acc24 kind=14 width=56
-    field attachments id=0xf901aa0340249a41 kind=14 width=68
+fixed table LoadoutConfig layout=0x87aceeef65b350e6
+    field grade id=0x32a89b2977c48ad4 kind=7 width=1 default=variant:Silver
+    field grades id=0xd90a4e7682f799c5 kind=14 width=11 default=born:0
+    field podium id=0xb46ff45a23d72549 kind=14 width=3 default=born:0
+    field perks id=0x4b06f5847096e54a kind=9 width=8 default=mask:0
+    field primary id=0xbf31137ff783e939 kind=13 width=28 default=zero
+    field backups id=0xde28f0f5118acc24 kind=14 width=56 default=born:0
+    field attachments id=0xf901aa0340249a41 kind=14 width=68 default=born:0
 
-fixed table PackConfig layout=0x707b15a7cf2effd9
-    field version id=0xbb62c62c9808ea37 kind=8 width=4
-    field global id=0x7fb43557b54149ce kind=13 width=72
-    field ships id=0x294a5c4913e1ad44 kind=16 width=324
-    field thresholds id=0x9cda940a344e1571 kind=16 width=12
-    field reserves id=0x77707fccd201c228 kind=14 width=328
+fixed table PackConfig layout=0xed22db9f9b3ca732
+    field version id=0xbb62c62c9808ea37 kind=8 width=4 default=1
+    field global id=0x7fb43557b54149ce kind=13 width=72 default=zero
+    field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0
+    field thresholds id=0x9cda940a344e1571 kind=16 width=12 default=born:0 min=0 max=1000
+    field reserves id=0x77707fccd201c228 kind=14 width=328 default=born:0
 
-fixed table Patrol layout=0x0992c902cca9a859
-    field active id=0x6580790b036f0c6f kind=1 width=1
-    field speed id=0x2281498aa0200e40 kind=10 width=4
-    field has_target id=0x247f0e7f55aacfbd kind=1 width=1
-    field target_id id=0xb7bc9ac015a25050 kind=4 width=4
-    field wander id=0xb8c758d8bd1845d4 kind=10 width=4
-    field note id=0x3bf8fbbad1587cdd kind=12 width=16
+fixed table Patrol layout=0xe5e88ef190270115
+    field active id=0x6580790b036f0c6f kind=1 width=1 default=false
+    field speed id=0x2281498aa0200e40 kind=10 width=4 default=1.0
+    field has_target id=0x247f0e7f55aacfbd kind=1 width=1 default=false
+    field target_id id=0xb7bc9ac015a25050 kind=4 width=4 default=0 min=0 max=1000
+    field wander id=0xb8c758d8bd1845d4 kind=10 width=4 default=0.5
+    field note id=0x3bf8fbbad1587cdd kind=12 width=16 default=bytes:
 
-fixed table ProfileConfig layout=0x125946f69bcadde9
-    field name id=0xc4bcadba8e631b86 kind=12 width=40
-    field icon id=0xdbff4cc56c2092f0 kind=14 width=20
-    field experience id=0xab8b6d521f80b969 kind=8 width=4
-    field tilt id=0x1e5088ef2e9bafc6 kind=2 width=1
-    field heading id=0xb128829190ca0f75 kind=3 width=2
-    field timestamp id=0x5ddc92338ef53403 kind=5 width=8
-    field badge id=0x10bda981fe095518 kind=6 width=1
-    field port id=0x8c2cdb0da8933fa6 kind=7 width=2
-    field epoch id=0xfc9697d1196e6ba6 kind=9 width=8
-    field precision id=0x288427f5babd05f7 kind=11 width=8
-    field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16
-    field has_loadout id=0xa06f5e0a148e253c kind=1 width=1
-    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176
+fixed table ProfileConfig layout=0xf8b07f6513cf03bf
+    field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
+    field icon id=0xdbff4cc56c2092f0 kind=14 width=20 default=bytes:
+    field experience id=0xab8b6d521f80b969 kind=8 width=4 default=0
+    field tilt id=0x1e5088ef2e9bafc6 kind=2 width=1 default=0
+    field heading id=0xb128829190ca0f75 kind=3 width=2 default=0
+    field timestamp id=0x5ddc92338ef53403 kind=5 width=8 default=0
+    field badge id=0x10bda981fe095518 kind=6 width=1 default=0
+    field port id=0x8c2cdb0da8933fa6 kind=7 width=2 default=0
+    field epoch id=0xfc9697d1196e6ba6 kind=9 width=8 default=0
+    field precision id=0x288427f5babd05f7 kind=11 width=8 default=0.0
+    field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16 default=born:0
+    field has_loadout id=0xa06f5e0a148e253c kind=1 width=1 default=false
+    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176 default=zero
 
-fixed table RangedSigned layout=0x3bc2e50892f57df7
-    field i8_span id=0x48121511bf702eb5 kind=2 width=1
-    field i8_low id=0x942bfe3168090f7d kind=2 width=1
-    field i8_high id=0xd182acd105b55dd1 kind=2 width=1
-    field i8_inside id=0xef9ded23c8912a81 kind=2 width=1
-    field i16_span id=0xb655574ea23760b4 kind=3 width=2
-    field i16_low id=0xd217b3af8d7a2bde kind=3 width=2
-    field i16_high id=0x90652f70c9127900 kind=3 width=2
-    field i16_inside id=0x6a659d7c354db158 kind=3 width=2
-    field i32_span id=0xe693bd88532c91d6 kind=4 width=4
-    field i32_low id=0x065ee827cf99fbb4 kind=4 width=4
-    field i32_high id=0xc9b121c4c2a186ee kind=4 width=4
-    field i32_inside id=0xd363dfa465acf27a kind=4 width=4
-    field i64_span id=0x7549c70700c49d6f kind=5 width=8
-    field i64_low id=0x1cce6617419771db kind=5 width=8
-    field i64_high id=0x3b54fa60620b5597 kind=5 width=8
-    field i64_inside id=0xd308fcb98ece5d23 kind=5 width=8
-    field edges id=0xc70cde6b85b6197d kind=14 width=12
+fixed table RangedSigned layout=0x6986cfad327fae32
+    field i8_span id=0x48121511bf702eb5 kind=2 width=1 default=0 min=-128 max=127
+    field i8_low id=0x942bfe3168090f7d kind=2 width=1 default=0 min=-128 max=126
+    field i8_high id=0xd182acd105b55dd1 kind=2 width=1 default=0 min=-127 max=127
+    field i8_inside id=0xef9ded23c8912a81 kind=2 width=1 default=0 min=-127 max=126
+    field i16_span id=0xb655574ea23760b4 kind=3 width=2 default=0 min=-32768 max=32767
+    field i16_low id=0xd217b3af8d7a2bde kind=3 width=2 default=0 min=-32768 max=32766
+    field i16_high id=0x90652f70c9127900 kind=3 width=2 default=0 min=-32767 max=32767
+    field i16_inside id=0x6a659d7c354db158 kind=3 width=2 default=0 min=-32767 max=32766
+    field i32_span id=0xe693bd88532c91d6 kind=4 width=4 default=0 min=-2147483648 max=2147483647
+    field i32_low id=0x065ee827cf99fbb4 kind=4 width=4 default=0 min=-2147483648 max=2147483646
+    field i32_high id=0xc9b121c4c2a186ee kind=4 width=4 default=0 min=-2147483647 max=2147483647
+    field i32_inside id=0xd363dfa465acf27a kind=4 width=4 default=0 min=-2147483647 max=2147483646
+    field i64_span id=0x7549c70700c49d6f kind=5 width=8 default=0 min=-9223372036854775808 max=9223372036854775807
+    field i64_low id=0x1cce6617419771db kind=5 width=8 default=0 min=-9223372036854775808 max=9223372036854775806
+    field i64_high id=0x3b54fa60620b5597 kind=5 width=8 default=0 min=-9223372036854775807 max=9223372036854775807
+    field i64_inside id=0xd308fcb98ece5d23 kind=5 width=8 default=0 min=-9223372036854775807 max=9223372036854775806
+    field edges id=0xc70cde6b85b6197d kind=14 width=12 default=born:0 min=-32768 max=32767
 
-fixed table RangedUnsigned layout=0x135ec77586e39c39
-    field u8_span id=0x0f8897557f37c021 kind=6 width=1
-    field u8_low id=0x2e17553f8200a2a1 kind=6 width=1
-    field u8_high id=0xa0e5c60df9301b7d kind=6 width=1
-    field u8_inside id=0x1cb2c073a6f5844d kind=6 width=1
-    field u16_span id=0x4ca0c150b1790960 kind=7 width=2
-    field u16_low id=0xf252136836b04cb2 kind=7 width=2
-    field u16_high id=0x4f37e1f216e7610c kind=7 width=2
-    field u16_inside id=0xd176b605978f3304 kind=7 width=2
-    field u32_span id=0x200b924de7479cda kind=8 width=4
-    field u32_low id=0xa53d2f2a31b5acb0 kind=8 width=4
-    field u32_high id=0x9759be8ea1a4e3d2 kind=8 width=4
-    field u32_inside id=0x8dc515fc082e3c0e kind=8 width=4
-    field u64_span id=0xbeecef11dbdf8973 kind=9 width=8
-    field u64_low id=0x0117ad66e0fff227 kind=9 width=8
-    field u64_high id=0xf2b45af3b50689db kind=9 width=8
-    field u64_inside id=0x713e12017eebcaf7 kind=9 width=8
-    field counts id=0xc341febe5aae51e5 kind=14 width=36
+fixed table RangedUnsigned layout=0x5943408e01c0cb4d
+    field u8_span id=0x0f8897557f37c021 kind=6 width=1 default=0 min=0 max=255
+    field u8_low id=0x2e17553f8200a2a1 kind=6 width=1 default=0 min=0 max=254
+    field u8_high id=0xa0e5c60df9301b7d kind=6 width=1 default=1 min=1 max=255
+    field u8_inside id=0x1cb2c073a6f5844d kind=6 width=1 default=1 min=1 max=254
+    field u16_span id=0x4ca0c150b1790960 kind=7 width=2 default=0 min=0 max=65535
+    field u16_low id=0xf252136836b04cb2 kind=7 width=2 default=0 min=0 max=65534
+    field u16_high id=0x4f37e1f216e7610c kind=7 width=2 default=1 min=1 max=65535
+    field u16_inside id=0xd176b605978f3304 kind=7 width=2 default=1 min=1 max=65534
+    field u32_span id=0x200b924de7479cda kind=8 width=4 default=0 min=0 max=4294967295
+    field u32_low id=0xa53d2f2a31b5acb0 kind=8 width=4 default=0 min=0 max=4294967294
+    field u32_high id=0x9759be8ea1a4e3d2 kind=8 width=4 default=1 min=1 max=4294967295
+    field u32_inside id=0x8dc515fc082e3c0e kind=8 width=4 default=1 min=1 max=4294967294
+    field u64_span id=0xbeecef11dbdf8973 kind=9 width=8 default=0 min=0 max=18446744073709551615
+    field u64_low id=0x0117ad66e0fff227 kind=9 width=8 default=0 min=0 max=18446744073709551614
+    field u64_high id=0xf2b45af3b50689db kind=9 width=8 default=1 min=1 max=18446744073709551615
+    field u64_inside id=0x713e12017eebcaf7 kind=9 width=8 default=1 min=1 max=18446744073709551614
+    field counts id=0xc341febe5aae51e5 kind=14 width=36 default=born:0 min=0 max=18446744073709551615
 
-fixed table RangedWidths layout=0xbfa68b9aafc7e8a6
-    field b8 id=0x08a60c07b54d8dc7 kind=6 width=4
-    field b16 id=0xff95701912ad97be kind=7 width=4
-    field b32 id=0xff9c5c1912b39470 kind=8 width=4
-    field b64 id=0xff92701912ab61e7 kind=9 width=8
-    field b12 id=0xff95741912ad9e8a kind=7 width=4
-    field b48 id=0xff8b681912a535a1 kind=9 width=8
+fixed table RangedWidths layout=0xaf0cc20950a8904e
+    field b8 id=0x08a60c07b54d8dc7 kind=6 width=4 default=0
+    field b16 id=0xff95701912ad97be kind=7 width=4 default=0
+    field b32 id=0xff9c5c1912b39470 kind=8 width=4 default=0
+    field b64 id=0xff92701912ab61e7 kind=9 width=8 default=0
+    field b12 id=0xff95741912ad9e8a kind=7 width=4 default=0
+    field b48 id=0xff8b681912a535a1 kind=9 width=8 default=0
 
-fixed table RootConfig layout=0xfda97d60e7ef7c05
-    field version_note id=0x8a67c9728746d394 kind=12 width=24
-    field weapons id=0x41cbd901b87fabb6 kind=14 width=228
-    field profiles id=0x8181e61fc0436767 kind=14 width=1220
+fixed table RootConfig layout=0xa4a3822c7b3048dc
+    field version_note id=0x8a67c9728746d394 kind=12 width=24 default=bytes:
+    field weapons id=0x41cbd901b87fabb6 kind=14 width=228 default=born:0
+    field profiles id=0x8181e61fc0436767 kind=14 width=1220 default=born:0
 
-fixed table ShipEntry layout=0x7795cb20ad8cf897
-    field display_name id=0x2d21d7cd66bd5a5d kind=12 width=40
-    field health id=0x7f69d4b5288ba9cf kind=10 width=4
-    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4
-    field hardpoints id=0x95d0cce09ca82b73 kind=14 width=20
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=37
+fixed table ShipEntry layout=0x46e047441e737a91
+    field display_name id=0x2d21d7cd66bd5a5d kind=12 width=40 default=bytes:
+    field health id=0x7f69d4b5288ba9cf kind=10 width=4 default=100.0
+    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
+    field hardpoints id=0x95d0cce09ca82b73 kind=14 width=20 default=born:0 min=0 max=8
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=37 default=zero optional
 
-fixed table TeamConfig layout=0xbd7f2cfc870f8dc7
-    field spawn_count id=0xceec99e2d65db674 kind=4 width=4
-    field banner id=0xbca0dab1c7a00ccf kind=12 width=24
+fixed table TeamConfig layout=0xf3999d79399a77ea
+    field spawn_count id=0xceec99e2d65db674 kind=4 width=4 default=4 min=0 max=64
+    field banner id=0xbca0dab1c7a00ccf kind=12 width=24 default=bytes:
 
-fixed table TurretConfig layout=0xa1ca43d0782104ac
-    field damage id=0x7f6308be8ab37fc0 kind=10 width=4
-    field cooldown id=0xdc2cbe6953343d48 kind=10 width=4
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=9
+fixed table TurretConfig layout=0x98d6e7f03daa17de
+    field damage id=0x7f6308be8ab37fc0 kind=10 width=4 default=10.0
+    field cooldown id=0xdc2cbe6953343d48 kind=10 width=4 default=0.5
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero optional
 
-fixed table WeaponConfig layout=0x421f6942f0db168a
-    field damage id=0x7f6308be8ab37fc0 kind=10 width=4
-    field velocity id=0x1733055702acb1d2 kind=10 width=4
-    field penetration id=0x4f31c5309e13e932 kind=4 width=4
-    field channel id=0xa5013e9ad5caeda4 kind=6 width=4
-    field homing id=0xad6587bc602e3f59 kind=1 width=1
-    field effect id=0x36c1c83b51f24394 kind=15 width=8
+fixed table WeaponConfig layout=0xf4e4dd2176d93061
+    field damage id=0x7f6308be8ab37fc0 kind=10 width=4 default=21.0
+    field velocity id=0x1733055702acb1d2 kind=10 width=4 default=500.0
+    field penetration id=0x4f31c5309e13e932 kind=4 width=4 default=1 min=0 max=10
+    field channel id=0xa5013e9ad5caeda4 kind=6 width=4 default=0
+    field homing id=0xad6587bc602e3f59 kind=1 width=1 default=false
+    field effect id=0x36c1c83b51f24394 kind=15 width=8 default=zero
 
-fixed table WideBlob layout=0x29741c1ebd9642b1
-    field label id=0x39f7fcec8fcb623d kind=12 width=70008
-    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=70004
-    field samples id=0xe3b1ca6a3b48dddc kind=14 width=140004
+fixed table WideBlob layout=0xb18a3f26237d25d0
+    field label id=0x39f7fcec8fcb623d kind=12 width=70008 default=bytes:
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=70004 default=bytes:
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=140004 default=born:0
+
+type Attachment layout=0x203fd5e47e2fd0c8
+    field slot id=0x6a771618f6fe31d1 kind=4 width=4 default=0 min=0 max=7
+    field power id=0xeef9d1358ae7b4e6 kind=10 width=4 default=1.0
+
+type Buff layout=0x95a2a02bde1f4141
+    field multiplier id=0x9adc623a805c87c6 kind=10 width=4 default=1.0
+
+type Debuff layout=0x4c66b13a4d53ad2e
+    field amount id=0x8113fe7ea2b16969 kind=4 width=4 default=0 min=0 max=100
+
+type ScoreBoard layout=0x7aa40527e9a30518
+    field per_team id=0xf10fad739a0e1660 kind=16 width=12 default=born:0 min=0 max=100000
+
+enum Difficulty values=0x8c7731ffcc25bee0
+    variant Easy
+    variant Normal
+    variant Hard
+
+enum Grade values=0xc56ae3781a1039bd
+    variant Bronze
+    variant Silver
+    variant Gold
+
+enum Hull values=0xc3cc3881c580dd9d
+    variant Interceptor
+    variant Gunship
+    variant Freighter
+
+enum ShipType values=0xe37048030170f42c
+    variant Fighter
+    variant Bomber
+    variant Scout
+
+enum Team values=0xc490f76cda16c53c
+    variant Red
+    variant Blue
+    variant Green
+
+enum Weapon values=0x56b73a1f4ab4e110
+    variant Cannon
+    variant Missile
+    variant Mine
+
+flags Perks values=0x1f153e786d4f23a7
+    variant Shielded
+    variant Cloaked
+    variant Turbo
+
+union Effect values=0x2ebda893340be256
+    arm buff
+    arm debuff

--- a/tables/examples/schema.lock
+++ b/tables/examples/schema.lock
@@ -1,13 +1,13 @@
-schema-lock 3
+schema-lock 4
 package tabledemo
 
-fixed table ArchiveConfig layout=0xe7b9cdfeabdf1fac
-    field root id=0xa354fd1ff0c467c5 kind=13 width=1480 default=zero held=RootConfig@0xadb5d5e768da8c47
+fixed table ArchiveConfig layout=0x18e055832d2ae20f
+    field root id=0xa354fd1ff0c467c5 kind=13 width=1480 default=zero held=RootConfig@0xb4320e868aa6e0f8
     field count id=0xb1e5e28e4479a274 kind=4 width=4 default=1 min=0 max=100
 
-fixed table GlobalSettings layout=0x9370b5814eb005ce
+fixed table GlobalSettings layout=0x17ec347e3e20b357
     field tick_rate id=0xa65f859b617deaf3 kind=8 width=4 default=60 min=1 max=240
-    field difficulty id=0x467f35a74c6e4a70 kind=7 width=1 default=variant:Normal
+    field difficulty id=0x467f35a74c6e4a70 kind=7 width=1 default=variant:Normal held=Difficulty@0x8c7731ffcc25bee0
     field build_note id=0x14ec921cc2549d60 kind=12 width=55 default=bytes:
     field spawn_delays id=0x09ae5613b0051271 kind=14 width=12 default=born:0 elem=10/4
 
@@ -20,29 +20,29 @@ fixed table GunnerSettings layout=0x4d7299bf23b53716
     field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false
     field callsign id=0x5bc44627b9848818 kind=12 width=31 default=bytes:
 
-fixed table HullConfig layout=0x7f5975fb9fddcaa4
+fixed table HullConfig layout=0x49fa8652005b3a25
     field health id=0x7f69d4b5288ba9cf kind=10 width=4 default=100.0
     field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
-    field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0
+    field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0 held=TurretConfig@0xd544f891dca5c02d
 
-fixed table KeyedConfig layout=0x303b68a38581458e
-    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0
-    field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0
+fixed table KeyedConfig layout=0x4d5e4cf3072476b1
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0 held=TeamConfig@0xf3999d79399a77ea
+    field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0 held=HullConfig@0x49fa8652005b3a25
     field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero held=ScoreBoard@0x7aa40527e9a30518
 
-fixed table LoadoutConfig layout=0x8ab96fc8392c8897
-    field grade id=0x32a89b2977c48ad4 kind=7 width=1 default=variant:Silver
-    field grades id=0xd90a4e7682f799c5 kind=14 width=11 default=born:0 elem=7/1
-    field podium id=0xb46ff45a23d72549 kind=14 width=3 default=born:0 elem=7/1
-    field perks id=0x4b06f5847096e54a kind=9 width=8 default=mask:0
+fixed table LoadoutConfig layout=0x3c738da0869f9933
+    field grade id=0x32a89b2977c48ad4 kind=7 width=1 default=variant:Silver held=Grade@0xc56ae3781a1039bd
+    field grades id=0xd90a4e7682f799c5 kind=14 width=11 default=born:0 held=Grade@0xc56ae3781a1039bd elem=7/1
+    field podium id=0xb46ff45a23d72549 kind=14 width=3 default=born:0 held=Grade@0xc56ae3781a1039bd elem=7/1
+    field perks id=0x4b06f5847096e54a kind=9 width=8 default=mask:0 held=Perks@0x1f153e786d4f23a7
     field primary id=0xbf31137ff783e939 kind=13 width=28 default=zero held=WeaponConfig@0xb8d345be27518024
     field backups id=0xde28f0f5118acc24 kind=14 width=56 default=born:0 held=WeaponConfig@0xb8d345be27518024 elem=13/28
     field attachments id=0xf901aa0340249a41 kind=14 width=68 default=born:0 held=Attachment@0x203fd5e47e2fd0c8 elem=13/8
 
-fixed table PackConfig layout=0x320b0b6b6125b1e4
+fixed table PackConfig layout=0x77d8789a464829f4
     field version id=0xbb62c62c9808ea37 kind=8 width=4 default=1
-    field global id=0x7fb43557b54149ce kind=13 width=72 default=zero held=GlobalSettings@0x9370b5814eb005ce
-    field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0
+    field global id=0x7fb43557b54149ce kind=13 width=72 default=zero held=GlobalSettings@0x17ec347e3e20b357
+    field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0 held=ShipEntry@0x09a64721f993b5da
     field thresholds id=0x9cda940a344e1571 kind=16 width=12 default=born:0 min=0 max=1000
     field reserves id=0x77707fccd201c228 kind=14 width=328 default=born:0 held=ShipEntry@0x09a64721f993b5da elem=13/108
 
@@ -54,7 +54,7 @@ fixed table Patrol layout=0xe5e88ef190270115
     field wander id=0xb8c758d8bd1845d4 kind=10 width=4 default=0.5
     field note id=0x3bf8fbbad1587cdd kind=12 width=16 default=bytes:
 
-fixed table ProfileConfig layout=0xbeb1829808ae9c73
+fixed table ProfileConfig layout=0xbc3a524e52a29909
     field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
     field icon id=0xdbff4cc56c2092f0 kind=14 width=20 default=bytes: elem=6/1
     field experience id=0xab8b6d521f80b969 kind=8 width=4 default=0
@@ -67,7 +67,7 @@ fixed table ProfileConfig layout=0xbeb1829808ae9c73
     field precision id=0x288427f5babd05f7 kind=11 width=8 default=0.0
     field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16 default=born:0 elem=10/4
     field has_loadout id=0xa06f5e0a148e253c kind=1 width=1 default=false
-    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176 default=zero held=LoadoutConfig@0x8ab96fc8392c8897
+    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176 default=zero held=LoadoutConfig@0x3c738da0869f9933
 
 fixed table RangedSigned layout=0x46f0399743407be4
     field i8_span id=0x48121511bf702eb5 kind=2 width=1 default=0 min=-128 max=127
@@ -115,10 +115,10 @@ fixed table RangedWidths layout=0xaf0cc20950a8904e
     field b12 id=0xff95741912ad9e8a kind=7 width=4 default=0
     field b48 id=0xff8b681912a535a1 kind=9 width=8 default=0
 
-fixed table RootConfig layout=0xadb5d5e768da8c47
+fixed table RootConfig layout=0xb4320e868aa6e0f8
     field version_note id=0x8a67c9728746d394 kind=12 width=24 default=bytes:
     field weapons id=0x41cbd901b87fabb6 kind=14 width=228 default=born:0 held=WeaponConfig@0xb8d345be27518024 elem=13/28
-    field profiles id=0x8181e61fc0436767 kind=14 width=1220 default=born:0 held=ProfileConfig@0xbeb1829808ae9c73 elem=13/304
+    field profiles id=0x8181e61fc0436767 kind=14 width=1220 default=born:0 held=ProfileConfig@0xbc3a524e52a29909 elem=13/304
 
 fixed table ShipEntry layout=0x09a64721f993b5da
     field display_name id=0x2d21d7cd66bd5a5d kind=12 width=40 default=bytes:

--- a/tables/examples/schema.lock
+++ b/tables/examples/schema.lock
@@ -1,0 +1,150 @@
+schema-lock 1
+package tabledemo
+
+fixed table ArchiveConfig layout=0x0504584a27e89ec6
+    field root id=0xa354fd1ff0c467c5 kind=13 width=1480
+    field count id=0xb1e5e28e4479a274 kind=4 width=4
+
+fixed table GlobalSettings layout=0xbe2b4b4dcd3340a5
+    field tick_rate id=0xa65f859b617deaf3 kind=8 width=4
+    field difficulty id=0x467f35a74c6e4a70 kind=7 width=1
+    field build_note id=0x14ec921cc2549d60 kind=12 width=55
+    field spawn_delays id=0x09ae5613b0051271 kind=14 width=12
+
+fixed table GunnerConfig layout=0x8ff20b5071239e4d
+    field reaction id=0xb75aa3662201646a kind=10 width=4
+    field tracking id=0xa6bf719a4602b0bc kind=1 width=1
+
+fixed table GunnerSettings layout=0xfd060839982f983c
+    field reaction id=0xb75aa3662201646a kind=10 width=4
+    field tracking id=0xa6bf719a4602b0bc kind=1 width=1
+    field callsign id=0x5bc44627b9848818 kind=12 width=31
+
+fixed table HullConfig layout=0xfd3c9c2f7dedb5a7
+    field health id=0x7f69d4b5288ba9cf kind=10 width=4
+    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4
+    field turrets id=0x84f8260bc283608c kind=16 width=60
+
+fixed table KeyedConfig layout=0x95a65b04f31448cf
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84
+    field hulls id=0xce0ac3c25694d8ff kind=16 width=204
+    field scores id=0x01986b0b27400fb2 kind=13 width=12
+
+fixed table LoadoutConfig layout=0xe2ca51a5b31f71c6
+    field grade id=0x32a89b2977c48ad4 kind=7 width=1
+    field grades id=0xd90a4e7682f799c5 kind=14 width=11
+    field podium id=0xb46ff45a23d72549 kind=14 width=3
+    field perks id=0x4b06f5847096e54a kind=9 width=8
+    field primary id=0xbf31137ff783e939 kind=13 width=28
+    field backups id=0xde28f0f5118acc24 kind=14 width=56
+    field attachments id=0xf901aa0340249a41 kind=14 width=68
+
+fixed table PackConfig layout=0x707b15a7cf2effd9
+    field version id=0xbb62c62c9808ea37 kind=8 width=4
+    field global id=0x7fb43557b54149ce kind=13 width=72
+    field ships id=0x294a5c4913e1ad44 kind=16 width=324
+    field thresholds id=0x9cda940a344e1571 kind=16 width=12
+    field reserves id=0x77707fccd201c228 kind=14 width=328
+
+fixed table Patrol layout=0x0992c902cca9a859
+    field active id=0x6580790b036f0c6f kind=1 width=1
+    field speed id=0x2281498aa0200e40 kind=10 width=4
+    field has_target id=0x247f0e7f55aacfbd kind=1 width=1
+    field target_id id=0xb7bc9ac015a25050 kind=4 width=4
+    field wander id=0xb8c758d8bd1845d4 kind=10 width=4
+    field note id=0x3bf8fbbad1587cdd kind=12 width=16
+
+fixed table ProfileConfig layout=0x125946f69bcadde9
+    field name id=0xc4bcadba8e631b86 kind=12 width=40
+    field icon id=0xdbff4cc56c2092f0 kind=14 width=20
+    field experience id=0xab8b6d521f80b969 kind=8 width=4
+    field tilt id=0x1e5088ef2e9bafc6 kind=2 width=1
+    field heading id=0xb128829190ca0f75 kind=3 width=2
+    field timestamp id=0x5ddc92338ef53403 kind=5 width=8
+    field badge id=0x10bda981fe095518 kind=6 width=1
+    field port id=0x8c2cdb0da8933fa6 kind=7 width=2
+    field epoch id=0xfc9697d1196e6ba6 kind=9 width=8
+    field precision id=0x288427f5babd05f7 kind=11 width=8
+    field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16
+    field has_loadout id=0xa06f5e0a148e253c kind=1 width=1
+    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176
+
+fixed table RangedSigned layout=0x3bc2e50892f57df7
+    field i8_span id=0x48121511bf702eb5 kind=2 width=1
+    field i8_low id=0x942bfe3168090f7d kind=2 width=1
+    field i8_high id=0xd182acd105b55dd1 kind=2 width=1
+    field i8_inside id=0xef9ded23c8912a81 kind=2 width=1
+    field i16_span id=0xb655574ea23760b4 kind=3 width=2
+    field i16_low id=0xd217b3af8d7a2bde kind=3 width=2
+    field i16_high id=0x90652f70c9127900 kind=3 width=2
+    field i16_inside id=0x6a659d7c354db158 kind=3 width=2
+    field i32_span id=0xe693bd88532c91d6 kind=4 width=4
+    field i32_low id=0x065ee827cf99fbb4 kind=4 width=4
+    field i32_high id=0xc9b121c4c2a186ee kind=4 width=4
+    field i32_inside id=0xd363dfa465acf27a kind=4 width=4
+    field i64_span id=0x7549c70700c49d6f kind=5 width=8
+    field i64_low id=0x1cce6617419771db kind=5 width=8
+    field i64_high id=0x3b54fa60620b5597 kind=5 width=8
+    field i64_inside id=0xd308fcb98ece5d23 kind=5 width=8
+    field edges id=0xc70cde6b85b6197d kind=14 width=12
+
+fixed table RangedUnsigned layout=0x135ec77586e39c39
+    field u8_span id=0x0f8897557f37c021 kind=6 width=1
+    field u8_low id=0x2e17553f8200a2a1 kind=6 width=1
+    field u8_high id=0xa0e5c60df9301b7d kind=6 width=1
+    field u8_inside id=0x1cb2c073a6f5844d kind=6 width=1
+    field u16_span id=0x4ca0c150b1790960 kind=7 width=2
+    field u16_low id=0xf252136836b04cb2 kind=7 width=2
+    field u16_high id=0x4f37e1f216e7610c kind=7 width=2
+    field u16_inside id=0xd176b605978f3304 kind=7 width=2
+    field u32_span id=0x200b924de7479cda kind=8 width=4
+    field u32_low id=0xa53d2f2a31b5acb0 kind=8 width=4
+    field u32_high id=0x9759be8ea1a4e3d2 kind=8 width=4
+    field u32_inside id=0x8dc515fc082e3c0e kind=8 width=4
+    field u64_span id=0xbeecef11dbdf8973 kind=9 width=8
+    field u64_low id=0x0117ad66e0fff227 kind=9 width=8
+    field u64_high id=0xf2b45af3b50689db kind=9 width=8
+    field u64_inside id=0x713e12017eebcaf7 kind=9 width=8
+    field counts id=0xc341febe5aae51e5 kind=14 width=36
+
+fixed table RangedWidths layout=0xbfa68b9aafc7e8a6
+    field b8 id=0x08a60c07b54d8dc7 kind=6 width=4
+    field b16 id=0xff95701912ad97be kind=7 width=4
+    field b32 id=0xff9c5c1912b39470 kind=8 width=4
+    field b64 id=0xff92701912ab61e7 kind=9 width=8
+    field b12 id=0xff95741912ad9e8a kind=7 width=4
+    field b48 id=0xff8b681912a535a1 kind=9 width=8
+
+fixed table RootConfig layout=0xfda97d60e7ef7c05
+    field version_note id=0x8a67c9728746d394 kind=12 width=24
+    field weapons id=0x41cbd901b87fabb6 kind=14 width=228
+    field profiles id=0x8181e61fc0436767 kind=14 width=1220
+
+fixed table ShipEntry layout=0x7795cb20ad8cf897
+    field display_name id=0x2d21d7cd66bd5a5d kind=12 width=40
+    field health id=0x7f69d4b5288ba9cf kind=10 width=4
+    field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4
+    field hardpoints id=0x95d0cce09ca82b73 kind=14 width=20
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=37
+
+fixed table TeamConfig layout=0xbd7f2cfc870f8dc7
+    field spawn_count id=0xceec99e2d65db674 kind=4 width=4
+    field banner id=0xbca0dab1c7a00ccf kind=12 width=24
+
+fixed table TurretConfig layout=0xa1ca43d0782104ac
+    field damage id=0x7f6308be8ab37fc0 kind=10 width=4
+    field cooldown id=0xdc2cbe6953343d48 kind=10 width=4
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=9
+
+fixed table WeaponConfig layout=0x421f6942f0db168a
+    field damage id=0x7f6308be8ab37fc0 kind=10 width=4
+    field velocity id=0x1733055702acb1d2 kind=10 width=4
+    field penetration id=0x4f31c5309e13e932 kind=4 width=4
+    field channel id=0xa5013e9ad5caeda4 kind=6 width=4
+    field homing id=0xad6587bc602e3f59 kind=1 width=1
+    field effect id=0x36c1c83b51f24394 kind=15 width=8
+
+fixed table WideBlob layout=0x29741c1ebd9642b1
+    field label id=0x39f7fcec8fcb623d kind=12 width=70008
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=70004
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=140004

--- a/tables/examples/schema.lock
+++ b/tables/examples/schema.lock
@@ -1,15 +1,15 @@
-schema-lock 2
+schema-lock 3
 package tabledemo
 
-fixed table ArchiveConfig layout=0x2a490501945fcf4e
-    field root id=0xa354fd1ff0c467c5 kind=13 width=1480 default=zero
+fixed table ArchiveConfig layout=0xe7b9cdfeabdf1fac
+    field root id=0xa354fd1ff0c467c5 kind=13 width=1480 default=zero held=RootConfig@0xadb5d5e768da8c47
     field count id=0xb1e5e28e4479a274 kind=4 width=4 default=1 min=0 max=100
 
-fixed table GlobalSettings layout=0xd10142c396a60776
+fixed table GlobalSettings layout=0x9370b5814eb005ce
     field tick_rate id=0xa65f859b617deaf3 kind=8 width=4 default=60 min=1 max=240
     field difficulty id=0x467f35a74c6e4a70 kind=7 width=1 default=variant:Normal
     field build_note id=0x14ec921cc2549d60 kind=12 width=55 default=bytes:
-    field spawn_delays id=0x09ae5613b0051271 kind=14 width=12 default=born:0
+    field spawn_delays id=0x09ae5613b0051271 kind=14 width=12 default=born:0 elem=10/4
 
 fixed table GunnerConfig layout=0xdd5ef1d77231ba48
     field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
@@ -25,26 +25,26 @@ fixed table HullConfig layout=0x7f5975fb9fddcaa4
     field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
     field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0
 
-fixed table KeyedConfig layout=0x15ddae216e2d83f3
+fixed table KeyedConfig layout=0x303b68a38581458e
     field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0
     field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0
-    field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero
+    field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero held=ScoreBoard@0x7aa40527e9a30518
 
-fixed table LoadoutConfig layout=0x87aceeef65b350e6
+fixed table LoadoutConfig layout=0x8ab96fc8392c8897
     field grade id=0x32a89b2977c48ad4 kind=7 width=1 default=variant:Silver
-    field grades id=0xd90a4e7682f799c5 kind=14 width=11 default=born:0
-    field podium id=0xb46ff45a23d72549 kind=14 width=3 default=born:0
+    field grades id=0xd90a4e7682f799c5 kind=14 width=11 default=born:0 elem=7/1
+    field podium id=0xb46ff45a23d72549 kind=14 width=3 default=born:0 elem=7/1
     field perks id=0x4b06f5847096e54a kind=9 width=8 default=mask:0
-    field primary id=0xbf31137ff783e939 kind=13 width=28 default=zero
-    field backups id=0xde28f0f5118acc24 kind=14 width=56 default=born:0
-    field attachments id=0xf901aa0340249a41 kind=14 width=68 default=born:0
+    field primary id=0xbf31137ff783e939 kind=13 width=28 default=zero held=WeaponConfig@0xb8d345be27518024
+    field backups id=0xde28f0f5118acc24 kind=14 width=56 default=born:0 held=WeaponConfig@0xb8d345be27518024 elem=13/28
+    field attachments id=0xf901aa0340249a41 kind=14 width=68 default=born:0 held=Attachment@0x203fd5e47e2fd0c8 elem=13/8
 
-fixed table PackConfig layout=0xed22db9f9b3ca732
+fixed table PackConfig layout=0x320b0b6b6125b1e4
     field version id=0xbb62c62c9808ea37 kind=8 width=4 default=1
-    field global id=0x7fb43557b54149ce kind=13 width=72 default=zero
+    field global id=0x7fb43557b54149ce kind=13 width=72 default=zero held=GlobalSettings@0x9370b5814eb005ce
     field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0
     field thresholds id=0x9cda940a344e1571 kind=16 width=12 default=born:0 min=0 max=1000
-    field reserves id=0x77707fccd201c228 kind=14 width=328 default=born:0
+    field reserves id=0x77707fccd201c228 kind=14 width=328 default=born:0 held=ShipEntry@0x09a64721f993b5da elem=13/108
 
 fixed table Patrol layout=0xe5e88ef190270115
     field active id=0x6580790b036f0c6f kind=1 width=1 default=false
@@ -54,9 +54,9 @@ fixed table Patrol layout=0xe5e88ef190270115
     field wander id=0xb8c758d8bd1845d4 kind=10 width=4 default=0.5
     field note id=0x3bf8fbbad1587cdd kind=12 width=16 default=bytes:
 
-fixed table ProfileConfig layout=0xf8b07f6513cf03bf
+fixed table ProfileConfig layout=0xbeb1829808ae9c73
     field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
-    field icon id=0xdbff4cc56c2092f0 kind=14 width=20 default=bytes:
+    field icon id=0xdbff4cc56c2092f0 kind=14 width=20 default=bytes: elem=6/1
     field experience id=0xab8b6d521f80b969 kind=8 width=4 default=0
     field tilt id=0x1e5088ef2e9bafc6 kind=2 width=1 default=0
     field heading id=0xb128829190ca0f75 kind=3 width=2 default=0
@@ -65,11 +65,11 @@ fixed table ProfileConfig layout=0xf8b07f6513cf03bf
     field port id=0x8c2cdb0da8933fa6 kind=7 width=2 default=0
     field epoch id=0xfc9697d1196e6ba6 kind=9 width=8 default=0
     field precision id=0x288427f5babd05f7 kind=11 width=8 default=0.0
-    field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16 default=born:0
+    field ratings id=0xb921eb8a3d0cb0f9 kind=14 width=16 default=born:0 elem=10/4
     field has_loadout id=0xa06f5e0a148e253c kind=1 width=1 default=false
-    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176 default=zero
+    field loadout id=0x5759ce7586bbb5a3 kind=13 width=176 default=zero held=LoadoutConfig@0x8ab96fc8392c8897
 
-fixed table RangedSigned layout=0x6986cfad327fae32
+fixed table RangedSigned layout=0x46f0399743407be4
     field i8_span id=0x48121511bf702eb5 kind=2 width=1 default=0 min=-128 max=127
     field i8_low id=0x942bfe3168090f7d kind=2 width=1 default=0 min=-128 max=126
     field i8_high id=0xd182acd105b55dd1 kind=2 width=1 default=0 min=-127 max=127
@@ -86,9 +86,9 @@ fixed table RangedSigned layout=0x6986cfad327fae32
     field i64_low id=0x1cce6617419771db kind=5 width=8 default=0 min=-9223372036854775808 max=9223372036854775806
     field i64_high id=0x3b54fa60620b5597 kind=5 width=8 default=0 min=-9223372036854775807 max=9223372036854775807
     field i64_inside id=0xd308fcb98ece5d23 kind=5 width=8 default=0 min=-9223372036854775807 max=9223372036854775806
-    field edges id=0xc70cde6b85b6197d kind=14 width=12 default=born:0 min=-32768 max=32767
+    field edges id=0xc70cde6b85b6197d kind=14 width=12 default=born:0 min=-32768 max=32767 elem=3/2
 
-fixed table RangedUnsigned layout=0x5943408e01c0cb4d
+fixed table RangedUnsigned layout=0x74b4fe7c44d4a561
     field u8_span id=0x0f8897557f37c021 kind=6 width=1 default=0 min=0 max=255
     field u8_low id=0x2e17553f8200a2a1 kind=6 width=1 default=0 min=0 max=254
     field u8_high id=0xa0e5c60df9301b7d kind=6 width=1 default=1 min=1 max=255
@@ -105,7 +105,7 @@ fixed table RangedUnsigned layout=0x5943408e01c0cb4d
     field u64_low id=0x0117ad66e0fff227 kind=9 width=8 default=0 min=0 max=18446744073709551614
     field u64_high id=0xf2b45af3b50689db kind=9 width=8 default=1 min=1 max=18446744073709551615
     field u64_inside id=0x713e12017eebcaf7 kind=9 width=8 default=1 min=1 max=18446744073709551614
-    field counts id=0xc341febe5aae51e5 kind=14 width=36 default=born:0 min=0 max=18446744073709551615
+    field counts id=0xc341febe5aae51e5 kind=14 width=36 default=born:0 min=0 max=18446744073709551615 elem=9/8
 
 fixed table RangedWidths layout=0xaf0cc20950a8904e
     field b8 id=0x08a60c07b54d8dc7 kind=6 width=4 default=0
@@ -115,39 +115,39 @@ fixed table RangedWidths layout=0xaf0cc20950a8904e
     field b12 id=0xff95741912ad9e8a kind=7 width=4 default=0
     field b48 id=0xff8b681912a535a1 kind=9 width=8 default=0
 
-fixed table RootConfig layout=0xa4a3822c7b3048dc
+fixed table RootConfig layout=0xadb5d5e768da8c47
     field version_note id=0x8a67c9728746d394 kind=12 width=24 default=bytes:
-    field weapons id=0x41cbd901b87fabb6 kind=14 width=228 default=born:0
-    field profiles id=0x8181e61fc0436767 kind=14 width=1220 default=born:0
+    field weapons id=0x41cbd901b87fabb6 kind=14 width=228 default=born:0 held=WeaponConfig@0xb8d345be27518024 elem=13/28
+    field profiles id=0x8181e61fc0436767 kind=14 width=1220 default=born:0 held=ProfileConfig@0xbeb1829808ae9c73 elem=13/304
 
-fixed table ShipEntry layout=0x46e047441e737a91
+fixed table ShipEntry layout=0x09a64721f993b5da
     field display_name id=0x2d21d7cd66bd5a5d kind=12 width=40 default=bytes:
     field health id=0x7f69d4b5288ba9cf kind=10 width=4 default=100.0
     field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
-    field hardpoints id=0x95d0cce09ca82b73 kind=14 width=20 default=born:0 min=0 max=8
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=37 default=zero optional
+    field hardpoints id=0x95d0cce09ca82b73 kind=14 width=20 default=born:0 min=0 max=8 elem=4/4
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=37 default=zero held=GunnerSettings@0x4d7299bf23b53716 optional
 
 fixed table TeamConfig layout=0xf3999d79399a77ea
     field spawn_count id=0xceec99e2d65db674 kind=4 width=4 default=4 min=0 max=64
     field banner id=0xbca0dab1c7a00ccf kind=12 width=24 default=bytes:
 
-fixed table TurretConfig layout=0x98d6e7f03daa17de
+fixed table TurretConfig layout=0xd544f891dca5c02d
     field damage id=0x7f6308be8ab37fc0 kind=10 width=4 default=10.0
     field cooldown id=0xdc2cbe6953343d48 kind=10 width=4 default=0.5
-    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero optional
+    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero held=GunnerConfig@0xdd5ef1d77231ba48 optional
 
-fixed table WeaponConfig layout=0xf4e4dd2176d93061
+fixed table WeaponConfig layout=0xb8d345be27518024
     field damage id=0x7f6308be8ab37fc0 kind=10 width=4 default=21.0
     field velocity id=0x1733055702acb1d2 kind=10 width=4 default=500.0
     field penetration id=0x4f31c5309e13e932 kind=4 width=4 default=1 min=0 max=10
     field channel id=0xa5013e9ad5caeda4 kind=6 width=4 default=0
     field homing id=0xad6587bc602e3f59 kind=1 width=1 default=false
-    field effect id=0x36c1c83b51f24394 kind=15 width=8 default=zero
+    field effect id=0x36c1c83b51f24394 kind=15 width=8 default=zero held=Effect@0xea9bfb331d351d05
 
-fixed table WideBlob layout=0xb18a3f26237d25d0
+fixed table WideBlob layout=0x960e9db464db71c6
     field label id=0x39f7fcec8fcb623d kind=12 width=70008 default=bytes:
-    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=70004 default=bytes:
-    field samples id=0xe3b1ca6a3b48dddc kind=14 width=140004 default=born:0
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=70004 default=bytes: elem=6/1
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=140004 default=born:0 elem=7/2
 
 type Attachment layout=0x203fd5e47e2fd0c8
     field slot id=0x6a771618f6fe31d1 kind=4 width=4 default=0 min=0 max=7
@@ -197,6 +197,6 @@ flags Perks values=0x1f153e786d4f23a7
     variant Cloaked
     variant Turbo
 
-union Effect values=0x2ebda893340be256
-    arm buff
-    arm debuff
+union Effect values=0xea9bfb331d351d05
+    arm buff payload=Buff@0x95a2a02bde1f4141
+    arm debuff payload=Debuff@0x4c66b13a4d53ad2e

--- a/tables/examples/schema.lock
+++ b/tables/examples/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package tabledemo
 
 fixed table ArchiveConfig layout=0x18e055832d2ae20f
@@ -20,15 +20,15 @@ fixed table GunnerSettings layout=0x4d7299bf23b53716
     field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false
     field callsign id=0x5bc44627b9848818 kind=12 width=31 default=bytes:
 
-fixed table HullConfig layout=0x49fa8652005b3a25
+fixed table HullConfig layout=0x6e784e90835ccba1
     field health id=0x7f69d4b5288ba9cf kind=10 width=4 default=100.0
     field mass id=0x1f3757a2ce7b0ab1 kind=10 width=4 default=1.0
-    field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0 held=TurretConfig@0xd544f891dca5c02d
+    field turrets id=0x84f8260bc283608c kind=16 width=60 default=born:0 held=TurretConfig@0xd544f891dca5c02d elem=13/20 key=Weapon@0x56b73a1f4ab4e110
 
-fixed table KeyedConfig layout=0x4d5e4cf3072476b1
-    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0 held=TeamConfig@0xf3999d79399a77ea
-    field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0 held=HullConfig@0x49fa8652005b3a25
-    field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero held=ScoreBoard@0x7aa40527e9a30518
+fixed table KeyedConfig layout=0xab84968dca861e82
+    field teams id=0xbaaeb048a5a8fa6d kind=16 width=84 default=born:0 held=TeamConfig@0xf3999d79399a77ea elem=13/28 key=Team@0xc490f76cda16c53c
+    field hulls id=0xce0ac3c25694d8ff kind=16 width=204 default=born:0 held=HullConfig@0x6e784e90835ccba1 elem=13/68 key=Hull@0xc3cc3881c580dd9d
+    field scores id=0x01986b0b27400fb2 kind=13 width=12 default=zero held=ScoreBoard@0xebf061aa96447088
 
 fixed table LoadoutConfig layout=0x3c738da0869f9933
     field grade id=0x32a89b2977c48ad4 kind=7 width=1 default=variant:Silver held=Grade@0xc56ae3781a1039bd
@@ -39,11 +39,11 @@ fixed table LoadoutConfig layout=0x3c738da0869f9933
     field backups id=0xde28f0f5118acc24 kind=14 width=56 default=born:0 held=WeaponConfig@0xb8d345be27518024 elem=13/28
     field attachments id=0xf901aa0340249a41 kind=14 width=68 default=born:0 held=Attachment@0x203fd5e47e2fd0c8 elem=13/8
 
-fixed table PackConfig layout=0x77d8789a464829f4
+fixed table PackConfig layout=0xc401fa1fabbdb99f
     field version id=0xbb62c62c9808ea37 kind=8 width=4 default=1
     field global id=0x7fb43557b54149ce kind=13 width=72 default=zero held=GlobalSettings@0x17ec347e3e20b357
-    field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0 held=ShipEntry@0x09a64721f993b5da
-    field thresholds id=0x9cda940a344e1571 kind=16 width=12 default=born:0 min=0 max=1000
+    field ships id=0x294a5c4913e1ad44 kind=16 width=324 default=born:0 held=ShipEntry@0x09a64721f993b5da elem=13/108 key=ShipType@0xe37048030170f42c
+    field thresholds id=0x9cda940a344e1571 kind=16 width=12 default=born:0 min=0 max=1000 elem=4/4 key=Difficulty@0x8c7731ffcc25bee0
     field reserves id=0x77707fccd201c228 kind=14 width=328 default=born:0 held=ShipEntry@0x09a64721f993b5da elem=13/108
 
 fixed table Patrol layout=0xe5e88ef190270115
@@ -159,8 +159,8 @@ type Buff layout=0x95a2a02bde1f4141
 type Debuff layout=0x4c66b13a4d53ad2e
     field amount id=0x8113fe7ea2b16969 kind=4 width=4 default=0 min=0 max=100
 
-type ScoreBoard layout=0x7aa40527e9a30518
-    field per_team id=0xf10fad739a0e1660 kind=16 width=12 default=born:0 min=0 max=100000
+type ScoreBoard layout=0xebf061aa96447088
+    field per_team id=0xf10fad739a0e1660 kind=16 width=12 default=born:0 min=0 max=100000 elem=4/4 key=Team@0xc490f76cda16c53c
 
 enum Difficulty values=0x8c7731ffcc25bee0
     variant Easy

--- a/tables/lists/schema.lock
+++ b/tables/lists/schema.lock
@@ -1,0 +1,31 @@
+schema-lock 1
+package listdemo
+
+fixed table Bounded layout=0xde4d2356cb2409ff
+    field items id=0x3e7884bf4f412c6f kind=14 width=36
+    field tag id=0x56d7ab194448a4f3 kind=4 width=4
+
+fixed table Item layout=0x02e33cb64d7a0933
+    field count id=0xb1e5e28e4479a274 kind=4 width=4
+
+fixed table LogEntry layout=0xcc7e27337ba5d9a6
+    field tick id=0x1e7683ef2ebc7684 kind=8 width=4
+
+fixed table Photo layout=0x55fc1627fe82a95d
+    field width id=0xdbdacd932fd1e9bf kind=8 width=4
+    field height id=0x17720bf67d347222 kind=8 width=4
+
+fixed table Placement layout=0x7234da57109b4470
+    field x id=0xaf63f54c86021707 kind=10 width=4
+    field y id=0xaf63f44c86021554 kind=10 width=4
+    field model id=0x9de543933e6e703a kind=8 width=4
+
+fixed table Point layout=0xed3b6866a6880895
+    field x id=0xaf63f54c86021707 kind=4 width=4
+    field y id=0xaf63f44c86021554 kind=4 width=4
+
+fixed table Sample layout=0x4c160b6acc8ee562
+    field v id=0xaf63eb4c86020609 kind=4 width=4
+
+fixed table Unit layout=0x4c160b6acc8ee562
+    field v id=0xaf63eb4c86020609 kind=4 width=4

--- a/tables/lists/schema.lock
+++ b/tables/lists/schema.lock
@@ -1,31 +1,31 @@
-schema-lock 1
+schema-lock 2
 package listdemo
 
-fixed table Bounded layout=0xde4d2356cb2409ff
-    field items id=0x3e7884bf4f412c6f kind=14 width=36
-    field tag id=0x56d7ab194448a4f3 kind=4 width=4
+fixed table Bounded layout=0x3b84d989bb000b0a
+    field items id=0x3e7884bf4f412c6f kind=14 width=36 default=born:0
+    field tag id=0x56d7ab194448a4f3 kind=4 width=4 default=0
 
-fixed table Item layout=0x02e33cb64d7a0933
-    field count id=0xb1e5e28e4479a274 kind=4 width=4
+fixed table Item layout=0xf8efefb09ce745f7
+    field count id=0xb1e5e28e4479a274 kind=4 width=4 default=0
 
-fixed table LogEntry layout=0xcc7e27337ba5d9a6
-    field tick id=0x1e7683ef2ebc7684 kind=8 width=4
+fixed table LogEntry layout=0x8f1087a414b43276
+    field tick id=0x1e7683ef2ebc7684 kind=8 width=4 default=0
 
-fixed table Photo layout=0x55fc1627fe82a95d
-    field width id=0xdbdacd932fd1e9bf kind=8 width=4
-    field height id=0x17720bf67d347222 kind=8 width=4
+fixed table Photo layout=0x1f8f993dd8576281
+    field width id=0xdbdacd932fd1e9bf kind=8 width=4 default=0
+    field height id=0x17720bf67d347222 kind=8 width=4 default=0
 
-fixed table Placement layout=0x7234da57109b4470
-    field x id=0xaf63f54c86021707 kind=10 width=4
-    field y id=0xaf63f44c86021554 kind=10 width=4
-    field model id=0x9de543933e6e703a kind=8 width=4
+fixed table Placement layout=0x953ca25156f66168
+    field x id=0xaf63f54c86021707 kind=10 width=4 default=0.0
+    field y id=0xaf63f44c86021554 kind=10 width=4 default=0.0
+    field model id=0x9de543933e6e703a kind=8 width=4 default=0
 
-fixed table Point layout=0xed3b6866a6880895
-    field x id=0xaf63f54c86021707 kind=4 width=4
-    field y id=0xaf63f44c86021554 kind=4 width=4
+fixed table Point layout=0x03e9da69f262a7ed
+    field x id=0xaf63f54c86021707 kind=4 width=4 default=0
+    field y id=0xaf63f44c86021554 kind=4 width=4 default=0
 
-fixed table Sample layout=0x4c160b6acc8ee562
-    field v id=0xaf63eb4c86020609 kind=4 width=4
+fixed table Sample layout=0x3157106757693e8a
+    field v id=0xaf63eb4c86020609 kind=4 width=4 default=0
 
-fixed table Unit layout=0x4c160b6acc8ee562
-    field v id=0xaf63eb4c86020609 kind=4 width=4
+fixed table Unit layout=0x3157106757693e8a
+    field v id=0xaf63eb4c86020609 kind=4 width=4 default=0

--- a/tables/lists/schema.lock
+++ b/tables/lists/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package listdemo
 
 fixed table Bounded layout=0x38e61d51e4cc8311

--- a/tables/lists/schema.lock
+++ b/tables/lists/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package listdemo
 
 fixed table Bounded layout=0x38e61d51e4cc8311

--- a/tables/lists/schema.lock
+++ b/tables/lists/schema.lock
@@ -1,8 +1,8 @@
-schema-lock 2
+schema-lock 3
 package listdemo
 
-fixed table Bounded layout=0x3b84d989bb000b0a
-    field items id=0x3e7884bf4f412c6f kind=14 width=36 default=born:0
+fixed table Bounded layout=0x38e61d51e4cc8311
+    field items id=0x3e7884bf4f412c6f kind=14 width=36 default=born:0 held=Unit@0x3157106757693e8a elem=13/4
     field tag id=0x56d7ab194448a4f3 kind=4 width=4 default=0
 
 fixed table Item layout=0xf8efefb09ce745f7

--- a/tables/maps/schema.lock
+++ b/tables/maps/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package mapdemo
 
 fixed table Item layout=0xf8efefb09ce745f7

--- a/tables/maps/schema.lock
+++ b/tables/maps/schema.lock
@@ -1,0 +1,9 @@
+schema-lock 1
+package mapdemo
+
+fixed table Item layout=0x02e33cb64d7a0933
+    field count id=0xb1e5e28e4479a274 kind=4 width=4
+
+fixed table ShipConfig layout=0xfc242dc508985025
+    field name id=0xc4bcadba8e631b86 kind=12 width=72
+    field health id=0x7f69d4b5288ba9cf kind=4 width=4

--- a/tables/maps/schema.lock
+++ b/tables/maps/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package mapdemo
 
 fixed table Item layout=0xf8efefb09ce745f7

--- a/tables/maps/schema.lock
+++ b/tables/maps/schema.lock
@@ -1,9 +1,9 @@
-schema-lock 1
+schema-lock 2
 package mapdemo
 
-fixed table Item layout=0x02e33cb64d7a0933
-    field count id=0xb1e5e28e4479a274 kind=4 width=4
+fixed table Item layout=0xf8efefb09ce745f7
+    field count id=0xb1e5e28e4479a274 kind=4 width=4 default=0
 
-fixed table ShipConfig layout=0xfc242dc508985025
-    field name id=0xc4bcadba8e631b86 kind=12 width=72
-    field health id=0x7f69d4b5288ba9cf kind=4 width=4
+fixed table ShipConfig layout=0xaf1f5d3432d47f86
+    field name id=0xc4bcadba8e631b86 kind=12 width=72 default=bytes:
+    field health id=0x7f69d4b5288ba9cf kind=4 width=4 default=0

--- a/tables/maps/schema.lock
+++ b/tables/maps/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package mapdemo
 
 fixed table Item layout=0xf8efefb09ce745f7

--- a/tables/messages/schema.lock
+++ b/tables/messages/schema.lock
@@ -1,0 +1,50 @@
+schema-lock 1
+package messagedemo
+
+fixed table Edit layout=0xbe47c6e1cd645f8a
+    field revision id=0xd6a4dbc46c8e8658 kind=8 width=4
+    field body id=0xcd4de79bc6c93295 kind=15 width=308
+
+fixed table InsertText layout=0xf04f8aa0fc1a17d3
+    field at id=0x089c4e07b545a968 kind=13 width=8
+    field text id=0xfa04f4ef1995407e kind=12 width=40
+    field origin id=0xb9eae4fe785a14cf kind=15 width=80
+    field origins id=0x4437d86681113b74 kind=14 width=164
+    field modes id=0x9de526933e6e3ef3 kind=14 width=9
+
+fixed table OpenDocument layout=0xb48d35e16433a8fe
+    field path id=0x03c52d0debd70676 kind=12 width=72
+    field mode id=0x0d3deba2c41dadb2 kind=7 width=1
+    field cursor id=0xf927453fbe6252ef kind=13 width=8
+
+fixed table RemoveText layout=0x8f035a1f94799ab1
+    field span id=0x8b7dc019093cd0e1 kind=13 width=16
+
+fixed table SaveDocument layout=0x38a5ca3bdf402daf
+    field path id=0x03c52d0debd70676 kind=12 width=72
+    field force id=0xe75ad8afb3eeebe4 kind=1 width=1
+
+fixed table Script layout=0xbba00356d8d64819
+    field path id=0x03c52d0debd70676 kind=12 width=72
+    field line id=0xbf4ba5ad694f5907 kind=8 width=4
+
+fixed table Selection layout=0x3b4d8007489d5099
+    field start id=0xee5d97ad45ad251f kind=13 width=8
+    field end id=0xc2f00318f053500a kind=13 width=8
+
+fixed table ToolMessage layout=0xeb616a40e97a4446
+    field sequence id=0xaa38aca481f528a8 kind=8 width=4
+    field body id=0xcd4de79bc6c93295 kind=15 width=1640
+    field history id=0x33428945bbd5f2ff kind=14 width=3284
+    field trace id=0xdec59ea6c4eb9aee kind=14 width=233
+    field marks id=0x9077d4a4e1726e29 kind=14 width=3
+
+fixed table Transaction layout=0x7ec646eff3287820
+    field reason id=0x65e8d7f3474f2639 kind=12 width=24
+    field edits id=0x9478d06b697549e6 kind=14 width=940
+    field pending id=0x52dea0d6eeb5083c kind=14 width=616
+    field checkpoints id=0x028afa1c4d757704 kind=14 width=9
+    field snapshots id=0x99dc6354a681403a kind=14 width=33
+
+fixed table User layout=0x7d09ab9b426398c0
+    field name id=0xc4bcadba8e631b86 kind=12 width=24

--- a/tables/messages/schema.lock
+++ b/tables/messages/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package messagedemo
 
 fixed table Edit layout=0xb3ec139d21d17c9a

--- a/tables/messages/schema.lock
+++ b/tables/messages/schema.lock
@@ -1,24 +1,24 @@
-schema-lock 2
+schema-lock 3
 package messagedemo
 
-fixed table Edit layout=0x6f6024d4e52f3ce4
+fixed table Edit layout=0xe5f61d113528350f
     field revision id=0xd6a4dbc46c8e8658 kind=8 width=4 default=0
-    field body id=0xcd4de79bc6c93295 kind=15 width=308 default=zero
+    field body id=0xcd4de79bc6c93295 kind=15 width=308 default=zero held=EditBody@0xe030492f7a325c4e
 
-fixed table InsertText layout=0xd2825df561ef8540
-    field at id=0x089c4e07b545a968 kind=13 width=8 default=zero
+fixed table InsertText layout=0xa964ff3cc1ffeb20
+    field at id=0x089c4e07b545a968 kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
     field text id=0xfa04f4ef1995407e kind=12 width=40 default=bytes:
-    field origin id=0xb9eae4fe785a14cf kind=15 width=80 default=zero
-    field origins id=0x4437d86681113b74 kind=14 width=164 default=born:0
-    field modes id=0x9de526933e6e3ef3 kind=14 width=9 default=born:0 optional
+    field origin id=0xb9eae4fe785a14cf kind=15 width=80 default=zero held=Origin@0x354ffdd877947c6d
+    field origins id=0x4437d86681113b74 kind=14 width=164 default=born:0 held=Origin@0x354ffdd877947c6d elem=15/80
+    field modes id=0x9de526933e6e3ef3 kind=14 width=9 default=born:0 elem=7/1 optional
 
-fixed table OpenDocument layout=0x4169eff253a0107a
+fixed table OpenDocument layout=0xcf66c6e6b1054122
     field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
     field mode id=0x0d3deba2c41dadb2 kind=7 width=1 default=variant:Read
-    field cursor id=0xf927453fbe6252ef kind=13 width=8 default=zero
+    field cursor id=0xf927453fbe6252ef kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
 
-fixed table RemoveText layout=0xe4aaf9cbd2784f45
-    field span id=0x8b7dc019093cd0e1 kind=13 width=16 default=zero
+fixed table RemoveText layout=0xc5487d2191b647dc
+    field span id=0x8b7dc019093cd0e1 kind=13 width=16 default=zero held=Selection@0xde26223e859e6221
 
 fixed table SaveDocument layout=0xd663204963a83a25
     field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
@@ -28,23 +28,23 @@ fixed table Script layout=0xb777ff39a7af3cd8
     field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
     field line id=0xbf4ba5ad694f5907 kind=8 width=4 default=0
 
-fixed table Selection layout=0xd3816a0bf4b58fb1
-    field start id=0xee5d97ad45ad251f kind=13 width=8 default=zero
-    field end id=0xc2f00318f053500a kind=13 width=8 default=zero
+fixed table Selection layout=0xde26223e859e6221
+    field start id=0xee5d97ad45ad251f kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
+    field end id=0xc2f00318f053500a kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
 
-fixed table ToolMessage layout=0x8f8c2dacddf928e9
+fixed table ToolMessage layout=0xb4dbe182679fcfcd
     field sequence id=0xaa38aca481f528a8 kind=8 width=4 default=0
-    field body id=0xcd4de79bc6c93295 kind=15 width=1640 default=zero
-    field history id=0x33428945bbd5f2ff kind=14 width=3284 default=born:0
-    field trace id=0xdec59ea6c4eb9aee kind=14 width=233 default=born:0 optional
-    field marks id=0x9077d4a4e1726e29 kind=14 width=3 default=born:0 optional
+    field body id=0xcd4de79bc6c93295 kind=15 width=1640 default=zero held=ToolBody@0x337b2592c25d4996
+    field history id=0x33428945bbd5f2ff kind=14 width=3284 default=born:0 held=ToolBody@0x337b2592c25d4996 elem=15/1640
+    field trace id=0xdec59ea6c4eb9aee kind=14 width=233 default=born:0 held=Script@0xb777ff39a7af3cd8 elem=13/76 optional
+    field marks id=0x9077d4a4e1726e29 kind=14 width=3 default=born:0 elem=7/1 optional
 
-fixed table Transaction layout=0xf8e3c04e9fa87a7b
+fixed table Transaction layout=0x1ff7c5ddf934351c
     field reason id=0x65e8d7f3474f2639 kind=12 width=24 default=bytes:
-    field edits id=0x9478d06b697549e6 kind=14 width=940 default=born:0
-    field pending id=0x52dea0d6eeb5083c kind=14 width=616 default=born:0
-    field checkpoints id=0x028afa1c4d757704 kind=14 width=9 default=born:0 optional
-    field snapshots id=0x99dc6354a681403a kind=14 width=33 default=born:0 optional
+    field edits id=0x9478d06b697549e6 kind=14 width=940 default=born:0 held=Edit@0xe5f61d113528350f elem=13/312
+    field pending id=0x52dea0d6eeb5083c kind=14 width=616 default=born:0 held=EditBody@0xe030492f7a325c4e elem=15/308
+    field checkpoints id=0x028afa1c4d757704 kind=14 width=9 default=born:0 elem=8/4 optional
+    field snapshots id=0x99dc6354a681403a kind=14 width=33 default=born:0 held=Selection@0xde26223e859e6221 elem=13/16 optional
 
 fixed table User layout=0xabbd6dfa650ebe49
     field name id=0xc4bcadba8e631b86 kind=12 width=24 default=bytes:
@@ -64,26 +64,26 @@ flags Capabilities values=0x38384ef20e92e294
     variant Trace
     variant Verbose
 
-union EditBody values=0x961387e9a1def7ed
-    arm insert
-    arm remove
-    arm count
-    arm marks
-    arm blob
-    arm mode
+union EditBody values=0xe030492f7a325c4e
+    arm insert payload=InsertText@0xa964ff3cc1ffeb20
+    arm remove payload=RemoveText@0xc5487d2191b647dc
+    arm count payload=int32
+    arm marks payload=[..3]uint16
+    arm blob payload=bytes(4)
+    arm mode payload=Mode
 
-union Origin values=0xd8ed427f8d2864c8
-    arm user
-    arm script
-    arm pid
-    arm note
+union Origin values=0x354ffdd877947c6d
+    arm user payload=User@0xabbd6dfa650ebe49
+    arm script payload=Script@0xb777ff39a7af3cd8
+    arm pid payload=uint32
+    arm note payload=string(24)
 
-union ToolBody values=0x8d528f544f260ba1
-    arm open
-    arm save
-    arm transact
-    arm ping
-    arm caps
-    arm spans
-    arm origin
+union ToolBody values=0x337b2592c25d4996
+    arm open payload=OpenDocument@0xcf66c6e6b1054122
+    arm save payload=SaveDocument@0xd663204963a83a25
+    arm transact payload=Transaction@0x1ff7c5ddf934351c
+    arm ping payload=Ping@0xa3b89594fbb34f54
+    arm caps payload=Capabilities
+    arm spans payload=[2]int32
+    arm origin payload=Origin@0x354ffdd877947c6d
     arm ack

--- a/tables/messages/schema.lock
+++ b/tables/messages/schema.lock
@@ -1,20 +1,20 @@
-schema-lock 3
+schema-lock 4
 package messagedemo
 
-fixed table Edit layout=0xe5f61d113528350f
+fixed table Edit layout=0xb3ec139d21d17c9a
     field revision id=0xd6a4dbc46c8e8658 kind=8 width=4 default=0
-    field body id=0xcd4de79bc6c93295 kind=15 width=308 default=zero held=EditBody@0xe030492f7a325c4e
+    field body id=0xcd4de79bc6c93295 kind=15 width=308 default=zero held=EditBody@0xa1a7ac45c70b89ee
 
-fixed table InsertText layout=0xa964ff3cc1ffeb20
+fixed table InsertText layout=0xbb31f946fa0c0eb7
     field at id=0x089c4e07b545a968 kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
     field text id=0xfa04f4ef1995407e kind=12 width=40 default=bytes:
     field origin id=0xb9eae4fe785a14cf kind=15 width=80 default=zero held=Origin@0x354ffdd877947c6d
     field origins id=0x4437d86681113b74 kind=14 width=164 default=born:0 held=Origin@0x354ffdd877947c6d elem=15/80
-    field modes id=0x9de526933e6e3ef3 kind=14 width=9 default=born:0 elem=7/1 optional
+    field modes id=0x9de526933e6e3ef3 kind=14 width=9 default=born:0 held=Mode@0xff134120cb6e4564 elem=7/1 optional
 
-fixed table OpenDocument layout=0xcf66c6e6b1054122
+fixed table OpenDocument layout=0x86f529a027eedb4b
     field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
-    field mode id=0x0d3deba2c41dadb2 kind=7 width=1 default=variant:Read
+    field mode id=0x0d3deba2c41dadb2 kind=7 width=1 default=variant:Read held=Mode@0xff134120cb6e4564
     field cursor id=0xf927453fbe6252ef kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
 
 fixed table RemoveText layout=0xc5487d2191b647dc
@@ -32,17 +32,17 @@ fixed table Selection layout=0xde26223e859e6221
     field start id=0xee5d97ad45ad251f kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
     field end id=0xc2f00318f053500a kind=13 width=8 default=zero held=Cursor@0x1c6c4747ec7d22b6
 
-fixed table ToolMessage layout=0xb4dbe182679fcfcd
+fixed table ToolMessage layout=0xa26c07ee3330441e
     field sequence id=0xaa38aca481f528a8 kind=8 width=4 default=0
-    field body id=0xcd4de79bc6c93295 kind=15 width=1640 default=zero held=ToolBody@0x337b2592c25d4996
-    field history id=0x33428945bbd5f2ff kind=14 width=3284 default=born:0 held=ToolBody@0x337b2592c25d4996 elem=15/1640
+    field body id=0xcd4de79bc6c93295 kind=15 width=1640 default=zero held=ToolBody@0x517d7c2e9bcc4890
+    field history id=0x33428945bbd5f2ff kind=14 width=3284 default=born:0 held=ToolBody@0x517d7c2e9bcc4890 elem=15/1640
     field trace id=0xdec59ea6c4eb9aee kind=14 width=233 default=born:0 held=Script@0xb777ff39a7af3cd8 elem=13/76 optional
-    field marks id=0x9077d4a4e1726e29 kind=14 width=3 default=born:0 elem=7/1 optional
+    field marks id=0x9077d4a4e1726e29 kind=14 width=3 default=born:0 held=Mode@0xff134120cb6e4564 elem=7/1 optional
 
-fixed table Transaction layout=0x1ff7c5ddf934351c
+fixed table Transaction layout=0xf35434b744559796
     field reason id=0x65e8d7f3474f2639 kind=12 width=24 default=bytes:
-    field edits id=0x9478d06b697549e6 kind=14 width=940 default=born:0 held=Edit@0xe5f61d113528350f elem=13/312
-    field pending id=0x52dea0d6eeb5083c kind=14 width=616 default=born:0 held=EditBody@0xe030492f7a325c4e elem=15/308
+    field edits id=0x9478d06b697549e6 kind=14 width=940 default=born:0 held=Edit@0xb3ec139d21d17c9a elem=13/312
+    field pending id=0x52dea0d6eeb5083c kind=14 width=616 default=born:0 held=EditBody@0xa1a7ac45c70b89ee elem=15/308
     field checkpoints id=0x028afa1c4d757704 kind=14 width=9 default=born:0 elem=8/4 optional
     field snapshots id=0x99dc6354a681403a kind=14 width=33 default=born:0 held=Selection@0xde26223e859e6221 elem=13/16 optional
 
@@ -64,13 +64,13 @@ flags Capabilities values=0x38384ef20e92e294
     variant Trace
     variant Verbose
 
-union EditBody values=0xe030492f7a325c4e
-    arm insert payload=InsertText@0xa964ff3cc1ffeb20
+union EditBody values=0xa1a7ac45c70b89ee
+    arm insert payload=InsertText@0xbb31f946fa0c0eb7
     arm remove payload=RemoveText@0xc5487d2191b647dc
     arm count payload=int32
     arm marks payload=[..3]uint16
     arm blob payload=bytes(4)
-    arm mode payload=Mode
+    arm mode payload=Mode@0xff134120cb6e4564
 
 union Origin values=0x354ffdd877947c6d
     arm user payload=User@0xabbd6dfa650ebe49
@@ -78,12 +78,12 @@ union Origin values=0x354ffdd877947c6d
     arm pid payload=uint32
     arm note payload=string(24)
 
-union ToolBody values=0x337b2592c25d4996
-    arm open payload=OpenDocument@0xcf66c6e6b1054122
+union ToolBody values=0x517d7c2e9bcc4890
+    arm open payload=OpenDocument@0x86f529a027eedb4b
     arm save payload=SaveDocument@0xd663204963a83a25
-    arm transact payload=Transaction@0x1ff7c5ddf934351c
+    arm transact payload=Transaction@0xf35434b744559796
     arm ping payload=Ping@0xa3b89594fbb34f54
-    arm caps payload=Capabilities
+    arm caps payload=Capabilities@0x38384ef20e92e294
     arm spans payload=[2]int32
     arm origin payload=Origin@0x354ffdd877947c6d
     arm ack

--- a/tables/messages/schema.lock
+++ b/tables/messages/schema.lock
@@ -1,50 +1,89 @@
-schema-lock 1
+schema-lock 2
 package messagedemo
 
-fixed table Edit layout=0xbe47c6e1cd645f8a
-    field revision id=0xd6a4dbc46c8e8658 kind=8 width=4
-    field body id=0xcd4de79bc6c93295 kind=15 width=308
+fixed table Edit layout=0x6f6024d4e52f3ce4
+    field revision id=0xd6a4dbc46c8e8658 kind=8 width=4 default=0
+    field body id=0xcd4de79bc6c93295 kind=15 width=308 default=zero
 
-fixed table InsertText layout=0xf04f8aa0fc1a17d3
-    field at id=0x089c4e07b545a968 kind=13 width=8
-    field text id=0xfa04f4ef1995407e kind=12 width=40
-    field origin id=0xb9eae4fe785a14cf kind=15 width=80
-    field origins id=0x4437d86681113b74 kind=14 width=164
-    field modes id=0x9de526933e6e3ef3 kind=14 width=9
+fixed table InsertText layout=0xd2825df561ef8540
+    field at id=0x089c4e07b545a968 kind=13 width=8 default=zero
+    field text id=0xfa04f4ef1995407e kind=12 width=40 default=bytes:
+    field origin id=0xb9eae4fe785a14cf kind=15 width=80 default=zero
+    field origins id=0x4437d86681113b74 kind=14 width=164 default=born:0
+    field modes id=0x9de526933e6e3ef3 kind=14 width=9 default=born:0 optional
 
-fixed table OpenDocument layout=0xb48d35e16433a8fe
-    field path id=0x03c52d0debd70676 kind=12 width=72
-    field mode id=0x0d3deba2c41dadb2 kind=7 width=1
-    field cursor id=0xf927453fbe6252ef kind=13 width=8
+fixed table OpenDocument layout=0x4169eff253a0107a
+    field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
+    field mode id=0x0d3deba2c41dadb2 kind=7 width=1 default=variant:Read
+    field cursor id=0xf927453fbe6252ef kind=13 width=8 default=zero
 
-fixed table RemoveText layout=0x8f035a1f94799ab1
-    field span id=0x8b7dc019093cd0e1 kind=13 width=16
+fixed table RemoveText layout=0xe4aaf9cbd2784f45
+    field span id=0x8b7dc019093cd0e1 kind=13 width=16 default=zero
 
-fixed table SaveDocument layout=0x38a5ca3bdf402daf
-    field path id=0x03c52d0debd70676 kind=12 width=72
-    field force id=0xe75ad8afb3eeebe4 kind=1 width=1
+fixed table SaveDocument layout=0xd663204963a83a25
+    field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
+    field force id=0xe75ad8afb3eeebe4 kind=1 width=1 default=false
 
-fixed table Script layout=0xbba00356d8d64819
-    field path id=0x03c52d0debd70676 kind=12 width=72
-    field line id=0xbf4ba5ad694f5907 kind=8 width=4
+fixed table Script layout=0xb777ff39a7af3cd8
+    field path id=0x03c52d0debd70676 kind=12 width=72 default=bytes:
+    field line id=0xbf4ba5ad694f5907 kind=8 width=4 default=0
 
-fixed table Selection layout=0x3b4d8007489d5099
-    field start id=0xee5d97ad45ad251f kind=13 width=8
-    field end id=0xc2f00318f053500a kind=13 width=8
+fixed table Selection layout=0xd3816a0bf4b58fb1
+    field start id=0xee5d97ad45ad251f kind=13 width=8 default=zero
+    field end id=0xc2f00318f053500a kind=13 width=8 default=zero
 
-fixed table ToolMessage layout=0xeb616a40e97a4446
-    field sequence id=0xaa38aca481f528a8 kind=8 width=4
-    field body id=0xcd4de79bc6c93295 kind=15 width=1640
-    field history id=0x33428945bbd5f2ff kind=14 width=3284
-    field trace id=0xdec59ea6c4eb9aee kind=14 width=233
-    field marks id=0x9077d4a4e1726e29 kind=14 width=3
+fixed table ToolMessage layout=0x8f8c2dacddf928e9
+    field sequence id=0xaa38aca481f528a8 kind=8 width=4 default=0
+    field body id=0xcd4de79bc6c93295 kind=15 width=1640 default=zero
+    field history id=0x33428945bbd5f2ff kind=14 width=3284 default=born:0
+    field trace id=0xdec59ea6c4eb9aee kind=14 width=233 default=born:0 optional
+    field marks id=0x9077d4a4e1726e29 kind=14 width=3 default=born:0 optional
 
-fixed table Transaction layout=0x7ec646eff3287820
-    field reason id=0x65e8d7f3474f2639 kind=12 width=24
-    field edits id=0x9478d06b697549e6 kind=14 width=940
-    field pending id=0x52dea0d6eeb5083c kind=14 width=616
-    field checkpoints id=0x028afa1c4d757704 kind=14 width=9
-    field snapshots id=0x99dc6354a681403a kind=14 width=33
+fixed table Transaction layout=0xf8e3c04e9fa87a7b
+    field reason id=0x65e8d7f3474f2639 kind=12 width=24 default=bytes:
+    field edits id=0x9478d06b697549e6 kind=14 width=940 default=born:0
+    field pending id=0x52dea0d6eeb5083c kind=14 width=616 default=born:0
+    field checkpoints id=0x028afa1c4d757704 kind=14 width=9 default=born:0 optional
+    field snapshots id=0x99dc6354a681403a kind=14 width=33 default=born:0 optional
 
-fixed table User layout=0x7d09ab9b426398c0
-    field name id=0xc4bcadba8e631b86 kind=12 width=24
+fixed table User layout=0xabbd6dfa650ebe49
+    field name id=0xc4bcadba8e631b86 kind=12 width=24 default=bytes:
+
+type Cursor layout=0x1c6c4747ec7d22b6
+    field line id=0xbf4ba5ad694f5907 kind=8 width=4 default=0
+    field column id=0x5f531287628bf287 kind=8 width=4 default=0
+
+type Ping layout=0xa3b89594fbb34f54
+    field nonce id=0x73a94c71d60dc0d8 kind=8 width=4 default=0
+
+enum Mode values=0xff134120cb6e4564
+    variant Read
+    variant Write
+
+flags Capabilities values=0x38384ef20e92e294
+    variant Trace
+    variant Verbose
+
+union EditBody values=0x961387e9a1def7ed
+    arm insert
+    arm remove
+    arm count
+    arm marks
+    arm blob
+    arm mode
+
+union Origin values=0xd8ed427f8d2864c8
+    arm user
+    arm script
+    arm pid
+    arm note
+
+union ToolBody values=0x8d528f544f260ba1
+    arm open
+    arm save
+    arm transact
+    arm ping
+    arm caps
+    arm spans
+    arm origin
+    arm ack

--- a/tables/pointers/schema.lock
+++ b/tables/pointers/schema.lock
@@ -1,17 +1,17 @@
-schema-lock 1
+schema-lock 2
 package graphdemo
 
-fixed table Meta layout=0xe8d4e14b6ab5de96
-    field build id=0x802517e298c70b03 kind=4 width=4
-    field tag id=0x56d7ab194448a4f3 kind=12 width=16
+fixed table Meta layout=0x3f9b4446d61d61b3
+    field build id=0x802517e298c70b03 kind=4 width=4 default=1 min=0 max=1000
+    field tag id=0x56d7ab194448a4f3 kind=12 width=16 default=bytes:
 
-fixed table Settings layout=0xe6f43718413f9fde
-    field quality id=0x7a8060916400fe66 kind=4 width=4
-    field label id=0x39f7fcec8fcb623d kind=12 width=24
+fixed table Settings layout=0x14186600bc9c40bf
+    field quality id=0x7a8060916400fe66 kind=4 width=4 default=2 min=0 max=4
+    field label id=0x39f7fcec8fcb623d kind=12 width=24 default=bytes:
 
-fixed table Stamp layout=0xfe173adc77eec5da
-    field tag id=0x56d7ab194448a4f3 kind=12 width=16
-    field seq id=0x823b8a195ce2133c kind=4 width=4
+fixed table Stamp layout=0xab1ee6bdcb000a32
+    field tag id=0x56d7ab194448a4f3 kind=12 width=16 default=bytes:
+    field seq id=0x823b8a195ce2133c kind=4 width=4 default=0 min=0 max=1000
 
-fixed table Tally layout=0x8b89b953e106699d
-    field hits id=0x732dfbcc9b0cf0bb kind=4 width=4
+fixed table Tally layout=0xb806fdff4d4b3a3a
+    field hits id=0x732dfbcc9b0cf0bb kind=4 width=4 default=0 min=0 max=10000

--- a/tables/pointers/schema.lock
+++ b/tables/pointers/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package graphdemo
 
 fixed table Meta layout=0x3f9b4446d61d61b3

--- a/tables/pointers/schema.lock
+++ b/tables/pointers/schema.lock
@@ -1,0 +1,17 @@
+schema-lock 1
+package graphdemo
+
+fixed table Meta layout=0xe8d4e14b6ab5de96
+    field build id=0x802517e298c70b03 kind=4 width=4
+    field tag id=0x56d7ab194448a4f3 kind=12 width=16
+
+fixed table Settings layout=0xe6f43718413f9fde
+    field quality id=0x7a8060916400fe66 kind=4 width=4
+    field label id=0x39f7fcec8fcb623d kind=12 width=24
+
+fixed table Stamp layout=0xfe173adc77eec5da
+    field tag id=0x56d7ab194448a4f3 kind=12 width=16
+    field seq id=0x823b8a195ce2133c kind=4 width=4
+
+fixed table Tally layout=0x8b89b953e106699d
+    field hits id=0x732dfbcc9b0cf0bb kind=4 width=4

--- a/tables/pointers/schema.lock
+++ b/tables/pointers/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package graphdemo
 
 fixed table Meta layout=0x3f9b4446d61d61b3

--- a/tables/pointers/schema.lock
+++ b/tables/pointers/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package graphdemo
 
 fixed table Meta layout=0x3f9b4446d61d61b3

--- a/tables/scalars/schema.lock
+++ b/tables/scalars/schema.lock
@@ -1,24 +1,34 @@
-schema-lock 1
+schema-lock 2
 package scalardemo
 
-fixed table SimState layout=0x89a2e672a446a9af
-    field tilt id=0x1e5088ef2e9bafc6 kind=20 width=1
-    field angle id=0x401ab8cd06158638 kind=22 width=4
-    field position id=0x4cbf3a26fca1d74a kind=23 width=8
-    field reach id=0x891da1f305deb858 kind=24 width=16
-    field ticks id=0x7fd9266c6a3e25b5 kind=22 width=4
-    field ratio id=0xfbc924118177ade4 kind=25 width=1
-    field speed id=0x2281498aa0200e40 kind=27 width=4
-    field span id=0x8b7dc019093cd0e1 kind=28 width=8
-    field mass id=0x1f3757a2ce7b0ab1 kind=29 width=16
-    field frames id=0x23e5906728b4e66f kind=27 width=4
-    field flux id=0xd61bdd7908af2642 kind=18 width=16
-    field energy id=0xf2fd4f9140ef2f15 kind=18 width=16
-    field entity_id id=0x23fcfd6678e36712 kind=19 width=16
-    field scale id=0x6aacb9fbb71a1d91 kind=22 width=4
-    field samples id=0xe3b1ca6a3b48dddc kind=14 width=12
-    field weights id=0xb1494b6ef08a411e kind=14 width=12
-    field axes id=0x32969e840d9c67b8 kind=16 width=24
-    field seeds id=0x5af1ac301b4ae16d kind=14 width=36
-    field pose id=0x8c2fd80da8957064 kind=13 width=24
-    field spawn id=0x4328f78ab20e1f98 kind=13 width=25
+fixed table SimState layout=0x7ec8ce173a6faac5
+    field tilt id=0x1e5088ef2e9bafc6 kind=20 width=1 default=0 min=-8 max=7 frac=4
+    field angle id=0x401ab8cd06158638 kind=22 width=4 default=0 min=-180 max=180 frac=16
+    field position id=0x4cbf3a26fca1d74a kind=23 width=8 default=0 min=-30000 max=30000 frac=16
+    field reach id=0x891da1f305deb858 kind=24 width=16 default=0 min=-1000000 max=1000000 frac=16
+    field ticks id=0x7fd9266c6a3e25b5 kind=22 width=4 default=0 min=0 max=1000000 frac=0
+    field ratio id=0xfbc924118177ade4 kind=25 width=1 default=0 min=0 max=15 frac=4
+    field speed id=0x2281498aa0200e40 kind=27 width=4 default=0 min=0 max=1000 frac=16
+    field span id=0x8b7dc019093cd0e1 kind=28 width=8 default=0 min=0 max=281474976710655 frac=16
+    field mass id=0x1f3757a2ce7b0ab1 kind=29 width=16 default=0 min=0 max=2000000 frac=16
+    field frames id=0x23e5906728b4e66f kind=27 width=4 default=0 min=0 max=4294967295 frac=0
+    field flux id=0xd61bdd7908af2642 kind=18 width=16 default=0 min=-1267650600228229401496703205376 max=1267650600228229401496703205376
+    field energy id=0xf2fd4f9140ef2f15 kind=18 width=16 default=-250 min=-5000000000 max=5000000000
+    field entity_id id=0x23fcfd6678e36712 kind=19 width=16 default=0
+    field scale id=0x6aacb9fbb71a1d91 kind=22 width=4 default=65536 min=-8 max=8 frac=16
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=12 default=born:0 min=-8 max=8 frac=16
+    field weights id=0xb1494b6ef08a411e kind=14 width=12 default=born:0 min=0 max=100 frac=8
+    field axes id=0x32969e840d9c67b8 kind=16 width=24 default=born:0 min=-100 max=100 frac=32
+    field seeds id=0x5af1ac301b4ae16d kind=14 width=36 default=born:0
+    field pose id=0x8c2fd80da8957064 kind=13 width=24 default=zero
+    field spawn id=0x4328f78ab20e1f98 kind=13 width=25 default=zero optional
+
+type Pose layout=0x650bf5ab768f3a23
+    field x id=0xaf63f54c86021707 kind=23 width=8 default=32768 min=-30000 max=30000 frac=16
+    field y id=0xaf63f44c86021554 kind=23 width=8 default=0 min=-30000 max=30000 frac=16
+    field heading id=0xb128829190ca0f75 kind=27 width=4 default=0 min=0 max=360 frac=16
+
+enum Axis values=0x795c3f7739e9c073
+    variant X
+    variant Y
+    variant Z

--- a/tables/scalars/schema.lock
+++ b/tables/scalars/schema.lock
@@ -1,7 +1,7 @@
-schema-lock 4
+schema-lock 5
 package scalardemo
 
-fixed table SimState layout=0x8ed3667ea95da031
+fixed table SimState layout=0x9ae957a466e9876a
     field tilt id=0x1e5088ef2e9bafc6 kind=20 width=1 default=0 min=-8 max=7 frac=4
     field angle id=0x401ab8cd06158638 kind=22 width=4 default=0 min=-180 max=180 frac=16
     field position id=0x4cbf3a26fca1d74a kind=23 width=8 default=0 min=-30000 max=30000 frac=16
@@ -18,7 +18,7 @@ fixed table SimState layout=0x8ed3667ea95da031
     field scale id=0x6aacb9fbb71a1d91 kind=22 width=4 default=65536 min=-8 max=8 frac=16
     field samples id=0xe3b1ca6a3b48dddc kind=14 width=12 default=born:0 min=-8 max=8 frac=16 elem=22/4
     field weights id=0xb1494b6ef08a411e kind=14 width=12 default=born:0 min=0 max=100 frac=8 elem=26/2
-    field axes id=0x32969e840d9c67b8 kind=16 width=24 default=born:0 min=-100 max=100 frac=32
+    field axes id=0x32969e840d9c67b8 kind=16 width=24 default=born:0 min=-100 max=100 frac=32 elem=23/8 key=Axis@0x795c3f7739e9c073
     field seeds id=0x5af1ac301b4ae16d kind=14 width=36 default=born:0 elem=19/16
     field pose id=0x8c2fd80da8957064 kind=13 width=24 default=zero held=Pose@0x650bf5ab768f3a23
     field spawn id=0x4328f78ab20e1f98 kind=13 width=25 default=zero held=Pose@0x650bf5ab768f3a23 optional

--- a/tables/scalars/schema.lock
+++ b/tables/scalars/schema.lock
@@ -1,0 +1,24 @@
+schema-lock 1
+package scalardemo
+
+fixed table SimState layout=0x89a2e672a446a9af
+    field tilt id=0x1e5088ef2e9bafc6 kind=20 width=1
+    field angle id=0x401ab8cd06158638 kind=22 width=4
+    field position id=0x4cbf3a26fca1d74a kind=23 width=8
+    field reach id=0x891da1f305deb858 kind=24 width=16
+    field ticks id=0x7fd9266c6a3e25b5 kind=22 width=4
+    field ratio id=0xfbc924118177ade4 kind=25 width=1
+    field speed id=0x2281498aa0200e40 kind=27 width=4
+    field span id=0x8b7dc019093cd0e1 kind=28 width=8
+    field mass id=0x1f3757a2ce7b0ab1 kind=29 width=16
+    field frames id=0x23e5906728b4e66f kind=27 width=4
+    field flux id=0xd61bdd7908af2642 kind=18 width=16
+    field energy id=0xf2fd4f9140ef2f15 kind=18 width=16
+    field entity_id id=0x23fcfd6678e36712 kind=19 width=16
+    field scale id=0x6aacb9fbb71a1d91 kind=22 width=4
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=12
+    field weights id=0xb1494b6ef08a411e kind=14 width=12
+    field axes id=0x32969e840d9c67b8 kind=16 width=24
+    field seeds id=0x5af1ac301b4ae16d kind=14 width=36
+    field pose id=0x8c2fd80da8957064 kind=13 width=24
+    field spawn id=0x4328f78ab20e1f98 kind=13 width=25

--- a/tables/scalars/schema.lock
+++ b/tables/scalars/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package scalardemo
 
 fixed table SimState layout=0x8ed3667ea95da031

--- a/tables/scalars/schema.lock
+++ b/tables/scalars/schema.lock
@@ -1,7 +1,7 @@
-schema-lock 2
+schema-lock 3
 package scalardemo
 
-fixed table SimState layout=0x7ec8ce173a6faac5
+fixed table SimState layout=0x8ed3667ea95da031
     field tilt id=0x1e5088ef2e9bafc6 kind=20 width=1 default=0 min=-8 max=7 frac=4
     field angle id=0x401ab8cd06158638 kind=22 width=4 default=0 min=-180 max=180 frac=16
     field position id=0x4cbf3a26fca1d74a kind=23 width=8 default=0 min=-30000 max=30000 frac=16
@@ -16,12 +16,12 @@ fixed table SimState layout=0x7ec8ce173a6faac5
     field energy id=0xf2fd4f9140ef2f15 kind=18 width=16 default=-250 min=-5000000000 max=5000000000
     field entity_id id=0x23fcfd6678e36712 kind=19 width=16 default=0
     field scale id=0x6aacb9fbb71a1d91 kind=22 width=4 default=65536 min=-8 max=8 frac=16
-    field samples id=0xe3b1ca6a3b48dddc kind=14 width=12 default=born:0 min=-8 max=8 frac=16
-    field weights id=0xb1494b6ef08a411e kind=14 width=12 default=born:0 min=0 max=100 frac=8
+    field samples id=0xe3b1ca6a3b48dddc kind=14 width=12 default=born:0 min=-8 max=8 frac=16 elem=22/4
+    field weights id=0xb1494b6ef08a411e kind=14 width=12 default=born:0 min=0 max=100 frac=8 elem=26/2
     field axes id=0x32969e840d9c67b8 kind=16 width=24 default=born:0 min=-100 max=100 frac=32
-    field seeds id=0x5af1ac301b4ae16d kind=14 width=36 default=born:0
-    field pose id=0x8c2fd80da8957064 kind=13 width=24 default=zero
-    field spawn id=0x4328f78ab20e1f98 kind=13 width=25 default=zero optional
+    field seeds id=0x5af1ac301b4ae16d kind=14 width=36 default=born:0 elem=19/16
+    field pose id=0x8c2fd80da8957064 kind=13 width=24 default=zero held=Pose@0x650bf5ab768f3a23
+    field spawn id=0x4328f78ab20e1f98 kind=13 width=25 default=zero held=Pose@0x650bf5ab768f3a23 optional
 
 type Pose layout=0x650bf5ab768f3a23
     field x id=0xaf63f54c86021707 kind=23 width=8 default=32768 min=-30000 max=30000 frac=16

--- a/tables/stream/schema.lock
+++ b/tables/stream/schema.lock
@@ -1,5 +1,5 @@
-schema-lock 1
+schema-lock 2
 package streamdemo
 
-fixed table Header layout=0x7d09ab9b426398c0
-    field name id=0xc4bcadba8e631b86 kind=12 width=24
+fixed table Header layout=0xabbd6dfa650ebe49
+    field name id=0xc4bcadba8e631b86 kind=12 width=24 default=bytes:

--- a/tables/stream/schema.lock
+++ b/tables/stream/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package streamdemo
 
 fixed table Header layout=0xabbd6dfa650ebe49

--- a/tables/stream/schema.lock
+++ b/tables/stream/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package streamdemo
 
 fixed table Header layout=0xabbd6dfa650ebe49

--- a/tables/stream/schema.lock
+++ b/tables/stream/schema.lock
@@ -1,0 +1,5 @@
+schema-lock 1
+package streamdemo
+
+fixed table Header layout=0x7d09ab9b426398c0
+    field name id=0xc4bcadba8e631b86 kind=12 width=24

--- a/tables/stream/schema.lock
+++ b/tables/stream/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package streamdemo
 
 fixed table Header layout=0xabbd6dfa650ebe49

--- a/tables/vocab/schema.lock
+++ b/tables/vocab/schema.lock
@@ -1,152 +1,152 @@
-schema-lock 1
+schema-lock 2
 package vocabdemo
 
-fixed table Wide00 layout=0xc2c133ca1fc91328
-    field field_00_00 id=0x0608e822268486dd kind=8 width=4
-    field field_00_01 id=0x0608e7222684852a kind=8 width=4
-    field field_00_02 id=0x0608e62226848377 kind=8 width=4
-    field field_00_03 id=0x0608e522268481c4 kind=8 width=4
-    field field_00_04 id=0x0608e42226848011 kind=8 width=4
-    field field_00_05 id=0x0608e32226847e5e kind=8 width=4
-    field field_00_06 id=0x0608e22226847cab kind=8 width=4
-    field field_00_07 id=0x0608e12226847af8 kind=8 width=4
-    field field_00_08 id=0x0608e02226847945 kind=8 width=4
-    field field_00_09 id=0x0608df2226847792 kind=8 width=4
-    field field_00_10 id=0x0605622226816d54 kind=8 width=4
-    field field_00_11 id=0x0605632226816f07 kind=8 width=4
-    field field_00_12 id=0x06056422268170ba kind=8 width=4
+fixed table Wide00 layout=0xb94cf83e0cd8b930
+    field field_00_00 id=0x0608e822268486dd kind=8 width=4 default=0
+    field field_00_01 id=0x0608e7222684852a kind=8 width=4 default=0
+    field field_00_02 id=0x0608e62226848377 kind=8 width=4 default=0
+    field field_00_03 id=0x0608e522268481c4 kind=8 width=4 default=0
+    field field_00_04 id=0x0608e42226848011 kind=8 width=4 default=0
+    field field_00_05 id=0x0608e32226847e5e kind=8 width=4 default=0
+    field field_00_06 id=0x0608e22226847cab kind=8 width=4 default=0
+    field field_00_07 id=0x0608e12226847af8 kind=8 width=4 default=0
+    field field_00_08 id=0x0608e02226847945 kind=8 width=4 default=0
+    field field_00_09 id=0x0608df2226847792 kind=8 width=4 default=0
+    field field_00_10 id=0x0605622226816d54 kind=8 width=4 default=0
+    field field_00_11 id=0x0605632226816f07 kind=8 width=4 default=0
+    field field_00_12 id=0x06056422268170ba kind=8 width=4 default=0
 
-fixed table Wide01 layout=0x220c0e90fb21c319
-    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4
-    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4
-    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4
-    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4
-    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4
-    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4
-    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4
-    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4
-    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4
-    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4
-    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4
-    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4
-    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4
+fixed table Wide01 layout=0x21d36688bd7d6629
+    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4 default=0
+    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4 default=0
+    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4 default=0
+    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4 default=0
+    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4 default=0
+    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4 default=0
+    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4 default=0
+    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4 default=0
+    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4 default=0
+    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4 default=0
+    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4 default=0
+    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4 default=0
+    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4 default=0
 
-fixed table Wide02 layout=0x900d32da562a8666
-    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4
-    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4
-    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4
-    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4
-    field field_02_04 id=0x89bba030246cf007 kind=8 width=4
-    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4
-    field field_02_06 id=0x89bba230246cf36d kind=8 width=4
-    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4
-    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4
-    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4
-    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4
-    field field_02_11 id=0x89b817302469d165 kind=8 width=4
-    field field_02_12 id=0x89b814302469cc4c kind=8 width=4
+fixed table Wide02 layout=0xad9ad49b1e90659a
+    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4 default=0
+    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4 default=0
+    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4 default=0
+    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4 default=0
+    field field_02_04 id=0x89bba030246cf007 kind=8 width=4 default=0
+    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4 default=0
+    field field_02_06 id=0x89bba230246cf36d kind=8 width=4 default=0
+    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4 default=0
+    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4 default=0
+    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4 default=0
+    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4 default=0
+    field field_02_11 id=0x89b817302469d165 kind=8 width=4 default=0
+    field field_02_12 id=0x89b814302469cc4c kind=8 width=4 default=0
 
-fixed table Wide03 layout=0x3942b013028b9b1f
-    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4
-    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4
-    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4
-    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4
-    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4
-    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4
-    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4
-    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4
-    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4
-    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4
-    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4
-    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4
-    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4
+fixed table Wide03 layout=0x4045bb7bfce62d23
+    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4 default=0
+    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4 default=0
+    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4 default=0
+    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4 default=0
+    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4 default=0
+    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4 default=0
+    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4 default=0
+    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4 default=0
+    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4 default=0
+    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4 default=0
+    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4 default=0
+    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4 default=0
+    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4 default=0
 
-fixed table Wide04 layout=0xe1a77fe5b6565480
-    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4
-    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4
-    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4
-    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4
-    field field_04_04 id=0x6078d44094e31365 kind=8 width=4
-    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4
-    field field_04_06 id=0x6078d24094e30fff kind=8 width=4
-    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4
-    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4
-    field field_04_09 id=0x6078d74094e3187e kind=8 width=4
-    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4
-    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4
-    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4
+fixed table Wide04 layout=0xd8bc65639f389030
+    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4 default=0
+    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4 default=0
+    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4 default=0
+    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4 default=0
+    field field_04_04 id=0x6078d44094e31365 kind=8 width=4 default=0
+    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4 default=0
+    field field_04_06 id=0x6078d24094e30fff kind=8 width=4 default=0
+    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4 default=0
+    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4 default=0
+    field field_04_09 id=0x6078d74094e3187e kind=8 width=4 default=0
+    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4 default=0
+    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4 default=0
+    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4 default=0
 
-fixed table Wide05 layout=0xc94b03ede1db474c
-    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4
-    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4
-    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4
-    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4
-    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4
-    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4
-    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4
-    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4
-    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4
-    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4
-    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4
-    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4
-    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4
+fixed table Wide05 layout=0xf6d92f3858ee3b88
+    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4 default=0
+    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4 default=0
+    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4 default=0
+    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4 default=0
+    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4 default=0
+    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4 default=0
+    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4 default=0
+    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4 default=0
+    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4 default=0
+    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4 default=0
+    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4 default=0
+    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4 default=0
+    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4 default=0
 
-fixed table Wide06 layout=0x56d07d371752dea8
-    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4
-    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4
-    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4
-    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4
-    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4
-    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4
-    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4
-    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4
-    field field_06_08 id=0x8e139c537b27149f kind=8 width=4
-    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4
-    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4
-    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4
-    field field_06_12 id=0x8e101c537b240548 kind=8 width=4
+fixed table Wide06 layout=0xf5292ae5a8460dd4
+    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4 default=0
+    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4 default=0
+    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4 default=0
+    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4 default=0
+    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4 default=0
+    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4 default=0
+    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4 default=0
+    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4 default=0
+    field field_06_08 id=0x8e139c537b27149f kind=8 width=4 default=0
+    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4 default=0
+    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4 default=0
+    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4 default=0
+    field field_06_12 id=0x8e101c537b240548 kind=8 width=4 default=0
 
-fixed table Wide07 layout=0x646af0cf090be58d
-    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4
-    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4
-    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4
-    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4
-    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4
-    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4
-    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4
-    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4
-    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4
-    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4
-    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4
-    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4
-    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4
+fixed table Wide07 layout=0x78295fe482437f65
+    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4 default=0
+    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4 default=0
+    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4 default=0
+    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4 default=0
+    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4 default=0
+    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4 default=0
+    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4 default=0
+    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4 default=0
+    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4 default=0
+    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4 default=0
+    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4 default=0
+    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4 default=0
+    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4 default=0
 
-fixed table Wide08 layout=0x143d2e3c1249a0b6
-    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4
-    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4
-    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4
-    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4
-    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4
-    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4
-    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4
-    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4
-    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4
-    field field_08_09 id=0x26de1edcb257014a kind=8 width=4
-    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4
-    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4
-    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4
+fixed table Wide08 layout=0x873005cb7127474a
+    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4 default=0
+    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4 default=0
+    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4 default=0
+    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4 default=0
+    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4 default=0
+    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4 default=0
+    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4 default=0
+    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4 default=0
+    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4 default=0
+    field field_08_09 id=0x26de1edcb257014a kind=8 width=4 default=0
+    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4 default=0
+    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4 default=0
+    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4 default=0
 
-fixed table Wide09 layout=0x7f0f8b0fd58444b0
-    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4
-    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4
-    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4
-    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4
-    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4
-    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4
-    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4
-    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4
-    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4
-    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4
-    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4
-    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4
-    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4
+fixed table Wide09 layout=0xbaff14c508eba608
+    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4 default=0
+    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4 default=0
+    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4 default=0
+    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4 default=0
+    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4 default=0
+    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4 default=0
+    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4 default=0
+    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4 default=0
+    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4 default=0
+    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4 default=0
+    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4 default=0
+    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4 default=0
+    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4 default=0

--- a/tables/vocab/schema.lock
+++ b/tables/vocab/schema.lock
@@ -1,0 +1,152 @@
+schema-lock 1
+package vocabdemo
+
+fixed table Wide00 layout=0xc2c133ca1fc91328
+    field field_00_00 id=0x0608e822268486dd kind=8 width=4
+    field field_00_01 id=0x0608e7222684852a kind=8 width=4
+    field field_00_02 id=0x0608e62226848377 kind=8 width=4
+    field field_00_03 id=0x0608e522268481c4 kind=8 width=4
+    field field_00_04 id=0x0608e42226848011 kind=8 width=4
+    field field_00_05 id=0x0608e32226847e5e kind=8 width=4
+    field field_00_06 id=0x0608e22226847cab kind=8 width=4
+    field field_00_07 id=0x0608e12226847af8 kind=8 width=4
+    field field_00_08 id=0x0608e02226847945 kind=8 width=4
+    field field_00_09 id=0x0608df2226847792 kind=8 width=4
+    field field_00_10 id=0x0605622226816d54 kind=8 width=4
+    field field_00_11 id=0x0605632226816f07 kind=8 width=4
+    field field_00_12 id=0x06056422268170ba kind=8 width=4
+
+fixed table Wide01 layout=0x220c0e90fb21c319
+    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4
+    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4
+    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4
+    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4
+    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4
+    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4
+    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4
+    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4
+    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4
+    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4
+    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4
+    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4
+    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4
+
+fixed table Wide02 layout=0x900d32da562a8666
+    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4
+    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4
+    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4
+    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4
+    field field_02_04 id=0x89bba030246cf007 kind=8 width=4
+    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4
+    field field_02_06 id=0x89bba230246cf36d kind=8 width=4
+    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4
+    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4
+    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4
+    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4
+    field field_02_11 id=0x89b817302469d165 kind=8 width=4
+    field field_02_12 id=0x89b814302469cc4c kind=8 width=4
+
+fixed table Wide03 layout=0x3942b013028b9b1f
+    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4
+    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4
+    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4
+    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4
+    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4
+    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4
+    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4
+    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4
+    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4
+    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4
+    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4
+    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4
+    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4
+
+fixed table Wide04 layout=0xe1a77fe5b6565480
+    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4
+    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4
+    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4
+    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4
+    field field_04_04 id=0x6078d44094e31365 kind=8 width=4
+    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4
+    field field_04_06 id=0x6078d24094e30fff kind=8 width=4
+    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4
+    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4
+    field field_04_09 id=0x6078d74094e3187e kind=8 width=4
+    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4
+    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4
+    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4
+
+fixed table Wide05 layout=0xc94b03ede1db474c
+    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4
+    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4
+    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4
+    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4
+    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4
+    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4
+    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4
+    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4
+    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4
+    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4
+    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4
+    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4
+    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4
+
+fixed table Wide06 layout=0x56d07d371752dea8
+    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4
+    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4
+    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4
+    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4
+    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4
+    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4
+    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4
+    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4
+    field field_06_08 id=0x8e139c537b27149f kind=8 width=4
+    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4
+    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4
+    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4
+    field field_06_12 id=0x8e101c537b240548 kind=8 width=4
+
+fixed table Wide07 layout=0x646af0cf090be58d
+    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4
+    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4
+    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4
+    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4
+    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4
+    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4
+    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4
+    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4
+    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4
+    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4
+    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4
+    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4
+    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4
+
+fixed table Wide08 layout=0x143d2e3c1249a0b6
+    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4
+    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4
+    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4
+    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4
+    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4
+    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4
+    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4
+    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4
+    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4
+    field field_08_09 id=0x26de1edcb257014a kind=8 width=4
+    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4
+    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4
+    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4
+
+fixed table Wide09 layout=0x7f0f8b0fd58444b0
+    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4
+    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4
+    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4
+    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4
+    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4
+    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4
+    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4
+    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4
+    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4
+    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4
+    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4
+    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4
+    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4

--- a/tables/vocab/schema.lock
+++ b/tables/vocab/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package vocabdemo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab/schema.lock
+++ b/tables/vocab/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package vocabdemo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab/schema.lock
+++ b/tables/vocab/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package vocabdemo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab9/schema.lock
+++ b/tables/vocab9/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package vocab9demo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab9/schema.lock
+++ b/tables/vocab9/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 2
+schema-lock 3
 package vocab9demo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab9/schema.lock
+++ b/tables/vocab9/schema.lock
@@ -1,302 +1,302 @@
-schema-lock 1
+schema-lock 2
 package vocab9demo
 
-fixed table Wide00 layout=0xc2c133ca1fc91328
-    field field_00_00 id=0x0608e822268486dd kind=8 width=4
-    field field_00_01 id=0x0608e7222684852a kind=8 width=4
-    field field_00_02 id=0x0608e62226848377 kind=8 width=4
-    field field_00_03 id=0x0608e522268481c4 kind=8 width=4
-    field field_00_04 id=0x0608e42226848011 kind=8 width=4
-    field field_00_05 id=0x0608e32226847e5e kind=8 width=4
-    field field_00_06 id=0x0608e22226847cab kind=8 width=4
-    field field_00_07 id=0x0608e12226847af8 kind=8 width=4
-    field field_00_08 id=0x0608e02226847945 kind=8 width=4
-    field field_00_09 id=0x0608df2226847792 kind=8 width=4
-    field field_00_10 id=0x0605622226816d54 kind=8 width=4
-    field field_00_11 id=0x0605632226816f07 kind=8 width=4
-    field field_00_12 id=0x06056422268170ba kind=8 width=4
+fixed table Wide00 layout=0xb94cf83e0cd8b930
+    field field_00_00 id=0x0608e822268486dd kind=8 width=4 default=0
+    field field_00_01 id=0x0608e7222684852a kind=8 width=4 default=0
+    field field_00_02 id=0x0608e62226848377 kind=8 width=4 default=0
+    field field_00_03 id=0x0608e522268481c4 kind=8 width=4 default=0
+    field field_00_04 id=0x0608e42226848011 kind=8 width=4 default=0
+    field field_00_05 id=0x0608e32226847e5e kind=8 width=4 default=0
+    field field_00_06 id=0x0608e22226847cab kind=8 width=4 default=0
+    field field_00_07 id=0x0608e12226847af8 kind=8 width=4 default=0
+    field field_00_08 id=0x0608e02226847945 kind=8 width=4 default=0
+    field field_00_09 id=0x0608df2226847792 kind=8 width=4 default=0
+    field field_00_10 id=0x0605622226816d54 kind=8 width=4 default=0
+    field field_00_11 id=0x0605632226816f07 kind=8 width=4 default=0
+    field field_00_12 id=0x06056422268170ba kind=8 width=4 default=0
 
-fixed table Wide01 layout=0x220c0e90fb21c319
-    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4
-    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4
-    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4
-    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4
-    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4
-    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4
-    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4
-    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4
-    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4
-    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4
-    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4
-    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4
-    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4
+fixed table Wide01 layout=0x21d36688bd7d6629
+    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4 default=0
+    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4 default=0
+    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4 default=0
+    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4 default=0
+    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4 default=0
+    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4 default=0
+    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4 default=0
+    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4 default=0
+    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4 default=0
+    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4 default=0
+    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4 default=0
+    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4 default=0
+    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4 default=0
 
-fixed table Wide02 layout=0x900d32da562a8666
-    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4
-    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4
-    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4
-    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4
-    field field_02_04 id=0x89bba030246cf007 kind=8 width=4
-    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4
-    field field_02_06 id=0x89bba230246cf36d kind=8 width=4
-    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4
-    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4
-    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4
-    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4
-    field field_02_11 id=0x89b817302469d165 kind=8 width=4
-    field field_02_12 id=0x89b814302469cc4c kind=8 width=4
+fixed table Wide02 layout=0xad9ad49b1e90659a
+    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4 default=0
+    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4 default=0
+    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4 default=0
+    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4 default=0
+    field field_02_04 id=0x89bba030246cf007 kind=8 width=4 default=0
+    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4 default=0
+    field field_02_06 id=0x89bba230246cf36d kind=8 width=4 default=0
+    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4 default=0
+    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4 default=0
+    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4 default=0
+    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4 default=0
+    field field_02_11 id=0x89b817302469d165 kind=8 width=4 default=0
+    field field_02_12 id=0x89b814302469cc4c kind=8 width=4 default=0
 
-fixed table Wide03 layout=0x3942b013028b9b1f
-    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4
-    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4
-    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4
-    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4
-    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4
-    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4
-    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4
-    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4
-    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4
-    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4
-    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4
-    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4
-    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4
+fixed table Wide03 layout=0x4045bb7bfce62d23
+    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4 default=0
+    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4 default=0
+    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4 default=0
+    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4 default=0
+    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4 default=0
+    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4 default=0
+    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4 default=0
+    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4 default=0
+    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4 default=0
+    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4 default=0
+    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4 default=0
+    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4 default=0
+    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4 default=0
 
-fixed table Wide04 layout=0xe1a77fe5b6565480
-    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4
-    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4
-    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4
-    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4
-    field field_04_04 id=0x6078d44094e31365 kind=8 width=4
-    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4
-    field field_04_06 id=0x6078d24094e30fff kind=8 width=4
-    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4
-    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4
-    field field_04_09 id=0x6078d74094e3187e kind=8 width=4
-    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4
-    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4
-    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4
+fixed table Wide04 layout=0xd8bc65639f389030
+    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4 default=0
+    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4 default=0
+    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4 default=0
+    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4 default=0
+    field field_04_04 id=0x6078d44094e31365 kind=8 width=4 default=0
+    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4 default=0
+    field field_04_06 id=0x6078d24094e30fff kind=8 width=4 default=0
+    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4 default=0
+    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4 default=0
+    field field_04_09 id=0x6078d74094e3187e kind=8 width=4 default=0
+    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4 default=0
+    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4 default=0
+    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4 default=0
 
-fixed table Wide05 layout=0xc94b03ede1db474c
-    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4
-    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4
-    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4
-    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4
-    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4
-    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4
-    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4
-    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4
-    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4
-    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4
-    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4
-    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4
-    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4
+fixed table Wide05 layout=0xf6d92f3858ee3b88
+    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4 default=0
+    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4 default=0
+    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4 default=0
+    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4 default=0
+    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4 default=0
+    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4 default=0
+    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4 default=0
+    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4 default=0
+    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4 default=0
+    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4 default=0
+    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4 default=0
+    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4 default=0
+    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4 default=0
 
-fixed table Wide06 layout=0x56d07d371752dea8
-    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4
-    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4
-    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4
-    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4
-    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4
-    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4
-    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4
-    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4
-    field field_06_08 id=0x8e139c537b27149f kind=8 width=4
-    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4
-    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4
-    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4
-    field field_06_12 id=0x8e101c537b240548 kind=8 width=4
+fixed table Wide06 layout=0xf5292ae5a8460dd4
+    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4 default=0
+    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4 default=0
+    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4 default=0
+    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4 default=0
+    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4 default=0
+    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4 default=0
+    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4 default=0
+    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4 default=0
+    field field_06_08 id=0x8e139c537b27149f kind=8 width=4 default=0
+    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4 default=0
+    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4 default=0
+    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4 default=0
+    field field_06_12 id=0x8e101c537b240548 kind=8 width=4 default=0
 
-fixed table Wide07 layout=0x646af0cf090be58d
-    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4
-    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4
-    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4
-    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4
-    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4
-    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4
-    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4
-    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4
-    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4
-    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4
-    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4
-    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4
-    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4
+fixed table Wide07 layout=0x78295fe482437f65
+    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4 default=0
+    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4 default=0
+    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4 default=0
+    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4 default=0
+    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4 default=0
+    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4 default=0
+    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4 default=0
+    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4 default=0
+    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4 default=0
+    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4 default=0
+    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4 default=0
+    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4 default=0
+    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4 default=0
 
-fixed table Wide08 layout=0x143d2e3c1249a0b6
-    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4
-    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4
-    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4
-    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4
-    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4
-    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4
-    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4
-    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4
-    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4
-    field field_08_09 id=0x26de1edcb257014a kind=8 width=4
-    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4
-    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4
-    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4
+fixed table Wide08 layout=0x873005cb7127474a
+    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4 default=0
+    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4 default=0
+    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4 default=0
+    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4 default=0
+    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4 default=0
+    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4 default=0
+    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4 default=0
+    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4 default=0
+    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4 default=0
+    field field_08_09 id=0x26de1edcb257014a kind=8 width=4 default=0
+    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4 default=0
+    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4 default=0
+    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4 default=0
 
-fixed table Wide09 layout=0x7f0f8b0fd58444b0
-    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4
-    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4
-    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4
-    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4
-    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4
-    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4
-    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4
-    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4
-    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4
-    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4
-    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4
-    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4
-    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4
+fixed table Wide09 layout=0xbaff14c508eba608
+    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4 default=0
+    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4 default=0
+    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4 default=0
+    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4 default=0
+    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4 default=0
+    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4 default=0
+    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4 default=0
+    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4 default=0
+    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4 default=0
+    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4 default=0
+    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4 default=0
+    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4 default=0
+    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4 default=0
 
-fixed table Wide10 layout=0x1a1e551dd2b29424
-    field field_10_00 id=0x768f8657129836da kind=8 width=4
-    field field_10_01 id=0x768f87571298388d kind=8 width=4
-    field field_10_02 id=0x768f845712983374 kind=8 width=4
-    field field_10_03 id=0x768f855712983527 kind=8 width=4
-    field field_10_04 id=0x768f82571298300e kind=8 width=4
-    field field_10_05 id=0x768f8357129831c1 kind=8 width=4
-    field field_10_06 id=0x768f805712982ca8 kind=8 width=4
-    field field_10_07 id=0x768f815712982e5b kind=8 width=4
-    field field_10_08 id=0x768f7e5712982942 kind=8 width=4
-    field field_10_09 id=0x768f7f5712982af5 kind=8 width=4
-    field field_10_10 id=0x7692ec57129b1a03 kind=8 width=4
-    field field_10_11 id=0x7692eb57129b1850 kind=8 width=4
-    field field_10_12 id=0x7692ee57129b1d69 kind=8 width=4
+fixed table Wide10 layout=0xdce4302f3fa78748
+    field field_10_00 id=0x768f8657129836da kind=8 width=4 default=0
+    field field_10_01 id=0x768f87571298388d kind=8 width=4 default=0
+    field field_10_02 id=0x768f845712983374 kind=8 width=4 default=0
+    field field_10_03 id=0x768f855712983527 kind=8 width=4 default=0
+    field field_10_04 id=0x768f82571298300e kind=8 width=4 default=0
+    field field_10_05 id=0x768f8357129831c1 kind=8 width=4 default=0
+    field field_10_06 id=0x768f805712982ca8 kind=8 width=4 default=0
+    field field_10_07 id=0x768f815712982e5b kind=8 width=4 default=0
+    field field_10_08 id=0x768f7e5712982942 kind=8 width=4 default=0
+    field field_10_09 id=0x768f7f5712982af5 kind=8 width=4 default=0
+    field field_10_10 id=0x7692ec57129b1a03 kind=8 width=4 default=0
+    field field_10_11 id=0x7692eb57129b1850 kind=8 width=4 default=0
+    field field_10_12 id=0x7692ee57129b1d69 kind=8 width=4 default=0
 
-fixed table Wide11 layout=0x34a6e80cd0672ee9
-    field field_11_00 id=0x9f5a7c4bc7bde1ab kind=8 width=4
-    field field_11_01 id=0x9f5a7b4bc7bddff8 kind=8 width=4
-    field field_11_02 id=0x9f5a7e4bc7bde511 kind=8 width=4
-    field field_11_03 id=0x9f5a7d4bc7bde35e kind=8 width=4
-    field field_11_04 id=0x9f5a804bc7bde877 kind=8 width=4
-    field field_11_05 id=0x9f5a7f4bc7bde6c4 kind=8 width=4
-    field field_11_06 id=0x9f5a824bc7bdebdd kind=8 width=4
-    field field_11_07 id=0x9f5a814bc7bdea2a kind=8 width=4
-    field field_11_08 id=0x9f5a744bc7bdd413 kind=8 width=4
-    field field_11_09 id=0x9f5a734bc7bdd260 kind=8 width=4
-    field field_11_10 id=0x9f56f64bc7bac822 kind=8 width=4
-    field field_11_11 id=0x9f56f74bc7bac9d5 kind=8 width=4
-    field field_11_12 id=0x9f56f44bc7bac4bc kind=8 width=4
+fixed table Wide11 layout=0xa80859d43bb4fa89
+    field field_11_00 id=0x9f5a7c4bc7bde1ab kind=8 width=4 default=0
+    field field_11_01 id=0x9f5a7b4bc7bddff8 kind=8 width=4 default=0
+    field field_11_02 id=0x9f5a7e4bc7bde511 kind=8 width=4 default=0
+    field field_11_03 id=0x9f5a7d4bc7bde35e kind=8 width=4 default=0
+    field field_11_04 id=0x9f5a804bc7bde877 kind=8 width=4 default=0
+    field field_11_05 id=0x9f5a7f4bc7bde6c4 kind=8 width=4 default=0
+    field field_11_06 id=0x9f5a824bc7bdebdd kind=8 width=4 default=0
+    field field_11_07 id=0x9f5a814bc7bdea2a kind=8 width=4 default=0
+    field field_11_08 id=0x9f5a744bc7bdd413 kind=8 width=4 default=0
+    field field_11_09 id=0x9f5a734bc7bdd260 kind=8 width=4 default=0
+    field field_11_10 id=0x9f56f64bc7bac822 kind=8 width=4 default=0
+    field field_11_11 id=0x9f56f74bc7bac9d5 kind=8 width=4 default=0
+    field field_11_12 id=0x9f56f44bc7bac4bc kind=8 width=4 default=0
 
-fixed table Wide12 layout=0x2e1fa39529081953
-    field field_12_00 id=0x9e1f3246a0b0489c kind=8 width=4
-    field field_12_01 id=0x9e1f3346a0b04a4f kind=8 width=4
-    field field_12_02 id=0x9e1f3446a0b04c02 kind=8 width=4
-    field field_12_03 id=0x9e1f3546a0b04db5 kind=8 width=4
-    field field_12_04 id=0x9e1f2e46a0b041d0 kind=8 width=4
-    field field_12_05 id=0x9e1f2f46a0b04383 kind=8 width=4
-    field field_12_06 id=0x9e1f3046a0b04536 kind=8 width=4
-    field field_12_07 id=0x9e1f3146a0b046e9 kind=8 width=4
-    field field_12_08 id=0x9e1f3a46a0b05634 kind=8 width=4
-    field field_12_09 id=0x9e1f3b46a0b057e7 kind=8 width=4
-    field field_12_10 id=0x9e223846a0b288a5 kind=8 width=4
-    field field_12_11 id=0x9e223746a0b286f2 kind=8 width=4
-    field field_12_12 id=0x9e223646a0b2853f kind=8 width=4
+fixed table Wide12 layout=0x1aa3b5d8ca49d21b
+    field field_12_00 id=0x9e1f3246a0b0489c kind=8 width=4 default=0
+    field field_12_01 id=0x9e1f3346a0b04a4f kind=8 width=4 default=0
+    field field_12_02 id=0x9e1f3446a0b04c02 kind=8 width=4 default=0
+    field field_12_03 id=0x9e1f3546a0b04db5 kind=8 width=4 default=0
+    field field_12_04 id=0x9e1f2e46a0b041d0 kind=8 width=4 default=0
+    field field_12_05 id=0x9e1f2f46a0b04383 kind=8 width=4 default=0
+    field field_12_06 id=0x9e1f3046a0b04536 kind=8 width=4 default=0
+    field field_12_07 id=0x9e1f3146a0b046e9 kind=8 width=4 default=0
+    field field_12_08 id=0x9e1f3a46a0b05634 kind=8 width=4 default=0
+    field field_12_09 id=0x9e1f3b46a0b057e7 kind=8 width=4 default=0
+    field field_12_10 id=0x9e223846a0b288a5 kind=8 width=4 default=0
+    field field_12_11 id=0x9e223746a0b286f2 kind=8 width=4 default=0
+    field field_12_12 id=0x9e223646a0b2853f kind=8 width=4 default=0
 
-fixed table Wide13 layout=0x459b87fe875bbf53
-    field field_13_00 id=0xc89d483b5747be4d kind=8 width=4
-    field field_13_01 id=0xc89d473b5747bc9a kind=8 width=4
-    field field_13_02 id=0xc89d463b5747bae7 kind=8 width=4
-    field field_13_03 id=0xc89d453b5747b934 kind=8 width=4
-    field field_13_04 id=0xc89d443b5747b781 kind=8 width=4
-    field field_13_05 id=0xc89d433b5747b5ce kind=8 width=4
-    field field_13_06 id=0xc89d423b5747b41b kind=8 width=4
-    field field_13_07 id=0xc89d413b5747b268 kind=8 width=4
-    field field_13_08 id=0xc89d403b5747b0b5 kind=8 width=4
-    field field_13_09 id=0xc89d3f3b5747af02 kind=8 width=4
-    field field_13_10 id=0xc899c23b5744a4c4 kind=8 width=4
-    field field_13_11 id=0xc899c33b5744a677 kind=8 width=4
-    field field_13_12 id=0xc899c43b5744a82a kind=8 width=4
+fixed table Wide13 layout=0xa0bae063b9a79713
+    field field_13_00 id=0xc89d483b5747be4d kind=8 width=4 default=0
+    field field_13_01 id=0xc89d473b5747bc9a kind=8 width=4 default=0
+    field field_13_02 id=0xc89d463b5747bae7 kind=8 width=4 default=0
+    field field_13_03 id=0xc89d453b5747b934 kind=8 width=4 default=0
+    field field_13_04 id=0xc89d443b5747b781 kind=8 width=4 default=0
+    field field_13_05 id=0xc89d433b5747b5ce kind=8 width=4 default=0
+    field field_13_06 id=0xc89d423b5747b41b kind=8 width=4 default=0
+    field field_13_07 id=0xc89d413b5747b268 kind=8 width=4 default=0
+    field field_13_08 id=0xc89d403b5747b0b5 kind=8 width=4 default=0
+    field field_13_09 id=0xc89d3f3b5747af02 kind=8 width=4 default=0
+    field field_13_10 id=0xc899c23b5744a4c4 kind=8 width=4 default=0
+    field field_13_11 id=0xc899c33b5744a677 kind=8 width=4 default=0
+    field field_13_12 id=0xc899c43b5744a82a kind=8 width=4 default=0
 
-fixed table Wide14 layout=0x32b1438eb651240e
-    field field_14_00 id=0xd0ff6e7580f6bc96 kind=8 width=4
-    field field_14_01 id=0xd0ff6f7580f6be49 kind=8 width=4
-    field field_14_02 id=0xd0ff6c7580f6b930 kind=8 width=4
-    field field_14_03 id=0xd0ff6d7580f6bae3 kind=8 width=4
-    field field_14_04 id=0xd0ff727580f6c362 kind=8 width=4
-    field field_14_05 id=0xd0ff737580f6c515 kind=8 width=4
-    field field_14_06 id=0xd0ff707580f6bffc kind=8 width=4
-    field field_14_07 id=0xd0ff717580f6c1af kind=8 width=4
-    field field_14_08 id=0xd0ff767580f6ca2e kind=8 width=4
-    field field_14_09 id=0xd0ff777580f6cbe1 kind=8 width=4
-    field field_14_10 id=0xd102f47580f9d61f kind=8 width=4
-    field field_14_11 id=0xd102f37580f9d46c kind=8 width=4
-    field field_14_12 id=0xd102f67580f9d985 kind=8 width=4
+fixed table Wide14 layout=0x96f095e58c71725e
+    field field_14_00 id=0xd0ff6e7580f6bc96 kind=8 width=4 default=0
+    field field_14_01 id=0xd0ff6f7580f6be49 kind=8 width=4 default=0
+    field field_14_02 id=0xd0ff6c7580f6b930 kind=8 width=4 default=0
+    field field_14_03 id=0xd0ff6d7580f6bae3 kind=8 width=4 default=0
+    field field_14_04 id=0xd0ff727580f6c362 kind=8 width=4 default=0
+    field field_14_05 id=0xd0ff737580f6c515 kind=8 width=4 default=0
+    field field_14_06 id=0xd0ff707580f6bffc kind=8 width=4 default=0
+    field field_14_07 id=0xd0ff717580f6c1af kind=8 width=4 default=0
+    field field_14_08 id=0xd0ff767580f6ca2e kind=8 width=4 default=0
+    field field_14_09 id=0xd0ff777580f6cbe1 kind=8 width=4 default=0
+    field field_14_10 id=0xd102f47580f9d61f kind=8 width=4 default=0
+    field field_14_11 id=0xd102f37580f9d46c kind=8 width=4 default=0
+    field field_14_12 id=0xd102f67580f9d985 kind=8 width=4 default=0
 
-fixed table Wide15 layout=0xe40c6a728d5abd89
-    field field_15_00 id=0xcfc4447059e959e7 kind=8 width=4
-    field field_15_01 id=0xcfc4437059e95834 kind=8 width=4
-    field field_15_02 id=0xcfc4467059e95d4d kind=8 width=4
-    field field_15_03 id=0xcfc4457059e95b9a kind=8 width=4
-    field field_15_04 id=0xcfc4407059e9531b kind=8 width=4
-    field field_15_05 id=0xcfc43f7059e95168 kind=8 width=4
-    field field_15_06 id=0xcfc4427059e95681 kind=8 width=4
-    field field_15_07 id=0xcfc4417059e954ce kind=8 width=4
-    field field_15_08 id=0xcfc43c7059e94c4f kind=8 width=4
-    field field_15_09 id=0xcfc43b7059e94a9c kind=8 width=4
-    field field_15_10 id=0xcfc0be7059e6405e kind=8 width=4
-    field field_15_11 id=0xcfc0bf7059e64211 kind=8 width=4
-    field field_15_12 id=0xcfc0bc7059e63cf8 kind=8 width=4
+fixed table Wide15 layout=0x82b854fa4ccaab55
+    field field_15_00 id=0xcfc4447059e959e7 kind=8 width=4 default=0
+    field field_15_01 id=0xcfc4437059e95834 kind=8 width=4 default=0
+    field field_15_02 id=0xcfc4467059e95d4d kind=8 width=4 default=0
+    field field_15_03 id=0xcfc4457059e95b9a kind=8 width=4 default=0
+    field field_15_04 id=0xcfc4407059e9531b kind=8 width=4 default=0
+    field field_15_05 id=0xcfc43f7059e95168 kind=8 width=4 default=0
+    field field_15_06 id=0xcfc4427059e95681 kind=8 width=4 default=0
+    field field_15_07 id=0xcfc4417059e954ce kind=8 width=4 default=0
+    field field_15_08 id=0xcfc43c7059e94c4f kind=8 width=4 default=0
+    field field_15_09 id=0xcfc43b7059e94a9c kind=8 width=4 default=0
+    field field_15_10 id=0xcfc0be7059e6405e kind=8 width=4 default=0
+    field field_15_11 id=0xcfc0bf7059e64211 kind=8 width=4 default=0
+    field field_15_12 id=0xcfc0bc7059e63cf8 kind=8 width=4 default=0
 
-fixed table Wide16 layout=0xf90d97dd618e7ed6
-    field field_16_00 id=0xf88f3a650f0f04b8 kind=8 width=4
-    field field_16_01 id=0xf88f3b650f0f066b kind=8 width=4
-    field field_16_02 id=0xf88f3c650f0f081e kind=8 width=4
-    field field_16_03 id=0xf88f3d650f0f09d1 kind=8 width=4
-    field field_16_04 id=0xf88f3e650f0f0b84 kind=8 width=4
-    field field_16_05 id=0xf88f3f650f0f0d37 kind=8 width=4
-    field field_16_06 id=0xf88f40650f0f0eea kind=8 width=4
-    field field_16_07 id=0xf88f41650f0f109d kind=8 width=4
-    field field_16_08 id=0xf88f32650f0ef720 kind=8 width=4
-    field field_16_09 id=0xf88f33650f0ef8d3 kind=8 width=4
-    field field_16_10 id=0xf892c0650f121e41 kind=8 width=4
-    field field_16_11 id=0xf892bf650f121c8e kind=8 width=4
-    field field_16_12 id=0xf892be650f121adb kind=8 width=4
+fixed table Wide16 layout=0x3d8b9a957fd4d73e
+    field field_16_00 id=0xf88f3a650f0f04b8 kind=8 width=4 default=0
+    field field_16_01 id=0xf88f3b650f0f066b kind=8 width=4 default=0
+    field field_16_02 id=0xf88f3c650f0f081e kind=8 width=4 default=0
+    field field_16_03 id=0xf88f3d650f0f09d1 kind=8 width=4 default=0
+    field field_16_04 id=0xf88f3e650f0f0b84 kind=8 width=4 default=0
+    field field_16_05 id=0xf88f3f650f0f0d37 kind=8 width=4 default=0
+    field field_16_06 id=0xf88f40650f0f0eea kind=8 width=4 default=0
+    field field_16_07 id=0xf88f41650f0f109d kind=8 width=4 default=0
+    field field_16_08 id=0xf88f32650f0ef720 kind=8 width=4 default=0
+    field field_16_09 id=0xf88f33650f0ef8d3 kind=8 width=4 default=0
+    field field_16_10 id=0xf892c0650f121e41 kind=8 width=4 default=0
+    field field_16_11 id=0xf892bf650f121c8e kind=8 width=4 default=0
+    field field_16_12 id=0xf892be650f121adb kind=8 width=4 default=0
 
-fixed table Wide17 layout=0xb46277f4de502ae7
-    field field_17_00 id=0xa229705d73a54449 kind=8 width=4
-    field field_17_01 id=0xa2296f5d73a54296 kind=8 width=4
-    field field_17_02 id=0xa2296e5d73a540e3 kind=8 width=4
-    field field_17_03 id=0xa2296d5d73a53f30 kind=8 width=4
-    field field_17_04 id=0xa229745d73a54b15 kind=8 width=4
-    field field_17_05 id=0xa229735d73a54962 kind=8 width=4
-    field field_17_06 id=0xa229725d73a547af kind=8 width=4
-    field field_17_07 id=0xa229715d73a545fc kind=8 width=4
-    field field_17_08 id=0xa229785d73a551e1 kind=8 width=4
-    field field_17_09 id=0xa229775d73a5502e kind=8 width=4
-    field field_17_10 id=0xa225ea5d73a22ac0 kind=8 width=4
-    field field_17_11 id=0xa225eb5d73a22c73 kind=8 width=4
-    field field_17_12 id=0xa225ec5d73a22e26 kind=8 width=4
+fixed table Wide17 layout=0x6506d36c63c22ae7
+    field field_17_00 id=0xa229705d73a54449 kind=8 width=4 default=0
+    field field_17_01 id=0xa2296f5d73a54296 kind=8 width=4 default=0
+    field field_17_02 id=0xa2296e5d73a540e3 kind=8 width=4 default=0
+    field field_17_03 id=0xa2296d5d73a53f30 kind=8 width=4 default=0
+    field field_17_04 id=0xa229745d73a54b15 kind=8 width=4 default=0
+    field field_17_05 id=0xa229735d73a54962 kind=8 width=4 default=0
+    field field_17_06 id=0xa229725d73a547af kind=8 width=4 default=0
+    field field_17_07 id=0xa229715d73a545fc kind=8 width=4 default=0
+    field field_17_08 id=0xa229785d73a551e1 kind=8 width=4 default=0
+    field field_17_09 id=0xa229775d73a5502e kind=8 width=4 default=0
+    field field_17_10 id=0xa225ea5d73a22ac0 kind=8 width=4 default=0
+    field field_17_11 id=0xa225eb5d73a22c73 kind=8 width=4 default=0
+    field field_17_12 id=0xa225ec5d73a22e26 kind=8 width=4 default=0
 
-fixed table Wide18 layout=0x49f88b91bb9d733a
-    field field_18_00 id=0x96f836119e0ead02 kind=8 width=4
-    field field_18_01 id=0x96f837119e0eaeb5 kind=8 width=4
-    field field_18_02 id=0x96f834119e0ea99c kind=8 width=4
-    field field_18_03 id=0x96f835119e0eab4f kind=8 width=4
-    field field_18_04 id=0x96f832119e0ea636 kind=8 width=4
-    field field_18_05 id=0x96f833119e0ea7e9 kind=8 width=4
-    field field_18_06 id=0x96f830119e0ea2d0 kind=8 width=4
-    field field_18_07 id=0x96f831119e0ea483 kind=8 width=4
-    field field_18_08 id=0x96f83e119e0eba9a kind=8 width=4
-    field field_18_09 id=0x96f83f119e0ebc4d kind=8 width=4
-    field field_18_10 id=0x96fb3c119e10ed0b kind=8 width=4
-    field field_18_11 id=0x96fb3b119e10eb58 kind=8 width=4
-    field field_18_12 id=0x96fb3e119e10f071 kind=8 width=4
+fixed table Wide18 layout=0xd179cdc8c30ebb96
+    field field_18_00 id=0x96f836119e0ead02 kind=8 width=4 default=0
+    field field_18_01 id=0x96f837119e0eaeb5 kind=8 width=4 default=0
+    field field_18_02 id=0x96f834119e0ea99c kind=8 width=4 default=0
+    field field_18_03 id=0x96f835119e0eab4f kind=8 width=4 default=0
+    field field_18_04 id=0x96f832119e0ea636 kind=8 width=4 default=0
+    field field_18_05 id=0x96f833119e0ea7e9 kind=8 width=4 default=0
+    field field_18_06 id=0x96f830119e0ea2d0 kind=8 width=4 default=0
+    field field_18_07 id=0x96f831119e0ea483 kind=8 width=4 default=0
+    field field_18_08 id=0x96f83e119e0eba9a kind=8 width=4 default=0
+    field field_18_09 id=0x96f83f119e0ebc4d kind=8 width=4 default=0
+    field field_18_10 id=0x96fb3c119e10ed0b kind=8 width=4 default=0
+    field field_18_11 id=0x96fb3b119e10eb58 kind=8 width=4 default=0
+    field field_18_12 id=0x96fb3e119e10f071 kind=8 width=4 default=0
 
-fixed table Wide19 layout=0x29bdebdd5a50400f
-    field field_19_00 id=0x3f4bec0a018f5073 kind=8 width=4
-    field field_19_01 id=0x3f4beb0a018f4ec0 kind=8 width=4
-    field field_19_02 id=0x3f4bee0a018f53d9 kind=8 width=4
-    field field_19_03 id=0x3f4bed0a018f5226 kind=8 width=4
-    field field_19_04 id=0x3f4bf00a018f573f kind=8 width=4
-    field field_19_05 id=0x3f4bef0a018f558c kind=8 width=4
-    field field_19_06 id=0x3f4bf20a018f5aa5 kind=8 width=4
-    field field_19_07 id=0x3f4bf10a018f58f2 kind=8 width=4
-    field field_19_08 id=0x3f4bf40a018f5e0b kind=8 width=4
-    field field_19_09 id=0x3f4bf30a018f5c58 kind=8 width=4
-    field field_19_10 id=0x3f48860a018c6d4a kind=8 width=4
-    field field_19_11 id=0x3f48870a018c6efd kind=8 width=4
-    field field_19_12 id=0x3f48840a018c69e4 kind=8 width=4
+fixed table Wide19 layout=0xb50de374dd14e94f
+    field field_19_00 id=0x3f4bec0a018f5073 kind=8 width=4 default=0
+    field field_19_01 id=0x3f4beb0a018f4ec0 kind=8 width=4 default=0
+    field field_19_02 id=0x3f4bee0a018f53d9 kind=8 width=4 default=0
+    field field_19_03 id=0x3f4bed0a018f5226 kind=8 width=4 default=0
+    field field_19_04 id=0x3f4bf00a018f573f kind=8 width=4 default=0
+    field field_19_05 id=0x3f4bef0a018f558c kind=8 width=4 default=0
+    field field_19_06 id=0x3f4bf20a018f5aa5 kind=8 width=4 default=0
+    field field_19_07 id=0x3f4bf10a018f58f2 kind=8 width=4 default=0
+    field field_19_08 id=0x3f4bf40a018f5e0b kind=8 width=4 default=0
+    field field_19_09 id=0x3f4bf30a018f5c58 kind=8 width=4 default=0
+    field field_19_10 id=0x3f48860a018c6d4a kind=8 width=4 default=0
+    field field_19_11 id=0x3f48870a018c6efd kind=8 width=4 default=0
+    field field_19_12 id=0x3f48840a018c69e4 kind=8 width=4 default=0

--- a/tables/vocab9/schema.lock
+++ b/tables/vocab9/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package vocab9demo
 
 fixed table Wide00 layout=0xb94cf83e0cd8b930

--- a/tables/vocab9/schema.lock
+++ b/tables/vocab9/schema.lock
@@ -1,0 +1,302 @@
+schema-lock 1
+package vocab9demo
+
+fixed table Wide00 layout=0xc2c133ca1fc91328
+    field field_00_00 id=0x0608e822268486dd kind=8 width=4
+    field field_00_01 id=0x0608e7222684852a kind=8 width=4
+    field field_00_02 id=0x0608e62226848377 kind=8 width=4
+    field field_00_03 id=0x0608e522268481c4 kind=8 width=4
+    field field_00_04 id=0x0608e42226848011 kind=8 width=4
+    field field_00_05 id=0x0608e32226847e5e kind=8 width=4
+    field field_00_06 id=0x0608e22226847cab kind=8 width=4
+    field field_00_07 id=0x0608e12226847af8 kind=8 width=4
+    field field_00_08 id=0x0608e02226847945 kind=8 width=4
+    field field_00_09 id=0x0608df2226847792 kind=8 width=4
+    field field_00_10 id=0x0605622226816d54 kind=8 width=4
+    field field_00_11 id=0x0605632226816f07 kind=8 width=4
+    field field_00_12 id=0x06056422268170ba kind=8 width=4
+
+fixed table Wide01 layout=0x220c0e90fb21c319
+    field field_01_00 id=0x5c6e9229c1ee10ec kind=8 width=4
+    field field_01_01 id=0x5c6e9329c1ee129f kind=8 width=4
+    field field_01_02 id=0x5c6e9429c1ee1452 kind=8 width=4
+    field field_01_03 id=0x5c6e9529c1ee1605 kind=8 width=4
+    field field_01_04 id=0x5c6e8e29c1ee0a20 kind=8 width=4
+    field field_01_05 id=0x5c6e8f29c1ee0bd3 kind=8 width=4
+    field field_01_06 id=0x5c6e9029c1ee0d86 kind=8 width=4
+    field field_01_07 id=0x5c6e9129c1ee0f39 kind=8 width=4
+    field field_01_08 id=0x5c6e9a29c1ee1e84 kind=8 width=4
+    field field_01_09 id=0x5c6e9b29c1ee2037 kind=8 width=4
+    field field_01_10 id=0x5c721829c1f12a75 kind=8 width=4
+    field field_01_11 id=0x5c721729c1f128c2 kind=8 width=4
+    field field_01_12 id=0x5c721629c1f1270f kind=8 width=4
+
+fixed table Wide02 layout=0x900d32da562a8666
+    field field_02_00 id=0x89bb9c30246ce93b kind=8 width=4
+    field field_02_01 id=0x89bb9b30246ce788 kind=8 width=4
+    field field_02_02 id=0x89bb9e30246ceca1 kind=8 width=4
+    field field_02_03 id=0x89bb9d30246ceaee kind=8 width=4
+    field field_02_04 id=0x89bba030246cf007 kind=8 width=4
+    field field_02_05 id=0x89bb9f30246cee54 kind=8 width=4
+    field field_02_06 id=0x89bba230246cf36d kind=8 width=4
+    field field_02_07 id=0x89bba130246cf1ba kind=8 width=4
+    field field_02_08 id=0x89bb9430246cdba3 kind=8 width=4
+    field field_02_09 id=0x89bb9330246cd9f0 kind=8 width=4
+    field field_02_10 id=0x89b816302469cfb2 kind=8 width=4
+    field field_02_11 id=0x89b817302469d165 kind=8 width=4
+    field field_02_12 id=0x89b814302469cc4c kind=8 width=4
+
+fixed table Wide03 layout=0x3942b013028b9b1f
+    field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 width=4
+    field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 width=4
+    field field_03_02 id=0x5f3da43b6dd5a684 kind=8 width=4
+    field field_03_03 id=0x5f3da53b6dd5a837 kind=8 width=4
+    field field_03_04 id=0x5f3da23b6dd5a31e kind=8 width=4
+    field field_03_05 id=0x5f3da33b6dd5a4d1 kind=8 width=4
+    field field_03_06 id=0x5f3da03b6dd59fb8 kind=8 width=4
+    field field_03_07 id=0x5f3da13b6dd5a16b kind=8 width=4
+    field field_03_08 id=0x5f3d9e3b6dd59c52 kind=8 width=4
+    field field_03_09 id=0x5f3d9f3b6dd59e05 kind=8 width=4
+    field field_03_10 id=0x5f410c3b6dd88d13 kind=8 width=4
+    field field_03_11 id=0x5f410b3b6dd88b60 kind=8 width=4
+    field field_03_12 id=0x5f410e3b6dd89079 kind=8 width=4
+
+fixed table Wide04 layout=0xe1a77fe5b6565480
+    field field_04_00 id=0x6078d04094e30c99 kind=8 width=4
+    field field_04_01 id=0x6078cf4094e30ae6 kind=8 width=4
+    field field_04_02 id=0x6078ce4094e30933 kind=8 width=4
+    field field_04_03 id=0x6078cd4094e30780 kind=8 width=4
+    field field_04_04 id=0x6078d44094e31365 kind=8 width=4
+    field field_04_05 id=0x6078d34094e311b2 kind=8 width=4
+    field field_04_06 id=0x6078d24094e30fff kind=8 width=4
+    field field_04_07 id=0x6078d14094e30e4c kind=8 width=4
+    field field_04_08 id=0x6078d84094e31a31 kind=8 width=4
+    field field_04_09 id=0x6078d74094e3187e kind=8 width=4
+    field field_04_10 id=0x6075ca4094e0cc90 kind=8 width=4
+    field field_04_11 id=0x6075cb4094e0ce43 kind=8 width=4
+    field field_04_12 id=0x6075cc4094e0cff6 kind=8 width=4
+
+fixed table Wide05 layout=0xc94b03ede1db474c
+    field field_05_00 id=0x37adda4bdfbd61c8 kind=8 width=4
+    field field_05_01 id=0x37addb4bdfbd637b kind=8 width=4
+    field field_05_02 id=0x37addc4bdfbd652e kind=8 width=4
+    field field_05_03 id=0x37addd4bdfbd66e1 kind=8 width=4
+    field field_05_04 id=0x37adde4bdfbd6894 kind=8 width=4
+    field field_05_05 id=0x37addf4bdfbd6a47 kind=8 width=4
+    field field_05_06 id=0x37ade04bdfbd6bfa kind=8 width=4
+    field field_05_07 id=0x37ade14bdfbd6dad kind=8 width=4
+    field field_05_08 id=0x37add24bdfbd5430 kind=8 width=4
+    field field_05_09 id=0x37add34bdfbd55e3 kind=8 width=4
+    field field_05_10 id=0x37b1604bdfc07b51 kind=8 width=4
+    field field_05_11 id=0x37b15f4bdfc0799e kind=8 width=4
+    field field_05_12 id=0x37b15e4bdfc077eb kind=8 width=4
+
+fixed table Wide06 layout=0x56d07d371752dea8
+    field field_06_00 id=0x8e13a4537b272237 kind=8 width=4
+    field field_06_01 id=0x8e13a3537b272084 kind=8 width=4
+    field field_06_02 id=0x8e13a6537b27259d kind=8 width=4
+    field field_06_03 id=0x8e13a5537b2723ea kind=8 width=4
+    field field_06_04 id=0x8e13a0537b271b6b kind=8 width=4
+    field field_06_05 id=0x8e139f537b2719b8 kind=8 width=4
+    field field_06_06 id=0x8e13a2537b271ed1 kind=8 width=4
+    field field_06_07 id=0x8e13a1537b271d1e kind=8 width=4
+    field field_06_08 id=0x8e139c537b27149f kind=8 width=4
+    field field_06_09 id=0x8e139b537b2712ec kind=8 width=4
+    field field_06_10 id=0x8e101e537b2408ae kind=8 width=4
+    field field_06_11 id=0x8e101f537b240a61 kind=8 width=4
+    field field_06_12 id=0x8e101c537b240548 kind=8 width=4
+
+fixed table Wide07 layout=0x646af0cf090be58d
+    field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 width=4
+    field field_07_01 id=0xb9ad8f59dc343159 kind=8 width=4
+    field field_07_02 id=0xb9ad8c59dc342c40 kind=8 width=4
+    field field_07_03 id=0xb9ad8d59dc342df3 kind=8 width=4
+    field field_07_04 id=0xb9ad9259dc343672 kind=8 width=4
+    field field_07_05 id=0xb9ad9359dc343825 kind=8 width=4
+    field field_07_06 id=0xb9ad9059dc34330c kind=8 width=4
+    field field_07_07 id=0xb9ad9159dc3434bf kind=8 width=4
+    field field_07_08 id=0xb9ad9659dc343d3e kind=8 width=4
+    field field_07_09 id=0xb9ad9759dc343ef1 kind=8 width=4
+    field field_07_10 id=0xb9b11459dc37492f kind=8 width=4
+    field field_07_11 id=0xb9b11359dc37477c kind=8 width=4
+    field field_07_12 id=0xb9b11659dc374c95 kind=8 width=4
+
+fixed table Wide08 layout=0x143d2e3c1249a0b6
+    field field_08_00 id=0x26de17dcb256f565 kind=8 width=4
+    field field_08_01 id=0x26de16dcb256f3b2 kind=8 width=4
+    field field_08_02 id=0x26de15dcb256f1ff kind=8 width=4
+    field field_08_03 id=0x26de14dcb256f04c kind=8 width=4
+    field field_08_04 id=0x26de13dcb256ee99 kind=8 width=4
+    field field_08_05 id=0x26de12dcb256ece6 kind=8 width=4
+    field field_08_06 id=0x26de11dcb256eb33 kind=8 width=4
+    field field_08_07 id=0x26de10dcb256e980 kind=8 width=4
+    field field_08_08 id=0x26de1fdcb25702fd kind=8 width=4
+    field field_08_09 id=0x26de1edcb257014a kind=8 width=4
+    field field_08_10 id=0x26db11dcb254b55c kind=8 width=4
+    field field_08_11 id=0x26db12dcb254b70f kind=8 width=4
+    field field_08_12 id=0x26db13dcb254b8c2 kind=8 width=4
+
+fixed table Wide09 layout=0x7f0f8b0fd58444b0
+    field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 width=4
+    field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 width=4
+    field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 width=4
+    field field_09_03 id=0xfbf3a4e7fb63c2cd kind=8 width=4
+    field field_09_04 id=0xfbf39de7fb63b6e8 kind=8 width=4
+    field field_09_05 id=0xfbf39ee7fb63b89b kind=8 width=4
+    field field_09_06 id=0xfbf39fe7fb63ba4e kind=8 width=4
+    field field_09_07 id=0xfbf3a0e7fb63bc01 kind=8 width=4
+    field field_09_08 id=0xfbf399e7fb63b01c kind=8 width=4
+    field field_09_09 id=0xfbf39ae7fb63b1cf kind=8 width=4
+    field field_09_10 id=0xfbf6a7e7fb65fdbd kind=8 width=4
+    field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 width=4
+    field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 width=4
+
+fixed table Wide10 layout=0x1a1e551dd2b29424
+    field field_10_00 id=0x768f8657129836da kind=8 width=4
+    field field_10_01 id=0x768f87571298388d kind=8 width=4
+    field field_10_02 id=0x768f845712983374 kind=8 width=4
+    field field_10_03 id=0x768f855712983527 kind=8 width=4
+    field field_10_04 id=0x768f82571298300e kind=8 width=4
+    field field_10_05 id=0x768f8357129831c1 kind=8 width=4
+    field field_10_06 id=0x768f805712982ca8 kind=8 width=4
+    field field_10_07 id=0x768f815712982e5b kind=8 width=4
+    field field_10_08 id=0x768f7e5712982942 kind=8 width=4
+    field field_10_09 id=0x768f7f5712982af5 kind=8 width=4
+    field field_10_10 id=0x7692ec57129b1a03 kind=8 width=4
+    field field_10_11 id=0x7692eb57129b1850 kind=8 width=4
+    field field_10_12 id=0x7692ee57129b1d69 kind=8 width=4
+
+fixed table Wide11 layout=0x34a6e80cd0672ee9
+    field field_11_00 id=0x9f5a7c4bc7bde1ab kind=8 width=4
+    field field_11_01 id=0x9f5a7b4bc7bddff8 kind=8 width=4
+    field field_11_02 id=0x9f5a7e4bc7bde511 kind=8 width=4
+    field field_11_03 id=0x9f5a7d4bc7bde35e kind=8 width=4
+    field field_11_04 id=0x9f5a804bc7bde877 kind=8 width=4
+    field field_11_05 id=0x9f5a7f4bc7bde6c4 kind=8 width=4
+    field field_11_06 id=0x9f5a824bc7bdebdd kind=8 width=4
+    field field_11_07 id=0x9f5a814bc7bdea2a kind=8 width=4
+    field field_11_08 id=0x9f5a744bc7bdd413 kind=8 width=4
+    field field_11_09 id=0x9f5a734bc7bdd260 kind=8 width=4
+    field field_11_10 id=0x9f56f64bc7bac822 kind=8 width=4
+    field field_11_11 id=0x9f56f74bc7bac9d5 kind=8 width=4
+    field field_11_12 id=0x9f56f44bc7bac4bc kind=8 width=4
+
+fixed table Wide12 layout=0x2e1fa39529081953
+    field field_12_00 id=0x9e1f3246a0b0489c kind=8 width=4
+    field field_12_01 id=0x9e1f3346a0b04a4f kind=8 width=4
+    field field_12_02 id=0x9e1f3446a0b04c02 kind=8 width=4
+    field field_12_03 id=0x9e1f3546a0b04db5 kind=8 width=4
+    field field_12_04 id=0x9e1f2e46a0b041d0 kind=8 width=4
+    field field_12_05 id=0x9e1f2f46a0b04383 kind=8 width=4
+    field field_12_06 id=0x9e1f3046a0b04536 kind=8 width=4
+    field field_12_07 id=0x9e1f3146a0b046e9 kind=8 width=4
+    field field_12_08 id=0x9e1f3a46a0b05634 kind=8 width=4
+    field field_12_09 id=0x9e1f3b46a0b057e7 kind=8 width=4
+    field field_12_10 id=0x9e223846a0b288a5 kind=8 width=4
+    field field_12_11 id=0x9e223746a0b286f2 kind=8 width=4
+    field field_12_12 id=0x9e223646a0b2853f kind=8 width=4
+
+fixed table Wide13 layout=0x459b87fe875bbf53
+    field field_13_00 id=0xc89d483b5747be4d kind=8 width=4
+    field field_13_01 id=0xc89d473b5747bc9a kind=8 width=4
+    field field_13_02 id=0xc89d463b5747bae7 kind=8 width=4
+    field field_13_03 id=0xc89d453b5747b934 kind=8 width=4
+    field field_13_04 id=0xc89d443b5747b781 kind=8 width=4
+    field field_13_05 id=0xc89d433b5747b5ce kind=8 width=4
+    field field_13_06 id=0xc89d423b5747b41b kind=8 width=4
+    field field_13_07 id=0xc89d413b5747b268 kind=8 width=4
+    field field_13_08 id=0xc89d403b5747b0b5 kind=8 width=4
+    field field_13_09 id=0xc89d3f3b5747af02 kind=8 width=4
+    field field_13_10 id=0xc899c23b5744a4c4 kind=8 width=4
+    field field_13_11 id=0xc899c33b5744a677 kind=8 width=4
+    field field_13_12 id=0xc899c43b5744a82a kind=8 width=4
+
+fixed table Wide14 layout=0x32b1438eb651240e
+    field field_14_00 id=0xd0ff6e7580f6bc96 kind=8 width=4
+    field field_14_01 id=0xd0ff6f7580f6be49 kind=8 width=4
+    field field_14_02 id=0xd0ff6c7580f6b930 kind=8 width=4
+    field field_14_03 id=0xd0ff6d7580f6bae3 kind=8 width=4
+    field field_14_04 id=0xd0ff727580f6c362 kind=8 width=4
+    field field_14_05 id=0xd0ff737580f6c515 kind=8 width=4
+    field field_14_06 id=0xd0ff707580f6bffc kind=8 width=4
+    field field_14_07 id=0xd0ff717580f6c1af kind=8 width=4
+    field field_14_08 id=0xd0ff767580f6ca2e kind=8 width=4
+    field field_14_09 id=0xd0ff777580f6cbe1 kind=8 width=4
+    field field_14_10 id=0xd102f47580f9d61f kind=8 width=4
+    field field_14_11 id=0xd102f37580f9d46c kind=8 width=4
+    field field_14_12 id=0xd102f67580f9d985 kind=8 width=4
+
+fixed table Wide15 layout=0xe40c6a728d5abd89
+    field field_15_00 id=0xcfc4447059e959e7 kind=8 width=4
+    field field_15_01 id=0xcfc4437059e95834 kind=8 width=4
+    field field_15_02 id=0xcfc4467059e95d4d kind=8 width=4
+    field field_15_03 id=0xcfc4457059e95b9a kind=8 width=4
+    field field_15_04 id=0xcfc4407059e9531b kind=8 width=4
+    field field_15_05 id=0xcfc43f7059e95168 kind=8 width=4
+    field field_15_06 id=0xcfc4427059e95681 kind=8 width=4
+    field field_15_07 id=0xcfc4417059e954ce kind=8 width=4
+    field field_15_08 id=0xcfc43c7059e94c4f kind=8 width=4
+    field field_15_09 id=0xcfc43b7059e94a9c kind=8 width=4
+    field field_15_10 id=0xcfc0be7059e6405e kind=8 width=4
+    field field_15_11 id=0xcfc0bf7059e64211 kind=8 width=4
+    field field_15_12 id=0xcfc0bc7059e63cf8 kind=8 width=4
+
+fixed table Wide16 layout=0xf90d97dd618e7ed6
+    field field_16_00 id=0xf88f3a650f0f04b8 kind=8 width=4
+    field field_16_01 id=0xf88f3b650f0f066b kind=8 width=4
+    field field_16_02 id=0xf88f3c650f0f081e kind=8 width=4
+    field field_16_03 id=0xf88f3d650f0f09d1 kind=8 width=4
+    field field_16_04 id=0xf88f3e650f0f0b84 kind=8 width=4
+    field field_16_05 id=0xf88f3f650f0f0d37 kind=8 width=4
+    field field_16_06 id=0xf88f40650f0f0eea kind=8 width=4
+    field field_16_07 id=0xf88f41650f0f109d kind=8 width=4
+    field field_16_08 id=0xf88f32650f0ef720 kind=8 width=4
+    field field_16_09 id=0xf88f33650f0ef8d3 kind=8 width=4
+    field field_16_10 id=0xf892c0650f121e41 kind=8 width=4
+    field field_16_11 id=0xf892bf650f121c8e kind=8 width=4
+    field field_16_12 id=0xf892be650f121adb kind=8 width=4
+
+fixed table Wide17 layout=0xb46277f4de502ae7
+    field field_17_00 id=0xa229705d73a54449 kind=8 width=4
+    field field_17_01 id=0xa2296f5d73a54296 kind=8 width=4
+    field field_17_02 id=0xa2296e5d73a540e3 kind=8 width=4
+    field field_17_03 id=0xa2296d5d73a53f30 kind=8 width=4
+    field field_17_04 id=0xa229745d73a54b15 kind=8 width=4
+    field field_17_05 id=0xa229735d73a54962 kind=8 width=4
+    field field_17_06 id=0xa229725d73a547af kind=8 width=4
+    field field_17_07 id=0xa229715d73a545fc kind=8 width=4
+    field field_17_08 id=0xa229785d73a551e1 kind=8 width=4
+    field field_17_09 id=0xa229775d73a5502e kind=8 width=4
+    field field_17_10 id=0xa225ea5d73a22ac0 kind=8 width=4
+    field field_17_11 id=0xa225eb5d73a22c73 kind=8 width=4
+    field field_17_12 id=0xa225ec5d73a22e26 kind=8 width=4
+
+fixed table Wide18 layout=0x49f88b91bb9d733a
+    field field_18_00 id=0x96f836119e0ead02 kind=8 width=4
+    field field_18_01 id=0x96f837119e0eaeb5 kind=8 width=4
+    field field_18_02 id=0x96f834119e0ea99c kind=8 width=4
+    field field_18_03 id=0x96f835119e0eab4f kind=8 width=4
+    field field_18_04 id=0x96f832119e0ea636 kind=8 width=4
+    field field_18_05 id=0x96f833119e0ea7e9 kind=8 width=4
+    field field_18_06 id=0x96f830119e0ea2d0 kind=8 width=4
+    field field_18_07 id=0x96f831119e0ea483 kind=8 width=4
+    field field_18_08 id=0x96f83e119e0eba9a kind=8 width=4
+    field field_18_09 id=0x96f83f119e0ebc4d kind=8 width=4
+    field field_18_10 id=0x96fb3c119e10ed0b kind=8 width=4
+    field field_18_11 id=0x96fb3b119e10eb58 kind=8 width=4
+    field field_18_12 id=0x96fb3e119e10f071 kind=8 width=4
+
+fixed table Wide19 layout=0x29bdebdd5a50400f
+    field field_19_00 id=0x3f4bec0a018f5073 kind=8 width=4
+    field field_19_01 id=0x3f4beb0a018f4ec0 kind=8 width=4
+    field field_19_02 id=0x3f4bee0a018f53d9 kind=8 width=4
+    field field_19_03 id=0x3f4bed0a018f5226 kind=8 width=4
+    field field_19_04 id=0x3f4bf00a018f573f kind=8 width=4
+    field field_19_05 id=0x3f4bef0a018f558c kind=8 width=4
+    field field_19_06 id=0x3f4bf20a018f5aa5 kind=8 width=4
+    field field_19_07 id=0x3f4bf10a018f58f2 kind=8 width=4
+    field field_19_08 id=0x3f4bf40a018f5e0b kind=8 width=4
+    field field_19_09 id=0x3f4bf30a018f5c58 kind=8 width=4
+    field field_19_10 id=0x3f48860a018c6d4a kind=8 width=4
+    field field_19_11 id=0x3f48870a018c6efd kind=8 width=4
+    field field_19_12 id=0x3f48840a018c69e4 kind=8 width=4

--- a/test/table-base64/schema.lock
+++ b/test/table-base64/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 3
+schema-lock 4
 package base64test
 
 fixed table Blob layout=0x6af9d88a34d3e508

--- a/test/table-base64/schema.lock
+++ b/test/table-base64/schema.lock
@@ -1,4 +1,4 @@
-schema-lock 4
+schema-lock 5
 package base64test
 
 fixed table Blob layout=0x6af9d88a34d3e508

--- a/test/table-base64/schema.lock
+++ b/test/table-base64/schema.lock
@@ -1,5 +1,5 @@
-schema-lock 1
+schema-lock 2
 package base64test
 
-fixed table Blob layout=0x7c665f2bc4654777
-    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=16388
+fixed table Blob layout=0x6ab704d528e40d7c
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=16388 default=bytes:

--- a/test/table-base64/schema.lock
+++ b/test/table-base64/schema.lock
@@ -1,0 +1,5 @@
+schema-lock 1
+package base64test
+
+fixed table Blob layout=0x7c665f2bc4654777
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=16388

--- a/test/table-base64/schema.lock
+++ b/test/table-base64/schema.lock
@@ -1,5 +1,5 @@
-schema-lock 2
+schema-lock 3
 package base64test
 
-fixed table Blob layout=0x6ab704d528e40d7c
-    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=16388 default=bytes:
+fixed table Blob layout=0x6af9d88a34d3e508
+    field payload id=0xcfb8a9d063b5e9e5 kind=14 width=16388 default=bytes: elem=6/1


### PR DESCRIPTION
## Glenn's decisions

Fixed tables evolve **append-only**, enforced by a lock file the compiler owns.
His words:

> "append only, and deprecation possibly. might keep it light weight?"

On the mechanism:

> "OK that sounds cool, go ahead."

And then, of the mechanism itself:

> "Is there anything schema check cannot catch in a fixed table? Can we fix
> that so it does?"

That question is what the lock's second half answers: the order and the widths
are what a reader stands on ONLY if nothing else about a field can move
underneath it, and six things could.

Network Next did this by hand for years — a `uint8` version at the front, bump
on change, append at the bottom, manual upgrades for a limited time:

> "manual stuff, and it is a footgun, but it worked."

It worked because the discipline is right. It was a footgun because nothing
enforced it. This PR is that discipline with the footgun taken away.

## Why fixed tables need it

A variable-length table rides the id-table wire, where evolution is wire
tolerance: fields may be added, removed and reordered, and the reader finds
each one by its id. **A fixed-size table has none of that.** It is a plain C
record — no ids, no terminators, no names, walked by offset — so the field
ORDER and the field WIDTHS *are* the contract. A reordered field, a removed
one, a widened one: every one of those is read as garbage by a reader holding
an older record, silently, with no counter to fire.

## The mechanism

**1. `schema.lock`**, committed beside the schemas at the unit root, written by
the compiler only. For every fixed table, its field sequence in declared order
— each entry carrying the field's **id**, **kind**, **width**, **default**
declared or implicit, declared **range** and resolution, **`?`** and
**`deprecated`** marker — and then a block for **every type those tables
reach**: a nested `type` as a record of its own, and an `enum`, a `flags` mask
or a `union` as its **value list in declared order**. Each block carries the
hash of its lines.

```
fixed table ShipConfig
{
    name     string(32)
    speed    float32 | min = 0, max = 100, resolution = 0.01
    armor    uint8 | deprecated
    shields  uint8 = 3
    hull     Hull = Gunship
    perks    Perks
    lanes    [4]Hull
    by_hull  [Hull]uint16
    gunner   ?GunnerSettings
}
```

```
schema-lock 5
package fleet

fixed table ShipConfig layout=0x24c95e6d7dc599a2
    field name id=0xc4bcadba8e631b86 kind=12 width=40 default=bytes:
    field speed id=0x2281498aa0200e40 kind=10 width=4 default=0.0 min=0.0 max=100.0 res=0.01
    field armor id=0xd19988b67e699194 kind=6 width=1 default=0 deprecated
    field shields id=0x798c587767067199 kind=6 width=1 default=3
    field hull id=0x80da8ccc11daadf6 kind=7 width=1 default=variant:Gunship held=Hull@0xc3cc3881c580dd9d
    field perks id=0x4b06f5847096e54a kind=9 width=8 default=mask:0 held=Perks@0x8e31a11d8a742b6a
    field lanes id=0xd14829ec544a2fb4 kind=14 width=4 default=born:0 held=Hull@0xc3cc3881c580dd9d elem=7/1
    field by_hull id=0x17e7d894ce9c89da kind=16 width=6 default=born:0 elem=7/2 key=Hull@0xc3cc3881c580dd9d
    field gunner id=0x40dbb648c0cd44aa kind=13 width=9 default=zero held=GunnerSettings@0xdd5ef1d77231ba48 optional

type GunnerSettings layout=0xdd5ef1d77231ba48
    field reaction id=0xb75aa3662201646a kind=10 width=4 default=0.2
    field tracking id=0xa6bf719a4602b0bc kind=1 width=1 default=false

enum Hull values=0xc3cc3881c580dd9d
    variant Interceptor
    variant Gunship
    variant Freighter

flags Perks values=0x8e31a11d8a742b6a
    variant Shielded
    variant Cloaked
```

**What the lock holds, in full:**

| fact | why a reader misreads without it |
| --- | --- |
| field **id**, **kind**, **width**, in declared order | the record has no ids in it; position and width are the walk |
| the **DEFAULT**, declared *or implicit* | a deprecated slot holds it, an absent field on the id-table wire reads back as it, and a reader handed an older writer's record fills the missing field from it |
| the **RANGE** — `min`, `max`, a compressed float's `res` | the bounds are the scale a stored value is read back at |
| a fixed-point field's **`frac`** | `fixed(16,16)` and `fixed(24,8)` are one width under one kind and read one stored number as two different values |
| the **`?`** | an optional carries a presence bool INSIDE the record; a reader expecting one where none is written takes the next field's first byte for the answer |
| the **`deprecated`** marker | one-way; readers were told to ignore the slot |
| every **enum** and **flags** type reached, value list in order, append-only | in a fixed record an enum rides as its dense ordinal and a flags variant is its bit position: the list is the mapping from a stored number to a meaning |
| every **union** reached, arm order, append-only | the tag is the arm's position |
| every **type in the closure**, not the root alone | a nested `type`'s fields ARE the holder's bytes, so a field retyped one level in moves what a reader of the root gets back without moving one line of the root's entries |
| which named type a slot **holds** — `held=Hull@0x…`, on kinds 13, 15, 7, 9 and an array of any of them | a slot repointed from one type to another of the SAME WIDTH moves no byte and no other fact: `Hull` → `Cargo` reads a stored ordinal 1 back as `Ice` where `Gunship` was written |
| an array's **element** kind and width — `elem=7/1`, on kinds 14 and 16 | the bound and the total width can both hold while each element becomes something else |
| which enum a keyed array is **keyed by** — `key=Hull@0x…`, on kind 16 | the key's variants ARE the slots, in declared order, so the list is what says which slot a value was written into |

The first row is the whole of the original revision. Everything under it
arrived since, and the rendering version has moved with each widening —
`1` → `2` → `3` → `4` → `5` — because every one of these facts sits on a
hashed line, and a lock that does not carry them cannot be repaired by hand.
Each bump makes every committed lock stale at once, deliberately and visibly.

**The name is compared, not the hash.** Two enums with identical value lists
hash identically — `enum Hull` and `enum Rank` over the same three variants
are both `values=0xc3cc3881c580dd9d` — so `held=` and `key=` carry the wire
NAME beside the hash, and it is the name the diff compares. A slot repointed
between two structurally identical types is still a slot that means something
else.

**The one class it cannot catch, and the spec says so.** A field that keeps its
name, its id, its kind, its width, its default, its range and its `?` and
changes only what it MEANS — `timeout` counted in seconds becoming `timeout`
counted in milliseconds, an index counted from zero becoming one counted from
one — moves no fact the lock records and no byte a reader could compare. The
rule for it is the rule for every other break: **deprecate and add.**

**An append inside a nested record is not an append.** A field at the bottom of
a `type` a fixed table holds by value grows the holder's slot, which slides
every field after it, so the compile reports both halves: the holder's width
first, and the nested record's own new entry beside it. A nested record has no
bottom of its own; the bottom belongs to the table.

The width is the field's WHOLE storage in the record — an array's elements
together, a `string(N)`'s buffer and its length companion, an optional's value
and its presence bool — because that is the fact a reader standing at an offset
is standing on. The layout hash is derived and written down anyway: it and the
entries above it are one statement made twice, so a lock whose halves disagree
has been edited by a hand rather than written by the compiler.

**2. The check, on every compile** (`schema check`, `schema generate`): THE
LOCK IN THE TREE IS THE LIVE SEQUENCE, entry for entry, value for value, block
for block. The
APPEND-ONLY rule says what a fixed table may BECOME; the check says the
committed file must BE what the unit declares today, so a lock the declaration
has moved past — an appended field, a new fixed table, a `deprecated` marker
not written down — is STALE and refused like any other drift, naming the table,
the first entry the lock lacks, and the one command that fixes it. Every change
to a fixed table therefore lands in the same commit as the record of it. No
file, no check.

**3. `schema lock`** rewrites the file and only ever appends entries and
values, adds blocks or flips `deprecated` on. It runs the check's own
comparison first and **refuses every break the check refuses** — a reorder, a
removal, a widening, a kind change, a moved default, a moved range, a flipped
`?`, a reordered value list, an un-deprecation, a table withdrawn, a type gone
from the closure, a hand-edited file — so the
one command that moves the file cannot be the one that breaks the rule. The ONE
difference between the two readings is the one this command exists for: where
the check refuses a declaration the lock has not caught up to, this command
writes it down. `--print` writes nothing.
A lock written under an OLDER rendering version is the one file this command
will not repair — the version is the compiler's own, and unlike a baseline
there is no history to salvage — so its refusal says the remedy that works:
`… delete it and write it again with `schema lock``. Every bump in this branch
keeps that path live, and it is walked twice by test: once from a two-line
stub, and once from a WHOLE well-formed lock one version back, which is the
file a person actually meets. Both verbs name the one remedy, `schema lock`
writes nothing over the file it cannot read, and the remedy reproduces the
current rendering byte for byte.

There is no `--reason` and no history, unlike `tables-baseline --update`:
moving a baseline declares a break with data already written, while every write
a lock accepts is an append, and an append breaks nothing.

**4. `| deprecated`**, a TAG (the valueless half of the qualification section —
there is nothing for it to take a value of). The slot stays exactly where it
is, the writer emits the field's default, the reader ignores it, and the one
NEW USE the compiler refuses is a **guard**: an `if` condition may not name a
deprecated field. The other half of "guard or key" the language already gives
for free — a map key takes no qualification at all (§2.8), so a key can never
carry the marker. It is one-way.

**5. `was = "old_name"`** keeps the field's id, and the lock records WIRE
names, so a rename moves not one line of the file.

**6. Compaction** is a new fixed table under a new name. No mechanism, one
sentence in the spec.

## The refusals, verbatim

Reorder / insert before the end / removal from the middle:

```
schema.lock: fixed table ShipConfig: entry 2, field speed (id=0x2281498aa0200e40), is field armor (id=0xd19988b67e699194) in the declaration — a fixed table evolves APPEND-ONLY: a field is added at the BOTTOM, never inserted, moved or removed, because the record has no ids in it and a reader at this offset would read one field as the other (docs/SPEC-TABLES.md §2.10)
```

Removal from the end:

```
schema.lock: fixed table ShipConfig: entry 3, field armor (id=0xd19988b67e699194), is in the lock and gone from the declaration — a fixed table evolves APPEND-ONLY: a field is deprecated in place, never removed, because the record has no ids in it and every field after a removed one slides (docs/SPEC-TABLES.md §2.10); restore it and mark it `| deprecated`
```

Width change (checked before the kind, because it is the fact that slides every field after it):

```
schema.lock: fixed table ShipConfig: entry 3, field armor (id=0xd19988b67e699194), is 1 bytes wide in the lock and 4 in the declaration — a field already in the lock keeps its width: a fixed record is walked by offset, so widening one field moves every field after it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

Kind change at the same width (`float32` read as `int32` moves no byte and still lies):

```
schema.lock: fixed table ShipConfig: entry 2, field speed (id=0x2281498aa0200e40), is kind 10 in the lock and kind 4 in the declaration — a field already in the lock keeps its type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

Un-deprecation:

```
schema.lock: fixed table ShipConfig: entry 3, field armor (id=0xd19988b67e699194), is deprecated in the lock and live in the declaration — deprecation is ONE-WAY: readers were told to ignore this slot and the writers that have run since left it at its default, so what comes back is not data (docs/SPEC-TABLES.md §2.10); append a new field instead
```

A moved default, declared or implicit:

```
schema.lock: fixed table ShipConfig: entry 4, field shields (id=0x798c587767067199), defaults to 3 in the lock and 7 in the declaration — a field already in the lock keeps its default: an older writer's missing field is filled from this default, and a deprecated slot holds it, so a record written before the change reads differently after it (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A moved range, resolution or fixed-point scale — none of which moves a byte:

```
schema.lock: fixed table ShipConfig: entry 2, field speed (id=0x2281498aa0200e40), is [0.0, 100.0] at resolution 0.01 in the lock and [0.0, 100.0] at resolution 0.001 in the declaration — a field already in the lock keeps its range: the bounds and the resolution are the scale a stored value is read back at, so moving them reads every record already written as a different number (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one

schema.lock: fixed table ShipConfig: entry 7, field tilt (id=0x1e5088ef2e9bafc6), is [-8, 8] at 16 fractional bits in the lock and [-8, 8] at 8 fractional bits in the declaration — a field already in the lock keeps its range: … (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A flipped `?`, checked before the width because it is the more exact account of
the same move:

```
schema.lock: fixed table ShipConfig: entry 6, field gunner (id=0x40dbb648c0cd44aa), is optional in the lock and plain in the declaration — a field already in the lock keeps its `?`: an optional carries a presence bool beside its value INSIDE the record, so a reader that expects one where none is written takes the next field's first byte for the answer (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A reordered, renamed or inserted enum variant, `flags` variant or union arm:

```
schema.lock: enum Hull: variant 1, Interceptor, is Gunship in the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: a new variant goes at the END, and one already in the lock is never inserted, moved or renamed, because a fixed record stores the PLACE and a reader would read one value as the other (docs/SPEC-TABLES.md §2.10); restore it, and add the new one at the END
```

A change one level in, inside a nested `type` — the root's own entries do not
move one line:

```
schema.lock: type GunnerSettings: entry 1, field reaction (id=0xb75aa3662201646a), is kind 10 in the lock and kind 4 in the declaration — a field already in the lock keeps its type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A slot repointed at a different type, at the same width and with every other
fact of the entry unmoved. One sentence covers a nested record, a union, an
enum, a flags mask and an array of any of them, because it is one break:

```
schema.lock: fixed table ShipConfig: entry 2, field hull (id=0x80da8ccc11daadf6), held Hull in the lock and Cargo in the declaration — a field already in the lock keeps the type it holds: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

An array's element respelled at the same total width — a `[4]Hull` that became
`[4]Cargo`, or a `[Hull]int32` that became `[Hull]float32`:

```
schema.lock: fixed table Slots: entry 1, field by_hull (id=0x17e7d894ce9c89da), holds int32 elements in the lock and float32 elements in the declaration — a field already in the lock keeps its element type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A keyed array pointed at a different key enum. `Hull` and `Cargo` have three
variants each, so the slot is the same width and the slot COUNT is the same
too; what moved is which variant each slot belongs to:

```
schema.lock: fixed table Slots: entry 1, field by_hull (id=0x17e7d894ce9c89da), is keyed by Hull in the lock and Cargo in the declaration — a field already in the lock keeps the enum it is keyed by: the key's variants ARE the slots, in declared order, so every record already written put its values in the slots the old list numbered (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one
```

A type gone from the closure:

```
schema.lock: enum Hull is in the lock and this unit's fixed tables no longer reach it — the lock holds every type a fixed record is made of, so a type leaving the closure is a field that changed what it holds; restore it, or deprecate that field and append a new one (docs/SPEC-TABLES.md §2.10)
```

An APPEND to an enum, allowed by the rule and still refused until it is
written down — `schema lock` then records it, with every line before it
untouched:

```
schema.lock: enum Hull: variant 4, Tanker, is in the declaration and not in the lock — the lock is the committed record of what a fixed table's readers stand on, and this declaration has moved past it: an append, a new block and a deprecation are the changes the rule allows, and a change the rule allows is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`
```

A fixed table that is gone:

```
schema.lock: fixed table Slot is in the lock and this unit no longer declares it as a fixed table — a fixed table's layout is a promise to every record already written, and a promise is not withdrawn; compaction is a NEW table under a NEW name (docs/SPEC-TABLES.md §2.10)
```

A lock hand-edited to lie:

```
schema.lock: fixed table ShipConfig: the lock records layout=0x913d299299757f2a over entries that hash to 0x9132e392996cb3b3 — the lock is written by the compiler and a hand-edit does not hold; regenerate it with `schema lock` and make the schema change you meant instead (docs/SPEC-TABLES.md §2.10)
```

A stale lock — an appended field, an appended variant or arm, a new block, a
`deprecated` marker the file has not caught up to. One sentence, one remedy; only the clause naming the difference
varies:

```
schema.lock: fixed table ShipConfig: entry 4, field shields (id=0x798c587767067199), is in the declaration and not in the lock — the lock is the committed record of a fixed table's layout, and this declaration has moved past it: an append, a new table and a deprecation are the changes the rule allows, and a change the rule allows is still a change the record must carry (docs/SPEC-TABLES.md §2.10); write it with `schema lock`
```

A deprecation reads `… is deprecated in the declaration and live in the lock`,
and a new block with no line yet has none to name:
`fixed table Marker is in the declaration and not in the lock — …`.

A guard on a deprecated field:

```
if condition active names a field marked `| deprecated` — a deprecated field is retired in place: its slot stays, nothing new may name it, and a guard is a NEW USE (docs/SPEC-TABLES.md §2.10); guard on a live field, or drop the marker
```

## Which tables are FIXED

`origin/fixed-table-keyword` does not exist yet, so this branches from `main`
and derives the set with `!ir.VariableTables(u)[name]`, in **one place** —
`lockfile.FixedTables` — carrying a `TODO(fixed-table-keyword)` naming the
declared flag. When the keyword lands, the switch is one line in that
function's body.

## Locks added (15)

`examples-wide`, `tables/arms`, `tables/backend`, `tables/block`,
`tables/blockhome`, `tables/examples`, `tables/lists`, `tables/maps`,
`tables/messages`, `tables/pointers`, `tables/scalars`, `tables/stream`,
`tables/vocab`, `tables/vocab9`, `test/table-base64`.

Every other unit in the tree declares no fixed table and carries no lock; a
`TestEveryUnitWithFixedTablesIsLocked` keeps that register honest and fails the
day a unit grows its first fixed table without one. `test/tables/` holds many
single-file units in one directory (SPEC §3.2), so it has no place for a unit
lock and is not covered.

## Held by test

`internal/lockfile` runs the whole mechanism over a fixture package, both ways:
append / new table / new fieldless table / `deprecated` → the check REFUSES
until `schema lock` writes it, then passes, and the write is an append (the old
entries are a prefix of the new ones, and `ir.RecordLayout` proves a
deprecation moved no byte); reorder / removal (middle and end) / widen / kind
change / insert in the middle / un-deprecation / a table withdrawn / a
hand-edited lock → each refused with the entry named; a reorder, a removal and
a kind change are refused BY BOTH VERBS with the file left alone; `was =`
rename → not a change, so nothing to catch up to and the file does not move;
the driver's own load path refuses.

`compiler/lockdeprecated_test.go` generates the same schema with and without
the marker across cpp / c / go / cs and requires the outputs to be identical
but for the reflection descriptors' tags column — so the slot is still
declared, still initialized to its default, its offset assertion unchanged, and
still written, and the claim assumes no particular wire.

`internal/lockfile/lockclosure_test.go` is the widening, measured on a second
fixture built in TWO HALVES that mirror each other field for field: a FIXED
`Config` and everything it reaches, beside a VARIABLE-LENGTH `Bag` (it holds a
`*Bag`) and a closure only it reaches. Every fact the file gained is measured
**three ways** — `TestClosureBreakRefused`, `TestClosureBreakOnAVariableTableIsNotTheLocksBusiness`,
`TestClosureBreakRefusedByLockToo` — over twenty-one edits: a moved default, a
default given to a slot that had none, a widened integer range, a moved
resolution, a moved fixed-point scale at the same width, a `?` turned on, a `?`
turned off, a kind change inside a nested `type`, a nested slot repointed at
another type, an optional nested slot the same way, a union arm's payloads
swapped with the names kept, an array's element type, an enum slot repointed,
a flags slot repointed, an array of enums repointed, a keyed array's key enum
repointed, a keyed array's element respelled at the same width, and a
reordered, renamed or removed enum variant, `flags` variant or union arm. Each is refused on the
fixed half with the line named; **each of them on the variable-length half
passes in silence and moves no byte of the file**, because a `table` with a
pointer in it rides the id-table wire where those edits are what the wire is
FOR; and `schema lock` refuses every one with the same sentence and leaves the
file exactly as it sat.

`TestClosureAppendRefusedUntilLocked` runs the appends the rule allows — a
variant at the end of an enum, of a `flags` mask, an arm at the end of a union
— refused as STALE and then written by `schema lock`, with every line before
them untouched and the file strictly longer.
`TestNestedRecordAppendSlidesTheHolder` is the case that is NOT an append: two
refusals, the holder's width first and the nested record's entry beside it.
`TestTypeLeavingTheClosureRefused` covers all four spellings (`type`, `enum`,
`flags`, `union`); `TestHandEditedValueListRefused` catches a value list edited
away from its hash; `TestLockHoldsTheWholeClosure` and
`TestValueListRoundTrips` pin the file's shape and its parser; and
`TestALockFromAnOlderRenderingSaysWhatToDo` walks the version bump's own path —
refused by both verbs with one remedy, and locking cleanly once it is taken.

`internal/lockfile/corpus_test.go` regenerates every committed lock byte for
byte and compiles each of those units with the check on. All fifteen committed
locks were regenerated under the widened rendering: the corpus's fixed tables
between them reach 99 fixed tables, 16 enums, 3 `flags` masks, 6 unions and 14
nested `type` records, every one of which is now held — and eight enum-keyed
array entries across `tables/examples`, `tables/block` and `tables/scalars`
now name their key and their element.

## Gates

- `go build ./...`, `go vet ./...`, `go test ./...` — clean
- `make check` — clean over the whole corpus
- `generated/` regenerated with this compiler — byte-identical, zero drift
- `golangci-lint` — 0 issues; `modernize` — clean
- the fifteen committed locks regenerate byte for byte, twice: in place, and
  deleted and rewritten from scratch
- `make shape-gate` — clean
- PORTING register gate (`compiler/porting_test.go`) — green
- `make check` over the tree's committed locks — clean; they are current, and
  under the strict reading that is now a claim the gate makes

**Each new comparison was sabotaged to prove its row is load-bearing.** Drop
the `*ir.Enum` arm from `held()` and the enum-slot and enum-array rows fail
and nothing else does; drop `*ir.Flags` and the flags row fails; stop the
renderer recording `key=`, or stop the diff comparing it, and the keyed-array
row fails; take kind 16 out of the `elem=` arm and the keyed-element row fails.
Every one of them turned exactly the intended rows red and left the rest
green, and the sources restored byte-identical after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
