### PR TITLE
tables: C fixedform generates and pins FU1/FU2

### DIFF
--- a/make/c.mk
+++ b/make/c.mk
@@ -882,7 +882,13 @@ test-c tables-c: tables-c-view
 # test/c-tables/fixedform.h is the whole surface between them and names no
 # generated type at all, and the main links them — the shape the conformance
 # driver already uses for two generations of one schema.
-build/tables-generated-c-fixed/.stamp: bin/schema test/tables/FX1.schema test/tables/FX2.schema test/tables/V1.schema test/tables/V2.schema test/tables/UT1.schema test/tables/UT2.schema
+#
+# FU1/FU2 is the TEXT-UNDER-AN-ARM pair whose compiled path is a TRAILING
+# FIELD, not a slid ordinal: FU1's second arm carries a string(8), FU2 appends
+# `extra` so a read of FU1's bytes is a compiled plan, and the two reads have
+# to agree on the text (reference-fix 12). UT1/UT2 is the two-lane / slid-arm
+# half of the same hole. C++ already generates the pair; this stamp did not.
+build/tables-generated-c-fixed/.stamp: bin/schema test/tables/FX1.schema test/tables/FX2.schema test/tables/V1.schema test/tables/V2.schema test/tables/UT1.schema test/tables/UT2.schema test/tables/FU1.schema test/tables/FU2.schema
 	@mkdir -p build/tables-generated-c-fixed
 	./bin/schema generate --lang c --out build/tables-generated-c-fixed/fx1 test/tables/FX1.schema
 	./bin/schema generate --lang c --out build/tables-generated-c-fixed/fx2 test/tables/FX2.schema
@@ -890,14 +896,18 @@ build/tables-generated-c-fixed/.stamp: bin/schema test/tables/FX1.schema test/ta
 	./bin/schema generate --lang c --out build/tables-generated-c-fixed/v2 test/tables/V2.schema
 	./bin/schema generate --lang c --out build/tables-generated-c-fixed/ut1 test/tables/UT1.schema
 	./bin/schema generate --lang c --out build/tables-generated-c-fixed/ut2 test/tables/UT2.schema
+	./bin/schema generate --lang c --out build/tables-generated-c-fixed/fu1 test/tables/FU1.schema
+	./bin/schema generate --lang c --out build/tables-generated-c-fixed/fu2 test/tables/FU2.schema
 	@touch $@
 
 C_FIXEDFORM_SOURCES := test/c-tables/fixedform_main.c test/c-tables/fixedform_fx1.c test/c-tables/fixedform_fx2.c \
 	test/c-tables/fixedform_v1.c test/c-tables/fixedform_v2.c \
-	test/c-tables/fixedform_ut1.c test/c-tables/fixedform_ut2.c
+	test/c-tables/fixedform_ut1.c test/c-tables/fixedform_ut2.c \
+	test/c-tables/fixedform_fu1.c test/c-tables/fixedform_fu2.c
 C_FIXEDFORM_INCLUDES := -Itest/c-tables -Ibuild/tables-generated-c-fixed/fx1 -Ibuild/tables-generated-c-fixed/fx2 \
 	-Ibuild/tables-generated-c-fixed/v1 -Ibuild/tables-generated-c-fixed/v2 \
-	-Ibuild/tables-generated-c-fixed/ut1 -Ibuild/tables-generated-c-fixed/ut2 -I$(SERIALIZE_C)
+	-Ibuild/tables-generated-c-fixed/ut1 -Ibuild/tables-generated-c-fixed/ut2 \
+	-Ibuild/tables-generated-c-fixed/fu1 -Ibuild/tables-generated-c-fixed/fu2 -I$(SERIALIZE_C)
 
 build/schema_test_c_fixedform: build/tables-generated-c-fixed/.stamp $(C_FIXEDFORM_SOURCES) test/c-tables/fixedform.h
 	@mkdir -p build

--- a/test/c-tables/fixedform.h
+++ b/test/c-tables/fixedform.h
@@ -34,6 +34,8 @@ int64_t fixed_ut1_write( uint8_t * buffer, int64_t capacity );
 int64_t fixed_ut1_bytes( void );
 int64_t fixed_ut2_write( uint8_t * buffer, int64_t capacity );
 int64_t fixed_ut2_bytes( void );
+int64_t fixed_fu1_write( uint8_t * buffer, int64_t capacity );
+int64_t fixed_fu1_bytes( void );
 
 /* ...and each reads the other's, through the ONE plan-driven path. */
 void fixed_fx1_read_own( const uint8_t * data, int64_t bytes );
@@ -51,6 +53,12 @@ void fixed_ut1_read_own( const uint8_t * data, int64_t bytes );
 void fixed_ut1_shared_lane_control( const uint8_t * data, int64_t bytes );
 void fixed_ut1_read_ut2( const uint8_t * data, int64_t bytes );
 void fixed_ut2_read_ut1( const uint8_t * data, int64_t bytes );
+
+/* TEXT UNDER AN ARM, identity then compiled (docs/SPEC-TABLES.md §3.4, §15).
+   FU2 appends a field so a read of FU1's bytes is a compiled plan; the text
+   in the union's SECOND arm has to land on both paths. */
+void fixed_fu1_read_own( const uint8_t * data, int64_t bytes );
+void fixed_fu2_read_fu1( const uint8_t * data, int64_t bytes );
 
 /* THE BOUNDS THE READ LOOP DOES NOT HOLD (docs/SPEC-TABLES.md §3.4): a ranged
    scalar's declared min and max, and an ORDINAL's set. Straight-line in the

--- a/test/c-tables/fixedform_fu1.c
+++ b/test/c-tables/fixedform_fu1.c
@@ -1,0 +1,73 @@
+/* FU1's half of TEXT UNDER AN ARM (docs/SPEC-TABLES.md §3.4, §15). A
+   `string(8)` sits in the union's SECOND arm, with a scalar either side so a
+   mislaid length or a mislaid guard moves a neighbour. This translation unit
+   is the ONLY one that names tblfu1's types; see fixedform.h for why there is
+   more than one.
+
+   THE IDENTITY SAVE is this side's job: two records, labelled then plain, so
+   the arm that is right by accident for flavour 1 sits beside the arm that is
+   not. The compiled read of the same bytes is FU2's. */
+
+#include <string.h>
+
+#include "FU1Table.h"
+#include "fixedform.h"
+
+#define PlanCapacity 8192
+static TableFixedEntry g_plan[PlanCapacity];
+
+static void fill_labelled( FuRoot * value )
+{
+    fu_root_reset( value );
+    value->flag = 1;
+    value->note = 44;
+    value->note_present = 1;
+    value->pick.type = PICK_TYPE_LABELLED; /* the SECOND arm */
+    value->pick.as.labelled.lead = 101;
+    strcpy( value->pick.as.labelled.label, "hello" );
+    value->pick.as.labelled.label_length = 5;
+    value->pick.as.labelled.trail = 202;
+    value->tail = 11;
+}
+
+static void fill_plain( FuRoot * value )
+{
+    fu_root_reset( value );
+    value->pick.type = PICK_TYPE_PLAIN;
+    value->pick.as.plain.n = 303;
+    value->tail = 12;
+}
+
+int64_t fixed_fu1_bytes( void ) { return fu_root_fixed_measure( 2 ); }
+
+int64_t fixed_fu1_write( uint8_t * buffer, int64_t capacity )
+{
+    FuRoot v[2];
+    fill_labelled( &v[0] );
+    fill_plain( &v[1] );
+    return fu_root_fixed_save( v, 2, buffer, capacity );
+}
+
+void fixed_fu1_read_own( const uint8_t * data, int64_t bytes )
+{
+    FuRoot back[2];
+    TableReport r;
+
+    memset( &r, 0, sizeof( r ) );
+    fixed_check( fu_root_fixed_load( back, 2, data, bytes, g_plan, PlanCapacity, NULL, &r ) == 2,
+                 "C text under an arm: the identity read takes both records" );
+    fixed_check( back[0].pick.type == PICK_TYPE_LABELLED, "C text under an arm: identity, the SECOND arm" );
+    fixed_check( back[0].pick.as.labelled.lead == 101,
+                 "C text under an arm: identity, the scalar BEFORE the text" );
+    fixed_check( back[0].pick.as.labelled.label_length == 5 &&
+                 strcmp( back[0].pick.as.labelled.label, "hello" ) == 0,
+                 "C text under an arm: the IDENTITY read lands the text" );
+    fixed_check( back[0].pick.as.labelled.trail == 202,
+                 "C text under an arm: identity, the scalar AFTER the text" );
+    fixed_check( back[0].flag == 1 && back[0].note_present == 1 && back[0].note == 44 && back[0].tail == 11,
+                 "C text under an arm: identity, the rest of the labelled record" );
+    fixed_check( back[1].pick.type == PICK_TYPE_PLAIN && back[1].pick.as.plain.n == 303 && back[1].tail == 12,
+                 "C text under an arm: identity, the FIRST arm as well" );
+    fixed_check( r.clamped == 0 && !r.malformed && !r.refused,
+                 "C text under an arm: identity, a clean read moves no counter" );
+}

--- a/test/c-tables/fixedform_fu2.c
+++ b/test/c-tables/fixedform_fu2.c
@@ -1,0 +1,41 @@
+/* FU2's half of TEXT UNDER AN ARM (docs/SPEC-TABLES.md §3.4, §15). FU2 appends
+   `extra` and nothing else moves, so a read of FU1's bytes is a COMPILED plan
+   rather than the identity one — and the compiled plan is the path where an
+   overloaded plan lane dropped a union arm's text (reference-fix 12). This
+   translation unit is the ONLY one that names tblfu2's types. */
+
+#include <string.h>
+
+#include "FU2Table.h"
+#include "fixedform.h"
+
+#define PlanCapacity 8192
+static TableFixedEntry g_plan[PlanCapacity];
+
+void fixed_fu2_read_fu1( const uint8_t * data, int64_t bytes )
+{
+    FuRoot back[2];
+    TableReport r;
+
+    memset( &r, 0, sizeof( r ) );
+    fixed_check( fu_root_fixed_load( back, 2, data, bytes, g_plan, PlanCapacity, NULL, &r ) == 2,
+                 "C text under an arm: the compiled read takes both records" );
+    fixed_check( back[0].pick.type == PICK_TYPE_LABELLED, "C text under an arm: compiled, the SECOND arm" );
+    fixed_check( back[0].pick.as.labelled.lead == 101,
+                 "C text under an arm: compiled, the scalar BEFORE the text" );
+    fixed_check( back[0].pick.as.labelled.label_length == 5 &&
+                 strcmp( back[0].pick.as.labelled.label, "hello" ) == 0,
+                 "C text under an arm: the COMPILED read still sees the text" );
+    fixed_check( back[0].pick.as.labelled.trail == 202,
+                 "C text under an arm: compiled, the scalar AFTER the text" );
+    fixed_check( back[0].flag == 1 && back[0].note_present == 1 && back[0].note == 44 && back[0].tail == 11,
+                 "C text under an arm: compiled, the rest of the labelled record" );
+    fixed_check( back[0].extra == 11,
+                 "C text under an arm: the field FU1 does not carry took its declared default" );
+    fixed_check( back[1].pick.type == PICK_TYPE_PLAIN && back[1].pick.as.plain.n == 303 && back[1].tail == 12,
+                 "C text under an arm: compiled, the FIRST arm as well" );
+    fixed_check( back[1].extra == 11,
+                 "C text under an arm: compiled, `extra` defaults on the FIRST arm too" );
+    fixed_check( r.clamped == 0 && !r.malformed && !r.refused,
+                 "C text under an arm: compiled, a clean read moves no counter" );
+}

--- a/test/c-tables/fixedform_main.c
+++ b/test/c-tables/fixedform_main.c
@@ -63,6 +63,11 @@ int main( void )
     fixed_check( n == fixed_ut2_bytes(), "UT2 save" );
     fixed_ut1_read_ut2( g_buffer, n );
 
+    n = fixed_fu1_write( g_buffer, BufferBytes );
+    fixed_check( n == fixed_fu1_bytes(), "FU1 save" );
+    fixed_fu1_read_own( g_buffer, n );
+    fixed_fu2_read_fu1( g_buffer, n );
+
     /* THE BYTE-FLIP FUZZ, and §3.4 says it is not optional. Every byte of a
        form-3 file, one bit at a time, handed to a reader of the other
        generation: three answers are allowed and a fourth — a step outside the


### PR DESCRIPTION
## Why

Leftover named when #838 closed as superseded by #854: FU1/FU2 (TEXT-UNDER-AN-ARM) sat on the tree, C++ already generated them, Rust and Elixir already listed them, and `tables-c-fixedform` did not.

A `string(8)` lives in a union's second arm. FU2 appends `extra` so a read of FU1's bytes goes through a compiled plan. That is the hole reference-fix 12 was: identity landed the text, compiled read it as empty, no counter.

UT1/UT2 already holds the two-lane / slid-arm half on this leg. This pair is the trailing-field compile trigger.

## What

`make/c.mk` now generates the pair the same way the sibling fixtures are generated:

```
./bin/schema generate --lang c --out build/tables-generated-c-fixed/fu1 test/tables/FU1.schema
./bin/schema generate --lang c --out build/tables-generated-c-fixed/fu2 test/tables/FU2.schema
```

The pin is two translation units (C has no namespace). Identity save of union arm 2 round-trips. FU2's compiled read of those bytes still sees the text, and `extra` takes its declared default. One path: `fu_root_fixed_load`. No second reader. No identity memcpy.

## Gate

`make tables-c-fixedform` green, including the ASan twin (2536 byte flips answered inside the buffer).

Draft against `fixed-table-form`. Do not merge.

Johnny Grok