### PR TITLE
CI: the pull-request gate runs on PRs into fixed-table-form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    # main, and the fixed-form integration branch while the nine language legs
+    # land on it (2026-09-09): a leg PR into that branch is a pull request the
+    # gate must run on, or the batch to main is the first time anybody sees red.
+    branches: [ main, fixed-table-form ]
   workflow_dispatch:
 
 # Superseded pushes to the same pull request cancel each other; a push to main


### PR DESCRIPTION
Nine language legs of the fixed form land on `fixed-table-form` before the batch goes to main. A pull request into that branch got no CI (`pull_request` was `main` only), so #827 was read without its gate. One line: the gate runs on PRs into `fixed-table-form` too, until the batch merges and the branch is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
