### PR TITLE
jstable: compare the union guard at ArgW, not one byte

### DIFF
--- a/generated/bench/paired/js/BenchTable.js
+++ b/generated/bench/paired/js/BenchTable.js
@@ -60,10 +60,10 @@ export const TableFixedEntryBytes = 17;
 // the layout's own framing: the u32 entry count, and nothing else
 export const TableFixedLayoutHeaderBytes = 4;
 
-// A PLAN ENTRY is eight int32 lanes of one flat Int32Array. A flat array of a
+// A PLAN ENTRY is nine int32 lanes of one flat Int32Array. A flat array of a
 // fixed stride is what keeps the read loop monomorphic: every lane is a
 // Smi, the loop never touches a property name, and nothing is allocated.
-export const TableFixedLanes = 8;
+export const TableFixedLanes = 9;
 // ONE BINDING PER LINE, and that is not a style choice: §11's claim is made
 // name by name, and a scan that reads a module's bindings sees the FIRST name
 // of a comma list. A lane folded into a list beside another is a lane nobody
@@ -76,6 +76,7 @@ const TableFixedLaneAux = 4;
 const TableFixedLaneGuard = 5;
 const TableFixedLaneArg = 6;
 const TableFixedLaneMeta = 7; // a widen's width and sign, a text entry's flavour
+const TableFixedLaneArgW = 8; // THE GUARD'S WIDTH IN BYTES: a union tag is 1, 2, 4 or 8
 
 // THE OPS ARE THE WHOLE SET. The IDENTITY plan carries only the first; the
 // others are what a plan compiled from another writer's layout adds.
@@ -162,6 +163,8 @@ export class TableFixedPlan {
     this.hashHi = 0;
     this.ready = false;
     this.overflow = false;
+    // the CURRENT union's tag width, stamped onto every push — C++'s c.argw
+    this.argw = 1;
   }
 }
 
@@ -219,6 +222,22 @@ function TableFixedGetU32(bytes, at) {
   return (bytes[at] | (bytes[at + 1] << 8) | (bytes[at + 2] << 16) | (bytes[at + 3] << 24)) >>> 0;
 }
 
+// THE TAG IS COMPARED AT ITS OWN WIDTH. A two- or four-byte tag whose low
+// byte happens to be 1 is not arm 1: it is an ordinal this build has no arm
+// for, and reading only the first byte let 0x0101 run arm 1's entries over
+// a stranger's record. ArgW 0 means 1, as C++.
+function TableFixedTagAt(src, at, argw) {
+  let w = argw | 0;
+  if (w === 0) { w = 1; }
+  else if (w > 8) { w = 8; }
+  let v = 0, p = 1;
+  for (let i = 0; i < w; i++) {
+    v += src[at + i] * p;
+    p *= 256;
+  }
+  return v;
+}
+
 // ---- THE ONE READ LOOP -----------------------------------------------------
 //
 // A READ IS A PREFILL AND THIS LOOP, AND NOTHING ELSE. Which plan it is handed
@@ -231,8 +250,12 @@ export function TableFixedRun(plan, entryCount, src, srcView, srcAt, dst, dstVie
   for (let i = 0; i < entryCount; i++) {
     const b = i * TableFixedLanes;
     const guard = e[b + TableFixedLaneGuard];
-    // an entry belonging to an ARM runs only under its own tag
-    if (guard !== TableFixedNoGuard && src[srcAt + guard] !== e[b + TableFixedLaneArg]) { continue; }
+    // an entry belonging to an ARM runs only under its own tag, compared at
+    // ArgW bytes, never as a prefix
+    if (guard !== TableFixedNoGuard &&
+        TableFixedTagAt(src, srcAt + guard, e[b + TableFixedLaneArgW]) !== (e[b + TableFixedLaneArg] >>> 0)) {
+      continue;
+    }
     const s = srcAt + e[b + TableFixedLaneSrc];
     const d = e[b + TableFixedLaneDst];
     const size = e[b + TableFixedLaneSize];
@@ -509,6 +532,10 @@ function TableFixedPush(plan, op, src, dst, size, aux, guard, arg, meta) {
   e[b + TableFixedLaneGuard] = guard;
   e[b + TableFixedLaneArg] = arg;
   e[b + TableFixedLaneMeta] = meta;
+  // argw IS THE GUARD'S WIDTH IN BYTES. Flavour stays in meta. Zero is one.
+  let w = plan.argw | 0;
+  if (w === 0) { w = 1; }
+  e[b + TableFixedLaneArgW] = w;
   plan.count++;
 }
 
@@ -633,6 +660,8 @@ function TableFixedCompileEntry(plan, theirs, ti, theirAt, mine, mi, dst, myAt, 
     case 15: { // a union: the tag, remapped, then each arm matched by id
       const theirTag = TableFixedTagBytes(theirs, ti);
       const myTag = TableFixedTagBytes(mine, mi);
+      const savedArgw = plan.argw;
+      plan.argw = (theirTag >= 1 && theirTag <= 8) ? theirTag : 1;
       const theirArms = TableFixedChildren(theirs, ti);
       const myArms = TableFixedChildren(mine, mi);
       let myArm = mi + 1;
@@ -650,6 +679,7 @@ function TableFixedCompileEntry(plan, theirs, ti, theirAt, mine, mi, dst, myAt, 
         }
         myArm += TableFixedSubtree(mine, myArm);
       }
+      plan.argw = savedArgw;
       break;
     }
     case 30: { // an enum: the ordinal is the layout's position, so it remaps
@@ -703,6 +733,7 @@ function TableFixedCoalesce(plan) {
       const p = (out - 1) * TableFixedLanes;
       if (e[p + TableFixedLaneOp] === TableFixedOpCopy && e[b + TableFixedLaneOp] === TableFixedOpCopy &&
           e[p + TableFixedLaneGuard] === e[b + TableFixedLaneGuard] && e[p + TableFixedLaneArg] === e[b + TableFixedLaneArg] &&
+          e[p + TableFixedLaneArgW] === e[b + TableFixedLaneArgW] &&
           e[p + TableFixedLaneSrc] + e[p + TableFixedLaneSize] === e[b + TableFixedLaneSrc] &&
           e[p + TableFixedLaneDst] + e[p + TableFixedLaneSize] === e[b + TableFixedLaneDst]) {
         e[p + TableFixedLaneSize] += e[b + TableFixedLaneSize];
@@ -724,6 +755,7 @@ export function TableFixedCompile(theirs, myLayout, myDst, plan, report) {
   plan.count = 0;
   plan.remapUsed = 0;
   plan.overflow = false;
+  plan.argw = 1;
   TableFixedMatchChildren(plan, theirs, 0, 0, mine, 0, myDst, 0, TableFixedNoGuard, 0, report);
   if (plan.overflow) { return -1; }
   TableFixedCoalesce(plan);

--- a/generated/bench/paired/js/FixedTableTable.js
+++ b/generated/bench/paired/js/FixedTableTable.js
@@ -299,7 +299,7 @@ const FixedTableFixedDst = new Int32Array([
 // source and destination advance together over the whole body and the walk
 // coalesces to exactly ONE run. That is the same coalescer the plan compiler
 // runs, reaching its best case rather than skipping a step.
-const FixedTableFixedIdentity = new Int32Array([0, 0, 0, 1236, 0, -1, 0, 0]);
+const FixedTableFixedIdentity = new Int32Array([0, 0, 0, 1236, 0, -1, 0, 0, 1]);
 
 // THE PLAN'S STORAGE IS THE CALLER'S, DECLARED BY CAPACITY, AND THE CODEC
 // NEVER ALLOCATES. One of these per peer; a layout whose plan does not fit is

--- a/internal/codegen/jstable/fixedform_test.go
+++ b/internal/codegen/jstable/fixedform_test.go
@@ -241,6 +241,58 @@ table Config {
 	}
 }
 
+// THE GUARD IS COMPARED AT ArgW BYTES, NEVER AS A PREFIX. A one-byte compare
+// fires arm 1 on a foreign 0x0101. The C++/IR leftover on #830 was that JS
+// still read src[guard] as a single byte; TableFixedTagAt is the C++ twin and
+// the ninth lane carries the width the compiler stamps the way C++ stamps
+// e.argw. Flavour stays in Meta. Identity is still one COPY of the body —
+// the ArgW lane on that entry is 1, which is the width a tag had when this
+// field did not exist.
+func TestFixedGuardComparedAtArgW(t *testing.T) {
+	u := unitFrom(t, `package probe
+table Root { n int32 }
+`)
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var src string
+	for _, b := range files {
+		s := string(b)
+		if strings.Contains(s, "function TableFixedRun(") {
+			src = s
+			break
+		}
+	}
+	if src == "" {
+		t.Fatal("no TableFixedRun in the generated unit")
+	}
+	if !strings.Contains(src, "function TableFixedTagAt(") {
+		t.Error("the runtime never names TableFixedTagAt")
+	}
+	if !strings.Contains(src, "const TableFixedLaneArgW = 8;") {
+		t.Error("the plan omits the ArgW lane")
+	}
+	if !strings.Contains(src, "export const TableFixedLanes = 9;") {
+		t.Error("a plan entry is nine int32 lanes, not eight")
+	}
+	if strings.Contains(src, "src[srcAt + guard] !== e[b + TableFixedLaneArg]") {
+		t.Error("the run loop still compares the union guard as one byte")
+	}
+	if !strings.Contains(src, "TableFixedTagAt(src, srcAt + guard, e[b + TableFixedLaneArgW])") {
+		t.Error("the run loop does not compare the guard at ArgW")
+	}
+	if strings.Contains(src, "if (identity)") {
+		t.Error("the load grew a second reader; hash chooses the plan and nothing else")
+	}
+	if !strings.Contains(src, "RootFixedIdentity = new Int32Array([0, 0, 0, 4, 0, -1, 0, 0, 1])") {
+		t.Error("the identity plan omitted the ArgW lane (ninth is 1)")
+	}
+	if !strings.Contains(src, "plan.argw = (theirTag >= 1 && theirTag <= 8) ? theirTag : 1;") {
+		t.Error("the compiler does not stamp ArgW from the writer's tag width")
+	}
+}
+
 func unitFrom(t *testing.T, src string) *ir.Unit {
 	t.Helper()
 	f, perrs := parser.Parse("Probe.schema", []byte(src))

--- a/internal/codegen/jstable/fixedmodule.go
+++ b/internal/codegen/jstable/fixedmodule.go
@@ -213,7 +213,7 @@ func (g *fixedModule) emitRoot(st *ir.Struct) {
 	g.pf("// source and destination advance together over the whole body and the walk\n")
 	g.pf("// coalesces to exactly ONE run. That is the same coalescer the plan compiler\n")
 	g.pf("// runs, reaching its best case rather than skipping a step.\n")
-	g.pf("const %sFixedIdentity = new Int32Array([0, 0, 0, %d, 0, -1, 0, 0]);\n\n", st.Name, body)
+	g.pf("const %sFixedIdentity = new Int32Array([0, 0, 0, %d, 0, -1, 0, 0, 1]);\n\n", st.Name, body)
 
 	// ---- the caller's plan storage ----
 	g.pf("// THE PLAN'S STORAGE IS THE CALLER'S, DECLARED BY CAPACITY, AND THE CODEC\n")

--- a/internal/codegen/jstable/fixedruntime.go
+++ b/internal/codegen/jstable/fixedruntime.go
@@ -52,10 +52,10 @@ export const TableFixedEntryBytes = 17;
 // the layout's own framing: the u32 entry count, and nothing else
 export const TableFixedLayoutHeaderBytes = 4;
 
-// A PLAN ENTRY is eight int32 lanes of one flat Int32Array. A flat array of a
+// A PLAN ENTRY is nine int32 lanes of one flat Int32Array. A flat array of a
 // fixed stride is what keeps the read loop monomorphic: every lane is a
 // Smi, the loop never touches a property name, and nothing is allocated.
-export const TableFixedLanes = 8;
+export const TableFixedLanes = 9;
 // ONE BINDING PER LINE, and that is not a style choice: §11's claim is made
 // name by name, and a scan that reads a module's bindings sees the FIRST name
 // of a comma list. A lane folded into a list beside another is a lane nobody
@@ -68,6 +68,7 @@ const TableFixedLaneAux = 4;
 const TableFixedLaneGuard = 5;
 const TableFixedLaneArg = 6;
 const TableFixedLaneMeta = 7; // a widen's width and sign, a text entry's flavour
+const TableFixedLaneArgW = 8; // THE GUARD'S WIDTH IN BYTES: a union tag is 1, 2, 4 or 8
 
 // THE OPS ARE THE WHOLE SET. The IDENTITY plan carries only the first; the
 // others are what a plan compiled from another writer's layout adds.
@@ -154,6 +155,8 @@ export class TableFixedPlan {
     this.hashHi = 0;
     this.ready = false;
     this.overflow = false;
+    // the CURRENT union's tag width, stamped onto every push — C++'s c.argw
+    this.argw = 1;
   }
 }
 
@@ -211,6 +214,22 @@ function TableFixedGetU32(bytes, at) {
   return (bytes[at] | (bytes[at + 1] << 8) | (bytes[at + 2] << 16) | (bytes[at + 3] << 24)) >>> 0;
 }
 
+// THE TAG IS COMPARED AT ITS OWN WIDTH. A two- or four-byte tag whose low
+// byte happens to be 1 is not arm 1: it is an ordinal this build has no arm
+// for, and reading only the first byte let 0x0101 run arm 1's entries over
+// a stranger's record. ArgW 0 means 1, as C++.
+function TableFixedTagAt(src, at, argw) {
+  let w = argw | 0;
+  if (w === 0) { w = 1; }
+  else if (w > 8) { w = 8; }
+  let v = 0, p = 1;
+  for (let i = 0; i < w; i++) {
+    v += src[at + i] * p;
+    p *= 256;
+  }
+  return v;
+}
+
 // ---- THE ONE READ LOOP -----------------------------------------------------
 //
 // A READ IS A PREFILL AND THIS LOOP, AND NOTHING ELSE. Which plan it is handed
@@ -223,8 +242,12 @@ export function TableFixedRun(plan, entryCount, src, srcView, srcAt, dst, dstVie
   for (let i = 0; i < entryCount; i++) {
     const b = i * TableFixedLanes;
     const guard = e[b + TableFixedLaneGuard];
-    // an entry belonging to an ARM runs only under its own tag
-    if (guard !== TableFixedNoGuard && src[srcAt + guard] !== e[b + TableFixedLaneArg]) { continue; }
+    // an entry belonging to an ARM runs only under its own tag, compared at
+    // ArgW bytes, never as a prefix
+    if (guard !== TableFixedNoGuard &&
+        TableFixedTagAt(src, srcAt + guard, e[b + TableFixedLaneArgW]) !== (e[b + TableFixedLaneArg] >>> 0)) {
+      continue;
+    }
     const s = srcAt + e[b + TableFixedLaneSrc];
     const d = e[b + TableFixedLaneDst];
     const size = e[b + TableFixedLaneSize];
@@ -501,6 +524,10 @@ function TableFixedPush(plan, op, src, dst, size, aux, guard, arg, meta) {
   e[b + TableFixedLaneGuard] = guard;
   e[b + TableFixedLaneArg] = arg;
   e[b + TableFixedLaneMeta] = meta;
+  // argw IS THE GUARD'S WIDTH IN BYTES. Flavour stays in meta. Zero is one.
+  let w = plan.argw | 0;
+  if (w === 0) { w = 1; }
+  e[b + TableFixedLaneArgW] = w;
   plan.count++;
 }
 
@@ -625,6 +652,8 @@ function TableFixedCompileEntry(plan, theirs, ti, theirAt, mine, mi, dst, myAt, 
     case 15: { // a union: the tag, remapped, then each arm matched by id
       const theirTag = TableFixedTagBytes(theirs, ti);
       const myTag = TableFixedTagBytes(mine, mi);
+      const savedArgw = plan.argw;
+      plan.argw = (theirTag >= 1 && theirTag <= 8) ? theirTag : 1;
       const theirArms = TableFixedChildren(theirs, ti);
       const myArms = TableFixedChildren(mine, mi);
       let myArm = mi + 1;
@@ -642,6 +671,7 @@ function TableFixedCompileEntry(plan, theirs, ti, theirAt, mine, mi, dst, myAt, 
         }
         myArm += TableFixedSubtree(mine, myArm);
       }
+      plan.argw = savedArgw;
       break;
     }
     case 30: { // an enum: the ordinal is the layout's position, so it remaps
@@ -695,6 +725,7 @@ function TableFixedCoalesce(plan) {
       const p = (out - 1) * TableFixedLanes;
       if (e[p + TableFixedLaneOp] === TableFixedOpCopy && e[b + TableFixedLaneOp] === TableFixedOpCopy &&
           e[p + TableFixedLaneGuard] === e[b + TableFixedLaneGuard] && e[p + TableFixedLaneArg] === e[b + TableFixedLaneArg] &&
+          e[p + TableFixedLaneArgW] === e[b + TableFixedLaneArgW] &&
           e[p + TableFixedLaneSrc] + e[p + TableFixedLaneSize] === e[b + TableFixedLaneSrc] &&
           e[p + TableFixedLaneDst] + e[p + TableFixedLaneSize] === e[b + TableFixedLaneDst]) {
         e[p + TableFixedLaneSize] += e[b + TableFixedLaneSize];
@@ -716,6 +747,7 @@ export function TableFixedCompile(theirs, myLayout, myDst, plan, report) {
   plan.count = 0;
   plan.remapUsed = 0;
   plan.overflow = false;
+  plan.argw = 1;
   TableFixedMatchChildren(plan, theirs, 0, 0, mine, 0, myDst, 0, TableFixedNoGuard, 0, report);
   if (plan.overflow) { return -1; }
   TableFixedCoalesce(plan);

--- a/internal/tablenames/js.go
+++ b/internal/tablenames/js.go
@@ -55,11 +55,12 @@ func init() {
 		Name{Name: "TableFixedTagBytes", What: "a union entry's tag width: its size less its widest arm"},
 		Name{Name: "TableFixedSameId", What: "whether two entries carry one wire id, compared in two uint32 lanes"},
 		Name{Name: "TableFixedGetU32", What: "the little-endian u32 read the framing itself needs"},
+		Name{Name: "TableFixedTagAt", What: "the little-endian tag load at ArgW bytes, never a prefix — a two-byte 0x0101 is not arm 1"},
 
-		// THE PLAN: eight int32 lanes of one flat Int32Array, and the lane
+		// THE PLAN: nine int32 lanes of one flat Int32Array, and the lane
 		// indices ONE BINDING PER LINE. A lane folded into a comma list beside
 		// another is a lane nobody claimed.
-		Name{Name: "TableFixedLanes", What: "a plan entry is eight int32 lanes, which is what keeps the read loop monomorphic"},
+		Name{Name: "TableFixedLanes", What: "a plan entry is nine int32 lanes, which is what keeps the read loop monomorphic"},
 		Name{Name: "TableFixedLaneOp", What: "the plan lane holding the op"},
 		Name{Name: "TableFixedLaneSrc", What: "the plan lane holding the source offset"},
 		Name{Name: "TableFixedLaneDst", What: "the plan lane holding the destination offset"},
@@ -68,6 +69,7 @@ func init() {
 		Name{Name: "TableFixedLaneGuard", What: "the plan lane holding the union tag an arm's entry runs under"},
 		Name{Name: "TableFixedLaneArg", What: "the plan lane holding the guard's VALUE: the tag an arm's entry answers to"},
 		Name{Name: "TableFixedLaneMeta", What: "the plan lane holding what an op needs beside its size — a widen's width and sign, a text entry's flavour"},
+		Name{Name: "TableFixedLaneArgW", What: "the plan lane holding the guard's WIDTH IN BYTES: a union tag is one, two, four or eight"},
 		Name{Name: "TableFixedNoGuard", What: "the guard a plan entry belonging to no union arm carries"},
 
 		// THE OPS ARE THE WHOLE SET, one binding each, and the flavours a text

--- a/test/js-tables/fixedform.mjs
+++ b/test/js-tables/fixedform.mjs
@@ -78,6 +78,7 @@ export async function checkFixedForm(check, generated, corpusDir, optionalDir, o
 
   await pairedCorpus(check, bench, fixed, corpusDir);
   forgedCounts(check, bench, fixed, corpusDir);
+  guardComparedAtArgW(check, fx1home);
   versioning(check, fx1, fx2, fx1home, fx2home);
   bytesArrayConvention(check, fx1, fx2, fx1home, fx2home, oracleDir);
   liveCountSlack(check, fx1, fx1home);
@@ -352,6 +353,43 @@ function f32bits(x) { CONV.setFloat32(0, x, true); return CONV.getUint32(0, true
 function f64bits(x) { CONV.setFloat64(0, x, true); return CONV.getBigUint64(0, true); }
 
 // ---------------------------------------------------------------------------
+// THE GUARD IS COMPARED AT ArgW BYTES, NEVER AS A PREFIX.
+// compiler/fixedguardwidth_test.go holds the IR stamp; this is the run loop.
+// A two-byte tag 0x0101 whose low byte is 1 is not arm 1. ONE PATH: this is
+// TableFixedRun, the same loop identity and compiled both take.
+// ---------------------------------------------------------------------------
+function guardComparedAtArgW(check, home) {
+  check(home.TableFixedLanes === 9,
+    `ArgW: a plan entry is nine int32 lanes, got ${home.TableFixedLanes}`);
+
+  const run = (lanes, srcBytes) => {
+    const src = new Uint8Array(srcBytes);
+    const srcView = new DataView(src.buffer, src.byteOffset, src.length);
+    const dst = new Uint8Array(1);
+    const dstView = new DataView(dst.buffer);
+    const r = new home.TableFixedReport();
+    // op=COPY src=2 dst=0 size=1 aux=0 guard=0 arg=1 meta=0 argw=lanes[8]
+    home.TableFixedRun(new Int32Array(lanes), 1, src, srcView, 0, dst, dstView, null, r);
+    return dst[0];
+  };
+  // COPY of the payload at byte 2, guarded at 0, answering to arm 1, width 2
+  const twoByte = [0, 2, 0, 1, 0, 0, 1, 0, 2];
+  check(run(twoByte, [0x01, 0x01, 0xAA]) === 0,
+    "ArgW: a two-byte tag 0x0101 whose low byte is 1 does NOT run arm 1");
+  check(run(twoByte, [0x01, 0x00, 0xAA]) === 0xAA,
+    "ArgW: a two-byte tag 0x0001 DOES run arm 1");
+  // ArgW 0 means 1, as C++: only the first byte is the tag
+  const zeroMeansOne = [0, 2, 0, 1, 0, 0, 1, 0, 0];
+  check(run(zeroMeansOne, [0x01, 0x01, 0xAA]) === 0xAA,
+    "ArgW: zero is read as one, so a 0x0101 prefix matches arm 1 at width 0");
+  const fourByte = [0, 4, 0, 1, 0, 0, 1, 0, 4];
+  check(run(fourByte, [0x01, 0x01, 0x00, 0x00, 0xBB]) === 0,
+    "ArgW: a four-byte tag 0x00000101 whose low byte is 1 does NOT run arm 1");
+  check(run(fourByte, [0x01, 0x00, 0x00, 0x00, 0xBB]) === 0xBB,
+    "ArgW: a four-byte tag 0x00000001 DOES run arm 1");
+}
+
+// ---------------------------------------------------------------------------
 // 3. THE VERSIONING CONFORMANCE — the twin of test/tables/fixedform_main.cpp
 // ---------------------------------------------------------------------------
 
@@ -489,7 +527,7 @@ function negativeControls(check, fx1, fx2, fx1home, fx2home) {
     const body = w2.subarray(LAYOUT_AT + fx2.FxRootFixedLayoutBytes + 8);
     const bodyView = new DataView(body.buffer, body.byteOffset, body.length);
     plan.image.set(new Uint8Array(plan.image.length)); // the prefill
-    fx1home.TableFixedRun(new Int32Array([0, 0, 0, fx1.FxRootFixedBodyBytes, 0, -1, 0, 0]),
+    fx1home.TableFixedRun(new Int32Array([0, 0, 0, fx1.FxRootFixedBodyBytes, 0, -1, 0, 0, 1]),
       1, body, bodyView, 0, plan.image, plan.view, null, wr);
     fx1home.FxRootFixedDecode(wrong[0], plan.view, 0, wr);
     check(wrong[0].Keep !== right[0].Keep || wrong[0].Renamed !== right[0].Renamed ||
@@ -917,7 +955,7 @@ function liveCountSlack(check, fx1, fx1home) {
 // HOLE PREFILL: identity's hole list is empty (one COPY of the whole body).
 // Compiled FX2→FX1 has holes for Gone; a dirty image still reads the default.
 function holePrefill(check, fx1, fx2, fx1home, fx2home) {
-  const identity = new Int32Array([0, 0, 0, fx1.FxRootFixedBodyBytes, 0, -1, 0, 0]);
+  const identity = new Int32Array([0, 0, 0, fx1.FxRootFixedBodyBytes, 0, -1, 0, 0, 1]);
   const idPlan = fx1.FxRootFixedNewPlan();
   const idHoles = fx1home.TableFixedHoles(identity, 1, idPlan.cover, idPlan.holes);
   check(idHoles === 0, `hole prefill: identity's hole list is empty, got ${idHoles}`);


### PR DESCRIPTION
Leftover named on landed #830: JS still compared the union guard as one byte. C++ and IR compare at ArgW (1/2/4/8, zero means one). A two-byte tag whose low byte happens to be 1 is not arm 1.

## What changed

- `TableFixedTagAt` in the JS runtime: little-endian load at ArgW bytes, never a prefix.
- Ninth plan lane `TableFixedLaneArgW`, stamped from the compiler the way C++ stamps `e.argw` (the current union's tag width). Flavour stays in Meta.
- `TableFixedRun` compares the guard at ArgW. Hash still chooses the plan and nothing else. Identity is one COPY of the body; no second reader, no `if (identity)`.
- Tests: `TestFixedGuardComparedAtArgW` (generated runtime) and `guardComparedAtArgW` in `test/js-tables/fixedform.mjs` (0x0101 does not run arm 1).

## Gates (cheap)

- `go test ./internal/codegen/jstable`
- `go test ./compiler -run 'TestJs|TestFixedGuardWidth'`
- `make tables-js-fixed-form`
- `make tables-js-union-arm-text-negative-control`

Off `origin/fixed-table-form` `2d6a4940bbe118c32f9aaa7074f670954d14b372` (Merge #839). Johnny Grok.

Still draft. Do not merge.