### PR TITLE
gotable: clamp and ordinal count live elements only

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -11131,6 +11131,7 @@ in build version (§20.5).
   FixedMeasure  FixedSave  FixedLoad  FixedWriteBody  FixedLeaves
   FixedBodyBytes  FixedRecordBytes  FixedHash  FixedLayout  FixedLayoutBytes
   FixedDst  FixedPlan  FixedPlanCount  FixedPlanGuarded
+  FixedClamp  FixedClampBody
   ```
 
   The `Fixed` row is §3.4's, and it is claimed on this list's own rule:
@@ -11141,6 +11142,11 @@ in build version (§20.5).
   has no struct to hang a plan's two numbers on and spells them as two more
   file-scope constants; the whole row is one claim across the ports, spelled
   `<name>_fixed_save` in C and Rust and `<Name>FixedSave` elsewhere.
+  `FixedClamp` and `FixedClampBody` are §3.4's READ-SIDE BOUNDS — the
+  straight-line pass a read makes after the copy — and they are claimed for
+  every closure member on the same rule and not only for the ones that declare
+  a bound today: a field gains a `min` or a `max`, or a union or an enum, as an
+  ordinary edit, and the name has to already be taken when it does.
 
   The set is claimed for EVERY closure member, not only pointer-bearing
   ones: a table gains or loses pointers as an edit, and a name that was

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -3881,6 +3881,12 @@ var tableGeneratedVerbs = []string{
 	"FixedMeasure", "FixedSave", "FixedLoad", "FixedWriteBody", "FixedLeaves",
 	"FixedBodyBytes", "FixedRecordBytes", "FixedHash", "FixedLayout", "FixedLayoutBytes",
 	"FixedDst", "FixedPlan", "FixedPlanCount", "FixedPlanGuarded",
+	// and §3.4's READ-SIDE BOUNDS: the straight-line pass a read makes after
+	// the copy, and the per-type body it calls. Claimed for EVERY closure
+	// member and not only the ones that declare a bound today — a field gains
+	// a `min` or a `max`, or a union or an enum, as an ordinary edit, and the
+	// name has to already be taken when it does.
+	"FixedClamp", "FixedClampBody",
 	// THE C BACKEND's own name-first spellings (internal/codegen/ctable). C++
 	// and C# put these on a class — a builder's Lock, a storage's Create, a
 	// block type's Type — and a member function claims nothing. C has no

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -97,6 +97,17 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Tab { x int32 }\ntype TabLoad { y int32 }\n"},
 		{name: "a declaration colliding with the mutable-life surface", want: "generated TABLE-wire functions",
 			src: "package t\ntable Tab { x int32 }\ntype TabBuilder { y int32 }\n"},
+		// THE FIXED FORM'S SPELLINGS (docs/SPEC-TABLES.md §3.4, §11), and the
+		// point of these two rows is the one the whole list rests on: the
+		// READ-SIDE BOUNDS are emitted only for a type that declares something
+		// bounded, and the names are claimed for a table that declares NOTHING
+		// bounded — because adding a `min`, a `max`, a union or an enum is an
+		// ordinary edit, and a name free before it must not become a collision
+		// after it.
+		{name: "a declaration colliding with the fixed form's read-side bounds", want: "generated TABLE-wire functions",
+			src: "package t\ntable Tab { x int32 }\ntype TabFixedClamp { y int32 }\n"},
+		{name: "a declaration colliding with the fixed form's per-type bounds body", want: "generated TABLE-wire functions",
+			src: "package t\ntable Tab { x int32 }\ntype TabFixedClampBody { y int32 }\n"},
 		// THE PER-ENUM IDENTITY PAIR (docs/SPEC-TABLES.md §5, §11). C++ and C#
 		// overload the pair on the enum's own type; JavaScript has no
 		// overloading and no nested scope to hide it in, so each enum brings

--- a/internal/codegen/gotable/codecs.go
+++ b/internal/codegen/gotable/codecs.go
@@ -79,6 +79,32 @@ func goIntLit(v *big.Int, signed bool, widthBytes int) string {
 	return s
 }
 
+// tableStorageRange is the inclusive range an integer storage of the given
+// width can hold.
+func tableStorageRange(signed bool, bits int) (*big.Int, *big.Int) {
+	one := big.NewInt(1)
+	if signed {
+		hi := new(big.Int).Lsh(one, uint(bits-1))
+		return new(big.Int).Neg(hi), new(big.Int).Sub(hi, one)
+	}
+	return big.NewInt(0), new(big.Int).Sub(new(big.Int).Lsh(one, uint(bits)), one)
+}
+
+// tableClampEnds answers which ends of a declared min/max range a read can
+// actually clamp at. A bound sitting ON the storage width's limit is a
+// comparison no stored value can satisfy, and the emitter drops it — the same
+// "this check cannot fire" test the bits(N) width clamp applies when N is the
+// storage width.
+func tableClampEnds(f *ir.Field, widthBytes int) (low, high bool) {
+	signed := ir.TableKindSigned(ir.TableScalarKind(f))
+	lo, hi := tableStorageRange(signed, widthBytes*8)
+	rlo, rhi, ok := ir.TableRawRange(f)
+	if !ok {
+		return false, false
+	}
+	return rlo.Cmp(lo) > 0, rhi.Cmp(hi) < 0
+}
+
 // fieldDefaultExpr renders the Go expression a field's default compares
 // against on the write side (elision) — identical values to the reader's
 // prefill, so measure, save and load agree.

--- a/internal/codegen/gotable/fixedform.go
+++ b/internal/codegen/gotable/fixedform.go
@@ -365,7 +365,13 @@ func (g *tableGen) emitFixedForm(members []*ir.Struct) {
 		g.emitFixedLeafWalk(st)
 		g.emitFixedWriteBody(st)
 	}
+	// THE READ-SIDE BOUNDS, in the same closure order the write bodies take —
+	// post-order, so a nested type's body stands before the call to it.
+	for _, st := range order {
+		g.emitFixedClampBodyFn(st)
+	}
 	for _, st := range roots {
+		g.emitFixedClamp(st)
 		g.emitFixedRoot(st)
 	}
 }
@@ -527,12 +533,12 @@ func (g *tableGen) emitFixedElementLeavesAt(f *ir.Field, src, dst string, tabs i
 			return
 		case *ir.Union:
 			tag := int64(ir.StorageBitsFor(r.Max) / 8)
-			// THE TAG IS NOT A COPY: a tag naming no arm of this reader lands
-			// as None and counts `unknown`, the way form 1 answers an arm id
-			// it does not know (docs/SPEC-TABLES.md §4). Aux carries this
-			// reader's own arm count.
-			g.pf("%sout[n] = TableFixedEntry{Src: %s, Dst: %s + %s, Size: %d, Aux: %d, Guard: tableFixedNoGuard, Op: tableFixedTag} // the tag\n",
-				ind, src, dst, offGo(f.Type.Name, "Type"), tag, len(r.Variants))
+			// THE TAG IS A COPY. A tag past the arm count is a bound the
+			// storage pass holds after the run, over live elements only —
+			// never a plan entry, which would cover slack slots of a counted
+			// array of unions and count them (docs/SPEC-TABLES.md §3.4).
+			g.pf("%sout[n] = TableFixedEntry{Src: %s, Dst: %s + %s, Size: %d, Guard: tableFixedNoGuard, Op: tableFixedCopy} // the tag\n",
+				ind, src, dst, offGo(f.Type.Name, "Type"), tag)
 			g.pf("%sn++\n", ind)
 			for i, v := range r.Variants {
 				g.pf("%s{ // arm %s, ordinal %d\n%s\tguardAt := n\n", ind, v.Name, i+1, ind)
@@ -775,8 +781,162 @@ func (g *tableGen) emitFixedRoot(st *ir.Struct) {
 	g.pf("\t\t}\n")
 	g.pf("\t\tif tableFixedGet64(at) != hash {\n\t\t\treturn tableFixedRefuse(report, \"no_layout\")\n\t\t}\n")
 	g.pf("\t\ttableFixedRun(entries, entryCount, at[8:], dst, report)\n")
+	if ir.TableFixedClampNeeded(st) {
+		g.pf("\t\t// AND THE BOUNDS THE LOOP DOES NOT HOLD, straight-line over the\n")
+		g.pf("\t\t// storage it just wrote: the same pass for either plan (§3.4).\n")
+		g.pf("\t\t%sFixedClamp(&values[k], report)\n", st.Name)
+	}
 	g.pf("\t\tat = at[recordBytes:]\n")
 	g.pf("\t}\n\treturn n\n}\n\n")
+}
+
+/* ---- the read-side bounds --------------------------------------------------
+
+A fixed record is a positional image, so the ONE read loop moves bytes and asks
+nothing about what they mean. What a declaration bounds is held HERE, as
+straight-line code in the generated decode, after the copy — never as plan
+entries, which would be a test per bounded field on every read of every record
+and is the cost the identity plan exists to avoid.
+
+THE PASS RUNS OVER STORAGE, so ONE pass covers both plans. It walks only what a
+read can have written: a counted array's LIVE elements and never its slack, an
+optional's payload only when the present byte says so. */
+
+func (g *tableGen) emitFixedClampBodyFn(st *ir.Struct) {
+	if !ir.TableFixedClampNeeded(st) {
+		return
+	}
+	g.pf("// %s's read-side bounds.\n", st.Name)
+	g.pf("func %sFixedClampBody(value *%s, clamped *int32) {\n", st.Name, st.Name)
+	g.pf("\t_, _ = value, clamped\n")
+	for _, f := range st.Fields {
+		g.emitFixedClampField(f, "value", 1)
+	}
+	g.pf("}\n\n")
+}
+
+func (g *tableGen) emitFixedClamp(st *ir.Struct) {
+	if !ir.TableFixedClampNeeded(st) {
+		return
+	}
+	g.pf("// THE READ-SIDE BOUNDS (docs/SPEC-TABLES.md §3.4): a ranged scalar's\n")
+	g.pf("// declared min and max, and an ORDINAL's set — a union tag past the arm\n")
+	g.pf("// count, an enum ordinal past the enum's top value. Straight-line, after\n")
+	g.pf("// the copy, over STORAGE, so the identity plan and a plan compiled from a\n")
+	g.pf("// stranger's layout are held to the same numbers by the same pass. Every\n")
+	g.pf("// clamp COUNTS. The pass walks LIVE elements only: a counted array's live\n")
+	g.pf("// count, not its slack; an optional's payload only when present; a union's\n")
+	g.pf("// set arm, not the others.\n")
+	g.pf("func %sFixedClamp(value *%s, report *TableReport) {\n", st.Name, st.Name)
+	g.pf("\tclamped := int32(0)\n")
+	g.pf("\t%sFixedClampBody(value, &clamped)\n", st.Name)
+	g.pf("\treport.Clamped += clamped\n}\n\n")
+}
+
+func (g *tableGen) emitFixedClampField(f *ir.Field, val string, tabs int) {
+	if !ir.TableFixedClampNeededField(f) {
+		return
+	}
+	ind := strings.Repeat("\t", tabs)
+	if f.Type.Optional {
+		g.pf("%sif %s.%sPresent {\n", ind, val, member(f))
+		g.emitFixedClampPayload(f, val, tabs+1)
+		g.pf("%s}\n", ind)
+		return
+	}
+	g.emitFixedClampPayload(f, val, tabs)
+}
+
+func (g *tableGen) emitFixedClampPayload(f *ir.Field, val string, tabs int) {
+	ind := strings.Repeat("\t", tabs)
+	switch {
+	case f.KeyEnum != "":
+		g.pf("%sfor i := int64(0); i < %d; i++ {\n", ind, f.KeyEnumRef.Max)
+		g.emitFixedClampElement(f, fmt.Sprintf("%s.%s[i]", val, member(f)), tabs+1)
+		g.pf("%s}\n", ind)
+	case f.Array == ir.ArrayFixed:
+		g.pf("%sfor i := int64(0); i < %d; i++ {\n", ind, f.ArrayBound)
+		g.emitFixedClampElement(f, fmt.Sprintf("%s.%s[i]", val, member(f)), tabs+1)
+		g.pf("%s}\n", ind)
+	case f.Array == ir.ArrayCounted:
+		g.pf("%sfor i := int64(0); i < int64(%s.%sCount); i++ {\n", ind, val, member(f))
+		g.emitFixedClampElement(f, fmt.Sprintf("%s.%s[i]", val, member(f)), tabs+1)
+		g.pf("%s}\n", ind)
+	default:
+		g.emitFixedClampElement(f, val+"."+member(f), tabs)
+	}
+}
+
+func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, tabs int) {
+	ind := strings.Repeat("\t", tabs)
+	if f.Type.Kind == ir.TNamed {
+		switch r := f.Type.Ref.(type) {
+		case *ir.Struct:
+			if ir.TableFixedClampNeeded(r) {
+				g.pf("%s%sFixedClampBody(&%s, clamped)\n", ind, r.Name, expr)
+			}
+			return
+		case *ir.Union:
+			g.pf("%sif uint32(%s.Type) > %d { %s.Type = %sTypeNone; (*clamped)++ }\n",
+				ind, expr, r.Max, expr, f.Type.Name)
+			if !ir.TableFixedClampNeededUnionArm(r) {
+				return
+			}
+			g.pf("%sswitch %s.Type {\n", ind, expr)
+			for _, v := range r.Variants {
+				if v.F == nil || !ir.TableFixedClampNeededField(v.F) {
+					continue
+				}
+				g.pf("%scase %sType%s:\n", ind, f.Type.Name, ir.GoExportName(v.Name))
+				g.emitFixedClampElement(v.F, expr+"."+ir.GoExportName(v.Name), tabs+1)
+			}
+			g.pf("%s}\n", ind)
+			return
+		case *ir.Enum:
+			g.pf("%sif uint64(%s) > %d { %s = %sNone; (*clamped)++ }\n",
+				ind, expr, r.Max, expr, f.Type.Name)
+			return
+		}
+		return
+	}
+	width := int(ir.TableFixedStorageBytes(f.Type))
+	switch {
+	case f.Type.Kind == ir.TFloat32 && f.HasFloatRange:
+		lo, hi := formatFloat32(f.FMin), formatFloat32(f.FMax)
+		g.pf("%sif %s < %s { %s = %s; (*clamped)++ } else if %s > %s { %s = %s; (*clamped)++ }\n",
+			ind, expr, lo, expr, lo, expr, hi, expr, hi)
+	case f.Type.Kind == ir.TFloat64 && f.HasFloatRange:
+		lo, hi := formatFloat64(f.FMin), formatFloat64(f.FMax)
+		g.pf("%sif %s < %s { %s = %s; (*clamped)++ } else if %s > %s { %s = %s; (*clamped)++ }\n",
+			ind, expr, lo, expr, lo, expr, hi, expr, hi)
+	default:
+		signed := ir.TableKindSigned(ir.TableScalarKind(f))
+		if rlo, rhi, ok := ir.TableRawRange(f); ok {
+			low, high := tableClampEnds(f, width)
+			wide := width == 16
+			var lo, hi, lt, gt string
+			if wide {
+				lo, hi = wideLiteral(rlo, signed), wideLiteral(rhi, signed)
+				lt, gt = expr+".Cmp("+lo+") < 0", expr+".Cmp("+hi+") > 0"
+			} else {
+				lo, hi = goIntLit(rlo, signed, width), goIntLit(rhi, signed, width)
+				lt, gt = expr+" < "+lo, expr+" > "+hi
+			}
+			switch {
+			case low && high:
+				g.pf("%sif %s { %s = %s; (*clamped)++ } else if %s { %s = %s; (*clamped)++ }\n",
+					ind, lt, expr, lo, gt, expr, hi)
+			case low:
+				g.pf("%sif %s { %s = %s; (*clamped)++ }\n", ind, lt, expr, lo)
+			case high:
+				g.pf("%sif %s { %s = %s; (*clamped)++ }\n", ind, gt, expr, hi)
+			}
+		}
+		if f.Type.Kind == ir.TBits && int64(f.Type.Width) < 8*int64(width) {
+			maxv := (uint64(1) << f.Type.Width) - 1
+			g.pf("%sif %s > %d { %s = %d; (*clamped)++ }\n", ind, expr, maxv, expr, maxv)
+		}
+	}
 }
 
 // emitFixedForm1Load is the form-1 file reader for a DECLARED fixed table

--- a/internal/codegen/gotable/fixedform_test.go
+++ b/internal/codegen/gotable/fixedform_test.go
@@ -73,6 +73,9 @@ table Point {
 	if !strings.Contains(fixedLoad, "PointReset(&def)") {
 		t.Error("compiled holes have no default image")
 	}
+	if strings.Contains(body, "PointFixedClamp") {
+		t.Error("a type that declares nothing bounded must not emit a clamp pass")
+	}
 }
 
 // TestFixedFormForm1RefusalIsByTheKeyword is the other half of the surface
@@ -233,6 +236,38 @@ func TestPlanPath(t *testing.T) {
 		}
 		if back[0].Nested.A != 111 || back[0].Nested.B != 222 || r != (tblfx1.TableReport{}) {
 			t.Fatalf("same schema nesting/report: %+v %+v", back[0].Nested, r)
+		}
+	}
+
+	{
+		poison := tblfx1.FxRoot{}
+		tblfx1.FxRootReset(&poison)
+		poison.Keep = 1
+		poison.Renamed = 5000
+		poison.Gone = -7
+		poison.Nested.A = 111
+		poison.Nested.B = 222
+		wb := make([]byte, tblfx1.FxRootFixedMeasure(1))
+		if n := tblfx1.FxRootFixedSave([]tblfx1.FxRoot{poison}, wb); n != int64(len(wb)) {
+			t.Fatalf("bounds save %d", n)
+		}
+		back := make([]tblfx1.FxRoot, 1)
+		var r tblfx1.TableReport
+		plan := make([]tblfx1.TableFixedEntry, 1024)
+		if n := tblfx1.FxRootFixedLoad(back, wb, plan, &r); n != 1 {
+			t.Fatalf("RANGE identity n=%d %+v", n, r)
+		}
+		if back[0].Renamed != 1000 || back[0].Gone != 0 || r.Clamped != 2 {
+			t.Fatalf("RANGE identity: renamed=%d gone=%d clamped=%d", back[0].Renamed, back[0].Gone, r.Clamped)
+		}
+		back2 := make([]tblfx2.FxRoot, 1)
+		var r2 tblfx2.TableReport
+		plan2 := make([]tblfx2.TableFixedEntry, 2048)
+		if n := tblfx2.FxRootFixedLoad(back2, wb, plan2, &r2); n != 1 {
+			t.Fatalf("RANGE compiled n=%d %+v", n, r2)
+		}
+		if back2[0].RenamedTo != 1000 || r2.Clamped != 1 {
+			t.Fatalf("RANGE compiled: renamed_to=%d clamped=%d (gone is a field FX2 cannot name)", back2[0].RenamedTo, r2.Clamped)
 		}
 	}
 
@@ -627,10 +662,11 @@ func TestHostileBoolNegativeControl(t *testing.T) {
 }
 
 // TestFixedFormHostileUnionTag is the union tag's control. A tag beyond the
-// arms this reader has is form 1's UNKNOWN ARM ID (docs/SPEC-TABLES.md §4):
-// the union lands as None and `unknown` counts. Copied raw it would land as a
-// discriminant no variant spells, with every arm's guard declining to fill it
-// — a value that is neither None nor an arm, and nothing counted to say so.
+// arms this reader has is an ORDINAL past the set (docs/SPEC-TABLES.md §3.4):
+// the storage pass lands None and `clamped` counts. Copied raw it would land
+// as a discriminant no variant spells, with every arm's guard declining to
+// fill it — a value that is neither None nor an arm, and nothing counted to
+// say so.
 func TestFixedFormHostileUnionTag(t *testing.T) {
 	runGenerated(t, `package probe
 type Hit { damage int32 }
@@ -684,8 +720,8 @@ func TestUnknownTagIsNoneAndCounts(t *testing.T) {
 		if got[0].Pick.Type != PickTypeNone {
 			t.Fatalf("tag %d landed as %d, not None", tag, got[0].Pick.Type)
 		}
-		if r.Unknown != 1 || r.KindMismatch != 0 || r.Malformed || r.Verdict != TableOpenOk {
-			t.Fatalf("tag %d: an unknown arm is one unknown and nothing else: %+v", tag, r)
+		if r.Clamped != 1 || r.Unknown != 0 || r.KindMismatch != 0 || r.Malformed || r.Verdict != TableOpenOk {
+			t.Fatalf("tag %d: an ordinal past the set is one clamp and nothing else: %+v", tag, r)
 		}
 		if got[0].Tail != 9 {
 			t.Fatalf("tag %d: the field past the union moved: %d", tag, got[0].Tail)
@@ -890,6 +926,184 @@ func TestOldArgLaneControl(t *testing.T) {
 	}
 	if got.Pick.Type != PickTypeB {
 		t.Fatalf("old-lane sabotage moved the arm: %d %+v", got.Pick.Type, r)
+	}
+}
+`)
+}
+
+func tableFile(files map[string][]byte) string {
+	body := ""
+	for name, data := range files {
+		if strings.HasSuffix(name, "Table.go") {
+			body += string(data)
+		}
+	}
+	return body
+}
+
+func TestFixedFormClampPassShape(t *testing.T) {
+	tagOnly := generate(t, `package probe
+type Boost { power int32 = 0 }
+type Ward { charge float32 = 0.0 }
+union Effect
+{
+    boost Boost
+    ward Ward
+}
+table Cfg {
+    a int32 = 5 | min = 0, max = 1000
+    effect Effect
+    marks [..4]int32 | min = 0, max = 10
+    note ?int32 | min = 0, max = 10
+}
+`)
+	body := tableFile(tagOnly)
+	clampBody := funcSource(body, "func CfgFixedClampBody(")
+	if clampBody == "" {
+		t.Fatal("CfgFixedClampBody was not emitted")
+	}
+	if !strings.Contains(clampBody, "if uint32(value.Effect.Type) > 2") {
+		t.Error("a union tag past the arm count must still remap to None")
+	}
+	if strings.Contains(clampBody, "switch value.Effect.Type") {
+		t.Error("a union whose arms declare nothing bounded must not emit a switch with nothing to switch on")
+	}
+	if !strings.Contains(clampBody, "for i := int64(0); i < int64(value.MarksCount); i++") {
+		t.Error("a counted array must clamp LIVE elements, not the declared bound")
+	}
+	if strings.Contains(clampBody, "i < 4") {
+		t.Error("a counted array's clamp loop must not walk the slack")
+	}
+	if !strings.Contains(clampBody, "if value.NotePresent") {
+		t.Error("an absent optional's payload must not be held to a bound")
+	}
+	load := funcSource(body, "func CfgFixedLoad(")
+	if !strings.Contains(load, "CfgFixedClamp(&values[k], report)") {
+		t.Error("FixedLoad must call the storage pass after the run, both paths")
+	}
+	if strings.Contains(body, "Op: tableFixedTag") {
+		t.Error("identity must copy the tag; the storage pass holds the bound")
+	}
+
+	rangedArm := generate(t, `package probe
+type Boost { power int32 = 0 | min = 0, max = 10 }
+type Ward { charge float32 = 0.0 }
+union Effect
+{
+    boost Boost
+    ward Ward
+}
+table Cfg {
+    a int32 = 5 | min = 0, max = 1000
+    effect Effect
+}
+`)
+	with := tableFile(rangedArm)
+	bodyFn := funcSource(with, "func CfgFixedClampBody(")
+	if !strings.Contains(bodyFn, "switch value.Effect.Type") {
+		t.Error("a union with a bounded arm must still switch over the set arm")
+	}
+	if !strings.Contains(bodyFn, "case EffectTypeBoost:") {
+		t.Error("the bounded arm must be a case")
+	}
+}
+
+func TestFixedFormClampLiveCount(t *testing.T) {
+	runGenerated(t, `package probe
+enum Grade { Bronze, Gold }
+type ArmA { n int32 = 0 | min = 0, max = 10 }
+type ArmB { m int32 = 0 }
+union Pick
+{
+    a ArmA
+    b ArmB
+}
+table Root {
+    n     int32 = 0 | min = 0, max = 10
+    marks [..4]int32 | min = 0, max = 10
+    note  ?int32 | min = 0, max = 10
+    pick  Pick
+    grade Grade
+}
+`, `package probe
+import ("testing")
+
+func TestLiveCount(t *testing.T) {
+	one := Root{}
+	RootReset(&one)
+	one.N = 99
+	one.MarksCount = 1
+	one.Marks[0] = 99
+	one.Marks[1] = 99
+	one.Marks[2] = 99
+	one.Marks[3] = 99
+	one.NotePresent = false
+	one.Note = 99
+	need := RootFixedMeasure(1)
+	buf := make([]byte, need)
+	if n := RootFixedSave([]Root{one}, buf); n != need {
+		t.Fatalf("save %d", n)
+	}
+	got := make([]Root, 1)
+	var r TableReport
+	plan := make([]TableFixedEntry, 256)
+	if n := RootFixedLoad(got, buf, plan, &r); n != 1 {
+		t.Fatalf("load %d %+v", n, r)
+	}
+	if got[0].N != 10 || r.Clamped != 2 {
+		t.Fatalf("LIVE: n=%d marks0=%d clamped=%d (want n=10, two clamps: n and marks[0]; slack must not count)", got[0].N, got[0].Marks[0], r.Clamped)
+	}
+	if got[0].Marks[0] != 10 {
+		t.Fatalf("live element %d", got[0].Marks[0])
+	}
+
+	tag := Root{}
+	RootReset(&tag)
+	tag.Pick.Type = PickType(7)
+	tb := make([]byte, RootFixedMeasure(1))
+	if n := RootFixedSave([]Root{tag}, tb); n != int64(len(tb)) {
+		t.Fatalf("tag save %d", n)
+	}
+	got = make([]Root, 1)
+	r = TableReport{}
+	if n := RootFixedLoad(got, tb, plan, &r); n != 1 {
+		t.Fatalf("tag load %d %+v", n, r)
+	}
+	if got[0].Pick.Type != PickTypeNone || r.Clamped != 1 || r.Unknown != 0 {
+		t.Fatalf("ORDINAL tag: type=%d clamped=%d unknown=%d", got[0].Pick.Type, r.Clamped, r.Unknown)
+	}
+
+	en := Root{}
+	RootReset(&en)
+	en.Grade = Grade(9)
+	eb := make([]byte, RootFixedMeasure(1))
+	if n := RootFixedSave([]Root{en}, eb); n != int64(len(eb)) {
+		t.Fatalf("enum save %d", n)
+	}
+	got = make([]Root, 1)
+	r = TableReport{}
+	if n := RootFixedLoad(got, eb, plan, &r); n != 1 {
+		t.Fatalf("enum load %d %+v", n, r)
+	}
+	if got[0].Grade != GradeNone || r.Clamped != 1 {
+		t.Fatalf("ORDINAL enum: grade=%d clamped=%d", got[0].Grade, r.Clamped)
+	}
+
+	arm := Root{}
+	RootReset(&arm)
+	arm.Pick.Type = PickTypeB
+	arm.Pick.A.N = 99
+	ab := make([]byte, RootFixedMeasure(1))
+	if n := RootFixedSave([]Root{arm}, ab); n != int64(len(ab)) {
+		t.Fatalf("arm save %d", n)
+	}
+	got = make([]Root, 1)
+	r = TableReport{}
+	if n := RootFixedLoad(got, ab, plan, &r); n != 1 {
+		t.Fatalf("arm load %d %+v", n, r)
+	}
+	if r.Clamped != 0 {
+		t.Fatalf("unselected arm must not count: clamped=%d", r.Clamped)
 	}
 }
 `)


### PR DESCRIPTION
Rowan ruling rowan-256bc36cd9c9: clamp and ordinal counters count LIVE elements only, both paths. Slack is never counted.

Off `johnny/go-fixed-form` at 9a825e9f. Does not rebase onto `fixed-table-form`.

Go had no storage pass. Identity counted union tags in the plan loop (`tableFixedTag` → `unknown`), which covers slack slots of a counted array of unions. Compiled remapped without counting.

This is the C++ reference's pass (`FixedClamp` after the copy, over storage):

- `RootFixedClamp` / `RootFixedClampBody` after `tableFixedRun` on both identity and compiled
- counted arrays walk `Count`, not the bound
- an optional's payload only when `Present`
- a union's set arm, not the others
- identity copies the tag; the pass remaps past the set to None and counts `clamped`

Tests: `TestFixedFormClampPassShape`, `TestFixedFormClampLiveCount`, FX1/FX2 range identity vs compiled, hostile tag now `clamped`.

Johnny Grok