### PR TITLE
tables: Dart generates FU1/FU2; C++ tables-fixedform pins them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5740,6 +5740,7 @@ build/schema_test_fixedform: build/tables-generated/.stamp test/tables/fixedform
 	    -Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
 	    -Ibuild/tables-generated/p1 -Ibuild/tables-generated/p3 \
 	    -Ibuild/tables-generated/ut1 -Ibuild/tables-generated/ut2 \
+	    -Ibuild/tables-generated/fu1 -Ibuild/tables-generated/fu2 \
 	    -I$(SERIALIZE) test/tables/fixedform_main.cpp -o $@
 
 # THE SANITIZED TWIN, and it is the point of the byte-flip fuzz inside it. A
@@ -5754,6 +5755,7 @@ build/schema_test_fixedform_asan: build/tables-generated/.stamp test/tables/fixe
 	    -Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
 	    -Ibuild/tables-generated/p1 -Ibuild/tables-generated/p3 \
 	    -Ibuild/tables-generated/ut1 -Ibuild/tables-generated/ut2 \
+	    -Ibuild/tables-generated/fu1 -Ibuild/tables-generated/fu2 \
 	    -I$(SERIALIZE) test/tables/fixedform_main.cpp -o $@
 
 # THE RUN COPY'S BOUND, ON ITS OWN (test/tables/fixedform_runcopy.cpp). The

--- a/internal/codegen/darttable/fixedform_test.go
+++ b/internal/codegen/darttable/fixedform_test.go
@@ -495,6 +495,57 @@ func fixedSubtree(entries []fixedLayoutEntry, i int) int {
 	return n
 }
 
+// TestFixedFormFU1FU2OnePath is the TEXT-UNDER-AN-ARM generate pin
+// (docs/SPEC-TABLES.md §3.4, §15; docs/FIXED-FORM-ALGORITHM.md §4.1 fix 12).
+// FU1 writes a string(8) in the union's SECOND arm; FU2 appends `extra` so a
+// read of those bytes is a COMPILED plan. The generated load is the one-path
+// load: hash chooses the plan, tableFixedRun walks it, empty fill/holes is
+// the skip. No second reader. No `if (identity)` door.
+func TestFixedFormFU1FU2OnePath(t *testing.T) {
+	fu1 := loadUnit(t, "../../../test/tables/FU1.schema")
+	fu2 := loadUnit(t, "../../../test/tables/FU2.schema")
+	files1, err := Generate(fu1)
+	if err != nil {
+		t.Fatalf("FU1 generate: %v", err)
+	}
+	files2, err := Generate(fu2)
+	if err != nil {
+		t.Fatalf("FU2 generate: %v", err)
+	}
+	var all1, all2 string
+	for _, b := range files1 {
+		all1 += string(b)
+	}
+	for _, b := range files2 {
+		all2 += string(b)
+	}
+	if !strings.Contains(all1, "int fuRootFixedLoad(") {
+		t.Fatal("FU1 did not emit fuRootFixedLoad")
+	}
+	if !strings.Contains(all2, "int fuRootFixedLoad(") {
+		t.Fatal("FU2 did not emit fuRootFixedLoad")
+	}
+	if strings.Contains(all1, "if (identity)") || strings.Contains(all1, "if identity") {
+		t.Error("FU1 load still forks on an identity flag")
+	}
+	if !strings.Contains(all1, "tableFixedRun(") {
+		t.Error("FU1 FixedLoad is not the one-path load")
+	}
+	if !strings.Contains(all2, "int extra = 11") {
+		t.Error("FU2 did not emit extra's declared default")
+	}
+	h1 := strings.Index(all1, "const int fuRootFixedHash = ")
+	h2 := strings.Index(all2, "const int fuRootFixedHash = ")
+	if h1 < 0 || h2 < 0 {
+		t.Fatal("missing fuRootFixedHash")
+	}
+	line1 := all1[h1 : h1+80]
+	line2 := all2[h2 : h2+80]
+	if line1 == line2 {
+		t.Fatal("FU2 extra did not change the layout hash; compiled path is not a compile trigger")
+	}
+}
+
 func findTable(t *testing.T, u *ir.Unit, name string) *ir.Struct {
 	t.Helper()
 	for _, f := range u.Files {

--- a/make/dart.mk
+++ b/make/dart.mk
@@ -259,10 +259,17 @@ build/conformance-dart: build/tables-generated-dart/.stamp test/conformance/dart
 # the negative controls, of which the one §3.4 names is a reader given the
 # WRONG PLAN for a record, which must come out wrong, and one corrupted-layout
 # case per NAMED RULE a reader holds an untrusted peer's layout to.
+#
+# FU1/FU2 is the TEXT-UNDER-AN-ARM pair whose compiled path is a TRAILING
+# FIELD, not a slid ordinal: FU1's second arm carries a string(8), FU2 appends
+# `extra` so a read of FU1's bytes is a compiled plan, and the two reads have
+# to agree on the text (reference-fix 12). C++ already generates the pair;
+# this stamp did not.
 build/dart-fixed/.stamp: bin/schema bench/corpus/Bench.schema bench/corpus/FixedTable.schema \
 		test/tables/FX1.schema test/tables/FX2.schema \
 		test/tables/V1.schema test/tables/V2.schema \
 		test/tables/P1.schema test/tables/P3.schema test/tables/FXW.schema \
+		test/tables/FU1.schema test/tables/FU2.schema \
 		$(SCHEMAS_TABLES) make/dart.mk
 	@rm -rf build/dart-fixed && mkdir -p build/dart-fixed
 	./bin/schema generate --lang dart --out build/dart-fixed/bench bench/corpus/Bench.schema bench/corpus/FixedTable.schema
@@ -272,6 +279,8 @@ build/dart-fixed/.stamp: bin/schema bench/corpus/Bench.schema bench/corpus/Fixed
 	./bin/schema generate --lang dart --out build/dart-fixed/v2 test/tables/V2.schema
 	./bin/schema generate --lang dart --out build/dart-fixed/p1 test/tables/P1.schema
 	./bin/schema generate --lang dart --out build/dart-fixed/p3 test/tables/P3.schema
+	./bin/schema generate --lang dart --out build/dart-fixed/fu1 test/tables/FU1.schema
+	./bin/schema generate --lang dart --out build/dart-fixed/fu2 test/tables/FU2.schema
 	./bin/schema generate --lang dart --out build/dart-fixed/examples tables/examples
 	# THE WIDE TEXT UNIT (docs/SPEC-TABLES.md §3.4, kind 33): its own file and
 	# its own directory, because every SHARED schema list is pinned to targets
@@ -316,6 +325,8 @@ tables-dart-fixed-form-negative-control: bin/schema build/fixedform-corpus/.stam
 	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/v2 test/tables/V2.schema
 	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/p1 test/tables/P1.schema
 	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/p3 test/tables/P3.schema
+	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/fu1 test/tables/FU1.schema
+	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/fu2 test/tables/FU2.schema
 	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/examples tables/examples
 	./build/dart-fixed-nc/schema generate --lang dart --out build/dart-fixed-nc/gen/fxw test/tables/FXW.schema
 	@sed 's|../../build/dart-fixed/|$(CURDIR)/build/dart-fixed-nc/gen/|g' \

--- a/test/dart-tables/fixedform.dart
+++ b/test/dart-tables/fixedform.dart
@@ -57,6 +57,12 @@ import '../../build/dart-fixed/fx2/FX2Fixed.dart' as fx2;
 import '../../build/dart-fixed/fx2/Tblfx2Fixed.dart' as fx2home;
 import '../../build/dart-fixed/fxw/FXWFixed.dart' as fxw;
 import '../../build/dart-fixed/fxw/TblfxwFixed.dart' as fxwhome;
+import '../../build/dart-fixed/fu1/FU1.dart' as fu1decl;
+import '../../build/dart-fixed/fu1/FU1Fixed.dart' as fu1;
+import '../../build/dart-fixed/fu1/Tblfu1Fixed.dart' as fu1home;
+import '../../build/dart-fixed/fu2/FU2.dart' as fu2decl;
+import '../../build/dart-fixed/fu2/FU2Fixed.dart' as fu2;
+import '../../build/dart-fixed/fu2/Tblfu2Fixed.dart' as fu2home;
 import '../../build/dart-fixed/p1/P1Fixed.dart' as p1;
 import '../../build/dart-fixed/p1/Tblp1Fixed.dart' as p1home;
 import '../../build/dart-fixed/p3/P3Fixed.dart' as p3;
@@ -1000,6 +1006,149 @@ void fxCase() {
   }
 }
 
+// TEXT UNDER AN ARM (docs/SPEC-TABLES.md §3.4, §15). FU1 writes a string(8)
+// in the union's SECOND arm; FU2 appends `extra` so a read of those bytes is
+// a COMPILED plan. Both reads go through fuRootFixedLoad — the same one-path
+// load the rest of this form uses. Hash chooses the plan. The compiled read
+// has to see "hello".
+void fuCase() {
+  check(
+    fu1.fuRootFixedHash != fu2.fuRootFixedHash,
+    'text under an arm: FU2 extra changed the layout hash',
+  );
+
+  final labelled = fu1home.FuRoot();
+  labelled.flag = true;
+  labelled.note = 44;
+  labelled.notePresent = true;
+  labelled.pick.type = fu1decl.PickType.labelled; // the SECOND arm
+  labelled.pick.labelled.lead = 101;
+  labelled.pick.labelled.label.setRange(0, 5, 'hello'.codeUnits);
+  labelled.pick.labelled.labelLength = 5;
+  labelled.pick.labelled.trail = 202;
+  labelled.tail = 11;
+
+  final plain = fu1home.FuRoot();
+  plain.pick.type = fu1decl.PickType.plain;
+  plain.pick.plain.n = 303;
+  plain.tail = 12;
+
+  final w = Uint8List(fu1.fuRootFixedMeasure(2));
+  check(
+    fu1.fuRootFixedSave(<fu1home.FuRoot>[labelled, plain], 2, w) == w.length,
+    'FU1 save',
+  );
+
+  {
+    final back = <fu1home.FuRoot>[fu1home.FuRoot(), fu1home.FuRoot()];
+    final r = fu1home.TableFixedReport();
+    final n = fu1.fuRootFixedLoad(
+      back,
+      2,
+      w,
+      w.length,
+      fu1.fuRootFixedNewPlan(),
+      r,
+    );
+    check(n == 2, 'text under an arm: the identity read takes both records');
+    check(
+      back[0].pick.type == fu1decl.PickType.labelled,
+      'text under an arm: identity, the SECOND arm',
+    );
+    check(
+      back[0].pick.labelled.lead == 101,
+      'text under an arm: identity, the scalar BEFORE the text',
+    );
+    check(
+      back[0].pick.labelled.labelLength == 5 &&
+          text(
+                back[0].pick.labelled.label,
+                back[0].pick.labelled.labelLength,
+              ) ==
+              'hello',
+      'text under an arm: the IDENTITY read lands the text',
+    );
+    check(
+      back[0].pick.labelled.trail == 202,
+      'text under an arm: identity, the scalar AFTER the text',
+    );
+    check(
+      back[0].flag &&
+          back[0].notePresent &&
+          back[0].note == 44 &&
+          back[0].tail == 11,
+      'text under an arm: identity, the rest of the labelled record',
+    );
+    check(
+      back[1].pick.type == fu1decl.PickType.plain &&
+          back[1].pick.plain.n == 303 &&
+          back[1].tail == 12,
+      'text under an arm: identity, the FIRST arm as well',
+    );
+    quiet(r, 'text under an arm: identity');
+  }
+
+  {
+    final back = <fu2home.FuRoot>[fu2home.FuRoot(), fu2home.FuRoot()];
+    final r = fu2home.TableFixedReport();
+    final n = fu2.fuRootFixedLoad(
+      back,
+      2,
+      w,
+      w.length,
+      fu2.fuRootFixedNewPlan(),
+      r,
+    );
+    check(n == 2, 'text under an arm: the compiled read takes both records');
+    check(
+      back[0].pick.type == fu2decl.PickType.labelled,
+      'text under an arm: compiled, the SECOND arm',
+    );
+    check(
+      back[0].pick.labelled.lead == 101,
+      'text under an arm: compiled, the scalar BEFORE the text',
+    );
+    check(
+      back[0].pick.labelled.labelLength == 5 &&
+          text(
+                back[0].pick.labelled.label,
+                back[0].pick.labelled.labelLength,
+              ) ==
+              'hello',
+      'text under an arm: the COMPILED read still sees the text',
+    );
+    check(
+      back[0].pick.labelled.trail == 202,
+      'text under an arm: compiled, the scalar AFTER the text',
+    );
+    check(
+      back[0].flag &&
+          back[0].notePresent &&
+          back[0].note == 44 &&
+          back[0].tail == 11,
+      'text under an arm: compiled, the rest of the labelled record',
+    );
+    check(
+      back[0].extra == 11,
+      'text under an arm: the field FU1 does not carry took its declared default',
+    );
+    check(
+      back[1].pick.type == fu2decl.PickType.plain &&
+          back[1].pick.plain.n == 303 &&
+          back[1].tail == 12,
+      'text under an arm: compiled, the FIRST arm as well',
+    );
+    check(
+      back[1].extra == 11,
+      'text under an arm: compiled, extra defaults on the FIRST arm too',
+    );
+    check(
+      !r.malformed && r.refused == 0 && r.clamped == 0,
+      'text under an arm: compiled, a clean read moves no counter',
+    );
+  }
+}
+
 // 6. AN ENUM VARIANT AND A UNION ARM INSERTED IN THE MIDDLE, and a keyed
 // array whose keys slid — remapped BY NAME and never by position.
 void vCase() {
@@ -1646,6 +1795,7 @@ void main(List<String> args) {
   corpusFiles(corpus);
   pairedCorpus(benchCorpus);
   fxCase();
+  fuCase();
   vCase();
   pCase();
   absentOptionalCase();

--- a/test/tables/fixedform_main.cpp
+++ b/test/tables/fixedform_main.cpp
@@ -44,6 +44,8 @@
 #include "P3Table.h"
 #include "UT1Table.h"
 #include "UT2Table.h"
+#include "FU1Table.h"
+#include "FU2Table.h"
 
 static int failures = 0;
 
@@ -829,6 +831,82 @@ static void union_text_case()
 
 // ---------------------------------------------------------------------------
 
+// TEXT UNDER AN ARM (docs/SPEC-TABLES.md §3.4, §15). UT1/UT2 is two-lanes /
+// a slid ordinal. FU1/FU2 is the same hole on a TRAILING FIELD: FU1's second
+// arm carries a string(8), FU2 appends `extra` so a read of FU1's bytes is a
+// COMPILED plan rather than the identity one. The compiled read has to see
+// "hello". Hash chooses the plan and nothing else; both reads go through
+// FuRootFixedLoad.
+static void text_under_arm_case()
+{
+    check( tblfu1::FuRootFixedHash != tblfu2::FuRootFixedHash,
+           "text under an arm: FU2 extra changed the layout hash" );
+
+    tblfu1::FuRoot v[2];
+    tblfu1::FuRootReset( v[0] );
+    v[0].flag = true;
+    v[0].note = 44;
+    v[0].note_present = true;
+    v[0].pick.type = tblfu1::PickType::Labelled; // the SECOND arm
+    v[0].pick.labelled.lead = 101;
+    std::strcpy( v[0].pick.labelled.label, "hello" );
+    v[0].pick.labelled.label_length = 5;
+    v[0].pick.labelled.trail = 202;
+    v[0].tail = 11;
+
+    tblfu1::FuRootReset( v[1] );
+    v[1].pick.type = tblfu1::PickType::Plain;
+    v[1].pick.plain.n = 303;
+    v[1].tail = 12;
+
+    std::vector<uint8_t> w( (size_t) tblfu1::FuRootFixedMeasure( 2 ) );
+    check( tblfu1::FuRootFixedSave( v, 2, w.data(), (int64_t) w.size() ) == (int64_t) w.size(), "FU1 save" );
+
+    {
+        tblfu1::FuRoot back[2];
+        tblfu1::TableReport r;
+        std::vector<tblfu1::TableFixedEntry> plan( 1024 );
+        check( tblfu1::FuRootFixedLoad( back, 2, w.data(), (int64_t) w.size(), plan.data(), 1024, NULL, &r ) == 2,
+               "text under an arm: the identity read takes both records" );
+        check( back[0].pick.type == tblfu1::PickType::Labelled, "text under an arm: identity, the SECOND arm" );
+        check( back[0].pick.labelled.lead == 101, "text under an arm: identity, the scalar BEFORE the text" );
+        check( back[0].pick.labelled.label_length == 5 && std::strcmp( back[0].pick.labelled.label, "hello" ) == 0,
+               "text under an arm: the IDENTITY read lands the text" );
+        check( back[0].pick.labelled.trail == 202, "text under an arm: identity, the scalar AFTER the text" );
+        check( back[0].flag && back[0].note_present && back[0].note == 44 && back[0].tail == 11,
+               "text under an arm: identity, the rest of the labelled record" );
+        check( back[1].pick.type == tblfu1::PickType::Plain && back[1].pick.plain.n == 303 && back[1].tail == 12,
+               "text under an arm: identity, the FIRST arm as well" );
+        check( r.clamped == 0 && !r.malformed && !r.refused,
+               "text under an arm: identity, a clean read moves no counter" );
+    }
+
+    {
+        tblfu2::FuRoot back[2];
+        tblfu2::TableReport r;
+        std::vector<tblfu2::TableFixedEntry> plan( 1024 );
+        check( tblfu2::FuRootFixedLoad( back, 2, w.data(), (int64_t) w.size(), plan.data(), 1024, NULL, &r ) == 2,
+               "text under an arm: the compiled read takes both records" );
+        check( back[0].pick.type == tblfu2::PickType::Labelled, "text under an arm: compiled, the SECOND arm" );
+        check( back[0].pick.labelled.lead == 101, "text under an arm: compiled, the scalar BEFORE the text" );
+        check( back[0].pick.labelled.label_length == 5 && std::strcmp( back[0].pick.labelled.label, "hello" ) == 0,
+               "text under an arm: the COMPILED read still sees the text" );
+        check( back[0].pick.labelled.trail == 202, "text under an arm: compiled, the scalar AFTER the text" );
+        check( back[0].flag && back[0].note_present && back[0].note == 44 && back[0].tail == 11,
+               "text under an arm: compiled, the rest of the labelled record" );
+        check( back[0].extra == 11,
+               "text under an arm: the field FU1 does not carry took its declared default" );
+        check( back[1].pick.type == tblfu2::PickType::Plain && back[1].pick.plain.n == 303 && back[1].tail == 12,
+               "text under an arm: compiled, the FIRST arm as well" );
+        check( back[1].extra == 11,
+               "text under an arm: compiled, `extra` defaults on the FIRST arm too" );
+        check( r.clamped == 0 && !r.malformed && !r.refused,
+               "text under an arm: compiled, a clean read moves no counter" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 // THE BOUNDS THE READ LOOP DOES NOT HOLD (docs/SPEC-TABLES.md §3.4). A fixed
 // record is a positional image and the one read loop moves bytes: it asks
 // nothing about what they mean. Two things a declaration bounds are therefore
@@ -1301,6 +1379,7 @@ int main()
     negative_control();
     slack_case();
     union_text_case();
+    text_under_arm_case();
     bytes_row_case();
     bounds_case();
     absent_optional_case();


### PR DESCRIPTION
## Why

On the live tip, Dart `make/dart.mk` `build/dart-fixed/.stamp` generated bench, FX1/FX2, V1/V2, P1/P3, examples, FXW. **No FU1/FU2.** C++ Makefile already **generated** fu1/fu2 (`tables_generate`) but `tables-fixedform` did not `-I` or call them.

A `string(8)` lives in a union's second arm, with a scalar either side. FU2 appends `extra` so a read of FU1's bytes is a **compiled** plan rather than the identity one. That is the hole reference-fix 12 was: identity landed the text, compiled read it as empty, no counter.

UT1/UT2 already holds the two-lane / slid-arm half on the C++ leg. This pair is the trailing-field compile trigger. C leftover of this hole is merged #862.

## What

Dart now generates the pair:

```
./bin/schema generate --lang dart --out build/dart-fixed/fu1 test/tables/FU1.schema
./bin/schema generate --lang dart --out build/dart-fixed/fu2 test/tables/FU2.schema
```

Stamp depends on `test/tables/FU1.schema` and `test/tables/FU2.schema`. The write-template negative control generates the pair too.

Pin is `test/dart-tables/fixedform.dart` `fuCase`: FU1 writes arm 2 `"hello"` and arm 1 beside it. Identity load through `fuRootFixedLoad` → `tableFixedRun` lands the text. FU2's compiled load of the same bytes still sees `"hello"`. `extra` takes its declared default 11.

C++ generate already existed. `tables-fixedform` now `-I`s `fu1`/`fu2` the way it already does `fx1`/`fx2`/`ut1`/`ut2`, and `text_under_arm_case` calls them through `FuRootFixedLoad`.

## ONE PATH

Hash chooses the plan and nothing else. Identity is a PLAN walked by the same loop. Empty fill/holes is the skip, not a second path. No identity memcpy. No `if (identity)` door. Generator pin: `TestFixedFormFU1FU2OnePath`.

Did not take Dart ArgW (merged #870). Did not take Dart FX1 (merged #863). Did not take Emma's Dart writer length. Did not take Dart per-record prefill.

## Tests

- `go test ./internal/codegen/darttable` ok
- `make tables-dart-fixed-form` OK (Dart SDK 3.13.2) — compiled read sees `"hello"`; oracle fixtures IDENTICAL
- `make tables-fixedform` OK including the ASan twin

Did not run the nine-language gate. Did not start a CI campaign.

`tableOnlyLanguages` is `[]string{"rust","java","js"}`. Dart is `pendingLanguages`. This PR does not regenerate paired Dart. Mixed paired-driver slots: none.

## Floors

Draft against `fixed-table-form`. Still draft. Did not merge. Did not undraft. Did not rebase. Did not force-push. Branched off live tip `0bcb8d60ce0ab177a13222f3a00f83c8b917e37d`.

Johnny Grok