### PR TITLE
tables: the Go leg refuses a hostile layout by name

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -1575,6 +1575,16 @@ const (
 const tableFixedNoGuard uint32 = 0xFFFFFFFF
 const tableFixedEntryBytes int32 = 17
 
+// THE LAYOUT'S OWN BOUNDS (docs/FIXED-FORM-ALGORITHM.md §1.1). The header is
+// the u32 entry count and nothing else. 65536 is the form's record body bound,
+// which a DECLARED fixed table is held to at compile time and an untrusted
+// peer's layout is held to here, so the two sides agree by construction. The
+// depth is a bound on THIS READER'S WALK and not on the wire: the reference
+// states 64 and every leg states the same number.
+const tableFixedLayoutHeaderBytes int32 = 4
+const tableFixedRecordMaxBytes uint32 = 65536
+const tableFixedMaxDepth int32 = 64
+
 // Arg is the guard's arm ordinal: tableFixedRun compares src[Guard] against
 // it. Meta is a text entry's flavour (tableFixedTextUtf8/Wide/Bytes). They
 // shared one lane until reference-fix 12; compiling a string under a union
@@ -1606,7 +1616,73 @@ func tableFixedWidens(from, to uint8) bool {
 	return from == 10 && to == 11
 }
 func tableFixedSignedKind(kind uint8) bool { return kind >= 2 && kind <= 5 }
-func tableFixedKindKnown(kind uint8) bool  { return kind <= 33 || kind == 35 }
+
+// THE CLOSED KIND SET (docs/FIXED-FORM-ALGORITHM.md §1): §3's own kinds 1..30,
+// the no-payload variant 32, wstring 33, and the ONE kind this form's layout
+// adds, the optional wrapper 35. 0 is no kind at all, 31 is §3's BODY framing
+// escape and 34 is reserved: none of the three is a kind a declaration spells,
+// so none is ever an entry's kind. A KIND OUTSIDE THIS SET IS A REFUSAL, not a
+// leaf to step over — the form byte versions the kinds behind it, so a kind
+// this build does not know names a FORM this reader never saw.
+func tableFixedKindKnown(kind uint8) bool {
+	if kind >= 1 && kind <= 30 {
+		return true
+	}
+	return kind == 32 || kind == 33 || kind == 35
+}
+
+// tableFixedOrdinalWidth is the widths an ordinal — an enum's, a union tag's —
+// is stored at.
+func tableFixedOrdinalWidth(n uint32) bool { return n == 1 || n == 2 || n == 4 || n == 8 }
+
+// tableFixedLeafSize answers whether a kind is a LEAF and, if it is, whether
+// the size it states is one its kind admits (§1.2). Kind and size fix each
+// other on this wire with ONE exception, stated here rather than left to be
+// found: a bits(N) field rides at its DECLARED STORAGE WIDTH — four bytes for
+// N <= 32 and eight above — under the unsigned integer kind its BIT COUNT
+// picks, so kinds 6 and 7 admit 4 as well as their own width.
+func tableFixedLeafSize(kind uint8, size uint32) (admitted, leaf bool) {
+	leaf = true
+	switch kind {
+	case 1, 2: // bool, i8
+		return size == 1, leaf
+	case 3: // i16
+		return size == 2, leaf
+	case 4: // i32
+		return size == 4, leaf
+	case 5: // i64
+		return size == 8, leaf
+	case 6: // u8, and bits( 1 .. 8 )
+		return size == 1 || size == 4, leaf
+	case 7: // u16, and bits( 9 .. 16 )
+		return size == 2 || size == 4, leaf
+	case 8: // u32, and bits( 17 .. 32 )
+		return size == 4, leaf
+	case 9: // u64, flags, and bits( 33 .. 64 )
+		return size == 8, leaf
+	case 10: // f32
+		return size == 4, leaf
+	case 11: // f64
+		return size == 8, leaf
+	case 17: // a pointer index, which no fixed table carries
+		return size == 4, leaf
+	case 18, 19: // i128, u128
+		return size == 16, leaf
+	case 20, 25: // fixed8, ufixed8
+		return size == 1, leaf
+	case 21, 26:
+		return size == 2, leaf
+	case 22, 27:
+		return size == 4, leaf
+	case 23, 28:
+		return size == 8, leaf
+	case 24, 29:
+		return size == 16, leaf
+	case 32: // a variant, and an arm that holds nothing
+		return size == 0, leaf
+	}
+	return true, false
+}
 
 // tableFixedRuns is whether an op advances src and dst together one byte at a
 // time, which is the whole of what lets two adjacent entries become one.
@@ -1811,8 +1887,16 @@ type tableFixedLayoutView struct {
 	Count int32
 }
 
+// AN INDEX PAST THE ENTRIES IS ANSWERED, NOT READ. Every index into a layout is
+// arithmetic over child counts a STRANGER wrote, so the one place that can hold
+// the whole walk inside the buffer is the one place that touches it. An
+// out-of-range index answers kind 0xFF, which is a kind no declaration has and
+// nothing matches, so the walk that asked for it finds nothing and moves on.
 func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
-	e := b.Bytes[4+int64(i)*int64(tableFixedEntryBytes):]
+	if b.Bytes == nil || i < 0 || i >= b.Count {
+		return tableFixedLayoutEntry{Kind: 0xFF}
+	}
+	e := b.Bytes[int64(tableFixedLayoutHeaderBytes)+int64(i)*int64(tableFixedEntryBytes):]
 	return tableFixedLayoutEntry{
 		Id:       tableFixedGet64(e),
 		Kind:     e[8],
@@ -1821,20 +1905,29 @@ func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
 	}
 }
 
+// tableFixedSubtree is how many entries the subtree rooted at i occupies, so a
+// walk steps over a child it does not want without knowing what is in it.
+//
+// ITERATIVE ON PURPOSE (docs/FIXED-FORM-ALGORITHM.md §1.1). A layout is a
+// stranger's bytes, so a chain of single-child entries is a stack depth the WIRE
+// gets to choose; this walk gives it none. The pending counter is the pre-order
+// walk's own arithmetic: one entry is owed at the start, each entry owes its
+// children, and the subtree ends when nothing is owed.
 func tableFixedSubtree(b tableFixedLayoutView, i int32) int32 {
 	if i < 0 || i >= b.Count {
 		return 1
 	}
-	e := tableFixedEntryAt(b, i)
-	n := int32(1)
-	at := i + 1
-	for c := uint32(0); c < e.Children; c++ {
-		if at >= b.Count {
+	pending := int64(1)
+	n := int32(0)
+	at := i
+	for pending > 0 && at < b.Count {
+		pending--
+		n++
+		pending += int64(tableFixedEntryAt(b, at).Children)
+		at++
+		if pending > int64(b.Count) {
 			break
 		}
-		sub := tableFixedSubtree(b, at)
-		at += sub
-		n += sub
 	}
 	return n
 }
@@ -1843,7 +1936,7 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	e := tableFixedEntryAt(b, i)
 	var widest uint32
 	at := i + 1
-	for k := uint32(0); k < e.Children; k++ {
+	for k := uint32(0); k < e.Children && at < b.Count; k++ {
 		a := tableFixedEntryAt(b, at)
 		if a.Size > widest {
 			widest = a.Size
@@ -1853,30 +1946,252 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	return widest
 }
 
+// ---- THE LAYOUT'S OWN VALIDATION, RULE BY NAMED RULE -----------------------
+//
+// A LAYOUT ARRIVES FROM AN UNTRUSTED PEER and it is the one structure a reader
+// must parse before it knows anything at all, so every rule below runs BEFORE a
+// single record byte is touched and each refuses under ITS OWN NAME rather than
+// under one word for all of them (docs/FIXED-FORM-ALGORITHM.md §1.1).
+//
+// NOR IS THERE A CYCLE RULE, because a pre-order walk cannot express a cycle: an
+// entry's children ARE THE ENTRIES THAT FOLLOW IT, so a child's index is always
+// higher than its parent's, the layout is finite, and there is no back reference
+// for a cycle to be made of. The tree-closure rule is what bounds the walk, and
+// the depth rule is what bounds the reader's stack.
+type tableFixedCheck struct {
+	layout tableFixedLayoutView
+	why    string
+}
+
+// Keep the FIRST reason and stop: the order of the rules is load-bearing, so the
+// reason a reader reports is the first one the layout broke.
+func (c *tableFixedCheck) fail(why string) {
+	if c.why == "" {
+		c.why = why
+	}
+}
+
+// tableFixedCheckEntry validates the subtree rooted at i and answers how many
+// entries it occupies, which is the same arithmetic tableFixedSubtree does and
+// is why that walk is safe to run afterwards and only afterwards.
+func tableFixedCheckEntry(c *tableFixedCheck, i, depth int32) int32 {
+	if c.why != "" {
+		return 0
+	}
+	if i < 0 || i >= c.layout.Count {
+		c.fail("layout_tree_unclosed")
+		return 0
+	}
+	if depth > tableFixedMaxDepth {
+		c.fail("layout_too_deep")
+		return 0
+	}
+	e := tableFixedEntryAt(c.layout, i)
+	// THE CLOSED KIND SET, FIRST: a kind outside it is a layout of another form
+	// and is refused whole, never walked and never stepped over.
+	if !tableFixedKindKnown(e.Kind) {
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	if e.Size > tableFixedRecordMaxBytes {
+		c.fail("layout_record_too_large")
+		return 0
+	}
+
+	// THE CHILDREN FIRST, in the pre-order the layout is written in.
+	at := i + 1
+	var sum uint64
+	var widest, firstSize, secondSize, firstChildren uint32
+	var firstKind uint8
+	kidsAreVariants := true
+	for k := uint32(0); k < e.Children; k++ {
+		child := at
+		used := tableFixedCheckEntry(c, child, depth+1)
+		if c.why != "" {
+			return 0
+		}
+		ce := tableFixedEntryAt(c.layout, child)
+		if k == 0 {
+			firstSize, firstKind, firstChildren = ce.Size, ce.Kind, ce.Children
+		}
+		if k == 1 {
+			secondSize = ce.Size
+		}
+		if ce.Kind != 32 {
+			kidsAreVariants = false
+		}
+		// THE SUM IS 64 BITS precisely so a u32 that overflows is CAUGHT rather
+		// than wrapped into a small number that then agrees with its parent.
+		sum += uint64(ce.Size)
+		if ce.Size > widest {
+			widest = ce.Size
+		}
+		if sum > uint64(tableFixedRecordMaxBytes) {
+			c.fail("layout_record_too_large")
+			return 0
+		}
+		at += used
+	}
+
+	admitted, leaf := tableFixedLeafSize(e.Kind, e.Size)
+	if !admitted {
+		c.fail("layout_size_mismatch")
+		return 0
+	}
+	if leaf {
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		return at - i
+	}
+	switch e.Kind {
+	case 13: // a TABLE: its size is the SUM of its fields'
+		if uint64(e.Size) != sum {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 35: // the OPTIONAL WRAPPER: one child, one present byte in front of it
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if uint64(e.Size) != sum+1 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 14: // an ARRAY: a whole number of elements, behind a count or not
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstSize == 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		bare := e.Size%firstSize == 0
+		counted := e.Size >= 4 && (e.Size-4)%firstSize == 0
+		if !bare && !counted {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 16: // an ENUM-KEYED array: the KEY ENUM then the ELEMENT, every slot written
+		if e.Children != 2 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstKind != 30 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if secondSize == 0 || e.Size%secondSize != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		// AT LEAST one slot per variant. Not exactly one: an enum widened by an
+		// explicit max has more slots than it has names, and the layout carries
+		// only the names.
+		if e.Size/secondSize < firstChildren {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 15: // a UNION: the TAG at its own width, then the WIDEST ARM
+		if e.Children == 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size <= widest {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if !tableFixedOrdinalWidth(e.Size - widest) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 30: // an ENUM: the ordinal's storage width, and its children are VARIANTS
+		if !tableFixedOrdinalWidth(e.Size) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if e.Children != 0 && !kidsAreVariants {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+	case 12: // string(N): the length, then N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 33: // wstring(N): the length in CODE UNITS, then 2N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 || (e.Size-4)%2 != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	default:
+		// Every kind of the closed set is either a leaf above or a case here, so
+		// this is unreachable — and it refuses rather than admits, because a
+		// kind that reached it is a kind the two lists disagree about.
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	return at - i
+}
+
 func tableFixedTagBytes(b tableFixedLayoutView, i int32) uint32 {
 	return tableFixedEntryAt(b, i).Size - tableFixedUnionArmBytes(b, i)
 }
 
-func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, bool) {
+// tableFixedParseLayout is the WHOLE of what a reader trusts a layout on. It
+// answers the view and a REASON BY NAME — empty when the layout passed every
+// rule — and the caller reports that reason. A layout that fails any rule SETS
+// NOTHING: no view, no plan, and no counter moved.
+//
+// THE ORDER IS LOAD-BEARING (docs/FIXED-FORM-ALGORITHM.md §1.1): rule 1; the
+// root's kind and size; then the walk — index in range (5), depth (7), kind
+// known (2), own size (6), the children, then the size and shape rules (3, 4);
+// and last that the walk consumed exactly the entries (5).
+func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, string) {
 	var out tableFixedLayoutView
-	if len(bytes) < 4 {
-		return out, false
+	// THE RESIDUE: bytes that are not a layout at all — fewer than a header's
+	// worth of them — are layout_malformed and not one of the seven.
+	if int32(len(bytes)) < tableFixedLayoutHeaderBytes {
+		return out, "layout_malformed"
 	}
+	// 1. THE ENTRY COUNT FITS THE LAYOUT LENGTH EXACTLY
 	count := tableFixedGet32(bytes)
-	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+4 != int64(len(bytes)) {
-		return out, false
+	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+int64(tableFixedLayoutHeaderBytes) != int64(len(bytes)) {
+		return out, "layout_count_mismatch"
 	}
-	out.Bytes = bytes
-	out.Count = int32(count)
-	if tableFixedSubtree(out, 0) != out.Count {
-		return tableFixedLayoutView{}, false
+	view := tableFixedLayoutView{Bytes: bytes, Count: int32(count)}
+	// 2. THE ROOT IS A TABLE, and its size is the record's body
+	root := tableFixedEntryAt(view, 0)
+	if root.Kind != 13 {
+		return out, "layout_kind_invalid"
 	}
-	for i := int32(0); i < out.Count; i++ {
-		if !tableFixedKindKnown(tableFixedEntryAt(out, i).Kind) {
-			return tableFixedLayoutView{}, false
-		}
+	if root.Size == 0 || root.Size > tableFixedRecordMaxBytes {
+		return out, "layout_record_too_large"
 	}
-	return out, true
+	// 3. EVERY KIND IN THE CLOSED SET AND USED AS ITS DEFINITION ALLOWS, EVERY
+	//    SIZE THE ONE ITS CHILDREN ACCOUNT FOR, NOTHING PAST THE WALK'S BOUND
+	c := tableFixedCheck{layout: view}
+	used := tableFixedCheckEntry(&c, 0, 0)
+	if c.why != "" {
+		return out, c.why
+	}
+	// 4. THE PRE-ORDER WALK CONSUMES EXACTLY THE ENTRIES: the tree closes and
+	//    the layout has nothing left over
+	if used != view.Count {
+		return out, "layout_tree_unclosed"
+	}
+	return view, ""
 }
 
 type tableFixedCompiler struct {
@@ -2089,9 +2404,11 @@ func tableFixedCompile(theirs tableFixedLayoutView, myLayout []byte, dst []Table
 	if len(plan) == 0 {
 		return -1
 	}
-	mine, ok := tableFixedParseLayout(myLayout)
-	if !ok {
-		return -1
+	// THE READER'S OWN LAYOUT, and a failure to parse it owes its OWN name and
+	// not plan_too_large: -2 is that, -1 is the plan storage (reference fix 3).
+	mine, why := tableFixedParseLayout(myLayout)
+	if why != "" {
+		return -2
 	}
 	c := tableFixedCompiler{plan: plan, capacity: int32(len(plan)), report: report}
 	tableFixedMatchChildren(&c, theirs, 0, 0, mine, 0, dst, 0, tableFixedNoGuard, 0)

--- a/generated/bench/paired/go/FixedTableTable.go
+++ b/generated/bench/paired/go/FixedTableTable.go
@@ -1286,9 +1286,6 @@ func FixedTableFixedLoad(values []FixedTable, data []byte, plan []TableFixedEntr
 	}
 	layout := data[TableFixedHeaderBytes+4 : TableFixedHeaderBytes+4+layoutBytes]
 	hash := tableFixedHashOf(layout)
-	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
-		return tableFixedRefuse(report, "layout_malformed")
-	}
 	at := data[TableFixedHeaderBytes+4+layoutBytes:]
 	rest := int64(len(data)) - TableFixedHeaderBytes - 4 - int64(layoutBytes)
 	entries := FixedTableFixedPlan.Entries
@@ -1296,17 +1293,26 @@ func FixedTableFixedLoad(values []FixedTable, data []byte, plan []TableFixedEntr
 	recordBytes := int64(FixedTableFixedRecordBytes)
 	identity := hash == FixedTableFixedHash
 	if !identity {
-		parsed, ok := tableFixedParseLayout(layout)
-		if !ok {
-			return tableFixedRefuse(report, "layout_malformed")
+		// ANOTHER WRITER: the same loop, over a plan compiled from its layout.
+		// THE LAYOUT IS VALIDATED BEFORE A SINGLE RECORD BYTE IS TOUCHED, and
+		// every rule it fails refuses under ITS OWN NAME (§1.1).
+		parsed, why := tableFixedParseLayout(layout)
+		if why != "" {
+			return tableFixedRefuse(report, why)
 		}
 		made := tableFixedCompile(parsed, FixedTableFixedLayout, FixedTableFixedDst, plan, report)
+		if made == -2 {
+			return tableFixedRefuse(report, "layout_malformed")
+		}
 		if made < 0 {
 			return tableFixedRefuse(report, "plan_too_large")
 		}
 		entries = plan
 		entryCount = made
 		recordBytes = 8 + int64(tableFixedEntryAt(parsed, 0).Size)
+	}
+	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
+		return tableFixedRefuse(report, "layout_malformed")
 	}
 	if recordBytes <= 8 || rest%recordBytes != 0 {
 		report.Malformed = true

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -1639,6 +1639,16 @@ const (
 const tableFixedNoGuard uint32 = 0xFFFFFFFF
 const tableFixedEntryBytes int32 = 17
 
+// THE LAYOUT'S OWN BOUNDS (docs/FIXED-FORM-ALGORITHM.md §1.1). The header is
+// the u32 entry count and nothing else. 65536 is the form's record body bound,
+// which a DECLARED fixed table is held to at compile time and an untrusted
+// peer's layout is held to here, so the two sides agree by construction. The
+// depth is a bound on THIS READER'S WALK and not on the wire: the reference
+// states 64 and every leg states the same number.
+const tableFixedLayoutHeaderBytes int32 = 4
+const tableFixedRecordMaxBytes uint32 = 65536
+const tableFixedMaxDepth int32 = 64
+
 // Arg is the guard's arm ordinal: tableFixedRun compares src[Guard] against
 // it. Meta is a text entry's flavour (tableFixedTextUtf8/Wide/Bytes). They
 // shared one lane until reference-fix 12; compiling a string under a union
@@ -1670,7 +1680,73 @@ func tableFixedWidens(from, to uint8) bool {
 	return from == 10 && to == 11
 }
 func tableFixedSignedKind(kind uint8) bool { return kind >= 2 && kind <= 5 }
-func tableFixedKindKnown(kind uint8) bool  { return kind <= 33 || kind == 35 }
+
+// THE CLOSED KIND SET (docs/FIXED-FORM-ALGORITHM.md §1): §3's own kinds 1..30,
+// the no-payload variant 32, wstring 33, and the ONE kind this form's layout
+// adds, the optional wrapper 35. 0 is no kind at all, 31 is §3's BODY framing
+// escape and 34 is reserved: none of the three is a kind a declaration spells,
+// so none is ever an entry's kind. A KIND OUTSIDE THIS SET IS A REFUSAL, not a
+// leaf to step over — the form byte versions the kinds behind it, so a kind
+// this build does not know names a FORM this reader never saw.
+func tableFixedKindKnown(kind uint8) bool {
+	if kind >= 1 && kind <= 30 {
+		return true
+	}
+	return kind == 32 || kind == 33 || kind == 35
+}
+
+// tableFixedOrdinalWidth is the widths an ordinal — an enum's, a union tag's —
+// is stored at.
+func tableFixedOrdinalWidth(n uint32) bool { return n == 1 || n == 2 || n == 4 || n == 8 }
+
+// tableFixedLeafSize answers whether a kind is a LEAF and, if it is, whether
+// the size it states is one its kind admits (§1.2). Kind and size fix each
+// other on this wire with ONE exception, stated here rather than left to be
+// found: a bits(N) field rides at its DECLARED STORAGE WIDTH — four bytes for
+// N <= 32 and eight above — under the unsigned integer kind its BIT COUNT
+// picks, so kinds 6 and 7 admit 4 as well as their own width.
+func tableFixedLeafSize(kind uint8, size uint32) (admitted, leaf bool) {
+	leaf = true
+	switch kind {
+	case 1, 2: // bool, i8
+		return size == 1, leaf
+	case 3: // i16
+		return size == 2, leaf
+	case 4: // i32
+		return size == 4, leaf
+	case 5: // i64
+		return size == 8, leaf
+	case 6: // u8, and bits( 1 .. 8 )
+		return size == 1 || size == 4, leaf
+	case 7: // u16, and bits( 9 .. 16 )
+		return size == 2 || size == 4, leaf
+	case 8: // u32, and bits( 17 .. 32 )
+		return size == 4, leaf
+	case 9: // u64, flags, and bits( 33 .. 64 )
+		return size == 8, leaf
+	case 10: // f32
+		return size == 4, leaf
+	case 11: // f64
+		return size == 8, leaf
+	case 17: // a pointer index, which no fixed table carries
+		return size == 4, leaf
+	case 18, 19: // i128, u128
+		return size == 16, leaf
+	case 20, 25: // fixed8, ufixed8
+		return size == 1, leaf
+	case 21, 26:
+		return size == 2, leaf
+	case 22, 27:
+		return size == 4, leaf
+	case 23, 28:
+		return size == 8, leaf
+	case 24, 29:
+		return size == 16, leaf
+	case 32: // a variant, and an arm that holds nothing
+		return size == 0, leaf
+	}
+	return true, false
+}
 
 // tableFixedRuns is whether an op advances src and dst together one byte at a
 // time, which is the whole of what lets two adjacent entries become one.
@@ -1875,8 +1951,16 @@ type tableFixedLayoutView struct {
 	Count int32
 }
 
+// AN INDEX PAST THE ENTRIES IS ANSWERED, NOT READ. Every index into a layout is
+// arithmetic over child counts a STRANGER wrote, so the one place that can hold
+// the whole walk inside the buffer is the one place that touches it. An
+// out-of-range index answers kind 0xFF, which is a kind no declaration has and
+// nothing matches, so the walk that asked for it finds nothing and moves on.
 func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
-	e := b.Bytes[4+int64(i)*int64(tableFixedEntryBytes):]
+	if b.Bytes == nil || i < 0 || i >= b.Count {
+		return tableFixedLayoutEntry{Kind: 0xFF}
+	}
+	e := b.Bytes[int64(tableFixedLayoutHeaderBytes)+int64(i)*int64(tableFixedEntryBytes):]
 	return tableFixedLayoutEntry{
 		Id:       tableFixedGet64(e),
 		Kind:     e[8],
@@ -1885,20 +1969,29 @@ func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
 	}
 }
 
+// tableFixedSubtree is how many entries the subtree rooted at i occupies, so a
+// walk steps over a child it does not want without knowing what is in it.
+//
+// ITERATIVE ON PURPOSE (docs/FIXED-FORM-ALGORITHM.md §1.1). A layout is a
+// stranger's bytes, so a chain of single-child entries is a stack depth the WIRE
+// gets to choose; this walk gives it none. The pending counter is the pre-order
+// walk's own arithmetic: one entry is owed at the start, each entry owes its
+// children, and the subtree ends when nothing is owed.
 func tableFixedSubtree(b tableFixedLayoutView, i int32) int32 {
 	if i < 0 || i >= b.Count {
 		return 1
 	}
-	e := tableFixedEntryAt(b, i)
-	n := int32(1)
-	at := i + 1
-	for c := uint32(0); c < e.Children; c++ {
-		if at >= b.Count {
+	pending := int64(1)
+	n := int32(0)
+	at := i
+	for pending > 0 && at < b.Count {
+		pending--
+		n++
+		pending += int64(tableFixedEntryAt(b, at).Children)
+		at++
+		if pending > int64(b.Count) {
 			break
 		}
-		sub := tableFixedSubtree(b, at)
-		at += sub
-		n += sub
 	}
 	return n
 }
@@ -1907,7 +2000,7 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	e := tableFixedEntryAt(b, i)
 	var widest uint32
 	at := i + 1
-	for k := uint32(0); k < e.Children; k++ {
+	for k := uint32(0); k < e.Children && at < b.Count; k++ {
 		a := tableFixedEntryAt(b, at)
 		if a.Size > widest {
 			widest = a.Size
@@ -1917,30 +2010,252 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	return widest
 }
 
+// ---- THE LAYOUT'S OWN VALIDATION, RULE BY NAMED RULE -----------------------
+//
+// A LAYOUT ARRIVES FROM AN UNTRUSTED PEER and it is the one structure a reader
+// must parse before it knows anything at all, so every rule below runs BEFORE a
+// single record byte is touched and each refuses under ITS OWN NAME rather than
+// under one word for all of them (docs/FIXED-FORM-ALGORITHM.md §1.1).
+//
+// NOR IS THERE A CYCLE RULE, because a pre-order walk cannot express a cycle: an
+// entry's children ARE THE ENTRIES THAT FOLLOW IT, so a child's index is always
+// higher than its parent's, the layout is finite, and there is no back reference
+// for a cycle to be made of. The tree-closure rule is what bounds the walk, and
+// the depth rule is what bounds the reader's stack.
+type tableFixedCheck struct {
+	layout tableFixedLayoutView
+	why    string
+}
+
+// Keep the FIRST reason and stop: the order of the rules is load-bearing, so the
+// reason a reader reports is the first one the layout broke.
+func (c *tableFixedCheck) fail(why string) {
+	if c.why == "" {
+		c.why = why
+	}
+}
+
+// tableFixedCheckEntry validates the subtree rooted at i and answers how many
+// entries it occupies, which is the same arithmetic tableFixedSubtree does and
+// is why that walk is safe to run afterwards and only afterwards.
+func tableFixedCheckEntry(c *tableFixedCheck, i, depth int32) int32 {
+	if c.why != "" {
+		return 0
+	}
+	if i < 0 || i >= c.layout.Count {
+		c.fail("layout_tree_unclosed")
+		return 0
+	}
+	if depth > tableFixedMaxDepth {
+		c.fail("layout_too_deep")
+		return 0
+	}
+	e := tableFixedEntryAt(c.layout, i)
+	// THE CLOSED KIND SET, FIRST: a kind outside it is a layout of another form
+	// and is refused whole, never walked and never stepped over.
+	if !tableFixedKindKnown(e.Kind) {
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	if e.Size > tableFixedRecordMaxBytes {
+		c.fail("layout_record_too_large")
+		return 0
+	}
+
+	// THE CHILDREN FIRST, in the pre-order the layout is written in.
+	at := i + 1
+	var sum uint64
+	var widest, firstSize, secondSize, firstChildren uint32
+	var firstKind uint8
+	kidsAreVariants := true
+	for k := uint32(0); k < e.Children; k++ {
+		child := at
+		used := tableFixedCheckEntry(c, child, depth+1)
+		if c.why != "" {
+			return 0
+		}
+		ce := tableFixedEntryAt(c.layout, child)
+		if k == 0 {
+			firstSize, firstKind, firstChildren = ce.Size, ce.Kind, ce.Children
+		}
+		if k == 1 {
+			secondSize = ce.Size
+		}
+		if ce.Kind != 32 {
+			kidsAreVariants = false
+		}
+		// THE SUM IS 64 BITS precisely so a u32 that overflows is CAUGHT rather
+		// than wrapped into a small number that then agrees with its parent.
+		sum += uint64(ce.Size)
+		if ce.Size > widest {
+			widest = ce.Size
+		}
+		if sum > uint64(tableFixedRecordMaxBytes) {
+			c.fail("layout_record_too_large")
+			return 0
+		}
+		at += used
+	}
+
+	admitted, leaf := tableFixedLeafSize(e.Kind, e.Size)
+	if !admitted {
+		c.fail("layout_size_mismatch")
+		return 0
+	}
+	if leaf {
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		return at - i
+	}
+	switch e.Kind {
+	case 13: // a TABLE: its size is the SUM of its fields'
+		if uint64(e.Size) != sum {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 35: // the OPTIONAL WRAPPER: one child, one present byte in front of it
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if uint64(e.Size) != sum+1 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 14: // an ARRAY: a whole number of elements, behind a count or not
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstSize == 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		bare := e.Size%firstSize == 0
+		counted := e.Size >= 4 && (e.Size-4)%firstSize == 0
+		if !bare && !counted {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 16: // an ENUM-KEYED array: the KEY ENUM then the ELEMENT, every slot written
+		if e.Children != 2 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstKind != 30 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if secondSize == 0 || e.Size%secondSize != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		// AT LEAST one slot per variant. Not exactly one: an enum widened by an
+		// explicit max has more slots than it has names, and the layout carries
+		// only the names.
+		if e.Size/secondSize < firstChildren {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 15: // a UNION: the TAG at its own width, then the WIDEST ARM
+		if e.Children == 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size <= widest {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if !tableFixedOrdinalWidth(e.Size - widest) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 30: // an ENUM: the ordinal's storage width, and its children are VARIANTS
+		if !tableFixedOrdinalWidth(e.Size) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if e.Children != 0 && !kidsAreVariants {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+	case 12: // string(N): the length, then N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 33: // wstring(N): the length in CODE UNITS, then 2N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 || (e.Size-4)%2 != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	default:
+		// Every kind of the closed set is either a leaf above or a case here, so
+		// this is unreachable — and it refuses rather than admits, because a
+		// kind that reached it is a kind the two lists disagree about.
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	return at - i
+}
+
 func tableFixedTagBytes(b tableFixedLayoutView, i int32) uint32 {
 	return tableFixedEntryAt(b, i).Size - tableFixedUnionArmBytes(b, i)
 }
 
-func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, bool) {
+// tableFixedParseLayout is the WHOLE of what a reader trusts a layout on. It
+// answers the view and a REASON BY NAME — empty when the layout passed every
+// rule — and the caller reports that reason. A layout that fails any rule SETS
+// NOTHING: no view, no plan, and no counter moved.
+//
+// THE ORDER IS LOAD-BEARING (docs/FIXED-FORM-ALGORITHM.md §1.1): rule 1; the
+// root's kind and size; then the walk — index in range (5), depth (7), kind
+// known (2), own size (6), the children, then the size and shape rules (3, 4);
+// and last that the walk consumed exactly the entries (5).
+func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, string) {
 	var out tableFixedLayoutView
-	if len(bytes) < 4 {
-		return out, false
+	// THE RESIDUE: bytes that are not a layout at all — fewer than a header's
+	// worth of them — are layout_malformed and not one of the seven.
+	if int32(len(bytes)) < tableFixedLayoutHeaderBytes {
+		return out, "layout_malformed"
 	}
+	// 1. THE ENTRY COUNT FITS THE LAYOUT LENGTH EXACTLY
 	count := tableFixedGet32(bytes)
-	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+4 != int64(len(bytes)) {
-		return out, false
+	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+int64(tableFixedLayoutHeaderBytes) != int64(len(bytes)) {
+		return out, "layout_count_mismatch"
 	}
-	out.Bytes = bytes
-	out.Count = int32(count)
-	if tableFixedSubtree(out, 0) != out.Count {
-		return tableFixedLayoutView{}, false
+	view := tableFixedLayoutView{Bytes: bytes, Count: int32(count)}
+	// 2. THE ROOT IS A TABLE, and its size is the record's body
+	root := tableFixedEntryAt(view, 0)
+	if root.Kind != 13 {
+		return out, "layout_kind_invalid"
 	}
-	for i := int32(0); i < out.Count; i++ {
-		if !tableFixedKindKnown(tableFixedEntryAt(out, i).Kind) {
-			return tableFixedLayoutView{}, false
-		}
+	if root.Size == 0 || root.Size > tableFixedRecordMaxBytes {
+		return out, "layout_record_too_large"
 	}
-	return out, true
+	// 3. EVERY KIND IN THE CLOSED SET AND USED AS ITS DEFINITION ALLOWS, EVERY
+	//    SIZE THE ONE ITS CHILDREN ACCOUNT FOR, NOTHING PAST THE WALK'S BOUND
+	c := tableFixedCheck{layout: view}
+	used := tableFixedCheckEntry(&c, 0, 0)
+	if c.why != "" {
+		return out, c.why
+	}
+	// 4. THE PRE-ORDER WALK CONSUMES EXACTLY THE ENTRIES: the tree closes and
+	//    the layout has nothing left over
+	if used != view.Count {
+		return out, "layout_tree_unclosed"
+	}
+	return view, ""
 }
 
 type tableFixedCompiler struct {
@@ -2153,9 +2468,11 @@ func tableFixedCompile(theirs tableFixedLayoutView, myLayout []byte, dst []Table
 	if len(plan) == 0 {
 		return -1
 	}
-	mine, ok := tableFixedParseLayout(myLayout)
-	if !ok {
-		return -1
+	// THE READER'S OWN LAYOUT, and a failure to parse it owes its OWN name and
+	// not plan_too_large: -2 is that, -1 is the plan storage (reference fix 3).
+	mine, why := tableFixedParseLayout(myLayout)
+	if why != "" {
+		return -2
 	}
 	c := tableFixedCompiler{plan: plan, capacity: int32(len(plan)), report: report}
 	tableFixedMatchChildren(&c, theirs, 0, 0, mine, 0, dst, 0, tableFixedNoGuard, 0)
@@ -10131,9 +10448,6 @@ func TableEntityFixedLoad(values []TableEntity, data []byte, plan []TableFixedEn
 	}
 	layout := data[TableFixedHeaderBytes+4 : TableFixedHeaderBytes+4+layoutBytes]
 	hash := tableFixedHashOf(layout)
-	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
-		return tableFixedRefuse(report, "layout_malformed")
-	}
 	at := data[TableFixedHeaderBytes+4+layoutBytes:]
 	rest := int64(len(data)) - TableFixedHeaderBytes - 4 - int64(layoutBytes)
 	entries := TableEntityFixedPlan.Entries
@@ -10141,17 +10455,26 @@ func TableEntityFixedLoad(values []TableEntity, data []byte, plan []TableFixedEn
 	recordBytes := int64(TableEntityFixedRecordBytes)
 	identity := hash == TableEntityFixedHash
 	if !identity {
-		parsed, ok := tableFixedParseLayout(layout)
-		if !ok {
-			return tableFixedRefuse(report, "layout_malformed")
+		// ANOTHER WRITER: the same loop, over a plan compiled from its layout.
+		// THE LAYOUT IS VALIDATED BEFORE A SINGLE RECORD BYTE IS TOUCHED, and
+		// every rule it fails refuses under ITS OWN NAME (§1.1).
+		parsed, why := tableFixedParseLayout(layout)
+		if why != "" {
+			return tableFixedRefuse(report, why)
 		}
 		made := tableFixedCompile(parsed, TableEntityFixedLayout, TableEntityFixedDst, plan, report)
+		if made == -2 {
+			return tableFixedRefuse(report, "layout_malformed")
+		}
 		if made < 0 {
 			return tableFixedRefuse(report, "plan_too_large")
 		}
 		entries = plan
 		entryCount = made
 		recordBytes = 8 + int64(tableFixedEntryAt(parsed, 0).Size)
+	}
+	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
+		return tableFixedRefuse(report, "layout_malformed")
 	}
 	if recordBytes <= 8 || rest%recordBytes != 0 {
 		report.Malformed = true
@@ -10272,9 +10595,6 @@ func TableStatFixedLoad(values []TableStat, data []byte, plan []TableFixedEntry,
 	}
 	layout := data[TableFixedHeaderBytes+4 : TableFixedHeaderBytes+4+layoutBytes]
 	hash := tableFixedHashOf(layout)
-	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
-		return tableFixedRefuse(report, "layout_malformed")
-	}
 	at := data[TableFixedHeaderBytes+4+layoutBytes:]
 	rest := int64(len(data)) - TableFixedHeaderBytes - 4 - int64(layoutBytes)
 	entries := TableStatFixedPlan.Entries
@@ -10282,17 +10602,26 @@ func TableStatFixedLoad(values []TableStat, data []byte, plan []TableFixedEntry,
 	recordBytes := int64(TableStatFixedRecordBytes)
 	identity := hash == TableStatFixedHash
 	if !identity {
-		parsed, ok := tableFixedParseLayout(layout)
-		if !ok {
-			return tableFixedRefuse(report, "layout_malformed")
+		// ANOTHER WRITER: the same loop, over a plan compiled from its layout.
+		// THE LAYOUT IS VALIDATED BEFORE A SINGLE RECORD BYTE IS TOUCHED, and
+		// every rule it fails refuses under ITS OWN NAME (§1.1).
+		parsed, why := tableFixedParseLayout(layout)
+		if why != "" {
+			return tableFixedRefuse(report, why)
 		}
 		made := tableFixedCompile(parsed, TableStatFixedLayout, TableStatFixedDst, plan, report)
+		if made == -2 {
+			return tableFixedRefuse(report, "layout_malformed")
+		}
 		if made < 0 {
 			return tableFixedRefuse(report, "plan_too_large")
 		}
 		entries = plan
 		entryCount = made
 		recordBytes = 8 + int64(tableFixedEntryAt(parsed, 0).Size)
+	}
+	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
+		return tableFixedRefuse(report, "layout_malformed")
 	}
 	if recordBytes <= 8 || rest%recordBytes != 0 {
 		report.Malformed = true
@@ -10561,9 +10890,6 @@ func TableMixedFixedLoad(values []TableMixed, data []byte, plan []TableFixedEntr
 	}
 	layout := data[TableFixedHeaderBytes+4 : TableFixedHeaderBytes+4+layoutBytes]
 	hash := tableFixedHashOf(layout)
-	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
-		return tableFixedRefuse(report, "layout_malformed")
-	}
 	at := data[TableFixedHeaderBytes+4+layoutBytes:]
 	rest := int64(len(data)) - TableFixedHeaderBytes - 4 - int64(layoutBytes)
 	entries := TableMixedFixedPlan.Entries
@@ -10571,17 +10897,26 @@ func TableMixedFixedLoad(values []TableMixed, data []byte, plan []TableFixedEntr
 	recordBytes := int64(TableMixedFixedRecordBytes)
 	identity := hash == TableMixedFixedHash
 	if !identity {
-		parsed, ok := tableFixedParseLayout(layout)
-		if !ok {
-			return tableFixedRefuse(report, "layout_malformed")
+		// ANOTHER WRITER: the same loop, over a plan compiled from its layout.
+		// THE LAYOUT IS VALIDATED BEFORE A SINGLE RECORD BYTE IS TOUCHED, and
+		// every rule it fails refuses under ITS OWN NAME (§1.1).
+		parsed, why := tableFixedParseLayout(layout)
+		if why != "" {
+			return tableFixedRefuse(report, why)
 		}
 		made := tableFixedCompile(parsed, TableMixedFixedLayout, TableMixedFixedDst, plan, report)
+		if made == -2 {
+			return tableFixedRefuse(report, "layout_malformed")
+		}
 		if made < 0 {
 			return tableFixedRefuse(report, "plan_too_large")
 		}
 		entries = plan
 		entryCount = made
 		recordBytes = 8 + int64(tableFixedEntryAt(parsed, 0).Size)
+	}
+	if tableFixedGet64(data[TableFixedHashAt:]) != hash {
+		return tableFixedRefuse(report, "layout_malformed")
 	}
 	if recordBytes <= 8 || rest%recordBytes != 0 {
 		report.Malformed = true

--- a/internal/codegen/gotable/fixedform.go
+++ b/internal/codegen/gotable/fixedform.go
@@ -740,7 +740,6 @@ func (g *tableGen) emitFixedRoot(st *ir.Struct) {
 	g.pf("\tif int64(layoutBytes)+TableFixedHeaderBytes+4 > int64(len(data)) {\n\t\treturn tableFixedRefuse(report, \"layout_malformed\")\n\t}\n")
 	g.pf("\tlayout := data[TableFixedHeaderBytes+4 : TableFixedHeaderBytes+4+layoutBytes]\n")
 	g.pf("\thash := tableFixedHashOf(layout)\n")
-	g.pf("\tif tableFixedGet64(data[TableFixedHashAt:]) != hash {\n\t\treturn tableFixedRefuse(report, \"layout_malformed\")\n\t}\n")
 	g.pf("\tat := data[TableFixedHeaderBytes+4+layoutBytes:]\n")
 	g.pf("\trest := int64(len(data)) - TableFixedHeaderBytes - 4 - int64(layoutBytes)\n")
 	g.pf("\tentries := %sFixedPlan.Entries\n", st.Name)
@@ -748,13 +747,23 @@ func (g *tableGen) emitFixedRoot(st *ir.Struct) {
 	g.pf("\trecordBytes := int64(%sFixedRecordBytes)\n", st.Name)
 	g.pf("\tidentity := hash == %sFixedHash\n", st.Name)
 	g.pf("\tif !identity {\n")
-	g.pf("\t\tparsed, ok := tableFixedParseLayout(layout)\n")
-	g.pf("\t\tif !ok {\n\t\t\treturn tableFixedRefuse(report, \"layout_malformed\")\n\t\t}\n")
+	g.pf("\t\t// ANOTHER WRITER: the same loop, over a plan compiled from its layout.\n")
+	g.pf("\t\t// THE LAYOUT IS VALIDATED BEFORE A SINGLE RECORD BYTE IS TOUCHED, and\n")
+	g.pf("\t\t// every rule it fails refuses under ITS OWN NAME (§1.1).\n")
+	g.pf("\t\tparsed, why := tableFixedParseLayout(layout)\n")
+	g.pf("\t\tif why != \"\" {\n\t\t\treturn tableFixedRefuse(report, why)\n\t\t}\n")
 	g.pf("\t\tmade := tableFixedCompile(parsed, %sFixedLayout, %sFixedDst, plan, report)\n", st.Name, st.Name)
+	g.pf("\t\tif made == -2 {\n\t\t\treturn tableFixedRefuse(report, \"layout_malformed\")\n\t\t}\n")
 	g.pf("\t\tif made < 0 {\n\t\t\treturn tableFixedRefuse(report, \"plan_too_large\")\n\t\t}\n")
 	g.pf("\t\tentries = plan\n\t\tentryCount = made\n")
 	g.pf("\t\trecordBytes = 8 + int64(tableFixedEntryAt(parsed, 0).Size)\n")
 	g.pf("\t}\n")
+	// THE HEADER NAMES THE LAYOUT ONCE, and it is checked LAST of the three
+	// (docs/FIXED-FORM-ALGORITHM.md §2.1 step 5): the layout's own rules each
+	// refuse under their own name first, so a broken layout is never reported as
+	// a lying header. A header whose hash is not the hash of the layout behind it
+	// is refused.
+	g.pf("\tif tableFixedGet64(data[TableFixedHashAt:]) != hash {\n\t\treturn tableFixedRefuse(report, \"layout_malformed\")\n\t}\n")
 	g.pf("\tif recordBytes <= 8 || rest%%recordBytes != 0 {\n\t\treport.Malformed = true\n\t\treturn -1\n\t}\n")
 	g.pf("\tn := rest / recordBytes\n")
 	g.pf("\tif n > int64(len(values)) {\n\t\treturn tableFixedRefuse(report, \"batch_too_large\")\n\t}\n")

--- a/internal/codegen/gotable/fixedform_test.go
+++ b/internal/codegen/gotable/fixedform_test.go
@@ -169,11 +169,15 @@ func TestRoundTrip(t *testing.T) {
 			t.Fatalf("FixedLoad form %d: want %s, got %d %+v", form, want, n, r)
 		}
 	}
+	// THE LAYOUT'S OWN RULES REFUSE UNDER THEIR OWN NAMES and before the header
+	// is doubted (docs/FIXED-FORM-ALGORITHM.md §1.1, §2.1 step 5): breaking the
+	// entry count is rule 1, so this is layout_count_mismatch and not the one
+	// word the residue keeps.
 	broken := append([]byte(nil), buf...)
 	broken[TableFixedHeaderBytes+4] ^= 0xFF
 	r = TableReport{}
-	if n := PointFixedLoad(got, broken, plan, &r); n >= 0 || r.Reason != "layout_malformed" {
-		t.Fatalf("layout_malformed: %d %+v", n, r)
+	if n := PointFixedLoad(got, broken, plan, &r); n >= 0 || r.Reason != "layout_count_mismatch" {
+		t.Fatalf("layout_count_mismatch: %d %+v", n, r)
 	}
 	lying := append([]byte(nil), buf...)
 	lying[TableFixedHeaderBytes+4+len(PointFixedLayout)] ^= 0xFF
@@ -358,8 +362,11 @@ func TestPlanPath(t *testing.T) {
 		plan := make([]tblfx1.TableFixedEntry, 1024)
 		v := make([]tblfx1.FxRoot, 1)
 		n := tblfx1.FxRootFixedLoad(v, broken, plan, &r)
-		if n >= 0 || r.Reason != "layout_malformed" || r.Unknown != 0 || r.KindMismatch != 0 || r.Malformed {
-			t.Fatalf("layout_malformed: n=%d %+v", n, r)
+		// RULE 1 BY ITS OWN NAME: 4 + 17*count is not the length given. The
+		// seven rules run before the header's hash is checked, so a broken
+		// layout is never reported as a lying header (§1.1, §2.1 step 5).
+		if n >= 0 || r.Reason != "layout_count_mismatch" || r.Unknown != 0 || r.KindMismatch != 0 || r.Malformed {
+			t.Fatalf("layout_count_mismatch: n=%d %+v", n, r)
 		}
 	}
 	{

--- a/internal/codegen/gotable/fixedlayout_test.go
+++ b/internal/codegen/gotable/fixedlayout_test.go
@@ -1,0 +1,275 @@
+package gotable
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestFixedFormLayoutRules is the Go twin of the C++ reference's
+// layout_validation() (test/tables/fixedform_main.cpp): ONE file that reads
+// clean, broken in exactly one place per case, and every case refused UNDER ITS
+// OWN NAME (docs/FIXED-FORM-ALGORITHM.md §1.1). A layout arrives from an
+// untrusted peer and is the one structure a reader parses before it knows
+// anything at all, so a single word for all seven rules is a validation nobody
+// can watch fail.
+//
+// It runs the GENERATED code, not the emitter: the layout walk is runtime
+// behaviour and a golden that contains the right substring is not a walk that
+// refuses. The writer is FX2 and the reader FX1, so the hash never matches and
+// the plan path — the path a stranger's layout takes — is the path under test.
+func TestFixedFormLayoutRules(t *testing.T) {
+	fx1, err := os.ReadFile("../../../test/tables/FX1.schema")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fx2, err := os.ReadFile("../../../test/tables/FX2.schema")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	runtime, err := filepath.Abs("../../../../serialize.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeUnit(t, filepath.Join(dir, "fx1"), "tblfx1", string(fx1), runtime)
+	writeUnit(t, filepath.Join(dir, "fx2"), "tblfx2", string(fx2), runtime)
+	testDir := filepath.Join(dir, "test")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mod := "module fixedlayouttest\n\ngo 1.26\n\nrequire (\n\ttblfx1 v0.0.0\n\ttblfx2 v0.0.0\n)\nreplace tblfx1 => ../fx1\nreplace tblfx2 => ../fx2\n"
+	if err := os.WriteFile(filepath.Join(testDir, "go.mod"), []byte(mod), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src := `package fixedlayouttest
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"tblfx1"
+	"tblfx2"
+)
+
+// THE FILE (docs/FIXED-FORM-ALGORITHM.md §2.1): form byte, seven reserved zero
+// bytes, the layout hash at 8, the body at 16 — so the layout's u32 length sits
+// at 16, the layout starts at 20, its entry count is the four bytes there, and
+// entry k is the seventeen bytes at 24 + 17k: id (u64), kind (u8), size (u32),
+// children (u32), every number little-endian.
+const layoutAt = tblfx1.TableFixedHeaderBytes + 4
+const entry0 = layoutAt + 4
+
+func put32(b []byte, at int, v uint32) { binary.LittleEndian.PutUint32(b[at:], v) }
+func get32(b []byte, at int) uint32    { return binary.LittleEndian.Uint32(b[at:]) }
+
+// entryAt answers the OFFSET of entry k, which is the arithmetic the walk does.
+func entryAt(k int) int { return entry0 + k*17 }
+
+// putEntry appends one entry to a hand-built layout, for the rules no single
+// break of a real layout reaches.
+func putEntry(layout []byte, id uint64, kind uint8, size, children uint32) []byte {
+	e := make([]byte, 17)
+	binary.LittleEndian.PutUint64(e, id)
+	e[8] = kind
+	binary.LittleEndian.PutUint32(e[9:], size)
+	binary.LittleEndian.PutUint32(e[13:], children)
+	return append(layout, e...)
+}
+
+// hashOf is §1's fnv1a64 over the layout's bytes as written, the four-byte
+// count included — written out HERE rather than borrowed from the runtime, so
+// the fixture is an oracle and not an echo.
+func hashOf(layout []byte) uint64 {
+	h := uint64(0xcbf29ce484222325)
+	for _, c := range layout {
+		h ^= uint64(c)
+		h *= 0x100000001b3
+	}
+	return h
+}
+
+// fileOf wraps a hand-built layout in a FILE with no records: every rule under
+// test refuses before a record byte is reached.
+func fileOf(layout []byte) []byte {
+	f := make([]byte, tblfx1.TableFixedHeaderBytes+4)
+	f[0] = 3
+	binary.LittleEndian.PutUint64(f[tblfx1.TableFixedHashAt:], hashOf(layout))
+	put32(f, tblfx1.TableFixedHeaderBytes, uint32(len(layout)))
+	return append(f, layout...)
+}
+
+func refuses(t *testing.T, broken []byte, want, what string) {
+	t.Helper()
+	v := make([]tblfx1.FxRoot, 1)
+	tblfx1.FxRootReset(&v[0])
+	var r tblfx1.TableReport
+	plan := make([]tblfx1.TableFixedEntry, 1024)
+	n := tblfx1.FxRootFixedLoad(v, broken, plan, &r)
+	if n >= 0 || r.Verdict != tblfx1.TableOpenRefused || r.Reason != want {
+		t.Fatalf("%s: want %s, got n=%d %+v", what, want, n, r)
+	}
+	// NOTHING WAS DECODED AND NOTHING WAS COUNTED. A refusal that half-read a
+	// record would be the damage the refusal exists to prevent.
+	if r.Unknown != 0 || r.KindMismatch != 0 || r.Widened != 0 || r.Clamped != 0 || r.Malformed {
+		t.Fatalf("%s: a layout refusal sets nothing and counts nothing: %+v", what, r)
+	}
+}
+
+func good(t *testing.T) []byte {
+	t.Helper()
+	var two tblfx2.FxRoot
+	tblfx2.FxRootReset(&two)
+	f := make([]byte, tblfx2.FxRootFixedMeasure(1))
+	if n := tblfx2.FxRootFixedSave([]tblfx2.FxRoot{two}, f); n != int64(len(f)) {
+		t.Fatalf("the unbroken file saves: %d", n)
+	}
+	// AND IT READS, so every refusal below is the ONE break and not the file.
+	v := make([]tblfx1.FxRoot, 1)
+	var r tblfx1.TableReport
+	plan := make([]tblfx1.TableFixedEntry, 1024)
+	if n := tblfx1.FxRootFixedLoad(v, f, plan, &r); n != 1 || r.Verdict == tblfx1.TableOpenRefused {
+		t.Fatalf("the unbroken file reads: n=%d %+v", n, r)
+	}
+	return f
+}
+
+func broken(t *testing.T) []byte { return append([]byte(nil), good(t)...) }
+
+// RULE 1: 4 + 17*count is the layout's stated length, and count is not zero.
+func TestRule1CountMismatch(t *testing.T) {
+	f := broken(t)
+	put32(f, layoutAt, get32(f, layoutAt)+1)
+	refuses(t, f, "layout_count_mismatch", "RULE 1: the entry count fits the layout length exactly")
+
+	z := broken(t)
+	put32(z, layoutAt, 0)
+	refuses(t, z, "layout_count_mismatch", "RULE 1: an entry count of zero is not a layout")
+}
+
+// RULE 2: every kind is in the closed set 1..30, 32, 33, 35. A fixed form's
+// kind set is CLOSED, so a kind outside it means a newer FORM BYTE — a
+// different form, not a newer layout of this one — and it is refused, never
+// stepped over. 0 is no kind at all and 31 is §3's framing escape: neither is a
+// kind a declaration spells, so neither is ever an entry's kind.
+func TestRule2KindUnknown(t *testing.T) {
+	for _, kind := range []byte{200, 0, 31, 34, 36, 255} {
+		f := broken(t)
+		f[entryAt(1)+8] = kind
+		refuses(t, f, "layout_kind_unknown", "RULE 2: a kind outside the closed set is REFUSED, not skipped")
+	}
+}
+
+// RULE 3: a size matches its kind (§1.2).
+func TestRule3SizeMismatch(t *testing.T) {
+	f := broken(t)
+	put32(f, entryAt(1)+9, 5) // a uint32 leaf in five bytes
+	refuses(t, f, "layout_size_mismatch", "RULE 3: a constant size its kind does not admit")
+
+	s := broken(t)
+	put32(s, entryAt(0)+9, get32(s, entryAt(0)+9)+4) // a table's size is the SUM of its fields'
+	refuses(t, s, "layout_size_mismatch", "RULE 3: a table's size is the sum of its fields'")
+}
+
+// RULE 4: a kind is used as its definition allows (§1.2) — here the root, which
+// a record's body is the size of, must be a table.
+func TestRule4KindInvalid(t *testing.T) {
+	f := broken(t)
+	f[entryAt(0)+8] = 14 // an array as the root of a record
+	refuses(t, f, "layout_kind_invalid", "RULE 4: the root entry is a TABLE")
+
+	// and a leaf carries no children: a kind this build KNOWS, used in a way
+	// its own definition does not allow.
+	k := broken(t)
+	put32(k, entryAt(1)+13, 1)
+	refuses(t, k, "layout_kind_invalid", "RULE 4: a leaf kind has no children")
+}
+
+// RULE 5: the pre-order walk consumes exactly count entries, ending on the last.
+func TestRule5TreeUnclosed(t *testing.T) {
+	f := broken(t)
+	put32(f, entryAt(0)+13, get32(f, entryAt(0)+13)+1)
+	refuses(t, f, "layout_tree_unclosed", "RULE 5: the tree runs out of layout")
+
+	// THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk
+	// reaches. It takes a hand-built layout, and that is itself worth stating:
+	// dropping a child of a TABLE is caught one rule sooner by the size that no
+	// longer sums, so the only subtree whose loss the size rule cannot see is
+	// one that contributes NO size — an enum's variants, at kind 32, size 0.
+	layout := make([]byte, 4)
+	put32(layout, 0, 4)
+	layout = putEntry(layout, 1, 13, 4, 1) // a table of one field
+	layout = putEntry(layout, 2, 30, 4, 0) // an enum, its TWO variants unreached
+	layout = putEntry(layout, 3, 32, 0, 0)
+	layout = putEntry(layout, 4, 32, 0, 0)
+	refuses(t, fileOf(layout), "layout_tree_unclosed", "RULE 5: the layout outlasts the tree")
+}
+
+// RULE 6: no entry's size, and no partial sum of a parent's children, passes
+// 65536 — the read side's whole defence (§4.2).
+func TestRule6RecordTooLarge(t *testing.T) {
+	f := broken(t)
+	put32(f, entryAt(0)+9, 65537)
+	refuses(t, f, "layout_record_too_large", "RULE 6: a record size past 65536")
+
+	// A SIZE THAT WOULD WRAP. The children's sizes are summed in 64 bits
+	// precisely so a u32 that overflows is CAUGHT rather than wrapped into a
+	// small number that then agrees with its parent.
+	w := broken(t)
+	put32(w, entryAt(1)+9, 0xFFFFFFFF)
+	refuses(t, w, "layout_record_too_large", "RULE 6: a size that would overflow the sum")
+}
+
+// RULE 7: nesting does not pass the reader's own walk bound. A bound on the
+// WALK and not on the wire: a chain of single-child entries is otherwise a
+// stack depth the wire gets to choose.
+func TestRule7TooDeep(t *testing.T) {
+	const depth = 4096 // far past any reader's own bound
+	layout := make([]byte, 4)
+	put32(layout, 0, depth+1)
+	for i := uint32(0); i < depth; i++ {
+		kind := uint8(35) // optional wrappers all the way down
+		if i == 0 {
+			kind = 13
+		}
+		layout = putEntry(layout, 1, kind, depth-i, 1)
+	}
+	layout = putEntry(layout, 2, 1, 1, 0) // a bool at the bottom
+	refuses(t, fileOf(layout), "layout_too_deep", "RULE 7: a nesting depth past the walk's own bound")
+}
+
+// AND THE RESIDUE: bytes that are not a layout at all, the one case the seven
+// named rules never reach — and the lying header, which is checked LAST of the
+// three so that a broken layout is never reported as a lying header.
+func TestLayoutMalformedResidue(t *testing.T) {
+	refuses(t, fileOf(make([]byte, 2)), "layout_malformed", "fewer bytes than a header is layout_malformed")
+
+	// THE HEADER NAMES THE LAYOUT ONCE (§2.1): the eight bytes at offset 8 are
+	// the LAYOUT's hash, and a header that claims a layout it does not carry is
+	// refused. The layout itself is whole here, so the plan was compiled before
+	// the header was doubted and the §4 counters it moved on the way are the
+	// reference's too: the one thing a refusal may never do is DAMAGE, so
+	// malformed stays clear and nothing was decoded.
+	f := broken(t)
+	f[tblfx1.TableFixedHashAt] ^= 0xFF
+	v := make([]tblfx1.FxRoot, 1)
+	tblfx1.FxRootReset(&v[0])
+	var r tblfx1.TableReport
+	plan := make([]tblfx1.TableFixedEntry, 1024)
+	n := tblfx1.FxRootFixedLoad(v, f, plan, &r)
+	if n >= 0 || r.Verdict != tblfx1.TableOpenRefused || r.Reason != "layout_malformed" || r.Malformed {
+		t.Fatalf("a header hash that is not the hash of the layout behind it: n=%d %+v", n, r)
+	}
+}
+`
+	if err := os.WriteFile(filepath.Join(testDir, "layout_test.go"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "test", "-count=1", "-v", ".")
+	cmd.Dir = testDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("the layout's seven rules, each by its own name: %v\n%s", err, out)
+	}
+}

--- a/internal/codegen/gotable/fixedruntime.go
+++ b/internal/codegen/gotable/fixedruntime.go
@@ -40,6 +40,16 @@ const (
 const tableFixedNoGuard uint32 = 0xFFFFFFFF
 const tableFixedEntryBytes int32 = 17
 
+// THE LAYOUT'S OWN BOUNDS (docs/FIXED-FORM-ALGORITHM.md §1.1). The header is
+// the u32 entry count and nothing else. 65536 is the form's record body bound,
+// which a DECLARED fixed table is held to at compile time and an untrusted
+// peer's layout is held to here, so the two sides agree by construction. The
+// depth is a bound on THIS READER'S WALK and not on the wire: the reference
+// states 64 and every leg states the same number.
+const tableFixedLayoutHeaderBytes int32 = 4
+const tableFixedRecordMaxBytes uint32 = 65536
+const tableFixedMaxDepth int32 = 64
+
 // Arg is the guard's arm ordinal: tableFixedRun compares src[Guard] against
 // it. Meta is a text entry's flavour (tableFixedTextUtf8/Wide/Bytes). They
 // shared one lane until reference-fix 12; compiling a string under a union
@@ -71,7 +81,73 @@ func tableFixedWidens(from, to uint8) bool {
 	return from == 10 && to == 11
 }
 func tableFixedSignedKind(kind uint8) bool { return kind >= 2 && kind <= 5 }
-func tableFixedKindKnown(kind uint8) bool { return kind <= 33 || kind == 35 }
+
+// THE CLOSED KIND SET (docs/FIXED-FORM-ALGORITHM.md §1): §3's own kinds 1..30,
+// the no-payload variant 32, wstring 33, and the ONE kind this form's layout
+// adds, the optional wrapper 35. 0 is no kind at all, 31 is §3's BODY framing
+// escape and 34 is reserved: none of the three is a kind a declaration spells,
+// so none is ever an entry's kind. A KIND OUTSIDE THIS SET IS A REFUSAL, not a
+// leaf to step over — the form byte versions the kinds behind it, so a kind
+// this build does not know names a FORM this reader never saw.
+func tableFixedKindKnown(kind uint8) bool {
+	if kind >= 1 && kind <= 30 {
+		return true
+	}
+	return kind == 32 || kind == 33 || kind == 35
+}
+
+// tableFixedOrdinalWidth is the widths an ordinal — an enum's, a union tag's —
+// is stored at.
+func tableFixedOrdinalWidth(n uint32) bool { return n == 1 || n == 2 || n == 4 || n == 8 }
+
+// tableFixedLeafSize answers whether a kind is a LEAF and, if it is, whether
+// the size it states is one its kind admits (§1.2). Kind and size fix each
+// other on this wire with ONE exception, stated here rather than left to be
+// found: a bits(N) field rides at its DECLARED STORAGE WIDTH — four bytes for
+// N <= 32 and eight above — under the unsigned integer kind its BIT COUNT
+// picks, so kinds 6 and 7 admit 4 as well as their own width.
+func tableFixedLeafSize(kind uint8, size uint32) (admitted, leaf bool) {
+	leaf = true
+	switch kind {
+	case 1, 2: // bool, i8
+		return size == 1, leaf
+	case 3: // i16
+		return size == 2, leaf
+	case 4: // i32
+		return size == 4, leaf
+	case 5: // i64
+		return size == 8, leaf
+	case 6: // u8, and bits( 1 .. 8 )
+		return size == 1 || size == 4, leaf
+	case 7: // u16, and bits( 9 .. 16 )
+		return size == 2 || size == 4, leaf
+	case 8: // u32, and bits( 17 .. 32 )
+		return size == 4, leaf
+	case 9: // u64, flags, and bits( 33 .. 64 )
+		return size == 8, leaf
+	case 10: // f32
+		return size == 4, leaf
+	case 11: // f64
+		return size == 8, leaf
+	case 17: // a pointer index, which no fixed table carries
+		return size == 4, leaf
+	case 18, 19: // i128, u128
+		return size == 16, leaf
+	case 20, 25: // fixed8, ufixed8
+		return size == 1, leaf
+	case 21, 26:
+		return size == 2, leaf
+	case 22, 27:
+		return size == 4, leaf
+	case 23, 28:
+		return size == 8, leaf
+	case 24, 29:
+		return size == 16, leaf
+	case 32: // a variant, and an arm that holds nothing
+		return size == 0, leaf
+	}
+	return true, false
+}
 
 // tableFixedRuns is whether an op advances src and dst together one byte at a
 // time, which is the whole of what lets two adjacent entries become one.
@@ -276,8 +352,16 @@ type tableFixedLayoutView struct {
 	Count int32
 }
 
+// AN INDEX PAST THE ENTRIES IS ANSWERED, NOT READ. Every index into a layout is
+// arithmetic over child counts a STRANGER wrote, so the one place that can hold
+// the whole walk inside the buffer is the one place that touches it. An
+// out-of-range index answers kind 0xFF, which is a kind no declaration has and
+// nothing matches, so the walk that asked for it finds nothing and moves on.
 func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
-	e := b.Bytes[4+int64(i)*int64(tableFixedEntryBytes):]
+	if b.Bytes == nil || i < 0 || i >= b.Count {
+		return tableFixedLayoutEntry{Kind: 0xFF}
+	}
+	e := b.Bytes[int64(tableFixedLayoutHeaderBytes)+int64(i)*int64(tableFixedEntryBytes):]
 	return tableFixedLayoutEntry{
 		Id: tableFixedGet64(e),
 		Kind: e[8],
@@ -286,20 +370,29 @@ func tableFixedEntryAt(b tableFixedLayoutView, i int32) tableFixedLayoutEntry {
 	}
 }
 
+// tableFixedSubtree is how many entries the subtree rooted at i occupies, so a
+// walk steps over a child it does not want without knowing what is in it.
+//
+// ITERATIVE ON PURPOSE (docs/FIXED-FORM-ALGORITHM.md §1.1). A layout is a
+// stranger's bytes, so a chain of single-child entries is a stack depth the WIRE
+// gets to choose; this walk gives it none. The pending counter is the pre-order
+// walk's own arithmetic: one entry is owed at the start, each entry owes its
+// children, and the subtree ends when nothing is owed.
 func tableFixedSubtree(b tableFixedLayoutView, i int32) int32 {
 	if i < 0 || i >= b.Count {
 		return 1
 	}
-	e := tableFixedEntryAt(b, i)
-	n := int32(1)
-	at := i + 1
-	for c := uint32(0); c < e.Children; c++ {
-		if at >= b.Count {
+	pending := int64(1)
+	n := int32(0)
+	at := i
+	for pending > 0 && at < b.Count {
+		pending--
+		n++
+		pending += int64(tableFixedEntryAt(b, at).Children)
+		at++
+		if pending > int64(b.Count) {
 			break
 		}
-		sub := tableFixedSubtree(b, at)
-		at += sub
-		n += sub
 	}
 	return n
 }
@@ -308,7 +401,7 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	e := tableFixedEntryAt(b, i)
 	var widest uint32
 	at := i + 1
-	for k := uint32(0); k < e.Children; k++ {
+	for k := uint32(0); k < e.Children && at < b.Count; k++ {
 		a := tableFixedEntryAt(b, at)
 		if a.Size > widest {
 			widest = a.Size
@@ -318,30 +411,252 @@ func tableFixedUnionArmBytes(b tableFixedLayoutView, i int32) uint32 {
 	return widest
 }
 
+// ---- THE LAYOUT'S OWN VALIDATION, RULE BY NAMED RULE -----------------------
+//
+// A LAYOUT ARRIVES FROM AN UNTRUSTED PEER and it is the one structure a reader
+// must parse before it knows anything at all, so every rule below runs BEFORE a
+// single record byte is touched and each refuses under ITS OWN NAME rather than
+// under one word for all of them (docs/FIXED-FORM-ALGORITHM.md §1.1).
+//
+// NOR IS THERE A CYCLE RULE, because a pre-order walk cannot express a cycle: an
+// entry's children ARE THE ENTRIES THAT FOLLOW IT, so a child's index is always
+// higher than its parent's, the layout is finite, and there is no back reference
+// for a cycle to be made of. The tree-closure rule is what bounds the walk, and
+// the depth rule is what bounds the reader's stack.
+type tableFixedCheck struct {
+	layout tableFixedLayoutView
+	why string
+}
+
+// Keep the FIRST reason and stop: the order of the rules is load-bearing, so the
+// reason a reader reports is the first one the layout broke.
+func (c *tableFixedCheck) fail(why string) {
+	if c.why == "" {
+		c.why = why
+	}
+}
+
+// tableFixedCheckEntry validates the subtree rooted at i and answers how many
+// entries it occupies, which is the same arithmetic tableFixedSubtree does and
+// is why that walk is safe to run afterwards and only afterwards.
+func tableFixedCheckEntry(c *tableFixedCheck, i, depth int32) int32 {
+	if c.why != "" {
+		return 0
+	}
+	if i < 0 || i >= c.layout.Count {
+		c.fail("layout_tree_unclosed")
+		return 0
+	}
+	if depth > tableFixedMaxDepth {
+		c.fail("layout_too_deep")
+		return 0
+	}
+	e := tableFixedEntryAt(c.layout, i)
+	// THE CLOSED KIND SET, FIRST: a kind outside it is a layout of another form
+	// and is refused whole, never walked and never stepped over.
+	if !tableFixedKindKnown(e.Kind) {
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	if e.Size > tableFixedRecordMaxBytes {
+		c.fail("layout_record_too_large")
+		return 0
+	}
+
+	// THE CHILDREN FIRST, in the pre-order the layout is written in.
+	at := i + 1
+	var sum uint64
+	var widest, firstSize, secondSize, firstChildren uint32
+	var firstKind uint8
+	kidsAreVariants := true
+	for k := uint32(0); k < e.Children; k++ {
+		child := at
+		used := tableFixedCheckEntry(c, child, depth+1)
+		if c.why != "" {
+			return 0
+		}
+		ce := tableFixedEntryAt(c.layout, child)
+		if k == 0 {
+			firstSize, firstKind, firstChildren = ce.Size, ce.Kind, ce.Children
+		}
+		if k == 1 {
+			secondSize = ce.Size
+		}
+		if ce.Kind != 32 {
+			kidsAreVariants = false
+		}
+		// THE SUM IS 64 BITS precisely so a u32 that overflows is CAUGHT rather
+		// than wrapped into a small number that then agrees with its parent.
+		sum += uint64(ce.Size)
+		if ce.Size > widest {
+			widest = ce.Size
+		}
+		if sum > uint64(tableFixedRecordMaxBytes) {
+			c.fail("layout_record_too_large")
+			return 0
+		}
+		at += used
+	}
+
+	admitted, leaf := tableFixedLeafSize(e.Kind, e.Size)
+	if !admitted {
+		c.fail("layout_size_mismatch")
+		return 0
+	}
+	if leaf {
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		return at - i
+	}
+	switch e.Kind {
+	case 13: // a TABLE: its size is the SUM of its fields'
+		if uint64(e.Size) != sum {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 35: // the OPTIONAL WRAPPER: one child, one present byte in front of it
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if uint64(e.Size) != sum+1 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 14: // an ARRAY: a whole number of elements, behind a count or not
+		if e.Children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstSize == 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		bare := e.Size%firstSize == 0
+		counted := e.Size >= 4 && (e.Size-4)%firstSize == 0
+		if !bare && !counted {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 16: // an ENUM-KEYED array: the KEY ENUM then the ELEMENT, every slot written
+		if e.Children != 2 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstKind != 30 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if secondSize == 0 || e.Size%secondSize != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		// AT LEAST one slot per variant. Not exactly one: an enum widened by an
+		// explicit max has more slots than it has names, and the layout carries
+		// only the names.
+		if e.Size/secondSize < firstChildren {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 15: // a UNION: the TAG at its own width, then the WIDEST ARM
+		if e.Children == 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size <= widest {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if !tableFixedOrdinalWidth(e.Size - widest) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 30: // an ENUM: the ordinal's storage width, and its children are VARIANTS
+		if !tableFixedOrdinalWidth(e.Size) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if e.Children != 0 && !kidsAreVariants {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+	case 12: // string(N): the length, then N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 33: // wstring(N): the length in CODE UNITS, then 2N bytes
+		if e.Children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.Size < 4 || (e.Size-4)%2 != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	default:
+		// Every kind of the closed set is either a leaf above or a case here, so
+		// this is unreachable — and it refuses rather than admits, because a
+		// kind that reached it is a kind the two lists disagree about.
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	return at - i
+}
+
 func tableFixedTagBytes(b tableFixedLayoutView, i int32) uint32 {
 	return tableFixedEntryAt(b, i).Size - tableFixedUnionArmBytes(b, i)
 }
 
-func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, bool) {
+// tableFixedParseLayout is the WHOLE of what a reader trusts a layout on. It
+// answers the view and a REASON BY NAME — empty when the layout passed every
+// rule — and the caller reports that reason. A layout that fails any rule SETS
+// NOTHING: no view, no plan, and no counter moved.
+//
+// THE ORDER IS LOAD-BEARING (docs/FIXED-FORM-ALGORITHM.md §1.1): rule 1; the
+// root's kind and size; then the walk — index in range (5), depth (7), kind
+// known (2), own size (6), the children, then the size and shape rules (3, 4);
+// and last that the walk consumed exactly the entries (5).
+func tableFixedParseLayout(bytes []byte) (tableFixedLayoutView, string) {
 	var out tableFixedLayoutView
-	if len(bytes) < 4 {
-		return out, false
+	// THE RESIDUE: bytes that are not a layout at all — fewer than a header's
+	// worth of them — are layout_malformed and not one of the seven.
+	if int32(len(bytes)) < tableFixedLayoutHeaderBytes {
+		return out, "layout_malformed"
 	}
+	// 1. THE ENTRY COUNT FITS THE LAYOUT LENGTH EXACTLY
 	count := tableFixedGet32(bytes)
-	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+4 != int64(len(bytes)) {
-		return out, false
+	if count == 0 || int64(count)*int64(tableFixedEntryBytes)+int64(tableFixedLayoutHeaderBytes) != int64(len(bytes)) {
+		return out, "layout_count_mismatch"
 	}
-	out.Bytes = bytes
-	out.Count = int32(count)
-	if tableFixedSubtree(out, 0) != out.Count {
-		return tableFixedLayoutView{}, false
+	view := tableFixedLayoutView{Bytes: bytes, Count: int32(count)}
+	// 2. THE ROOT IS A TABLE, and its size is the record's body
+	root := tableFixedEntryAt(view, 0)
+	if root.Kind != 13 {
+		return out, "layout_kind_invalid"
 	}
-	for i := int32(0); i < out.Count; i++ {
-		if !tableFixedKindKnown(tableFixedEntryAt(out, i).Kind) {
-			return tableFixedLayoutView{}, false
-		}
+	if root.Size == 0 || root.Size > tableFixedRecordMaxBytes {
+		return out, "layout_record_too_large"
 	}
-	return out, true
+	// 3. EVERY KIND IN THE CLOSED SET AND USED AS ITS DEFINITION ALLOWS, EVERY
+	//    SIZE THE ONE ITS CHILDREN ACCOUNT FOR, NOTHING PAST THE WALK'S BOUND
+	c := tableFixedCheck{layout: view}
+	used := tableFixedCheckEntry(&c, 0, 0)
+	if c.why != "" {
+		return out, c.why
+	}
+	// 4. THE PRE-ORDER WALK CONSUMES EXACTLY THE ENTRIES: the tree closes and
+	//    the layout has nothing left over
+	if used != view.Count {
+		return out, "layout_tree_unclosed"
+	}
+	return view, ""
 }
 
 type tableFixedCompiler struct {
@@ -554,9 +869,11 @@ func tableFixedCompile(theirs tableFixedLayoutView, myLayout []byte, dst []Table
 	if len(plan) == 0 {
 		return -1
 	}
-	mine, ok := tableFixedParseLayout(myLayout)
-	if !ok {
-		return -1
+	// THE READER'S OWN LAYOUT, and a failure to parse it owes its OWN name and
+	// not plan_too_large: -2 is that, -1 is the plan storage (reference fix 3).
+	mine, why := tableFixedParseLayout(myLayout)
+	if why != "" {
+		return -2
 	}
 	c := tableFixedCompiler{plan: plan, capacity: int32(len(plan)), report: report}
 	tableFixedMatchChildren(&c, theirs, 0, 0, mine, 0, dst, 0, tableFixedNoGuard, 0)


### PR DESCRIPTION
The Go leg's fixed-form LAYOUT WALK, held to `docs/FIXED-FORM-ALGORITHM.md` §1.1. Before this, the walk kept **one word — `layout_malformed` — for all seven rules**, did not implement two of them at all, and let a stranger's layout choose this reader's stack: `tableFixedSubtree` recursed once per entry and ran *before* any check, so a megabyte of single-child entries was ~61,000 frames the peer picked.

## The seven rules, and where each is now raised

The reader reports reasons as strings through `tableFixedRefuse` (this leg's existing convention), so each rule's name is a distinct value reported exactly the way `previous_form`, `no_layout` and `plan_too_large` already are.

| # | rule | refusal | raised at |
|---|---|---|---|
| 1 | `4 + 17*count` is the stated length, `count != 0` | `layout_count_mismatch` | `internal/codegen/gotable/fixedruntime.go:636` |
| 2 | every kind is in the closed set `1..30, 32, 33, 35` | `layout_kind_unknown` | `fixedruntime.go:458` (walk), `:607` (the unreachable default, which refuses rather than admits) |
| 3 | a size matches its kind (§1.2) | `layout_size_mismatch` | `fixedruntime.go:503` (leaf widths), `:516, :525, :534, :540, :553, :560, :569, :573, :578, :591, :600` (table / optional / array / keyed / union / enum / string / wstring) |
| 4 | a kind is used as its definition allows (§1.2) | `layout_kind_invalid` | `fixedruntime.go:642` (the root is a table), `:508` (a leaf with children), `:521, :530, :545, :549, :565, :582, :587, :596` |
| 5 | the pre-order walk consumes exactly `count`, ending on the last | `layout_tree_unclosed` | `fixedruntime.go:447` (an index past the entries), `:657` (the layout outlasting the tree) |
| 6 | no size, and no partial sum of a parent's children, passes 65536 | `layout_record_too_large` | `fixedruntime.go:645` (the root's body), `:462` (an entry's own size), `:495` (the running sum, in 64 bits so an overflow is caught and not wrapped) |
| 7 | nesting does not pass the reader's walk bound (the reference's 64) | `layout_too_deep` | `fixedruntime.go:451` |

And the residue: bytes that are not a layout at all stay `layout_malformed` (`fixedruntime.go:631`), as does a header whose hash is not the hash of the layout behind it (`fixedform.go:766`), and a failure to parse the reader's OWN layout (`fixedform.go:756`, the compiler's `-2`, reference fix 3 — not `plan_too_large`).

Also in the walk, from the C++ reference:

- **`tableFixedSubtree` is iterative** on the reference's own pending counter — the wire gets no say in stack depth — and the validating walk is depth-bounded at 64 (`tableFixedMaxDepth`).
- **An index past the entries is answered, not read**: `tableFixedEntryAt` returns kind `0xFF` instead of slicing out of range (it previously had no bound at all, and `tableFixedUnionArmBytes` walked past `Count`).
- **The closed set is fixed**: `kind <= 33 || kind == 35` admitted kind `0` and §3's framing escape `31`.
- **The header hash is checked LAST of the three** (§2.1 step 5), so a broken layout is never reported as a lying header. Two existing assertions that expected `layout_malformed` for a broken entry count now expect `layout_count_mismatch`.
- **One read path**: the hash still only *selects* the plan (identity plan vs. compiled), read-side checks always run, and nothing was added to the write side.

## Red first

The fixture (`internal/codegen/gotable/fixedlayout_test.go`) is the C++ reference's `layout_validation()` in Go, over **generated code** rather than goldens — FX2 writes, FX1 reads, so the plan path is the path under test; one file that reads clean, broken in exactly one place per case. Before the change:

```
=== RUN   TestRule1CountMismatch
    RULE 1: the entry count fits the layout length exactly: want layout_count_mismatch, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule1CountMismatch
=== RUN   TestRule2KindUnknown
    RULE 2: a kind outside the closed set is REFUSED, not skipped: want layout_kind_unknown, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule2KindUnknown
=== RUN   TestRule3SizeMismatch
    RULE 3: a constant size its kind does not admit: want layout_size_mismatch, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule3SizeMismatch
=== RUN   TestRule4KindInvalid
    RULE 4: the root entry is a TABLE: want layout_kind_invalid, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule4KindInvalid
=== RUN   TestRule5TreeUnclosed
    RULE 5: the tree runs out of layout: want layout_tree_unclosed, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule5TreeUnclosed
=== RUN   TestRule6RecordTooLarge
    RULE 6: a record size past 65536: want layout_record_too_large, got n=-1 {... Reason:layout_malformed ...}
--- FAIL: TestRule6RecordTooLarge
=== RUN   TestRule7TooDeep
    RULE 7: a nesting depth past the walk's own bound: want layout_too_deep, got n=0 {Verdict:0 Reason: Unknown:1 ...}
--- FAIL: TestRule7TooDeep
=== RUN   TestLayoutMalformedResidue
--- PASS: TestLayoutMalformedResidue
```

Rule 7's line is the one worth reading twice: **n=0, no refusal at all** — a 4096-deep layout was walked and accepted. All eight pass now.

## Commands

| command | time | result |
|---|---|---|
| `go test ./internal/codegen/gotable -run TestFixedFormLayoutRules -count=1` | 1.3 s | ok (8 cases) |
| `make tables-go-fixedform` | 3.1 s | **8 failures, the same 8 as on the tip** (`cff9c18d`), none of them mine — see below |
| `go test ./internal/codegen/gotable -count=1` | 45 s | 21 failures, **failure set byte-identical to the tip's** |
| `go vet ./internal/codegen/gotable ./compiler ./ir` | 1.1 s | clean |
| `go vet ./...` in `generated/bench/paired/go` | 0.2 s | clean |
| regenerate `generated/` (all five Go stamps + `bin/schema`) | 1.4 s | drift in the three Go files only, `gofmt` clean |

**`tables-go-fixedform` is already red on `fixed-table-form`** at `cff9c18d`, ahead of this branch: `TestFixedFormEmitsSurface`, `TestFixedFormRoundTrip`, `TestFixedFormHostileBoolByte`, `TestFixedFormHostileUnionTag`, `TestFixedFormArgLaneTextUnderSecondArm`, `TestFixedFormArgLaneOldEncodingControl`, `TestFixedFormClampPassShape`, `TestFixedFormClampLiveCount` — all of them "undefined: `PointFixedSave`" / "`arm.Pick.A.N` undefined", i.e. the fixed surface no longer emitted for a table nobody declared `fixed`, which is the keyword change landing on this branch and not this walk. I verified the set is identical with my changes stashed and restored. The fixture here passes in spite of it because it uses `fixed table` schemas (FX1/FX2).

## What I did not do

- No other leg touched: C++, Java, C#, Rust, Dart, Elixir, C, JS are unchanged. The backport of the *Go* wording (the iterative subtree comment, the `-2` split) is not proposed here.
- No fix for the eight pre-existing `tables-go-fixedform` failures — they are the keyword change's and belong to whoever is landing it.
- `tableFixedCompile` still refuses a plan that does not fit with `plan_too_large`; I added the `-2` path for the reader's own layout but did not give it a separate name beyond `layout_malformed` (the reference does the same).
- No new names in `internal/tablenames/go.go` (fix 8's module-scope name claims) — out of scope.
- Nothing run beyond the Go leg: no C++/Java/C# suites, no full `make test`.
