### PR TITLE
jstable: layout refusals by name

### DIFF
--- a/internal/codegen/jstable/fixedmodule.go
+++ b/internal/codegen/jstable/fixedmodule.go
@@ -290,7 +290,7 @@ func (g *fixedModule) emitRoot(st *ir.Struct) {
 	g.pf("    // CACHED BY HASH, so the compile is paid once per peer, not per record.\n")
 	g.pf("    if (!plan.ready || (plan.hashLo >>> 0) !== hashLo || (plan.hashHi >>> 0) !== hashHi) {\n")
 	g.pf("      const theirs = new TableFixedLayoutView();\n")
-	g.pf("      if (!TableFixedParseLayout(bytes, layoutAt, layoutBytes, theirs)) { report.refused = TableFixedRefusal.LayoutMalformed; return -1; }\n")
+	g.pf("      if (!TableFixedParseLayout(bytes, layoutAt, layoutBytes, theirs)) { report.refused = theirs.refusal; return -1; }\n")
 	g.pf("      const made = TableFixedCompile(theirs, %sFixedLayout, %sFixedDst, plan, report);\n", st.Name, st.Name)
 	g.pf("      if (made < 0) { report.refused = TableFixedRefusal.PlanTooLarge; return -1; }\n")
 	g.pf("      plan.recordBytes = 8 + TableFixedSize(theirs, 0);\n")

--- a/internal/codegen/jstable/fixedruntime.go
+++ b/internal/codegen/jstable/fixedruntime.go
@@ -43,14 +43,24 @@ export const TableFixedMessageForm = 2;
 export const TableFixedHeaderBytes = 16;
 export const TableFixedHashAt = 8;
 
-// An entry is SEVENTEEN BYTES and the layout is a count and a run of them. THE
-// FORMAT NEVER MOVES, which is what lets a reader of this major parse a later
-// major's layout and step over a kind it does not know by the size the entry
-// states.
+// An entry is SEVENTEEN BYTES and the layout is a COUNT and a run of them.
+// THERE IS NO VERSION BYTE INSIDE IT (docs/SPEC-TABLES.md §3.4): the FORM BYTE
+// versions everything behind it, the layout's own format included, so a layout
+// format change is a NEW FORM BYTE and never a wider entry.
 export const TableFixedEntryBytes = 17;
 
 // the layout's own framing: the u32 entry count, and nothing else
 export const TableFixedLayoutHeaderBytes = 4;
+
+// §3.4'S RECORD BOUND, and a reader holds an untrusted peer's layout to it for
+// the same reason the compiler holds a declaration to it: a record past it is
+// one this build will not decode.
+export const TableFixedRecordMaxBytes = 65536;
+
+// A BOUND ON THE WALK, not on the wire: the validation below is recursive, so
+// a hostile layout of three thousand entries each claiming one child would
+// otherwise spend a reader's stack before any rule fired. The reference states 64.
+export const TableFixedMaxDepth = 64;
 
 // A PLAN ENTRY is nine int32 lanes of one flat Int32Array. A flat array of a
 // fixed stride is what keeps the read loop monomorphic: every lane is a
@@ -97,9 +107,41 @@ export const TableFixedRefusal = Object.freeze({
   NewerForm: 3,         // a form byte newer than this build
   NoLayout: 4,          // a hash naming no layout this reader holds
   LayoutMalformed: 5,   // bytes handed to this form as a layout that are not one
-  PlanTooLarge: 6,      // a layout whose compiled plan does not fit the caller's storage
-  BatchTooLarge: 7,     // more records than the caller's capacity
+  // THE SEVEN NAMED LAYOUT RULES (docs/FIXED-FORM-ALGORITHM.md §1.1). Each is
+  // its own reason, never collapsed into LayoutMalformed. layout_malformed is
+  // the residue after the seven: fewer bytes than a header, or none at all.
+  LayoutCountMismatch: 6,
+  LayoutKindUnknown: 7,
+  LayoutSizeMismatch: 8,
+  LayoutKindInvalid: 9,
+  LayoutTreeUnclosed: 10,
+  LayoutRecordTooLarge: 11,
+  LayoutTooDeep: 12,
+  PlanTooLarge: 13,     // a layout whose compiled plan does not fit the caller's storage
+  BatchTooLarge: 14,    // more records than the caller's capacity
 });
+
+// THE REFUSAL'S OWN NAME, matching the C++ reference's spellings exactly.
+export function TableFixedRefusalName(r) {
+  switch (r) {
+    case TableFixedRefusal.None: return "none";
+    case TableFixedRefusal.PreviousForm: return "previous_form";
+    case TableFixedRefusal.MessageFormAsFile: return "message_form_as_file";
+    case TableFixedRefusal.NewerForm: return "newer_form";
+    case TableFixedRefusal.NoLayout: return "no_layout";
+    case TableFixedRefusal.LayoutMalformed: return "layout_malformed";
+    case TableFixedRefusal.LayoutCountMismatch: return "layout_count_mismatch";
+    case TableFixedRefusal.LayoutKindUnknown: return "layout_kind_unknown";
+    case TableFixedRefusal.LayoutSizeMismatch: return "layout_size_mismatch";
+    case TableFixedRefusal.LayoutKindInvalid: return "layout_kind_invalid";
+    case TableFixedRefusal.LayoutTreeUnclosed: return "layout_tree_unclosed";
+    case TableFixedRefusal.LayoutRecordTooLarge: return "layout_record_too_large";
+    case TableFixedRefusal.LayoutTooDeep: return "layout_too_deep";
+    case TableFixedRefusal.PlanTooLarge: return "plan_too_large";
+    case TableFixedRefusal.BatchTooLarge: return "batch_too_large";
+    default: return "???";
+  }
+}
 
 // A REPORT is §4's six counters and the refusal beside them. The caller owns
 // it and the codec never makes one.
@@ -425,6 +467,10 @@ export class TableFixedLayoutView {
     this.bytes = null;
     this.at = 0;
     this.count = 0;
+    // the rule the last parse failed, by name; TableFixedRefusal.None when it
+    // passed. A field of the view rather than an out-parameter, so a parse
+    // allocates nothing at all.
+    this.refusal = TableFixedRefusal.None;
   }
 }
 
@@ -443,21 +489,20 @@ function TableFixedSameId(a, ai, b, bi) {
 // TableFixedSubtree is how many entries the subtree rooted at i occupies, so a
 // walk steps over a child it does not want without knowing what is in it.
 // THIS IS WHAT MAKES SKIPPING FREE: an unknown field, and an unknown NESTED
-// TYPE, are stepped over by the size their entry states.
+// TYPE, are stepped over by the size their entry states. ITERATIVE ON PURPOSE:
+// a layout is a stranger's bytes, so a chain of single-child entries is a
+// stack depth the wire gets to choose; this walk gives it none. It is only
+// ever called on a layout that has already passed every rule below, so the
+// tree closes.
 export function TableFixedSubtree(b, i) {
   if (i < 0 || i >= b.count) { return 1; }
-  const children = TableFixedChildren(b, i);
-  let n = 1, at = i + 1;
-  for (let c = 0; c < children; c++) {
-    // A CHILD COUNT THAT DOES NOT CLOSE IS layout_malformed (§3.4), so the
-    // overrun is SIGNALLED and not stepped around: an entry claiming a child
-    // the layout does not hold must fail the whole-layout check, or the plan
-    // compiler walks past the last entry it has.
-    if (at >= b.count) { return -1; }
-    const sub = TableFixedSubtree(b, at);
-    if (sub < 0) { return -1; }
-    at += sub;
-    n += sub;
+  let pending = 1, n = 0, at = i;
+  while (pending > 0 && at < b.count) {
+    pending--;
+    n++;
+    pending += TableFixedChildren(b, at);
+    at++;
+    if (pending > b.count) { break; }
   }
   return n;
 }
@@ -475,18 +520,228 @@ function TableFixedUnionArmBytes(b, i) {
 
 function TableFixedTagBytes(b, i) { return TableFixedSize(b, i) - TableFixedUnionArmBytes(b, i); }
 
-// A LAYOUT IS REFUSED WHOLE OR NOT AT ALL: a count that overruns, a tree that
-// does not close. It sets nothing on its way out.
+// ---- THE LAYOUT'S OWN VALIDATION, RULE BY NAMED RULE -----------------------
+//
+// A LAYOUT ARRIVES FROM AN UNTRUSTED PEER and it is the one structure a reader
+// must parse before it knows anything at all, so every rule below runs BEFORE
+// a single record byte is touched and each refuses under its OWN NAME rather
+// than under one word for all of them (docs/SPEC-TABLES.md §3.4,
+// docs/FIXED-FORM-ALGORITHM.md §1.1).
+//
+// A KIND THIS BUILD DOES NOT KNOW IS A REFUSAL, and that is a ruling rather
+// than an oversight. A FIXED FORM HAS A CLOSED KIND SET: the form byte versions
+// everything behind it, kinds included, so a layout carrying a kind outside the
+// set is not a newer layout of THIS form — it is a layout of a form whose byte
+// this reader never saw, and there is no version of "step over it" that is
+// honest about that. layout_kind_unknown says exactly what happened, and the
+// peer is told to speak this form or a form this reader carries.
+//
+// NOR IS THERE A CYCLE RULE, because a pre-order walk cannot express a cycle:
+// an entry's children ARE THE ENTRIES THAT FOLLOW IT, so a child's index is
+// always higher than its parent's, the layout is finite, and there is no back
+// reference for a cycle to be made of. The tree-closure rule is what bounds
+// the walk, and the depth rule is what bounds the reader's stack.
+
+function TableFixedFail(b, why) {
+  if (b.refusal === TableFixedRefusal.None) { b.refusal = why; }
+}
+
+// A LEAF KIND'S ADMITTED SIZES. Kind and size fix each other on this wire with
+// ONE exception, and it is stated here rather than left to be found: a
+// bits(N) field rides at its DECLARED STORAGE WIDTH — four bytes for N <= 32 and
+// eight above (§3.4) — under the unsigned integer kind its BIT COUNT picks
+// (§3), so kinds 6 and 7 admit four as well as their own width.
+// Answers 1 if leaf and size ok, 0 if leaf and size bad, -1 if not a leaf.
+function TableFixedLeafSize(kind, size) {
+  switch (kind) {
+    case 1:  return size === 1 ? 1 : 0;                 // bool
+    case 2:  return size === 1 ? 1 : 0;                 // i8
+    case 3:  return size === 2 ? 1 : 0;                 // i16
+    case 4:  return size === 4 ? 1 : 0;                 // i32
+    case 5:  return size === 8 ? 1 : 0;                 // i64
+    case 6:  return size === 1 || size === 4 ? 1 : 0;   // u8,  and bits( 1 .. 8 )
+    case 7:  return size === 2 || size === 4 ? 1 : 0;   // u16, and bits( 9 .. 16 )
+    case 8:  return size === 4 ? 1 : 0;                 // u32, and bits( 17 .. 32 )
+    case 9:  return size === 8 ? 1 : 0;                 // u64, flags, and bits( 33 .. 64 )
+    case 10: return size === 4 ? 1 : 0;                 // f32
+    case 11: return size === 8 ? 1 : 0;                 // f64
+    case 17: return size === 4 ? 1 : 0;                 // a pointer index, which no fixed table carries
+    case 18: case 19: return size === 16 ? 1 : 0;       // i128, u128
+    case 20: case 25: return size === 1 ? 1 : 0;        // fixed8, ufixed8
+    case 21: case 26: return size === 2 ? 1 : 0;
+    case 22: case 27: return size === 4 ? 1 : 0;
+    case 23: case 28: return size === 8 ? 1 : 0;
+    case 24: case 29: return size === 16 ? 1 : 0;
+    case 32: return size === 0 ? 1 : 0;                 // a variant, and an arm that holds nothing
+  }
+  return -1;
+}
+
+function TableFixedOrdinalWidth(n) { return n === 1 || n === 2 || n === 4 || n === 8; }
+
+// THE CLOSED KIND SET (docs/SPEC-TABLES.md §3, §3.4): §3's own kinds 1..30,
+// the no-payload variant 32, wstring 33, and the ONE kind this form's layout
+// adds, the optional wrapper 35. 31 is §3's BODY framing escape and 34 is
+// reserved: neither is a kind a declaration spells, so neither is ever an
+// entry's kind. A KIND OUTSIDE THIS SET IS A REFUSAL, not a leaf to step over.
+function TableFixedKnownKind(kind) {
+  if (kind >= 1 && kind <= 30) { return true; }
+  return kind === 32 || kind === 33 || kind === 35;
+}
+
+function TableFixedClearView(out) {
+  out.bytes = null;
+  out.at = 0;
+  out.count = 0;
+}
+
+// TableFixedCheckEntry validates the subtree rooted at i and answers how many
+// entries it occupies, which is the same arithmetic TableFixedSubtree does and
+// is why that walk is safe to run afterwards and only afterwards.
+function TableFixedCheckEntry(b, i, depth) {
+  if (b.refusal !== TableFixedRefusal.None) { return 0; }
+  if (i < 0 || i >= b.count) { TableFixedFail(b, TableFixedRefusal.LayoutTreeUnclosed); return 0; }
+  if (depth > TableFixedMaxDepth) { TableFixedFail(b, TableFixedRefusal.LayoutTooDeep); return 0; }
+  const kind = TableFixedKind(b, i);
+  const size = TableFixedSize(b, i);
+  // THE CLOSED KIND SET, FIRST: a kind outside it is a layout of another form
+  // and is refused whole, never walked and never stepped over.
+  if (!TableFixedKnownKind(kind)) { TableFixedFail(b, TableFixedRefusal.LayoutKindUnknown); return 0; }
+  if (size > TableFixedRecordMaxBytes) { TableFixedFail(b, TableFixedRefusal.LayoutRecordTooLarge); return 0; }
+
+  // THE CHILDREN FIRST, in the pre-order the layout is written in.
+  const kids = TableFixedChildren(b, i);
+  let at = i + 1;
+  let sum = 0;
+  let widest = 0;
+  let firstSize = 0, secondSize = 0, firstKind = 0, firstChildren = 0;
+  let kidsAreVariants = true;
+  for (let k = 0; k < kids; k++) {
+    const child = at;
+    const used = TableFixedCheckEntry(b, child, depth + 1);
+    if (b.refusal !== TableFixedRefusal.None) { return 0; }
+    const childSize = TableFixedSize(b, child);
+    if (k === 0) {
+      firstSize = childSize;
+      firstKind = TableFixedKind(b, child);
+      firstChildren = TableFixedChildren(b, child);
+    }
+    if (k === 1) { secondSize = childSize; }
+    if (TableFixedKind(b, child) !== 32) { kidsAreVariants = false; }
+    sum += childSize;
+    if (childSize > widest) { widest = childSize; }
+    if (sum > TableFixedRecordMaxBytes) { TableFixedFail(b, TableFixedRefusal.LayoutRecordTooLarge); return 0; }
+    at += used;
+  }
+
+  const leaf = TableFixedLeafSize(kind, size);
+  if (leaf === 0) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+  if (leaf === 1) {
+    if (kids !== 0) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+    return at - i;
+  }
+  switch (kind) {
+    case 13: { // a TABLE: its size is the SUM of its fields'
+      if (size !== sum) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 35: { // the OPTIONAL WRAPPER: one child, one present byte in front of it
+      if (kids !== 1) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (size !== sum + 1) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 14: { // an ARRAY: a whole number of elements, behind a count or not
+      if (kids !== 1) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (firstSize === 0) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      const bare = (size % firstSize) === 0;
+      const counted = size >= 4 && ((size - 4) % firstSize) === 0;
+      if (!bare && !counted) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 16: { // an ENUM-KEYED array: the KEY ENUM then the ELEMENT, every slot written
+      if (kids !== 2) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (firstKind !== 30) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (secondSize === 0 || (size % secondSize) !== 0) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      // AT LEAST one slot per variant. Not exactly one: an enum widened
+      // by an explicit max has more slots than it has names, and the
+      // layout carries only the names.
+      if (((size / secondSize) | 0) < firstChildren) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 15: { // a UNION: the TAG at its own width, then the WIDEST ARM
+      if (kids === 0) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (size <= widest) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      if (!TableFixedOrdinalWidth(size - widest)) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 30: { // an ENUM: the ordinal's storage width, and its children are VARIANTS
+      if (!TableFixedOrdinalWidth(size)) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      if (kids !== 0 && !kidsAreVariants) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      break;
+    }
+    case 12: { // string(N): the length, then N bytes
+      if (kids !== 0) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (size < 4) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    case 33: { // wstring(N): the length in CODE UNITS, then 2N bytes
+      if (kids !== 0) { TableFixedFail(b, TableFixedRefusal.LayoutKindInvalid); return 0; }
+      if (size < 4 || ((size - 4) % 2) !== 0) { TableFixedFail(b, TableFixedRefusal.LayoutSizeMismatch); return 0; }
+      break;
+    }
+    // Every kind of the closed set is either a leaf above or a case here,
+    // so this is unreachable — and it refuses rather than admits, because
+    // a kind that reached it is a kind the two lists disagree about.
+    default: TableFixedFail(b, TableFixedRefusal.LayoutKindUnknown); return 0;
+  }
+  return at - i;
+}
+
+// TableFixedParseLayout is the WHOLE of what a reader trusts a layout on. It
+// answers false and a REASON BY NAME on the view, and the caller reports that
+// reason. A layout that fails any rule SETS NOTHING: no plan is compiled, no
+// counter moves, and the reader is in the state it was in before the bytes
+// arrived.
 export function TableFixedParseLayout(bytes, at, length, out) {
-  if (bytes === null || length < TableFixedLayoutHeaderBytes) { return false; }
+  TableFixedClearView(out);
+  out.refusal = TableFixedRefusal.None;
+  if (bytes === null || length < TableFixedLayoutHeaderBytes) {
+    out.refusal = TableFixedRefusal.LayoutMalformed;
+    return false;
+  }
+  // 1. THE ENTRY COUNT FITS THE LAYOUT LENGTH EXACTLY
   const count = TableFixedGetU32(bytes, at);
-  if (count === 0 || count * TableFixedEntryBytes + TableFixedLayoutHeaderBytes !== length) { return false; }
+  if (count === 0 || count * TableFixedEntryBytes + TableFixedLayoutHeaderBytes !== length) {
+    out.refusal = TableFixedRefusal.LayoutCountMismatch;
+    return false;
+  }
   out.bytes = bytes;
   out.at = at;
   out.count = count;
-  // THE TREE HAS TO CLOSE: the root's subtree is the whole layout
-  if (TableFixedSubtree(out, 0) !== out.count) {
-    out.bytes = null; out.at = 0; out.count = 0;
+  // 2. THE ROOT IS A TABLE, and its size is the record's body
+  if (TableFixedKind(out, 0) !== 13) {
+    out.refusal = TableFixedRefusal.LayoutKindInvalid;
+    TableFixedClearView(out);
+    return false;
+  }
+  const rootSize = TableFixedSize(out, 0);
+  if (rootSize === 0 || rootSize > TableFixedRecordMaxBytes) {
+    out.refusal = TableFixedRefusal.LayoutRecordTooLarge;
+    TableFixedClearView(out);
+    return false;
+  }
+  // 3. EVERY KIND IN THE CLOSED SET AND USED AS ITS DEFINITION ALLOWS, EVERY
+  //    SIZE THE ONE ITS CHILDREN ACCOUNT FOR, NOTHING PAST THE WALK'S BOUND
+  const used = TableFixedCheckEntry(out, 0, 0);
+  if (out.refusal !== TableFixedRefusal.None) {
+    TableFixedClearView(out);
+    return false;
+  }
+  // 4. THE PRE-ORDER WALK CONSUMES EXACTLY THE ENTRIES: the tree closes and
+  //    the layout has nothing left over
+  if (used !== out.count) {
+    out.refusal = TableFixedRefusal.LayoutTreeUnclosed;
+    TableFixedClearView(out);
     return false;
   }
   return true;

--- a/internal/tablenames/js.go
+++ b/internal/tablenames/js.go
@@ -43,8 +43,17 @@ func init() {
 		// framing, its view and the five reads a walk of it makes
 		Name{Name: "TableFixedLayoutHeaderBytes", What: "the layout's own framing: the u32 entry count, and nothing else"},
 		Name{Name: "TableFixedEntryBytes", What: "a layout entry is seventeen bytes, and the format never moves"},
-		Name{Name: "TableFixedLayoutView", What: "a parsed layout: the bytes, the offset and the entry count"},
-		Name{Name: "TableFixedParseLayout", What: "a layout is refused WHOLE or not at all — a count that overruns, a tree that does not close"},
+		Name{Name: "TableFixedRecordMaxBytes", What: "the fixed form: §3.4's 65536-byte record ceiling"},
+		Name{Name: "TableFixedMaxDepth", What: "the fixed form: a bound on the layout WALK, not on the wire"},
+		Name{Name: "TableFixedLayoutView", What: "a parsed layout: the bytes, the offset, the entry count and the named refusal"},
+		Name{Name: "TableFixedParseLayout", What: "a layout is refused WHOLE or not at all — each of §1.1's seven rules under its own name"},
+		Name{Name: "TableFixedKnownKind", What: "whether a kind is in the closed set — a kind outside it is layout_kind_unknown, never stepped over"},
+		Name{Name: "TableFixedLeafSize", What: "a leaf kind's admitted sizes — 1 ok, 0 size mismatch, -1 not a leaf"},
+		Name{Name: "TableFixedOrdinalWidth", What: "whether n is an ordinal width: 1, 2, 4 or 8"},
+		Name{Name: "TableFixedFail", What: "keep the FIRST layout-refusal reason and stop"},
+		Name{Name: "TableFixedClearView", What: "a failed parse sets nothing: bytes, offset and count go back to empty"},
+		Name{Name: "TableFixedCheckEntry", What: "validate the subtree at i: kind, size, shape, depth, then how many entries it occupies"},
+		Name{Name: "TableFixedRefusalName", What: "the refusal's own name, matching the C++ reference's spellings"},
 		Name{Name: "TableFixedIdLo", What: "an entry's wire id, low lane: an id is compared, never arithmetic, so it never becomes a BigInt"},
 		Name{Name: "TableFixedIdHi", What: "an entry's wire id, high lane"},
 		Name{Name: "TableFixedKind", What: "an entry's kind byte"},
@@ -91,7 +100,7 @@ func init() {
 		Name{Name: "TableFixedPlanCache", What: "the plan cache BY HASH, so a compile is paid once per peer and never once per record"},
 		Name{Name: "TableFixedReport", What: "the fixed form's read report — §4's six counters and the refusal beside them"},
 		Name{Name: "TableFixedResetReport", What: "the report reset, which the caller owns and the codec never allocates"},
-		Name{Name: "TableFixedRefusal", What: "the fixed form's refusals, each one BY NAME — the three directions a form byte can be wrong in among them"},
+		Name{Name: "TableFixedRefusal", What: "the fixed form's refusals, each one BY NAME — the three directions a form byte can be wrong in, and the seven named layout rules"},
 
 		// the hash, the ONE read loop, and the plan compiler with its own
 		// private walk

--- a/test/js-tables/fixedform.mjs
+++ b/test/js-tables/fixedform.mjs
@@ -84,6 +84,7 @@ export async function checkFixedForm(check, generated, corpusDir, optionalDir, o
   liveCountSlack(check, fx1, fx1home);
   holePrefill(check, fx1, fx2, fx1home, fx2home);
   negativeControls(check, fx1, fx2, fx1home, fx2home);
+  layoutValidation(check, fx1, fx2, fx1home, fx2home);
   unionArmText(check, ut1, ut2, ut1home, ut2home, ut1types, ut2types);
   if (oracleDir) {
     referenceOracle(check, fx1, fx2, fx1home, oracleDir);
@@ -539,6 +540,35 @@ function negativeControls(check, fx1, fx2, fx1home, fx2home) {
   // nothing is decoded and there is nothing to count.
   const fresh = () => [new fx1home.FxRoot()];
   {
+    const R = fx1home.TableFixedRefusal;
+    const seven = [
+      R.LayoutCountMismatch, R.LayoutKindUnknown, R.LayoutSizeMismatch,
+      R.LayoutKindInvalid, R.LayoutTreeUnclosed, R.LayoutRecordTooLarge,
+      R.LayoutTooDeep,
+    ];
+    check(new Set(seven).size === 7 && seven.every((v) => v !== R.LayoutMalformed && v !== R.None),
+      "the seven layout refusals are distinct, and none is layout_malformed");
+  }
+  {
+    // A LAYOUT THAT IS NOT A LAYOUT IS REFUSED BY NAME, whole, and never damage.
+    // Every rule has its own case in layoutValidation() below; this one is
+    // here because it is also the check that a refusal MOVES NO COUNTER.
+    const two = new fx2home.FxRoot();
+    const w2 = new Uint8Array(fx2.FxRootFixedMeasure(1));
+    fx2.FxRootFixedSave([two], 1, w2);
+    const broken = Uint8Array.from(w2);
+    // THE ENTRY COUNT, which is the layout's own first four bytes and not
+    // the u32 LENGTH in front of them: a length that no longer matches the
+    // file is a different rule with a different name.
+    broken[LAYOUT_AT] ^= 0xff;
+    const r = new fx1home.TableFixedReport();
+    const n = fx1.FxRootFixedLoad(fresh(), 1, broken, broken.length, fx1.FxRootFixedNewPlan(), r);
+    check(n === -1 && r.refused === fx1home.TableFixedRefusal.LayoutCountMismatch,
+      "REFUSED BY NAME: layout_count_mismatch");
+    check(r.unknown === 0 && r.kindMismatch === 0 && !r.malformed,
+      "REFUSED BY NAME: a refusal moves no counter");
+  }
+  {
     // THE FORM BYTE SAYS WHICH DIRECTION (§3). The registry is ORDERED, so a
     // byte this reader cannot read is named by WHERE IT SITS relative to this
     // form — and never by one word for all three.
@@ -580,8 +610,8 @@ function negativeControls(check, fx1, fx2, fx1home, fx2home) {
     bad[LAYOUT_AT + 4 + 13] = 0x7f; // the root's child count, which now closes nothing
     const r = new fx1home.TableFixedReport();
     const n = fx1.FxRootFixedLoad(fresh(), 1, bad, bad.length, fx1.FxRootFixedNewPlan(), r);
-    check(n === -1 && r.refused === fx1home.TableFixedRefusal.LayoutMalformed,
-      "REFUSAL: a layout whose tree does not close is layout_malformed, and it sets nothing");
+    check(n === -1 && r.refused === fx1home.TableFixedRefusal.LayoutTreeUnclosed,
+      "REFUSAL: a layout whose tree does not close is layout_tree_unclosed, and it sets nothing");
   }
   {
     // THE HEADER NAMES THE LAYOUT ONCE, AND IT IS CHECKED LAST (§3): a header
@@ -642,6 +672,199 @@ function negativeControls(check, fx1, fx2, fx1home, fx2home) {
     const small = new Uint8Array(fx1.FxRootFixedMeasure(1) - 1);
     check(fx1.FxRootFixedSave([one], 1, small) === -1,
       "REFUSAL: a buffer too small for the file answers -1");
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// THE LAYOUT ARRIVES FROM AN UNTRUSTED PEER (docs/SPEC-TABLES.md §3.4)
+// ---------------------------------------------------------------------------
+//
+// It is the one structure a reader must parse before it knows anything at all,
+// so every rule it is held to refuses under ITS OWN NAME, before a single
+// record byte is touched. A VALIDATION NOBODY WATCHED FAIL IS A VALIDATION
+// NOBODY HAS, so there is one case per named rule, each taking a layout this
+// reader accepts and breaking EXACTLY ONE THING in it. Fixtures match the C++
+// reference (test/tables/fixedform_main.cpp layout_validation). Rowan's
+// hostile-layout fixtures PR, when it posts, is the shared corpus; until then
+// this pins the C++ names.
+
+const ENTRY0 = LAYOUT_AT + 4;
+
+function putU32(b, at, v) {
+  v = v >>> 0;
+  b[at] = v & 0xff;
+  b[at + 1] = (v >>> 8) & 0xff;
+  b[at + 2] = (v >>> 16) & 0xff;
+  b[at + 3] = (v >>> 24) & 0xff;
+}
+
+function getU32(b, at) {
+  return (b[at] | (b[at + 1] << 8) | (b[at + 2] << 16) | (b[at + 3] << 24)) >>> 0;
+}
+
+function entryAt(k) { return ENTRY0 + k * 17; }
+
+function putEntryAt(layout, at, id, kind, size, children) {
+  putU32(layout, at, id);
+  putU32(layout, at + 4, 0);
+  layout[at + 8] = kind;
+  putU32(layout, at + 9, size);
+  putU32(layout, at + 13, children);
+}
+
+function putEntry(layout, id, kind, size, children) {
+  const at = layout.length;
+  const next = new Uint8Array(at + 17);
+  next.set(layout);
+  putEntryAt(next, at, id, kind, size, children);
+  return next;
+}
+
+// a FILE around a hand-built layout: the form byte, the layout's length, the
+// layout, and no records — every rule below refuses before a record is reached
+function fileOf(fx1home, layout) {
+  const f = new Uint8Array(LAYOUT_AT + layout.length);
+  f[0] = 3;
+  const h = fx1home.TableFixedHashOf(layout, 0, layout.length);
+  const lo = h[0] | 0, hi = h[1] | 0;
+  putU32(f, HASH_AT, lo);
+  putU32(f, HASH_AT + 4, hi);
+  putU32(f, LAYOUT_LENGTH_AT, layout.length);
+  f.set(layout, LAYOUT_AT);
+  return f;
+}
+
+function layoutValidation(check, fx1, fx2, fx1home, fx2home) {
+  const nameOf = (r) => fx1home.TableFixedRefusalName(r);
+  const refuses = (broken, want, what) => {
+    const v = [new fx1home.FxRoot()];
+    const r = new fx1home.TableFixedReport();
+    const n = fx1.FxRootFixedLoad(v, 1, broken, broken.length, fx1.FxRootFixedNewPlan(), r);
+    check(n < 0 && r.refused === want,
+      `${what} (got ${nameOf(r.refused)}, want ${nameOf(want)})`);
+    check(r.unknown === 0 && r.kindMismatch === 0 && r.widened === 0 && r.clamped === 0 && !r.malformed,
+      `${what}: a layout refusal sets nothing and counts nothing`);
+  };
+
+  // the layout this reader ACCEPTS, which every case below breaks once
+  const two = new fx2home.FxRoot();
+  const good = new Uint8Array(fx2.FxRootFixedMeasure(1));
+  check(fx2.FxRootFixedSave([two], 1, good) === good.length,
+    "layout validation: the unbroken file saves");
+  {
+    const v = [new fx1home.FxRoot()];
+    const r = new fx1home.TableFixedReport();
+    check(fx1.FxRootFixedLoad(v, 1, good, good.length, fx1.FxRootFixedNewPlan(), r) === 1 && r.refused === 0,
+      "layout validation: the unbroken file reads, so the breaks below are the breaks");
+  }
+  const copy = () => Uint8Array.from(good);
+
+  // 1. THE ENTRY COUNT FITS THE LAYOUT'S LENGTH EXACTLY
+  {
+    const f = copy();
+    putU32(f, LAYOUT_AT, getU32(f, LAYOUT_AT) + 1);
+    refuses(f, fx1home.TableFixedRefusal.LayoutCountMismatch,
+      "RULE: the entry count fits the layout length exactly");
+  }
+  {
+    const f = copy();
+    putU32(f, LAYOUT_AT, 0);
+    refuses(f, fx1home.TableFixedRefusal.LayoutCountMismatch,
+      "RULE: an entry count of zero is not a layout");
+  }
+
+  // 2. EVERY KIND IS IN THE CLOSED SET. A fixed form's kind set is CLOSED, so
+  //    a kind outside it means a NEWER FORM BYTE — a different form — and not
+  //    a newer layout of this one. It is refused, never stepped over.
+  {
+    const f = copy();
+    f[entryAt(1) + 8] = 200; // a kind no form byte this build carries defines
+    refuses(f, fx1home.TableFixedRefusal.LayoutKindUnknown,
+      "RULE: a kind outside the closed set is REFUSED, not skipped");
+  }
+
+  // 3. A KIND IS USED AS ITS DEFINITION ALLOWS — here, the ROOT is a table
+  {
+    const f = copy();
+    f[entryAt(0) + 8] = 14; // an array as the root of a record
+    refuses(f, fx1home.TableFixedRefusal.LayoutKindInvalid,
+      "RULE: the root entry is a TABLE");
+  }
+
+  // 4. A CONSTANT SIZE MATCHES ITS KIND
+  {
+    const f = copy();
+    putU32(f, entryAt(1) + 9, 5); // a uint32 leaf in five bytes
+    refuses(f, fx1home.TableFixedRefusal.LayoutSizeMismatch,
+      "RULE: a constant size its kind does not admit");
+  }
+  {
+    const f = copy();
+    putU32(f, entryAt(0) + 9, getU32(f, entryAt(0) + 9) + 4);
+    refuses(f, fx1home.TableFixedRefusal.LayoutSizeMismatch,
+      "RULE: a table's size is the sum of its fields'");
+  }
+
+  // 5. THE PRE-ORDER CHILD WALK CONSUMES EXACTLY THE ENTRIES
+  {
+    const f = copy();
+    putU32(f, entryAt(0) + 13, getU32(f, entryAt(0) + 13) + 1);
+    refuses(f, fx1home.TableFixedRefusal.LayoutTreeUnclosed,
+      "RULE: the tree runs out of layout");
+  }
+  {
+    // THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk
+    // reaches. It takes a hand-built layout to reach, and that is itself
+    // worth stating: dropping a child of a TABLE is caught one rule sooner,
+    // by the size that no longer sums, so the only subtree whose loss the
+    // size rule cannot see is one that contributes NO size — an enum's
+    // variants, at kind 32 and size 0.
+    let layout = new Uint8Array(4);
+    putU32(layout, 0, 4);
+    layout = putEntry(layout, 1, 13, 4, 1); // a table of one field
+    layout = putEntry(layout, 2, 30, 4, 0); // an enum, its TWO variants unreached
+    layout = putEntry(layout, 3, 32, 0, 0);
+    layout = putEntry(layout, 4, 32, 0, 0);
+    refuses(fileOf(fx1home, layout), fx1home.TableFixedRefusal.LayoutTreeUnclosed,
+      "RULE: the layout outlasts the tree");
+  }
+
+  // 6. THE TOTAL RECORD SIZE IS WITHIN 65536 AND DOES NOT OVERFLOW
+  {
+    const f = copy();
+    putU32(f, entryAt(0) + 9, 65537);
+    refuses(f, fx1home.TableFixedRefusal.LayoutRecordTooLarge,
+      "RULE: a record size past 65536");
+  }
+  {
+    const f = copy();
+    putU32(f, entryAt(1) + 9, 0xffffffff);
+    refuses(f, fx1home.TableFixedRefusal.LayoutRecordTooLarge,
+      "RULE: a size that would overflow the sum");
+  }
+
+  // 7. NOTHING NESTED PAST THE READER'S WALK BOUND. A BOUND ON THE WALK AND
+  //    NOT ON THE WIRE: the validation recurses, so a layout of a thousand
+  //    entries each claiming one child would spend a reader's stack before
+  //    any other rule could fire. Nothing in §3.4 fixes the number.
+  {
+    const depth = 4096; // far past any reader's own bound
+    const layout = new Uint8Array(4 + (depth + 1) * 17);
+    putU32(layout, 0, depth + 1);
+    for (let i = 0; i < depth; i++) {
+      putEntryAt(layout, 4 + i * 17, 1, i === 0 ? 13 : 35, depth - i, 1);
+    }
+    putEntryAt(layout, 4 + depth * 17, 2, 1, 1, 0); // a bool at the bottom
+    refuses(fileOf(fx1home, layout), fx1home.TableFixedRefusal.LayoutTooDeep,
+      "RULE: a nesting depth past the walk's own bound");
+  }
+
+  // AND THE RESIDUE: bytes that are not a layout at all, which is the one
+  // case the seven named rules never reach.
+  {
+    refuses(fileOf(fx1home, new Uint8Array(2)), fx1home.TableFixedRefusal.LayoutMalformed,
+      "RULE: fewer bytes than a header is layout_malformed");
   }
 }
 


### PR DESCRIPTION
The JS walk collapsed rules 1 and 5 into `LayoutMalformed`, had no kind check, no 65536 bound, and no rules 3, 4, or 7. Zero named layout refusals were asserted in `test/js-tables/fixedform.mjs`.

## What changed

`TableFixedParseLayout` now holds a peer layout to the seven named rules the C++ reference does (`TableFixedCheckEntry`), in the same order: count, root is a table, kind known first, 65536, size and shape, tree close, depth 64. `layout_malformed` is the residue after the seven.

- `layout_count_mismatch`
- `layout_kind_unknown`
- `layout_size_mismatch`
- `layout_kind_invalid`
- `layout_tree_unclosed`
- `layout_record_too_large`
- `layout_too_deep`

ONE PATH: hash still chooses the plan. Identity is still a PLAN. There is no identity door. A failed parse sets nothing.

`test/js-tables/fixedform.mjs` pins the C++ `layout_validation` fixtures (one break per name). Rowan's hostile-layout fixtures PR is not up yet; leftover is prove against it when it posts.

## Gates (cheap)

- `make tables-js-fixed-form` — OK

Off `origin/fixed-table-form` `0bcb8d60ce0ab177a13222f3a00f83c8b917e37d`. Commit `a1b15489ade2d2edc2a61e62559248d9dde3b364`. Johnny Grok.

Still draft. Do not merge.