### PR TITLE
cpptable: omit a union clamp switch with nothing to switch on

### DIFF
--- a/compiler/tablefixedclamp_test.go
+++ b/compiler/tablefixedclamp_test.go
@@ -1,0 +1,113 @@
+// A UNION WHOSE ARMS DECLARE NOTHING BOUNDED is still a bound on the TAG
+// (docs/SPEC-TABLES.md §3.4). The clamp pass remaps a tag past the arm count
+// to None and counts; it must not emit a switch with only `default`, which
+// MSVC /W4 /WX refuses (C4065). The nearest neighbour, with one ranged arm,
+// still carries the switch and still compiles.
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+const clampTagOnlySrc = `package probe
+
+type Boost
+{
+    power int32 = 0
+}
+
+type Ward
+{
+    charge float32 = 0.0
+}
+
+union Effect
+{
+    boost Boost
+    ward  Ward
+}
+
+table Cfg
+{
+    a      int32 = 5 | min = 0, max = 1000
+    effect Effect
+}
+`
+
+const clampRangedArmSrc = `package probe
+
+type Boost
+{
+    power int32 = 0 | min = 0, max = 10
+}
+
+type Ward
+{
+    charge float32 = 0.0
+}
+
+union Effect
+{
+    boost Boost
+    ward  Ward
+}
+
+table Cfg
+{
+    a      int32 = 5 | min = 0, max = 1000
+    effect Effect
+}
+`
+
+func extractFn(src, name string) string {
+	i := strings.Index(src, name)
+	if i < 0 {
+		return ""
+	}
+	rest := src[i:]
+	end := strings.Index(rest, "\n}\n")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end+3]
+}
+
+func TestCppTableFixedClampOmitsEmptyUnionSwitch(t *testing.T) {
+	without, files := deadCppHeader(t, clampTagOnlySrc)
+	body := extractFn(without, "CfgFixedClampBody")
+	if !strings.Contains(body, "value.effect.type = EffectType::None") {
+		t.Error("a union tag past the arm count must still remap to None")
+	}
+	if strings.Contains(body, "switch") {
+		t.Error("a union whose arms declare nothing bounded must not emit a switch with nothing to switch on")
+	}
+	deadCppCompile(t, files)
+
+	with, files := deadCppHeader(t, clampRangedArmSrc)
+	body = extractFn(with, "CfgFixedClampBody")
+	if !strings.Contains(body, "switch ( value.effect.type )") {
+		t.Error("a union with a bounded arm must still switch over the set arm")
+	}
+	if !strings.Contains(body, "case EffectType::Boost:") {
+		t.Error("the bounded arm must be a case")
+	}
+	deadCppCompile(t, files)
+}
+
+func TestCTableFixedClampOmitsEmptyUnionSwitch(t *testing.T) {
+	without, _ := deadCHeader(t, clampTagOnlySrc)
+	body := extractFn(without, "cfg_fixed_clamp_body_")
+	if !strings.Contains(body, "EFFECT_TYPE_NONE") {
+		t.Error("a union tag past the arm count must still remap to None")
+	}
+	if strings.Contains(body, "switch") {
+		t.Error("a union whose arms declare nothing bounded must not emit a switch with nothing to switch on")
+	}
+
+	with, _ := deadCHeader(t, clampRangedArmSrc)
+	body = extractFn(with, "cfg_fixed_clamp_body_")
+	if !strings.Contains(body, "switch ( value->effect.type )") {
+		t.Error("a union with a bounded arm must still switch over the set arm")
+	}
+}

--- a/internal/codegen/cpptable/fixedform.go
+++ b/internal/codegen/cpptable/fixedform.go
@@ -632,6 +632,9 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 			// counts.
 			g.pf("%sif ( (uint32_t) %s.type > %du ) { %s.type = %sType::None; clamped++; }\n",
 				ind, expr, r.Max, expr, f.Type.Name)
+			if !ir.TableFixedClampNeededUnionArm(r) {
+				return
+			}
 			g.pf("%sswitch ( %s.type )\n%s{\n", ind, expr, ind)
 			for _, v := range r.Variants {
 				if v.F == nil || !ir.TableFixedClampNeededField(v.F) {

--- a/internal/codegen/ctable/fixedform.go
+++ b/internal/codegen/ctable/fixedform.go
@@ -606,6 +606,9 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 		case *ir.Union:
 			g.pf("%sif ( (uint32_t) %s.type > %du ) { %s.type = %s; (*clamped)++; }\n",
 				ind, expr, r.Max, expr, enumNoneConst(f.Type.Name+"Type"))
+			if !ir.TableFixedClampNeededUnionArm(r) {
+				return
+			}
 			g.pf("%sswitch ( %s.type )\n%s{\n", ind, expr, ind)
 			for _, v := range r.Variants {
 				if v.F == nil || !ir.TableFixedClampNeededField(v.F) {

--- a/ir/fixedform.go
+++ b/ir/fixedform.go
@@ -1133,6 +1133,19 @@ func TableFixedClampNeededField(f *Field) bool {
 	return tableFixedClampNeededField(f, map[string]bool{})
 }
 
+// TableFixedClampNeededUnionArm is whether ANY arm's payload is bounded. The
+// tag is a bound of its own (TableFixedClampNeededField is true of every
+// union); a switch over arms that none of them need is not emitted, rather
+// than emitted with nothing to switch on.
+func TableFixedClampNeededUnionArm(r *Union) bool {
+	for _, v := range r.Variants {
+		if v.F != nil && TableFixedClampNeededField(v.F) {
+			return true
+		}
+	}
+	return false
+}
+
 func tableFixedClampNeededField(f *Field, seen map[string]bool) bool {
 	if f.Type.Kind == TNamed {
 		switch r := f.Type.Ref.(type) {


### PR DESCRIPTION
MSVC `/W4 /WX` **C4065** on **V1Table.h**: Effect's tag is a bound and none of its arms are, so the generated clamp `switch` had only `default: break;`.

The tag remap to `None` stays. The empty switch is not emitted. Same guard on the C leg.

Tiny branch off `origin/fixed-table-form` at **`22a161c5103c638174990167dc170eaf419f4eb6`**. Head **`2538a89f031470283e35277a62ce59e789f4176a`**. Not cherry-picked from `johnny/go-fixed-form` (9a825e9f mixed this with Go-only work).

Johnny Grok.

---

## What

`TableFixedClampNeededUnionArm` is true iff any arm payload is bounded. After the tag remap:

```
if ( (uint32_t) value.effect.type > N ) { value.effect.type = EffectType::None; clamped++; }
```

if no arm needs a clamp, return before emitting `switch (value.effect.type)`.

## Tests

- `go test ./compiler -count=1 -run 'TestCppTableFixedClampOmitsEmptyUnionSwitch|TestCTableFixedClampOmitsEmptyUnionSwitch'`
  - tag-only union remaps to `None` / `EFFECT_TYPE_NONE` and has no `switch`
  - ranged-arm neighbour still has `switch ( value.effect.type )` / `switch ( value->effect.type )` and `case EffectType::Boost:`
- `go test ./ir -count=1`

## Review

**Do not merge.** One independent read after it is open. Draft into `fixed-table-form`, not `main`.