### PR TITLE
darttable: named string(N) default lives in constructed storage

### DIFF
--- a/compiler/valuedefaults_test.go
+++ b/compiler/valuedefaults_test.go
@@ -241,6 +241,14 @@ func TestFixedTableValueDefaultsEveryLeg(t *testing.T) {
 					t.Errorf("C fixed-form prefill lacks %q", want)
 				}
 			}
+		case "dart":
+			// construction storage, not length-only: `"fx"` in the generated
+			// field initializer, the way C++ writes `char label[8 + 1] = "fx"`
+			for _, want := range []string{`"fx"`, "labelLength = 2", "..[0] = 0x66", "..[1] = 0x78"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("dart fixed-form storage lacks %q", want)
+				}
+			}
 		}
 	}
 }

--- a/internal/codegen/darttable/fixeddart.go
+++ b/internal/codegen/darttable/fixeddart.go
@@ -402,8 +402,20 @@ func (g *fixedGen) emitFieldStorage(f *ir.Field, ind string) {
 		g.emitListStorage(f, ind, name, f.ArrayBound)
 		g.pf("%sint %sCount = %d;\n", ind, name, f.ArrayMin)
 	case f.Type.Kind == ir.TString, f.Type.Kind == ir.TBytes:
-		g.pf("%sfinal Uint8List %s = Uint8List(%d);\n", ind, name, f.Type.Size)
-		g.pf("%sint %sLength = %d;\n", ind, name, fixedDefaultTextLength(f))
+		// THE DECLARED DEFAULT IS THE VALUE, NOT JUST ITS LENGTH (SPEC §4.2).
+		// Length-only left a constructed record claiming N used bytes of an
+		// empty buffer: C++ writes `char label[8 + 1] = "fx"` and JS
+		// `.set([102, 120])` at construction. Reset already laid the bytes
+		// back in; construction did not.
+		n := fixedDefaultTextLength(f)
+		if n == 0 {
+			g.pf("%sfinal Uint8List %s = Uint8List(%d);\n", ind, name, f.Type.Size)
+		} else {
+			g.pf("%s// the declared default (SPEC §4.2): %q\n", ind, string(f.DefBytes[:n]))
+			g.pf("%sfinal Uint8List %s = Uint8List(%d)\n", ind, name, f.Type.Size)
+			g.emitTextDefaultCascade(f, ind, n)
+		}
+		g.pf("%sint %sLength = %d;\n", ind, name, n)
 	case f.Type.Kind == ir.TWString:
 		g.pf("%sfinal Uint16List %s = Uint16List(%d);\n", ind, name, f.Type.Size)
 		g.pf("%sint %sLength = 0;\n", ind, name)
@@ -524,6 +536,17 @@ func (g *fixedGen) emitTextDefaultBytes(f *ir.Field, ind, target string) {
 	name := dartName(f.Name)
 	for i := range n {
 		g.pf("%s%s.%s[%d] = 0x%02x;\n", ind, target, name, i, f.DefBytes[i])
+	}
+}
+
+// emitTextDefaultCascade lays the same default into a field initializer.
+func (g *fixedGen) emitTextDefaultCascade(f *ir.Field, ind string, n int64) {
+	for i := range n {
+		end := ""
+		if i == n-1 {
+			end = ";"
+		}
+		g.pf("%s  ..[%d] = 0x%02x%s\n", ind, i, f.DefBytes[i], end)
 	}
 }
 

--- a/internal/codegen/darttable/fixedform_test.go
+++ b/internal/codegen/darttable/fixedform_test.go
@@ -308,6 +308,40 @@ func TestFixedPrefillCarriesDeclaredDefaults(t *testing.T) {
 	}
 }
 
+// A NAMED string(N) DEFAULT LIVES IN CONSTRUCTED STORAGE, not only in the
+// prefill and not only as a used length. FX1's `label string(8) = "fx"` is
+// the leftover: C++ still writes `char label[8 + 1] = "fx"`, and Dart used
+// to emit `Uint8List(8)` plus `labelLength = 2` — two claimed bytes of NULs.
+func TestNamedStringDefaultLivesInStorage(t *testing.T) {
+	u := unitFrom(t, `package probe
+
+table Fx1
+{
+    label string(8) = "fx"
+}
+`)
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var all string
+	for _, b := range files {
+		all += string(b)
+	}
+	if !strings.Contains(all, `"fx"`) {
+		t.Fatalf("generated Dart must carry the named default \"fx\":\n%s", all)
+	}
+	if !strings.Contains(all, "labelLength = 2") {
+		t.Fatalf("generated Dart must carry labelLength = 2:\n%s", all)
+	}
+	if strings.Contains(all, "final Uint8List label = Uint8List(8);") {
+		t.Fatalf("construction allocated an empty buffer; \"fx\" is length-only:\n%s", all)
+	}
+	if !strings.Contains(all, "..[0] = 0x66") || !strings.Contains(all, "..[1] = 0x78") {
+		t.Fatalf("construction must lay the bytes of \"fx\" into the buffer:\n%s", all)
+	}
+}
+
 // THE IDENTITY PLAN IS THE REFERENCE'S LEAF WALK COALESCED, and what this pins
 // is the property that makes it correct rather than merely small: EVERY COUNT
 // AND EVERY TEXT LENGTH THE TYPE DECLARES HAS ITS OWN ENTRY. Those two are the

--- a/test/dart-tables/fixedform.dart
+++ b/test/dart-tables/fixedform.dart
@@ -194,6 +194,16 @@ void corpusFiles(String dir) {
     final out = Uint8List(fx1.fxRootFixedMeasure(n));
     check(fx1.fxRootFixedSave(values, n, out) == out.length, 'fx1: save');
     sameBytes(out, file, 'fx1');
+
+    // A DECLARED DEFAULT IS THE VALUE, NOT JUST ITS LENGTH. The round trip
+    // above cannot see this: a value READ from the file already has the
+    // record's bytes. C++ writes `char label[8 + 1] = "fx"`; a fresh FxRoot
+    // used to claim two used bytes of NULs.
+    final fresh = fx1home.FxRoot();
+    check(
+      fresh.labelLength == 2 && text(fresh.label, 2) == 'fx',
+      'fx1: a fresh FxRoot carries label "fx", not two NULs of length 2',
+    );
   }
 
   // ---- fx2.bin: one record of FX2's FxRoot, with the extra nested type ----


### PR DESCRIPTION
## Leftover

#834 landed Dart's fixed form. FX1 leftover stayed named: `label string(8) = "fx"`. Not registered.

C++ still writes `char label[8 + 1] = "fx"`. Dart's dest-row and identity fill were not the hole. Identity is still the leaf walk (copy + count + text), no hole list, no second reader. Prefill and `init*` already laid the bytes.

The hole was the **generated field initializer**: construction emitted `Uint8List(8)` plus `labelLength = 2` — two claimed bytes of NULs. The darttable probe schemas also dropped `= "fx"`, so the go tests could not see it.

## Fix

`emitFieldStorage` now cascades the declared default into the `Uint8List` at construction, the twin of JS `.set([102, 120])`. Generated Dart carries `"fx"` in a comment and the bytes `0x66, 0x78`.

ONE PATH. Hash still chooses the plan. Did not invent a hole list. Did not add identity memcpy / a second reader.

## Tests

- `go test ./internal/codegen/darttable` (new `TestNamedStringDefaultLivesInStorage`)
- `go test ./compiler -run TestFixedTableValueDefaultsEveryLeg` (dart case now asserts `"fx"`)
- `make tables-dart-fixed-form` (fresh `FxRoot()` carries `label == "fx"`)

Draft against `fixed-table-form`. Do not merge.

Johnny Grok