### PR TITLE
javatable: generate and pin FU1/FU2

### DIFF
--- a/internal/codegen/javatable/fixedform_test.go
+++ b/internal/codegen/javatable/fixedform_test.go
@@ -70,7 +70,7 @@ table Probe
 func TestFixedLoadPrefillsHolesOnly(t *testing.T) {
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -98,7 +98,7 @@ table ByRoot
 func TestWriteAndScatterWalkLiveCount(t *testing.T) {
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -129,7 +129,7 @@ func TestIdentityCompiledBytesN(t *testing.T) {
 	}
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -335,7 +335,7 @@ enum Grade
     Gold
 }
 
-table LiveRoot
+fixed table LiveRoot
 {
     grades [1..4]Grade
 }
@@ -368,3 +368,283 @@ table LiveRoot
 		t.Fatalf("counted-array write must zero slack past the live count:\n%s", write)
 	}
 }
+
+// TestFixedFormFU1FU2 is the TEXT-UNDER-AN-ARM pin (docs/SPEC-TABLES.md §3.4,
+// §15; docs/FIXED-FORM-ALGORITHM.md §4.1 fix 12). FU1 writes a string(8) in
+// the union's SECOND arm; FU2 appends `extra` so a read of those bytes is a
+// COMPILED plan. Both reads go through FuRootFixed.load — the same one-path
+// load the rest of this form uses. The compiled read has to see "hello".
+func TestFixedFormFU1FU2(t *testing.T) {
+	fu1Files, err := Generate(schemaUnit(t, "FU1.schema"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fu2Files, err := Generate(schemaUnit(t, "FU2.schema"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fu1Load := string(fu1Files["FuRootFixed.java"])
+	fu2Load := string(fu2Files["FuRootFixed.java"])
+	if fu1Load == "" || fu2Load == "" {
+		t.Fatal("FU1/FU2 did not emit FuRootFixed.java")
+	}
+	assertOnePathLoad(t, fu1Load, "FU1")
+	assertOnePathLoad(t, fu2Load, "FU2")
+	h1 := fixedHashLine(fu1Load)
+	h2 := fixedHashLine(fu2Load)
+	if h1 == "" || h2 == "" {
+		t.Fatal("FU1/FU2 did not emit a layout hash")
+	}
+	if h1 == h2 {
+		t.Fatal("FU2 extra did not change the layout hash; compiled path is not a compile trigger")
+	}
+
+	javac, javaBin := javaTools(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	classes := filepath.Join(dir, "classes")
+	if err := os.MkdirAll(classes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixedJava(t, src, "tblfu1", fu1Files)
+	writeFixedJava(t, src, "tblfu2", fu2Files)
+	if err := os.WriteFile(filepath.Join(src, "Driver.java"), []byte(fu1fu2Driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fu1src, err := filepath.Glob(filepath.Join(src, "tblfu1", "*.java"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fu2src, err := filepath.Glob(filepath.Join(src, "tblfu2", "*.java"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := append([]string{"--release", "17", "-d", classes}, fu1src...)
+	args = append(args, fu2src...)
+	args = append(args, filepath.Join(src, "Driver.java"))
+	cmd := exec.Command(javac, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("javac: %v\n%s", err, out)
+	}
+	run := exec.Command(javaBin, "-ea", "-cp", classes, "Driver")
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("java: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Fatalf("driver: %s", out)
+	}
+}
+
+func schemaUnit(t *testing.T, name string) *ir.Unit {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "test", "tables", name)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, perrs := parser.Parse(name, src)
+	if len(perrs) > 0 {
+		t.Fatalf("parse %s: %v", name, perrs[0])
+	}
+	base := strings.TrimSuffix(name, ".schema")
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: name, Name: name, Base: base, Bytes: src, AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check %s: %v", name, cerrs[0])
+	}
+	return u
+}
+
+func assertOnePathLoad(t *testing.T, src, who string) {
+	t.Helper()
+	if !strings.Contains(src, "public static int load(") {
+		t.Fatalf("%s did not emit load", who)
+	}
+	if strings.Contains(src, "if (identity)") {
+		t.Errorf("%s: identity flag still forks the record loop", who)
+	}
+	if !strings.Contains(src, "TableFixed.holes(") || !strings.Contains(src, "TableFixed.run(") {
+		t.Errorf("%s load is not the one-path load", who)
+	}
+	if !strings.Contains(src, "for (int h = 0; h < holeN; h++)") {
+		t.Errorf("%s skips the hole loop; identity empty is the list, not a skip", who)
+	}
+	if strings.Contains(src, "System.arraycopy(defaults, 0, image, 0, bodyBytes)") {
+		t.Errorf("%s still prefills the whole image", who)
+	}
+}
+
+func fixedHashLine(src string) string {
+	for _, line := range strings.Split(src, "\n") {
+		if strings.Contains(line, "public static final long hash =") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
+func writeFixedJava(t *testing.T, dir, pkg string, files map[string][]byte) {
+	t.Helper()
+	out := filepath.Join(dir, pkg)
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for name, data := range files {
+		if name != "TableFixed.java" && !strings.HasSuffix(name, "Fixed.java") {
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(out, name), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		n++
+	}
+	if n == 0 {
+		t.Fatalf("%s: no fixed-form files", pkg)
+	}
+}
+
+func javaTools(t *testing.T) (javac, javaBin string) {
+	t.Helper()
+	try := func(jc, j string) bool {
+		if jc == "" || j == "" {
+			return false
+		}
+		if st, err := os.Stat(jc); err != nil || st.IsDir() {
+			return false
+		}
+		if st, err := os.Stat(j); err != nil || st.IsDir() {
+			return false
+		}
+		if err := exec.Command(jc, "-version").Run(); err != nil {
+			return false
+		}
+		return true
+	}
+	if try(os.Getenv("JAVAC"), os.Getenv("JAVA")) {
+		return os.Getenv("JAVAC"), os.Getenv("JAVA")
+	}
+	if p, err := exec.LookPath("javac"); err == nil {
+		j, jerr := exec.LookPath("java")
+		if jerr == nil && try(p, j) {
+			return p, j
+		}
+	}
+	homes := []string{
+		"/Users/glenn/toolchains/schema-dist/jdk-21.0.12.1/Contents/Home",
+	}
+	if wd, err := os.Getwd(); err == nil {
+		homes = append(homes, filepath.Join(wd, "..", "..", "..", "dist", "jdk-21.0.12.1", "Contents", "Home"))
+	}
+	for _, home := range homes {
+		jc := filepath.Join(home, "bin", "javac")
+		j := filepath.Join(home, "bin", "java")
+		if try(jc, j) {
+			return jc, j
+		}
+	}
+	t.Skip("no working javac (set JAVAC/JAVA or install a JDK)")
+	return "", ""
+}
+
+const fu1fu2Driver = `public final class Driver {
+    private Driver() {}
+
+    static void fail(String what) {
+        System.out.println("FAILED: " + what);
+        System.exit(1);
+    }
+
+    static void setText(byte[] buf, String s) {
+        final byte[] raw = s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        System.arraycopy(raw, 0, buf, 0, raw.length);
+    }
+
+    static String textOf(byte[] buf, int length) {
+        return new String(buf, 0, length, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static void main(String[] args) {
+        if (tblfu1.FuRootFixed.hash == tblfu2.FuRootFixed.hash) {
+            fail("FU2 extra did not change the layout hash");
+        }
+
+        final byte[] cover = new byte[tblfu1.FuRootFixed.bodyBytes];
+        final int[] hole = new int[Math.max(2, tblfu1.FuRootFixed.bodyBytes * 2)];
+        if (tblfu1.TableFixed.holes(tblfu1.FuRootFixed.identityPlan(), 1, cover, hole) != 0) {
+            fail("identity holes must be empty; empty is the skip, not a second path");
+        }
+
+        final tblfu1.FuRootFixed.Value labelled = new tblfu1.FuRootFixed.Value();
+        labelled.flag = true;
+        labelled.notePresent = true;
+        labelled.note = 44;
+        labelled.pick.type = tblfu1.PickFixed.labelled;
+        labelled.pick.labelled.lead = 101;
+        setText(labelled.pick.labelled.label, "hello");
+        labelled.pick.labelled.labelLength = 5;
+        labelled.pick.labelled.trail = 202;
+        labelled.tail = 11;
+
+        final tblfu1.FuRootFixed.Value plain = new tblfu1.FuRootFixed.Value();
+        plain.pick.type = tblfu1.PickFixed.plain;
+        plain.pick.plain.n = 303;
+        plain.tail = 12;
+
+        final byte[] file = new byte[tblfu1.FuRootFixed.measure(2)];
+        if (tblfu1.FuRootFixed.save(new tblfu1.FuRootFixed.Value[] { labelled, plain }, 2, file) != file.length) {
+            fail("FU1 save");
+        }
+
+        final tblfu1.FuRootFixed.Value[] mine = {
+            new tblfu1.FuRootFixed.Value(), new tblfu1.FuRootFixed.Value()
+        };
+        final tblfu1.TableFixed.Report r = new tblfu1.TableFixed.Report();
+        final int n = tblfu1.FuRootFixed.load(mine, 2, file, tblfu1.TableFixed.plan(1024),
+                new short[1024], tblfu1.FuRootFixed.image(), r);
+        if (n != 2) { fail("identity n=" + n + " refused=" + r.refused + " malformed=" + r.malformed); }
+        if (mine[0].pick.type != tblfu1.PickFixed.labelled) { fail("identity arm"); }
+        if (mine[0].pick.labelled.lead != 101) { fail("identity lead"); }
+        if (mine[0].pick.labelled.labelLength != 5
+                || !textOf(mine[0].pick.labelled.label, mine[0].pick.labelled.labelLength).equals("hello")) {
+            fail("identity text");
+        }
+        if (mine[0].pick.labelled.trail != 202) { fail("identity trail"); }
+        if (!mine[0].flag || !mine[0].notePresent || mine[0].note != 44 || mine[0].tail != 11) {
+            fail("identity labelled rest");
+        }
+        if (mine[1].pick.type != tblfu1.PickFixed.plain || mine[1].pick.plain.n != 303 || mine[1].tail != 12) {
+            fail("identity plain");
+        }
+        if (r.refused || r.malformed || r.clamped != 0) { fail("identity report"); }
+
+        final tblfu2.FuRootFixed.Value[] theirs = {
+            new tblfu2.FuRootFixed.Value(), new tblfu2.FuRootFixed.Value()
+        };
+        final tblfu2.TableFixed.Report r2 = new tblfu2.TableFixed.Report();
+        final int n2 = tblfu2.FuRootFixed.load(theirs, 2, file, tblfu2.TableFixed.plan(1024),
+                new short[1024], tblfu2.FuRootFixed.image(), r2);
+        if (n2 != 2) { fail("compiled n=" + n2 + " refused=" + r2.refused + " malformed=" + r2.malformed + " reason=" + r2.reason); }
+        if (theirs[0].pick.type != tblfu2.PickFixed.labelled) { fail("compiled arm"); }
+        if (theirs[0].pick.labelled.lead != 101) { fail("compiled lead"); }
+        final String got = textOf(theirs[0].pick.labelled.label, theirs[0].pick.labelled.labelLength);
+        if (theirs[0].pick.labelled.labelLength != 5 || !got.equals("hello")) {
+            fail("ARG LANE BITES: compiled read of string under union arm 2 landed '" + got
+                    + "' (len " + theirs[0].pick.labelled.labelLength + ")");
+        }
+        if (theirs[0].pick.labelled.trail != 202) { fail("compiled trail"); }
+        if (!theirs[0].flag || !theirs[0].notePresent || theirs[0].note != 44 || theirs[0].tail != 11) {
+            fail("compiled labelled rest");
+        }
+        if (theirs[0].extra != 11) { fail("compiled extra default"); }
+        if (theirs[1].pick.type != tblfu2.PickFixed.plain || theirs[1].pick.plain.n != 303 || theirs[1].tail != 12) {
+            fail("compiled plain");
+        }
+        if (theirs[1].extra != 11) { fail("compiled extra default on plain"); }
+        if (r2.refused || r2.malformed || r2.clamped != 0) { fail("compiled report"); }
+        System.out.println("ok");
+    }
+}
+`

--- a/make/java.mk
+++ b/make/java.mk
@@ -84,7 +84,7 @@ generated/java-ludicrous/.stamp: bin/schema $(SCHEMAS128)
 # the committed generated/ tree. The full unit is generated (packet .java +
 # <Table>Block.java + <Table>Cook.java + the Row accessors and the runtime
 # types), because a record's descriptors name the packet emitter's own enums.
-build/tables-generated-java/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) $(SCHEMAS_TABLES_BLOCK) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P3.schema test/tables/FX1.schema test/tables/FX2.schema test/tables/UT.schema $(SCHEMAS_TABLES_SCALARS)
+build/tables-generated-java/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) $(SCHEMAS_TABLES_BLOCK) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P3.schema test/tables/FX1.schema test/tables/FX2.schema test/tables/UT.schema test/tables/FU1.schema test/tables/FU2.schema $(SCHEMAS_TABLES_SCALARS)
 	@mkdir -p build/tables-generated-java
 	./bin/schema generate --lang java --out build/tables-generated-java/examples tables/examples
 	# the POINTERED unit: its cook readers are the reason it is here — the two
@@ -105,6 +105,13 @@ build/tables-generated-java/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLE
 	# had no fixture for, and the one that catches an op borrowing the guard's
 	# own byte (test/tables/UT.schema).
 	./bin/schema generate --lang java --out build/tables-generated-java/ut test/tables/UT.schema
+	# FU1/FU2 is the TEXT-UNDER-AN-ARM pair whose compiled path is a TRAILING
+	# FIELD, not a slid ordinal: FU1's second arm carries a string(8), FU2 appends
+	# `extra` so a read of FU1's bytes is a compiled plan, and the two reads have
+	# to agree on the text (reference-fix 12). C++ already generates the pair;
+	# this stamp did not.
+	./bin/schema generate --lang java --out build/tables-generated-java/fu1 test/tables/FU1.schema
+	./bin/schema generate --lang java --out build/tables-generated-java/fu2 test/tables/FU2.schema
 	# THE WIDE-KIND UNIT (docs/SPEC-TABLES.md §15): its int128, uint128 and
 	# fixed-point fields cost it the two ACCELERATORS, so the FIXED FORM is the
 	# whole of its generated table surface — and that form spells a 128-bit
@@ -256,11 +263,12 @@ tables-java-fuzz-negative-control: build/cook-open/.stamp
 # differently is a byte that does not come back.
 #
 # Beside it rides the VERSIONING CONFORMANCE — the FX1/FX2 pair, the V1/V2
-# slide and P1 against P3, exactly the cases the C++ leg runs
-# (test/tables/fixedform_main.cpp) — and the negative controls, of which the
-# one §3.4 names is a reader given the WRONG PLAN for a record, which must come
-# out wrong, and one CORRUPTED-LAYOUT case per named rule a reader holds an
-# untrusted peer's layout to.
+# slide and P1 against P3, and FU1/FU2 (text under an arm: FU2 appends `extra`
+# so a read of FU1's bytes is a compiled plan) — the cases the C++ and C legs
+# run — and the negative controls, of which the one §3.4 names is a reader
+# given the WRONG PLAN for a record, which must come out wrong, and one
+# CORRUPTED-LAYOUT case per named rule a reader holds an untrusted peer's
+# layout to.
 build/java-fixedform/.stamp: build/tables-generated-java/.stamp test/java-fixedform/src/Main.java
 	@rm -rf build/java-fixedform && mkdir -p build/java-fixedform
 	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-fixedform \
@@ -268,6 +276,7 @@ build/java-fixedform/.stamp: build/tables-generated-java/.stamp test/java-fixedf
 		build/tables-generated-java/p1/*.java build/tables-generated-java/p3/*.java \
 		build/tables-generated-java/v1/*.java build/tables-generated-java/v2/*.java \
 		build/tables-generated-java/ut/*.java \
+		build/tables-generated-java/fu1/*.java build/tables-generated-java/fu2/*.java \
 		build/tables-generated-java/scalars/*.java \
 		build/tables-generated-java/examples/*.java test/java-fixedform/src/Main.java
 	@touch $@
@@ -359,6 +368,8 @@ tables-java-fixedform-arm-negative-control: bin/schema build/fixedform-corpus/.s
 	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/ut test/tables/UT.schema
 	@grep -q "SABOTAGED" $(JAVA_ARM_SABOTAGE)/src/ut/TableFixed.java || \
 		{ echo "NEGATIVE CONTROL FAILED: the sabotaged emitter emitted an unsabotaged runtime"; exit 1; }
+	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/fu1 test/tables/FU1.schema
+	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/fu2 test/tables/FU2.schema
 	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/fx1 test/tables/FX1.schema
 	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/fx2 test/tables/FX2.schema
 	$(JAVA_ARM_SABOTAGE)/schema generate --lang java --out $(JAVA_ARM_SABOTAGE)/src/p1 test/tables/P1.schema

--- a/test/java-fixedform/src/Main.java
+++ b/test/java-fixedform/src/Main.java
@@ -420,6 +420,101 @@ public final class Main {
     }
 
     // ------------------------------------------------------------------
+    // TEXT UNDER A UNION ARM (docs/SPEC-TABLES.md §3.4, §15) — FU1 and FU2
+    // ------------------------------------------------------------------
+    //
+    // A PLAN ENTRY FOR A TEXT FIELD INSIDE A UNION ARM HAS TO CARRY TWO FACTS
+    // AT ONCE: which arm's tag it is guarded by, and which flavour of text it
+    // moves. A port that spends ONE LANE on both loses whichever it wrote
+    // second, and the loss is silent — a `string(N)` in a union's SECOND arm
+    // read as '' through a compiled plan while the identity read landed the
+    // text, with no counter and no refusal (reference-fix 12). UT.schema asks
+    // the same question by compiling a plan from this reader's own layout.
+    // FU1/FU2 asks it through the ONE PATH the rest of this form uses: FU2
+    // appends `extra` so a read of FU1's bytes is a COMPILED plan, and both
+    // reads go through FuRootFixed.load. The hash chooses the plan and
+    // nothing else.
+
+    static void textUnderAnArm() {
+        check(tblfu1.FuRootFixed.hash != tblfu2.FuRootFixed.hash,
+                "text under an arm: FU2 extra changes the layout hash");
+
+        final tblfu1.FuRootFixed.Value[] older = {
+            new tblfu1.FuRootFixed.Value(), new tblfu1.FuRootFixed.Value()
+        };
+        older[0].flag = true;
+        older[0].notePresent = true;
+        older[0].note = 44;
+        older[0].pick.type = tblfu1.PickFixed.labelled;
+        older[0].pick.labelled.lead = 101;
+        setText(older[0].pick.labelled.label, "hello");
+        older[0].pick.labelled.labelLength = 5;
+        older[0].pick.labelled.trail = 202;
+        older[0].tail = 11;
+
+        older[1].pick.type = tblfu1.PickFixed.plain;
+        older[1].pick.plain.n = 303;
+        older[1].tail = 12;
+
+        final byte[] file = new byte[tblfu1.FuRootFixed.measure(2)];
+        check(tblfu1.FuRootFixed.save(older, 2, file) == file.length,
+                "text under an arm: FU1 writes its two records");
+
+        // THE IDENTITY READ, through the same load the compiled read uses.
+        final tblfu1.FuRootFixed.Value[] mine = {
+            new tblfu1.FuRootFixed.Value(), new tblfu1.FuRootFixed.Value()
+        };
+        final tblfu1.TableFixed.Report r = new tblfu1.TableFixed.Report();
+        check(tblfu1.FuRootFixed.load(mine, 2, file, tblfu1.TableFixed.plan(1024),
+                new short[1024], tblfu1.FuRootFixed.image(), r) == 2,
+                "text under an arm: the identity read takes both records");
+        check(!r.refused && !r.malformed && r.clamped == 0 && r.unknown == 0 && r.kindMismatch == 0,
+                "text under an arm: its own layout is the identity plan, and it moves no counter");
+        check(mine[0].pick.type == tblfu1.PickFixed.labelled,
+                "text under an arm: identity, the SECOND arm");
+        check(mine[0].pick.labelled.lead == 101,
+                "text under an arm: identity, the scalar BEFORE the text");
+        check(mine[0].pick.labelled.labelLength == 5
+                && textOf(mine[0].pick.labelled.label, mine[0].pick.labelled.labelLength).equals("hello"),
+                "text under an arm: the IDENTITY read lands the text");
+        check(mine[0].pick.labelled.trail == 202,
+                "text under an arm: identity, the scalar AFTER the text");
+        check(mine[0].flag && mine[0].notePresent && mine[0].note == 44 && mine[0].tail == 11,
+                "text under an arm: identity, the rest of the labelled record");
+        check(mine[1].pick.type == tblfu1.PickFixed.plain && mine[1].pick.plain.n == 303 && mine[1].tail == 12,
+                "text under an arm: identity, the FIRST arm as well");
+
+        // AND THE COMPILED READ of the same bytes through a peer whose layout
+        // hash differs — which is the only thing that changes.
+        final tblfu2.FuRootFixed.Value[] theirs = {
+            new tblfu2.FuRootFixed.Value(), new tblfu2.FuRootFixed.Value()
+        };
+        final tblfu2.TableFixed.Report r2 = new tblfu2.TableFixed.Report();
+        check(tblfu2.FuRootFixed.load(theirs, 2, file, tblfu2.TableFixed.plan(1024),
+                new short[1024], tblfu2.FuRootFixed.image(), r2) == 2,
+                "text under an arm: the compiled read takes both records");
+        check(!r2.malformed && !r2.refused && r2.clamped == 0 && r2.kindMismatch == 0,
+                "text under an arm: and nothing was damaged, clamped or refused");
+        check(theirs[0].pick.type == tblfu2.PickFixed.labelled,
+                "text under an arm: compiled, the SECOND arm");
+        check(theirs[0].pick.labelled.lead == 101,
+                "text under an arm: compiled, the scalar BEFORE the text");
+        check(theirs[0].pick.labelled.labelLength == 5
+                && textOf(theirs[0].pick.labelled.label, theirs[0].pick.labelled.labelLength).equals("hello"),
+                "text under an arm: the COMPILED read still sees the text");
+        check(theirs[0].pick.labelled.trail == 202,
+                "text under an arm: compiled, the scalar AFTER the text");
+        check(theirs[0].flag && theirs[0].notePresent && theirs[0].note == 44 && theirs[0].tail == 11,
+                "text under an arm: compiled, the rest of the labelled record");
+        check(theirs[0].extra == 11,
+                "text under an arm: the field FU1 does not carry took its declared default");
+        check(theirs[1].pick.type == tblfu2.PickFixed.plain && theirs[1].pick.plain.n == 303 && theirs[1].tail == 12,
+                "text under an arm: compiled, the FIRST arm as well");
+        check(theirs[1].extra == 11,
+                "text under an arm: compiled, `extra` defaults on the FIRST arm too");
+    }
+
+    // ------------------------------------------------------------------
     // THE VERSIONING CONFORMANCE
     // ------------------------------------------------------------------
 
@@ -826,6 +921,7 @@ public final class Main {
         packWrite(dir);
         compiledSelfPlan(dir);
         armTextUnderASecondArm();
+        textUnderAnArm();
         anOlderWriter(dir);
         aNewerWriter(dir);
         anOptional(dir);


### PR DESCRIPTION
## Why

On the live tip, `make/java.mk` `build/tables-generated-java/.stamp` generated FX1/FX2 and UT. **No FU1/FU2.** C++ already generates the pair. Rust lists `tblfu1`/`tblfu2`. Elixir lists `fu1`/`fu2`. C leftover of this hole is merged #862.

A `string(8)` lives in a union's second arm, with a scalar either side. FU2 appends `extra` so a read of FU1's bytes is a **compiled** plan rather than the identity one. That is the hole reference-fix 12 was: identity landed the text, compiled read it as empty, no counter.

UT.schema already holds the two-lane / own-layout compile half on this leg. This pair is the trailing-field compile trigger through the same one-path load.

## What

`make/java.mk` now generates the pair the same way the sibling fixtures are generated:

```
./bin/schema generate --lang java --out build/tables-generated-java/fu1 test/tables/FU1.schema
./bin/schema generate --lang java --out build/tables-generated-java/fu2 test/tables/FU2.schema
```

Stamp depends on `test/tables/FU1.schema` and `test/tables/FU2.schema`. `build/java-fixedform/.stamp` compiles them. The arm-text negative control generates the pair too so `Main.java` still compiles.

Pin is `test/java-fixedform/src/Main.java` `textUnderAnArm`: FU1 writes arm 2 `"hello"` and arm 1 beside it. Identity load through `FuRootFixed.load` lands the text. FU2's compiled load of the same bytes still sees `"hello"`. `extra` takes its declared default 11.

## ONE PATH

Hash chooses the plan and nothing else. Identity is one COPY of the body. Empty fill/holes is the skip, not a second path. No identity memcpy. No `if (identity)` door. Generator pin: `TestFixedFormFU1FU2`.

Did not take Java ArgW (draft #866 already). Did not take Java nested-guard.

Four existing javatable `Generate` tests now declare `fixed table`, because after `0bcb8d60ce0ab177a13222f3a00f83c8b917e37d` a plain `table` is not a fixed-form root and those tests were already red on the tip. Same file as the FU pin; the named `go test ./internal/codegen/javatable` is otherwise red.

## Tests

- `go test ./internal/codegen/javatable` ok (1.471s)
- `JAVA`/`JAVAC` at `/Users/glenn/toolchains/schema-dist/jdk-21.0.12.1` `make tables-java-fixedform` OK (both `-ea` and default)

Did not run the nine-language gate. Did not start a CI campaign.

`tableOnlyLanguages` is `[]string{"rust","java","js"}`. This PR does not regenerate paired Java.

## Floors

Draft against `fixed-table-form`. Still draft. Did not merge. Did not undraft. Did not rebase. Did not force-push. Branched off the live tip `0bcb8d60ce0ab177a13222f3a00f83c8b917e37d` (expected earlier `2d6a4940bbe118c32f9aaa7074f670954d14b372`; old tip is ancestor).

Johnny Grok