### PR TITLE
rusttable: named string(N) default lives in constructed storage

### DIFF
--- a/compiler/valuedefaults_test.go
+++ b/compiler/valuedefaults_test.go
@@ -249,6 +249,14 @@ func TestFixedTableValueDefaultsEveryLeg(t *testing.T) {
 					t.Errorf("dart fixed-form storage lacks %q", want)
 				}
 			}
+		case "rust":
+			// constructed Row::default(), not length-only zeroed: C++ writes
+			// `char label[8 + 1] = "fx"` and `uint8_t tag[4] = { 0x61, 0x62 }`
+			for _, want := range []string{`copy_from_slice(b"fx")`, "label_length = 2", `copy_from_slice(b"ab")`, "tag_length = 2"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("rust fixed-form storage lacks %q", want)
+				}
+			}
 		}
 	}
 }

--- a/internal/codegen/rusttable/cook.go
+++ b/internal/codegen/rusttable/cook.go
@@ -632,8 +632,91 @@ func (g *gen) emitCookRow(st *ir.Struct) {
 	g.pf("    fn default() -> Self {\n")
 	g.pf("        // a cooked record is plain bytes with no niche in it, so the zero\n")
 	g.pf("        // form is a value of the type by construction\n")
-	g.pf("        unsafe { core::mem::zeroed() }\n")
+	if cookNamedTextReachable(st) {
+		// NAMED string(N)/bytes(N) DEFAULTS LIVE HERE (SPEC §4.2), matching
+		// C++ `char label[8 + 1] = "fx"`. Prefill already carries the same
+		// bytes for holes the plan does not write; this is constructed
+		// storage, not dest-row, not identity fill.
+		g.pf("        let mut value: Self = unsafe { core::mem::zeroed() };\n")
+		g.emitCookNamedTextDefaults(st, "        ")
+		g.pf("        value\n")
+	} else {
+		g.pf("        unsafe { core::mem::zeroed() }\n")
+	}
 	g.pf("    }\n}\n\n")
+}
+
+// cookNamedTextReachable reports whether constructed storage of st, or of a
+// nested struct it holds, carries a named string(N) or bytes(N) default.
+func cookNamedTextReachable(st *ir.Struct) bool {
+	return cookNamedTextWalk(st, make(map[*ir.Struct]bool))
+}
+
+func cookNamedTextWalk(st *ir.Struct, seen map[*ir.Struct]bool) bool {
+	if st == nil || seen[st] {
+		return false
+	}
+	seen[st] = true
+	for _, f := range st.Fields {
+		if cookFieldNamedText(f) {
+			return true
+		}
+		if f.Type.Kind != ir.TNamed {
+			continue
+		}
+		nested, ok := f.Type.Ref.(*ir.Struct)
+		if ok && cookNamedTextWalk(nested, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func cookFieldNamedText(f *ir.Field) bool {
+	if f.Array != ir.ArrayNone || f.KeyEnum != "" || f.Type.Pointer {
+		return false
+	}
+	switch f.Type.Kind {
+	case ir.TString, ir.TBytes:
+		return f.HasDefault && len(f.DefBytes) > 0
+	}
+	return false
+}
+
+// emitCookNamedTextDefaults overlays declared string(N)/bytes(N) defaults onto
+// a zeroed Row, then constructs nested Rows that carry one of their own.
+func (g *gen) emitCookNamedTextDefaults(st *ir.Struct, ind string) {
+	for _, f := range st.Fields {
+		if cookFieldNamedText(f) {
+			n := len(f.DefBytes)
+			if int64(n) > f.Type.Size {
+				n = int(f.Type.Size)
+			}
+			g.pf("%svalue.%s[..%d].copy_from_slice(b%s); // the declared default (SPEC §4.2)\n",
+				ind, f.Name, n, fixedRustByteString(f.DefBytes[:n]))
+			g.pf("%svalue.%s_length = %d;\n", ind, f.Name, n)
+			continue
+		}
+		if f.Type.Kind != ir.TNamed {
+			continue
+		}
+		nested, ok := f.Type.Ref.(*ir.Struct)
+		if !ok || !cookNamedTextReachable(nested) {
+			continue
+		}
+		switch {
+		case f.KeyEnum != "":
+			g.pf("%sfor i in 0..%d {\n", ind, f.KeyEnumRef.Max)
+			g.pf("%s    value.%s[i] = %sRow::default();\n", ind, f.Name, nested.Name)
+			g.pf("%s}\n", ind)
+		case f.Array != ir.ArrayNone:
+			g.pf("%sfor i in 0..%d {\n", ind, f.ArrayBound)
+			g.pf("%s    value.%s[i] = %sRow::default();\n", ind, f.Name, nested.Name)
+			g.pf("%s}\n", ind)
+		default:
+			g.pf("%svalue.%s = %sRow::default();\n", ind, f.Name, nested.Name)
+		}
+	}
 }
 
 func (g *gen) emitCookRowField(f *ir.Field) {

--- a/internal/codegen/rusttable/fixedform.go
+++ b/internal/codegen/rusttable/fixedform.go
@@ -99,11 +99,12 @@ func fixedCounted(e ir.TableFixedLayoutEntry) bool { return e.Dst.Counted != 0 }
 // THE PREFILL IMAGE: the declared defaults, as record bytes
 //
 // §3.4's answer to an absent field is a PREFILL, and this is what this port
-// prefills WITH. C++ calls the type's own Reset; Rust's table surface has no
-// by-value reset (a `<Name>Row` is `core::mem::zeroed`), so the defaults are
-// laid down HERE, as the record image a fresh value would write. It is a
-// compile-time constant like the block and the template, and it is the one
-// place a declared default reaches this form.
+// prefills WITH. C++ calls the type's own Reset. Named string(N)/bytes(N)
+// defaults also live in constructed `<Name>Row::default()` (matching C++
+// `char label[8 + 1] = "fx"`). The load copies THIS image into the holes the
+// plan does not write (Glenn: prefill the bytes the plan does not write).
+// Identity's hole list is empty because its plan is one Copy of the whole
+// body — empty fill is the skip, not a second path.
 // ---------------------------------------------------------------------------
 
 func fixedDefaultImage(st *ir.Struct) []byte {

--- a/internal/codegen/rusttable/rusttable_test.go
+++ b/internal/codegen/rusttable/rusttable_test.go
@@ -730,3 +730,79 @@ func TestFixedFormWriteIsLiveCountAndLength(t *testing.T) {
 		t.Error("the save still branches on identity; there is one writer for both paths")
 	}
 }
+
+// rustDefaultImpl is the source of one generated `impl Default`, from the
+// impl header to the matching close brace.
+func rustDefaultImpl(body, typeName string) string {
+	sig := "impl Default for " + typeName + " {"
+	i := strings.Index(body, sig)
+	if i < 0 {
+		return ""
+	}
+	n := 0
+	for j := i; j < len(body); j++ {
+		switch body[j] {
+		case '{':
+			n++
+		case '}':
+			n--
+			if n == 0 {
+				return body[i : j+1]
+			}
+		}
+	}
+	return body[i:]
+}
+
+// A NAMED string(N) DEFAULT LIVES IN CONSTRUCTED STORAGE, not only in the
+// prefill and not only as a used length. FX1's `label string(8) = "fx"` is
+// the leftover: C++ writes `char label[8 + 1] = "fx"`, and Rust used to
+// emit `core::mem::zeroed()` — two claimed bytes of NULs. Prefill already
+// carries 0x66, 0x78; this is Default, not dest-row, not identity fill.
+func TestNamedStringDefaultLivesInStorage(t *testing.T) {
+	out := generate(t, `package probe
+
+fixed table Fx1
+{
+    label string(8) = "fx"
+}
+`)
+	records := string(out["probe_records.rs"])
+	def := rustDefaultImpl(records, "Fx1Row")
+	if def == "" {
+		t.Fatal("impl Default for Fx1Row was not emitted")
+	}
+	for _, want := range []string{
+		`copy_from_slice(b"fx")`,
+		"label_length = 2",
+		"core::mem::zeroed()",
+		"let mut value: Self",
+	} {
+		if !strings.Contains(def, want) {
+			t.Errorf("constructed storage is missing %q:\n%s", want, def)
+		}
+	}
+
+	fixed := string(out["probe_fixed.rs"])
+	if !strings.Contains(fixed, "0x66") || !strings.Contains(fixed, "0x78") {
+		t.Error("prefill lost the named default bytes; do not double-write, do not drop")
+	}
+	scatter := rustFn(fixed, "fx1_fixed_scatter")
+	if scatter == "" {
+		t.Fatal("fx1_fixed_scatter was not emitted")
+	}
+	if strings.Contains(scatter, `b"fx"`) {
+		t.Error("dest-row writes the named default; the hole is Default, not scatter")
+	}
+	load := rustFn(fixed, "fx1_fixed_load")
+	if load == "" {
+		t.Fatal("fx1_fixed_load was not emitted")
+	}
+	i := strings.Index(load, "for k in 0..n")
+	if i < 0 {
+		t.Fatal("the load has no record loop")
+	}
+	if strings.Contains(load[i:], "identity") {
+		t.Error("the load loop still branches on identity; an empty hole list is what skips work")
+	}
+}

--- a/test/rust-fixedform/src/main.rs
+++ b/test/rust-fixedform/src/main.rs
@@ -88,6 +88,15 @@ fn the_write(dir: &str) {
         fx_root_fixed_load, fx_root_fixed_save, fx_root_fixed_measure
     );
     check(n == 2, "fx1.bin: two records");
+    // A DECLARED DEFAULT IS THE VALUE, NOT JUST ITS LENGTH. The round trip
+    // above cannot see this: a value READ from the file already has the
+    // record's bytes. C++ writes `char label[8 + 1] = "fx"`; a fresh
+    // FxRootRow used to claim two used bytes of NULs from zeroed Default.
+    let fresh = tblfx1::FxRootRow::default();
+    check(
+        fresh.label_length == 2 && fresh.label[..2] == *b"fx",
+        "fx1: a fresh FxRootRow carries label \"fx\", not two NULs of length 2",
+    );
     round_trip!(
         dir, "fx2.bin", tblfx2, FxRootRow, 8,
         fx_root_fixed_load, fx_root_fixed_save, fx_root_fixed_measure


### PR DESCRIPTION
## Leftover

FX1 `label string(8) = "fx"` was not registered in constructed storage.

C++ still writes `char label[8 + 1] = "fx"`. Prefill already carries `0x66, 0x78`. Dest-row and identity fill were not the hole. The hole was `Row::default()`: `unsafe { core::mem::zeroed() }` — two claimed bytes of NULs.

Dart leftover of this hole was #863 (merged). This is the Rust twin.

## Fix

`impl Default for <Name>Row` still starts from `core::mem::zeroed()` (plain bytes, no niche). Named `string(N)` / `bytes(N)` defaults overlay onto that value (`copy_from_slice(b"fx")`, `label_length = 2`). Nested Rows that carry one get `T::default()`. Prefill is unchanged — Glenn: prefill the bytes the plan does not write. Do not double-write.

ONE PATH. Identity is a PLAN walked by the same loop. Hash chooses the plan and nothing else. Empty fill/holes is the skip, not a second path. No `if identity` door.

## Tests

- `go test ./internal/codegen/rusttable -run TestNamedStringDefaultLivesInStorage` (new pin: constructed storage, prefill still has the bytes, scatter does not write them, load loop has no identity branch)
- `make tables-rust-fixedform` green debug and release: a fresh `FxRootRow::default()` carries `label == "fx"`; the C++ reference's bytes still round-trip

Draft against `fixed-table-form`. Do not merge.

Johnny Grok