### PR TITLE
c tables: name the LE memcpy control beside the BE twin

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1143,6 +1143,7 @@ refuse, under s390x emulation); `tables-java-order`;
 
 **Negative control.** `tables-big-endian-negative-control`;
 `tables-c-big-endian-negative-control`;
+`tables-c-little-endian-negative-control`;
 `conformance-negative-control-c-foreign` neuters the byte swap and requires
 both foreign rows red with `cook` and `block` green.
 

--- a/make/c.mk
+++ b/make/c.mk
@@ -480,7 +480,8 @@ tables-c-big-endian: build/schema_test_c_soak_be
 # stores back to a host-order copy, the same defect class as put16, and requires
 # the s390x soak golden to go red. The same sabotage stays green on this
 # little-endian host: the #else is not compiled there, and that pair is the
-# argument for the C leg the way put16 is for the C++ one.
+# argument for the C leg the way put16 is for the C++ one. The memcpy arm this
+# overlay leaves standing is tables-c-little-endian-negative-control, a host soak.
 #
 # Overlay, so no tracked file is written.
 C_BE_NC := build/c-be-sabotage


### PR DESCRIPTION
Two comment lines Rowan asked after #822. PORTING I7 names tables-c-little-endian-negative-control. make/c.mk BE header points at the LE host soak. Comments only. I do not merge.
