### PR TITLE
fixed form: the seven layout refusals as fixtures on JS, Rust, C and Elixir, red first

### DIFF
--- a/make/c.mk
+++ b/make/c.mk
@@ -908,6 +908,7 @@ build/tables-generated-c-fixed/.stamp: bin/schema test/tables/FX1.schema test/ta
 	@touch $@
 
 C_FIXEDFORM_SOURCES := test/c-tables/fixedform_main.c test/c-tables/fixedform_fx1.c test/c-tables/fixedform_fx2.c \
+	test/c-tables/fixedform_layout.c \
 	test/c-tables/fixedform_v1.c test/c-tables/fixedform_v2.c \
 	test/c-tables/fixedform_ut1.c test/c-tables/fixedform_ut2.c \
 	test/c-tables/fixedform_fu1.c test/c-tables/fixedform_fu2.c

--- a/test/c-tables/fixedform.h
+++ b/test/c-tables/fixedform.h
@@ -72,6 +72,16 @@ void fixed_v1_absent_optional( void );
 void fixed_fx1_text_content( void );
 void fixed_guard_width( void );
 
+/* THE LAYOUT VALIDATION (docs/SPEC-TABLES.md §3.4,
+   docs/FIXED-FORM-ALGORITHM.md §1.1). A layout arrives from an UNTRUSTED PEER
+   and is the one structure a reader must parse before it knows anything at
+   all, so §1.1's SEVEN named refusals each get a case of their own: one
+   hostile layout per rule, each breaking EXACTLY ONE THING in a layout this
+   reader accepts, plus the residue — bytes that are not a layout at all. It is
+   the FX1 reader on a file built around FX2's layout, so the bytes arrive as a
+   parameter the way they do for fixed_fx1_read_fx2. */
+void fixed_fx1_layout_validation( const uint8_t * data, int64_t bytes );
+
 /* THE BYTE-FLIP FUZZ's reader (docs/SPEC-TABLES.md §3.4, "held by test"): it
    makes no claim about the values, only that the read answers one of the three
    ways the form allows and never leaves the buffer doing it. Every offset this

--- a/test/c-tables/fixedform_layout.c
+++ b/test/c-tables/fixedform_layout.c
@@ -1,0 +1,254 @@
+/* THE LAYOUT VALIDATION, C leg (docs/SPEC-TABLES.md §3.4,
+   docs/FIXED-FORM-ALGORITHM.md §1.1). The C++ reference is the
+   layout_validation() function of test/tables/fixedform_main.cpp and this is
+   its twin: the same twelve hostile layouts, refused under the same names.
+
+   THE LAYOUT ARRIVES FROM AN UNTRUSTED PEER. It is the one structure a reader
+   must parse before it knows anything at all, so every rule it is held to
+   refuses under ITS OWN NAME, before a single record byte is touched. A
+   VALIDATION NOBODY WATCHED FAIL IS A VALIDATION NOBODY HAS, so there is one
+   case per named rule, each taking a layout this reader ACCEPTS and breaking
+   EXACTLY ONE THING in it.
+
+   THIS IS THE FX1 READER ON A FILE BUILT AROUND FX2'S LAYOUT, which is what
+   the reference does too (its `good` is written by tblfx2 and read by tblfx1).
+   C has no namespace, so the two generations cannot share a translation unit
+   (fixedform.h says why): the FX2 bytes arrive as a parameter, exactly as they
+   do for fixed_fx1_read_fx2.
+
+   The file is the HEADER (docs/SPEC-TABLES.md §3: the form byte, seven
+   reserved zero bytes, the layout hash at 8, the body at 16), then `u32 layout
+   length, layout, records` — so the layout starts at byte 20, the entry count
+   is the four bytes there, and entry k is the seventeen bytes at 20 + 4 + 17k:
+   id (u64), kind (u8), size (u32), children (u32), every number
+   little-endian.
+
+   THE HEADER'S HASH IS NOT RECOMPUTED AFTER A BREAK, and that is deliberate
+   rather than sloppy. Changing a byte inside the layout makes the hash at
+   offset 8 no longer the hash of the layout behind it, and the algorithm doc
+   §2 step 5 says that hash is checked LAST so the layout's own rules refuse
+   first. VERIFIED on this leg: the generated load (internal/codegen/ctable's
+   fixedform.go) parses and validates the layout in the not-my-hash branch and
+   only then compares the header hash, under a comment that says exactly that.
+   So each case below refuses by its own name and never as a lying header. */
+
+#include <string.h>
+
+#include "FX1Table.h"
+#include "fixedform.h"
+
+/* the plan storage the caller owns; no layout below ever gets as far as
+   compiling, which is the point — a refusal costs no plan */
+#define PlanCapacity 1024
+static TableFixedEntry g_plan[PlanCapacity];
+
+/* THIS LEG ALLOCATES NOTHING, HERE LEAST OF ALL. fixedform_main.c holds its
+   own bytes in a static g_buffer and so does every translation unit beside
+   this one, so the hostile files are static arrays too. The deep case is the
+   reason there are two: 4097 entries is about 70KB, past main's 65536. */
+#define BrokenBytes 4096
+static uint8_t g_broken[BrokenBytes];
+
+#define DeepEntries 4097u
+#define DeepLayoutBytes ( 4u + DeepEntries * 17u )
+#define DeepFileBytes ( (size_t) kTableFixedHeaderBytes + 4u + DeepLayoutBytes )
+static uint8_t g_deep[DeepFileBytes];
+
+#define LayoutAt ( (size_t) kTableFixedHeaderBytes + 4u )
+#define Entry0At ( LayoutAt + 4u )
+
+static uint8_t * entry_at( uint8_t * f, size_t k ) { return f + Entry0At + k * 17u; }
+
+/* an entry written straight into a hand-built file, for the rules no single
+   break of a real layout reaches */
+static void put_entry( uint8_t * f, size_t k, uint64_t id, uint8_t kind, uint32_t size, uint32_t children )
+{
+    uint8_t * e = entry_at( f, k );
+    table_fixed_put64( e, id );
+    e[8] = kind;
+    table_fixed_put32( e + 9, size );
+    table_fixed_put32( e + 13, children );
+}
+
+/* THE FILE AROUND A HAND-BUILT LAYOUT: the form byte, the layout's length, the
+   layout's own hash in the header, and NO RECORDS — every rule below refuses
+   before a record is reached, so there is nothing for one to be. The C twin of
+   the reference's file_of, except that the layout is built in place: a second
+   buffer for the deep case would be another 70KB for nothing. */
+static int64_t hand_built( uint8_t * f, uint32_t entries )
+{
+    const uint32_t layout_bytes = 4u + entries * 17u;
+    f[0] = 3; /* the fixed form's byte */
+    table_fixed_put32( f + LayoutAt, entries );
+    table_fixed_put32( f + kTableFixedHeaderBytes, layout_bytes );
+    table_fixed_put64( f + kTableFixedHashAt, table_fixed_hash_of( f + LayoutAt, (int64_t) layout_bytes ) );
+    return (int64_t) kTableFixedHeaderBytes + 4 + (int64_t) layout_bytes;
+}
+
+static void refuses( const uint8_t * broken, int64_t bytes, int want, const char * what )
+{
+    FxRoot v;
+    TableReport r;
+    int64_t n;
+    fx_root_reset( &v );
+    memset( &r, 0, sizeof( r ) );
+    n = fx_root_fixed_load( &v, 1, broken, bytes, g_plan, PlanCapacity, NULL, &r );
+    fixed_check( n < 0 && r.refused && r.reason == want, what );
+    /* NOTHING WAS DECODED AND NOTHING WAS COUNTED. A refusal that half-read a
+       record would be the damage the refusal exists to prevent. */
+    fixed_check( r.unknown == 0 && r.kind_mismatch == 0 && r.widened == 0 && r.clamped == 0 && !r.malformed,
+                 "a layout refusal sets nothing and counts nothing" );
+}
+
+void fixed_fx1_layout_validation( const uint8_t * data, int64_t bytes )
+{
+    fixed_check( bytes > 0 && bytes <= (int64_t) BrokenBytes,
+                 "C layout validation: the unbroken file fits this unit's buffer" );
+    if ( bytes <= 0 || bytes > (int64_t) BrokenBytes ) { return; }
+
+    /* THE NEGATIVE CONTROL, FIRST: the UNBROKEN file READS, so every refusal
+       below is the ONE break and not the file. */
+    {
+        FxRoot v;
+        TableReport r;
+        fx_root_reset( &v );
+        memset( &r, 0, sizeof( r ) );
+        fixed_check( fx_root_fixed_load( &v, 1, data, bytes, g_plan, PlanCapacity, NULL, &r ) == 1 && !r.refused,
+                     "C layout validation: the unbroken file reads, so the breaks below are the breaks" );
+    }
+
+    /* 1. THE ENTRY COUNT FITS THE LAYOUT'S LENGTH EXACTLY */
+    {
+        uint32_t count;
+        memcpy( g_broken, data, (size_t) bytes );
+        count = table_fixed_get32( g_broken + LayoutAt );
+        table_fixed_put32( g_broken + LayoutAt, count + 1u );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_COUNT_MISMATCH,
+                 "RULE: the entry count fits the layout length exactly" );
+    }
+    {
+        /* a count of ZERO is not a layout either: there is no root to walk */
+        memcpy( g_broken, data, (size_t) bytes );
+        table_fixed_put32( g_broken + LayoutAt, 0u );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_COUNT_MISMATCH,
+                 "RULE: an entry count of zero is not a layout" );
+    }
+
+    /* 2. EVERY KIND IS IN THE CLOSED SET. A fixed form's kind set is CLOSED,
+          so a kind outside it means a NEWER FORM BYTE — a different form — and
+          not a newer layout of this one. It is refused, never stepped over. */
+    {
+        memcpy( g_broken, data, (size_t) bytes );
+        entry_at( g_broken, 1 )[8] = 200; /* a kind no form byte this build carries defines */
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_KIND_UNKNOWN,
+                 "RULE: a kind outside the closed set is REFUSED, not skipped" );
+    }
+
+    /* 3. A KIND IS USED AS ITS DEFINITION ALLOWS — here, the ROOT is a table */
+    {
+        memcpy( g_broken, data, (size_t) bytes );
+        entry_at( g_broken, 0 )[8] = 14; /* an array as the root of a record */
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_KIND_INVALID,
+                 "RULE: the root entry is a TABLE" );
+    }
+
+    /* 4. A CONSTANT SIZE MATCHES ITS KIND. ENTRY 1 IS THE FOUR-BYTE LEAF this
+          case needs, and on this layout it is not a guess: FX2's FxRoot is the
+          root table at entry 0 and `keep`, a uint32, is its first field — kind
+          8, size 4, no children. */
+    {
+        memcpy( g_broken, data, (size_t) bytes );
+        fixed_check( entry_at( g_broken, 1 )[8] == 8 && table_fixed_get32( entry_at( g_broken, 1 ) + 9 ) == 4u,
+                     "C layout validation: entry 1 really is a four-byte uint32 leaf" );
+        table_fixed_put32( entry_at( g_broken, 1 ) + 9, 5u ); /* a uint32 leaf in five bytes */
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_SIZE_MISMATCH,
+                 "RULE: a constant size its kind does not admit" );
+    }
+    {
+        /* and a TABLE's size is the SUM of its children's, not a number of its own */
+        uint32_t body;
+        memcpy( g_broken, data, (size_t) bytes );
+        body = table_fixed_get32( entry_at( g_broken, 0 ) + 9 );
+        table_fixed_put32( entry_at( g_broken, 0 ) + 9, body + 4u );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_SIZE_MISMATCH,
+                 "RULE: a table's size is the sum of its fields'" );
+    }
+
+    /* 5. THE PRE-ORDER CHILD WALK CONSUMES EXACTLY THE ENTRIES */
+    {
+        uint32_t kids;
+        memcpy( g_broken, data, (size_t) bytes );
+        kids = table_fixed_get32( entry_at( g_broken, 0 ) + 13 );
+        table_fixed_put32( entry_at( g_broken, 0 ) + 13, kids + 1u );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_TREE_UNCLOSED,
+                 "RULE: the tree runs out of layout" );
+    }
+    {
+        /* THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk
+           reaches. It takes a hand-built layout to reach, and that is itself
+           worth stating: dropping a child of a TABLE is caught one rule
+           sooner, by the size that no longer sums, so the only subtree whose
+           loss the size rule cannot see is one that contributes NO size — an
+           enum's variants, at kind 32 and size 0. */
+        int64_t total;
+        memset( g_broken, 0, sizeof( g_broken ) );
+        put_entry( g_broken, 0, 1u, 13u, 4u, 1u ); /* a table of one field */
+        put_entry( g_broken, 1, 2u, 30u, 4u, 0u ); /* an enum, its TWO variants unreached */
+        put_entry( g_broken, 2, 3u, 32u, 0u, 0u );
+        put_entry( g_broken, 3, 4u, 32u, 0u, 0u );
+        total = hand_built( g_broken, 4u );
+        refuses( g_broken, total, SCHEMA_TABLE_LAYOUT_TREE_UNCLOSED,
+                 "RULE: the layout outlasts the tree" );
+    }
+
+    /* 6. THE TOTAL RECORD SIZE IS WITHIN 65536 AND DOES NOT OVERFLOW */
+    {
+        memcpy( g_broken, data, (size_t) bytes );
+        table_fixed_put32( entry_at( g_broken, 0 ) + 9, 65537u );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_RECORD_TOO_LARGE,
+                 "RULE: a record size past 65536" );
+    }
+    {
+        /* A SIZE THAT WOULD WRAP. The children's sizes are summed in 64 bits
+           precisely so a u32 that overflows is CAUGHT rather than wrapped into
+           a small number that then agrees with a parent. */
+        memcpy( g_broken, data, (size_t) bytes );
+        table_fixed_put32( entry_at( g_broken, 1 ) + 9, 0xFFFFFFFFu );
+        refuses( g_broken, bytes, SCHEMA_TABLE_LAYOUT_RECORD_TOO_LARGE,
+                 "RULE: a size that would overflow the sum" );
+    }
+
+    /* 7. NOTHING NESTED PAST THE READER'S WALK BOUND. A BOUND ON THE WALK AND
+          NOT ON THE WIRE: the validation recurses, so a layout of a thousand
+          entries each claiming one child would spend a reader's stack before
+          any other rule could fire. Nothing in §3.4 fixes the number. */
+    {
+        const uint32_t depth = DeepEntries - 1u; /* far past any reader's own bound */
+        uint32_t i;
+        int64_t total;
+        memset( g_deep, 0, sizeof( g_deep ) );
+        for ( i = 0; i < depth; ++i )
+        {
+            /* a table, then optional wrappers all the way down */
+            put_entry( g_deep, i, 1u, ( i == 0u ) ? 13u : 35u, depth - i, 1u );
+        }
+        put_entry( g_deep, depth, 2u, 1u, 1u, 0u ); /* a bool at the bottom */
+        total = hand_built( g_deep, depth + 1u );
+        refuses( g_deep, total, SCHEMA_TABLE_LAYOUT_TOO_DEEP,
+                 "RULE: a nesting depth past the walk's own bound" );
+    }
+
+    /* AND THE RESIDUE: bytes that are not a layout at all, which is the one
+       case the seven named rules never reach. A layout needs four bytes to
+       carry an entry count and these are two. */
+    {
+        const uint32_t layout_bytes = 2u;
+        memset( g_broken, 0, LayoutAt + layout_bytes );
+        g_broken[0] = 3;
+        table_fixed_put32( g_broken + kTableFixedHeaderBytes, layout_bytes );
+        table_fixed_put64( g_broken + kTableFixedHashAt,
+                           table_fixed_hash_of( g_broken + LayoutAt, (int64_t) layout_bytes ) );
+        refuses( g_broken, (int64_t) LayoutAt + layout_bytes, SCHEMA_TABLE_LAYOUT_MALFORMED,
+                 "RULE: fewer bytes than a header is layout_malformed" );
+    }
+}

--- a/test/c-tables/fixedform_main.c
+++ b/test/c-tables/fixedform_main.c
@@ -38,6 +38,7 @@ int main( void )
     n = fixed_fx2_write( g_buffer, BufferBytes );
     fixed_check( n == fixed_fx2_bytes(), "FX2 save" );
     fixed_fx1_read_fx2( g_buffer, n );
+    fixed_fx1_layout_validation( g_buffer, n );
 
     n = fixed_v1_write( g_buffer, BufferBytes );
     fixed_check( n == fixed_v1_bytes(), "V1 save" );

--- a/test/elixir-fixedform/main.exs
+++ b/test/elixir-fixedform/main.exs
@@ -944,15 +944,59 @@ Leg.eq(
 {:ok, stated, layout, records} = Tblfx1.FixedRuntime.read_file_header(read.("fx1.bin"))
 Leg.eq("the header names the layout it carries", stated, Tblfx1.FixedRuntime.hash(layout))
 
+# A VALIDATION NOBODY WATCHED FAIL IS A VALIDATION NOBODY HAS, so there is one
+# case per named rule, each taking a layout this reader accepts and breaking
+# EXACTLY ONE THING in it — and each asserting the other half of a refusal
+# beside the name: NOTHING WAS DECODED AND NOTHING WAS COUNTED. A refusal that
+# half-read a record would be the damage the refusal exists to prevent, which is
+# what the C++ reference asserts beside every case of its own
+# (test/tables/fixedform_main.cpp, `refuses`).
+refuse_file = fn name, data, want ->
+  case Tblfx1.FX1Fixed.fx_root_fixed_load(data) do
+    {:error, why, report} ->
+      Leg.eq(name, why, want)
+
+      Leg.eq(
+        "#{name}: a layout refusal sets nothing and counts nothing",
+        report,
+        Tblfx1.FixedRuntime.report()
+      )
+
+    {:ok, _values, _report} ->
+      Leg.eq(name, :accepted, want)
+  end
+end
+
+# THE HEADER'S HASH IS RECOMPUTED FROM THE BROKEN LAYOUT, never carried over
+# from the good one: §2 step 5 checks the header hash LAST, after the layout's
+# own seven rules, so a stale hash would not mask the rule under test — but a
+# hash that already agrees makes the case say so without leaning on the order.
 refuse = fn name, bad, want ->
-  data =
+  refuse_file.(
+    name,
     IO.iodata_to_binary([
       Tblfx1.FixedRuntime.file_header(Tblfx1.FixedRuntime.hash(bad), byte_size(bad)),
       bad,
       records
-    ])
+    ]),
+    want
+  )
+end
 
-  Leg.eq(name, Tblfx1.FX1Fixed.fx_root_fixed_load(data) |> elem(1), want)
+# AN ENTRY, AND A FILE AROUND A HAND-BUILT LAYOUT — the two rules no single
+# break of a real layout reaches need a layout written from nothing: seventeen
+# bytes an entry (id u64, kind u8, size u32, children u32, §1.1), and a file of
+# the form byte, the layout's own hash, its length, the layout, and NO RECORDS,
+# because every rule below refuses before a record byte is reached.
+entry = fn id, kind, size, children ->
+  <<id::little-unsigned-64, kind, size::little-unsigned-32, children::little-unsigned-32>>
+end
+
+file_of = fn built ->
+  IO.iodata_to_binary([
+    Tblfx1.FixedRuntime.file_header(Tblfx1.FixedRuntime.hash(built), byte_size(built)),
+    built
+  ])
 end
 
 <<_count::little-unsigned-32, entries::binary>> = layout
@@ -996,17 +1040,83 @@ bad_tree =
   <<binary_part(layout, 0, 17)::binary, 99, 0, 0, 0,
     binary_part(layout, 21, byte_size(layout) - 21)::binary>>
 
-Leg.check(
-  "a child count that does not close refuses by name",
-  Tblfx1.FX1Fixed.fx_root_fixed_load(
-    IO.iodata_to_binary([
-      Tblfx1.FixedRuntime.file_header(Tblfx1.FixedRuntime.hash(bad_tree), byte_size(bad_tree)),
-      bad_tree,
-      records
-    ])
-  )
-  |> elem(1)
-  |> then(&(&1 in [:layout_tree_unclosed, :layout_size_mismatch, :layout_kind_invalid]))
+# AND THE NAME IS `layout_tree_unclosed` ALONE, not one of three. §1.1's order
+# is LOAD-BEARING: inside the walk, per entry, INDEX IN RANGE (rule 5) is tested
+# before depth (7), kind (2), the entry's own size (6) and every shape rule — so
+# a root claiming a ninth child when the layout holds eight runs off the end of
+# the entry table and rule 5 is the FIRST reason, which is the one kept. Neither
+# `layout_size_mismatch` nor `layout_kind_invalid` can fire here: both are the
+# root's SHAPE rules, and the walk that would have summed its children to reach
+# them never returns (docs/FIXED-FORM-ALGORITHM.md §1.1).
+refuse.(
+  "a child count that does not close is `layout_tree_unclosed`",
+  bad_tree,
+  :layout_tree_unclosed
+)
+
+# THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk reaches.
+# It takes a hand-built layout to reach, and that is itself worth stating:
+# dropping a child of a TABLE is caught one rule sooner, by the size that no
+# longer sums, so the only subtree whose loss the size rule cannot see is one
+# that contributes NO size — an enum's variants, at kind 32 and size 0.
+unreached =
+  IO.iodata_to_binary([
+    <<4::little-unsigned-32>>,
+    entry.(1, 13, 4, 1),
+    entry.(2, 30, 4, 0),
+    entry.(3, 32, 0, 0),
+    entry.(4, 32, 0, 0)
+  ])
+
+refuse_file.(
+  "RULE: the layout outlasts the tree",
+  file_of.(unreached),
+  :layout_tree_unclosed
+)
+
+# THE TOTAL RECORD SIZE IS WITHIN 65536 AND DOES NOT OVERFLOW (rule 6). The
+# record carries no lengths, so every offset the plan uses is arithmetic over
+# the sizes the WRITER wrote down: a size past the bound is a record this reader
+# will not hold, and a size that wraps is a small number that then AGREES with
+# its parent (docs/SPEC-TABLES.md §3.4, docs/FIXED-FORM-ALGORITHM.md §1.1).
+#
+# Entry 0's size is the four bytes at 4 + 9 — one past the bound, where the
+# neighbouring `bad_size` case above sat one BELOW it and was caught by the sum.
+too_large =
+  <<binary_part(layout, 0, 13)::binary, 65537::little-unsigned-32,
+    binary_part(layout, 17, byte_size(layout) - 17)::binary>>
+
+refuse.("RULE: a record size past 65536", too_large, :layout_record_too_large)
+
+# A SIZE THAT WOULD WRAP. The children's sizes are summed in 64 bits precisely
+# so a u32 that overflows is CAUGHT rather than wrapped into a small number that
+# then agrees with a parent. Entry 1's size is the four bytes at 4 + 17 + 9.
+wrapping =
+  <<binary_part(layout, 0, 30)::binary, 0xFFFFFFFF::little-unsigned-32,
+    binary_part(layout, 34, byte_size(layout) - 34)::binary>>
+
+refuse.("RULE: a size that would overflow the sum", wrapping, :layout_record_too_large)
+
+# NOTHING NESTED PAST THE READER'S WALK BOUND (rule 7). A BOUND ON THE WALK AND
+# NOT ON THE WIRE: the validation descends, so a layout of a thousand entries
+# each claiming one child would spend a reader's stack before any other rule
+# could fire. Nothing in §3.4 fixes the number. A table, then optional wrappers
+# all the way down, and a bool at the bottom — and the depth rule fires ahead of
+# the optional's own `size == sum + 1`, which the bottom of this chain breaks.
+chain_depth = 4096
+
+too_deep =
+  IO.iodata_to_binary([
+    <<chain_depth + 1::little-unsigned-32>>,
+    entry.(1, 13, chain_depth, 1),
+    for(i <- 1..(chain_depth - 1), do: entry.(1, 35, chain_depth - i, 1)),
+    entry.(2, 1, 1, 0)
+  ])
+
+refuse_file.(
+  "RULE: a nesting depth past the walk's own bound",
+  file_of.(too_deep),
+  :layout_too_deep
 )
 
 # A HEADER WHOSE HASH IS NOT THE HASH OF THE LAYOUT BEHIND IT is refused, and

--- a/test/js-tables/fixedform.mjs
+++ b/test/js-tables/fixedform.mjs
@@ -84,6 +84,7 @@ export async function checkFixedForm(check, generated, corpusDir, optionalDir, o
   liveCountSlack(check, fx1, fx1home);
   holePrefill(check, fx1, fx2, fx1home, fx2home);
   negativeControls(check, fx1, fx2, fx1home, fx2home);
+  layoutValidation(check, fx1, fx2, fx1home, fx2home);
   unionArmText(check, ut1, ut2, ut1home, ut2home, ut1types, ut2types);
   if (oracleDir) {
     referenceOracle(check, fx1, fx2, fx1home, oracleDir);
@@ -642,6 +643,297 @@ function negativeControls(check, fx1, fx2, fx1home, fx2home) {
     const small = new Uint8Array(fx1.FxRootFixedMeasure(1) - 1);
     check(fx1.FxRootFixedSave([one], 1, small) === -1,
       "REFUSAL: a buffer too small for the file answers -1");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// THE LAYOUT VALIDATION — §1.1'S SEVEN RULES, EACH UNDER ITS OWN NAME
+// ---------------------------------------------------------------------------
+//
+// THE LAYOUT ARRIVES FROM AN UNTRUSTED PEER (docs/SPEC-TABLES.md §3.4). It is
+// the one structure a reader must parse before it knows anything at all, so
+// docs/FIXED-FORM-ALGORITHM.md §1.1 holds it to SEVEN RULES and gives each one
+// ITS OWN NAME, raised before a single record byte is touched. A VALIDATION
+// NOBODY WATCHED FAIL IS A VALIDATION NOBODY HAS, so there is one case per
+// named rule here — the C++ reference's own twelve, in its own order
+// (test/tables/fixedform_main.cpp, layout_validation) — each taking a layout
+// this reader ACCEPTS and breaking EXACTLY ONE THING in it.
+//
+// THE ASSERTION IS ON THE NAME AND NOT ON THE VALUE, which is the one place
+// this leg departs from the reference's spelling. `TableFixedRefusal` does not
+// carry §1.1's seven members yet, so `fx1home.TableFixedRefusal.LayoutCountMismatch`
+// is `undefined` and `r.refused === undefined` would go red reading "false" —
+// one opaque failure that says nothing about which rule is missing. So the
+// refusal's VALUE is reverse-mapped through the frozen enum to its MEMBER NAME
+// and the name string is what is compared. That is exactly as strong as the
+// enum comparison — a wrong member fails it, and it passes unchanged the day
+// the runtime registers the seven — and it makes every red say what the
+// document owes and what this leg actually answers.
+//
+// The file is §3's HEADER (the form byte, seven reserved zero bytes, the layout
+// hash at 8, the body at 16), then `u32 layout length, layout, records` — so
+// the layout starts at LAYOUT_AT, the entry count is the four bytes there, and
+// entry k is the seventeen bytes at LAYOUT_AT + 4 + 17k: id (u64), kind (u8),
+// size (u32), children (u32), every number little-endian.
+//
+// AND THE BROKEN FILE IS SEALED AROUND THE BREAK. A hostile peer writes a file
+// that is consistent with itself: the header's hash IS the hash of the layout
+// it carries, and so is every record's. §2 step 5 puts the header hash check
+// LAST of the three for exactly this reason — so a broken layout is never
+// reported as a lying header — and this leg's loader does order it last in its
+// code. But the rules it orders it after are the ones it HAS, and §1.1's seven
+// are not among them: a file left with the good layout's hash in its header
+// would be refused `layout_malformed` for the tampering rather than for the
+// rule, and every red below would read the same whether the rule is checked
+// late, misnamed, or absent. So the layout's fnv1a64 is recomputed over the
+// broken bytes and stamped into the header and into the record behind it. What
+// refuses a sealed file is the RULE or nothing, which is the measurement.
+//
+// The hash is computed here from §1's own definition, in BigInt, rather than
+// borrowed from the module under test — a driver that hashed with the code it
+// is checking would agree with whatever that code happened to do. The seal is
+// proved against the good file first: resealing bytes that are already right
+// must change nothing.
+
+function layoutValidation(check, fx1, fx2, fx1home, fx2home) {
+  // §1'S HASH: fnv1a64 over the layout's bytes as written, THE 4-BYTE COUNT
+  // INCLUDED. A fixture's oracle, so it is written the plain way.
+  const fnv1a64 = (bytes, at, length) => {
+    let h = 0xcbf29ce484222325n;
+    for (let i = 0; i < length; i++) {
+      h = ((h ^ BigInt(bytes[at + i])) * 0x100000001b3n) & 0xffffffffffffffffn;
+    }
+    return h;
+  };
+
+  const get32 = (f, at) => (f[at] | (f[at + 1] << 8) | (f[at + 2] << 16) | (f[at + 3] << 24)) >>> 0;
+  const put32 = (f, at, v) => {
+    f[at] = v & 0xff; f[at + 1] = (v >>> 8) & 0xff;
+    f[at + 2] = (v >>> 16) & 0xff; f[at + 3] = (v >>> 24) & 0xff;
+  };
+
+  const ENTRY_BYTES = 17;
+  const entryAt = (k) => LAYOUT_AT + 4 + ENTRY_BYTES * k;
+  const KIND_AT = 8, SIZE_AT = 9, CHILDREN_AT = 13; // inside an entry
+
+  // the hash stamped into the header and into every record behind the layout
+  const seal = (f, recordBytes) => {
+    const layoutBytes = get32(f, LAYOUT_LENGTH_AT);
+    const h = fnv1a64(f, LAYOUT_AT, layoutBytes);
+    const lo = Number(h & 0xffffffffn), hi = Number((h >> 32n) & 0xffffffffn);
+    put32(f, HASH_AT, lo); put32(f, HASH_AT + 4, hi);
+    for (let at = LAYOUT_AT + layoutBytes; recordBytes > 0 && at + 8 <= f.length; at += recordBytes) {
+      put32(f, at, lo); put32(f, at + 4, hi);
+    }
+    return f;
+  };
+
+  // A FILE AROUND A HAND-BUILT LAYOUT, for the rules no single break of a real
+  // layout reaches: the form byte, the layout's length, the layout, NO records.
+  // Every rule below refuses before a record would be reached.
+  const fileOf = (layout) => {
+    const f = new Uint8Array(LAYOUT_AT + layout.length);
+    f[0] = 3; // the fixed form's byte
+    put32(f, LAYOUT_LENGTH_AT, layout.length);
+    f.set(layout, LAYOUT_AT);
+    return seal(f, 0);
+  };
+
+  const putEntry = (out, id, kind, size, children) => {
+    out.push(id & 0xff, (id >>> 8) & 0xff, (id >>> 16) & 0xff, (id >>> 24) & 0xff, 0, 0, 0, 0);
+    out.push(kind & 0xff);
+    out.push(size & 0xff, (size >>> 8) & 0xff, (size >>> 16) & 0xff, (size >>> 24) & 0xff);
+    out.push(children & 0xff, (children >>> 8) & 0xff, (children >>> 16) & 0xff, (children >>> 24) & 0xff);
+    return out;
+  };
+
+  const handLayout = (count, build) => {
+    const out = build([0, 0, 0, 0]);
+    const layout = Uint8Array.from(out);
+    put32(layout, 0, count);
+    return layout;
+  };
+
+  // THE NAME, NOT THE VALUE: the frozen enum read backwards. A refusal this
+  // build does not register at all comes back as the bare number, which is
+  // itself the report — a reader answering a value nobody named.
+  const REFUSAL_NAME = new Map(Object.entries(fx1home.TableFixedRefusal).map(([name, v]) => [v, name]));
+  const refusalName = (v) => REFUSAL_NAME.get(v) ?? `an unregistered refusal value (${v})`;
+
+  const read = (bytes) => {
+    const values = [new fx1home.FxRoot()];
+    const r = new fx1home.TableFixedReport();
+    const n = fx1.FxRootFixedLoad(values, 1, bytes, bytes.length, fx1.FxRootFixedNewPlan(), r);
+    return { n, r };
+  };
+
+  // ONE CASE IS ONE RED AND NEVER THE RUN'S LAST WORD: a throw out of the
+  // loader is a failure of THAT case and the rest are still measured, because a
+  // reader that walks a hostile layout off the end of its own array is the
+  // damage the validation exists to prevent and not a reason to stop looking.
+  const refuses = (bytes, want, what) => {
+    let got = null, n = 0, threw = null;
+    try {
+      const out = read(bytes);
+      n = out.n; got = out.r;
+    } catch (e) {
+      threw = e;
+    }
+    if (threw !== null) {
+      check(false, `${what} — expected ${want}, and the read THREW ${threw.name}: ${threw.message}`);
+      return;
+    }
+    const name = refusalName(got.refused);
+    check(n === -1 && got.refused !== 0 && name === want,
+      `${what} — expected ${want}, got ${name}` + (n === -1 ? "" : ` and a read of ${n} record(s)`));
+    // NOTHING WAS DECODED AND NOTHING WAS COUNTED. A refusal that half-read a
+    // record, or that compiled a plan over the hostile layout on its way out,
+    // would be the damage the refusal exists to prevent.
+    check(got.unknown === 0 && got.kindMismatch === 0 && got.widened === 0 && got.clamped === 0 && !got.malformed,
+      `${what}: a layout refusal sets nothing and counts nothing ` +
+      `(unknown ${got.unknown}, kindMismatch ${got.kindMismatch}, widened ${got.widened}, ` +
+      `clamped ${got.clamped}, malformed ${got.malformed})`);
+  };
+
+  // the layout this reader ACCEPTS, which every case below breaks once: the
+  // OTHER generation's file, read by this one, which is the versioning path
+  const two = new fx2home.FxRoot();
+  two.Keep = 5150; two.Narrow = 70000; two.RenamedTo = 808; two.Added = 909;
+  two.Nested.A = 33; two.Nested.B = 44; two.Extra.X = 55; two.Extra.Y = 66;
+  const good = new Uint8Array(fx2.FxRootFixedMeasure(1));
+  check(fx2.FxRootFixedSave([two], 1, good) === good.length,
+    "layout validation: the unbroken file saves");
+  const RECORD_BYTES = fx2.FxRootFixedRecordBytes;
+
+  {
+    // and it READS, so every refusal below is the ONE break and not the file
+    const { n, r } = read(good);
+    check(n === 1 && r.refused === 0 && !r.malformed,
+      `layout validation: the unbroken file reads, so the breaks below are the breaks ` +
+      `(got ${n}, refused ${refusalName(r.refused)})`);
+  }
+  {
+    // THE SEAL IS THE READER'S OWN ARITHMETIC. Resealing a file that is already
+    // consistent must not move a byte; if this goes red every case below is
+    // measuring a hash of the fixture's own making and nothing else.
+    const resealed = seal(Uint8Array.from(good), RECORD_BYTES);
+    let same = resealed.length === good.length;
+    for (let i = 0; same && i < good.length; i++) { same = resealed[i] === good[i]; }
+    check(same, "layout validation: resealing the unbroken file changes nothing, so the seal is §1's own hash");
+  }
+  {
+    // and the two entries every case below indexes are the entries it thinks
+    // they are: the ROOT is the table, entry 1 is `keep`, a u32 leaf in four
+    check(good[entryAt(0) + KIND_AT] === 13 && get32(good, entryAt(0) + SIZE_AT) > 0,
+      `layout validation: entry 0 is the root TABLE, kind 13 (got kind ${good[entryAt(0) + KIND_AT]})`);
+    check(good[entryAt(1) + KIND_AT] === 8 && get32(good, entryAt(1) + SIZE_AT) === 4 &&
+      get32(good, entryAt(1) + CHILDREN_AT) === 0,
+      `layout validation: entry 1 is a u32 LEAF in four bytes (got kind ${good[entryAt(1) + KIND_AT]}, ` +
+      `size ${get32(good, entryAt(1) + SIZE_AT)})`);
+  }
+
+  const broken = (mutate) => {
+    const f = Uint8Array.from(good);
+    mutate(f);
+    return seal(f, RECORD_BYTES);
+  };
+
+  // 1. THE ENTRY COUNT FITS THE LAYOUT'S LENGTH EXACTLY (§1.1 rule 1)
+  {
+    const f = broken((f) => put32(f, LAYOUT_AT, get32(f, LAYOUT_AT) + 1));
+    refuses(f, "LayoutCountMismatch", "RULE: the entry count fits the layout length exactly");
+  }
+  {
+    // a count of ZERO is not a layout either: there is no root to walk
+    const f = broken((f) => put32(f, LAYOUT_AT, 0));
+    refuses(f, "LayoutCountMismatch", "RULE: an entry count of zero is not a layout");
+  }
+
+  // 2. EVERY KIND IS IN THE CLOSED SET (§1.1 rule 2). A fixed form's kind set is
+  //    CLOSED — 1..30, 32, 33, 35 — so a kind outside it means a NEWER FORM
+  //    BYTE, a different form, and not a newer layout of this one. It is
+  //    refused, never stepped over.
+  {
+    const f = broken((f) => { f[entryAt(1) + KIND_AT] = 200; }); // a kind no form byte this build carries defines
+    refuses(f, "LayoutKindUnknown", "RULE: a kind outside the closed set is REFUSED, not skipped");
+  }
+
+  // 3. A KIND IS USED AS ITS DEFINITION ALLOWS (§1.1 rule 4) — here, the ROOT
+  //    is a table
+  {
+    const f = broken((f) => { f[entryAt(0) + KIND_AT] = 14; }); // an array as the root of a record
+    refuses(f, "LayoutKindInvalid", "RULE: the root entry is a TABLE");
+  }
+
+  // 4. A CONSTANT SIZE MATCHES ITS KIND (§1.1 rule 3, §1.2)
+  {
+    const f = broken((f) => put32(f, entryAt(1) + SIZE_AT, 5)); // a uint32 leaf in five bytes
+    refuses(f, "LayoutSizeMismatch", "RULE: a constant size its kind does not admit");
+  }
+  {
+    // and a TABLE's size is the SUM of its children's, not a number of its own
+    const f = broken((f) => put32(f, entryAt(0) + SIZE_AT, get32(f, entryAt(0) + SIZE_AT) + 4));
+    refuses(f, "LayoutSizeMismatch", "RULE: a table's size is the sum of its fields'");
+  }
+
+  // 5. THE PRE-ORDER CHILD WALK CONSUMES EXACTLY THE ENTRIES (§1.1 rule 5)
+  {
+    const f = broken((f) => put32(f, entryAt(0) + CHILDREN_AT, get32(f, entryAt(0) + CHILDREN_AT) + 1));
+    refuses(f, "LayoutTreeUnclosed", "RULE: the tree runs out of layout");
+  }
+  {
+    // THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk
+    // reaches. It takes a hand-built layout to reach, and that is itself worth
+    // stating: dropping a child of a TABLE is caught one rule sooner, by the
+    // size that no longer sums, so the only subtree whose loss the size rule
+    // cannot see is one that contributes NO size — an enum's variants, at kind
+    // 32 and size 0.
+    const layout = handLayout(4, (out) => {
+      putEntry(out, 1, 13, 4, 1); // a table of one field
+      putEntry(out, 2, 30, 4, 0); // an enum, its TWO variants unreached
+      putEntry(out, 3, 32, 0, 0);
+      putEntry(out, 4, 32, 0, 0);
+      return out;
+    });
+    refuses(fileOf(layout), "LayoutTreeUnclosed", "RULE: the layout outlasts the tree");
+  }
+
+  // 6. THE TOTAL RECORD SIZE IS WITHIN 65536 AND DOES NOT OVERFLOW (§1.1 rule 6)
+  {
+    const f = broken((f) => put32(f, entryAt(0) + SIZE_AT, 65537));
+    refuses(f, "LayoutRecordTooLarge", "RULE: a record size past 65536");
+  }
+  {
+    // A SIZE THAT WOULD WRAP. The children's sizes are summed wider than 32
+    // bits precisely so a u32 that overflows is CAUGHT rather than wrapped into
+    // a small number that then agrees with a parent.
+    const f = broken((f) => put32(f, entryAt(1) + SIZE_AT, 0xffffffff));
+    refuses(f, "LayoutRecordTooLarge", "RULE: a size that would overflow the sum");
+  }
+
+  // 7. NOTHING NESTED PAST THE READER'S WALK BOUND (§1.1 rule 7). A BOUND ON
+  //    THE WALK AND NOT ON THE WIRE: the validation recurses, so a layout of a
+  //    thousand entries each claiming one child would spend a reader's stack
+  //    before any other rule could fire. Nothing in §3.4 fixes the number; the
+  //    reference states 64.
+  {
+    const depth = 4096; // far past any reader's own bound
+    const layout = handLayout(depth + 1, (out) => {
+      for (let i = 0; i < depth; i++) {
+        // a table, then optional wrappers all the way down
+        putEntry(out, 1, i === 0 ? 13 : 35, depth - i, 1);
+      }
+      putEntry(out, 2, 1, 1, 0); // a bool at the bottom
+      return out;
+    });
+    refuses(fileOf(layout), "LayoutTooDeep", "RULE: a nesting depth past the walk's own bound");
+  }
+
+  // AND THE RESIDUE: bytes that are not a layout at all, which is the one case
+  // the seven named rules never reach (§1.1).
+  {
+    refuses(fileOf(new Uint8Array(2)), "LayoutMalformed",
+      "RULE: fewer bytes than a layout header is layout_malformed");
   }
 }
 

--- a/test/rust-fixedform/src/main.rs
+++ b/test/rust-fixedform/src/main.rs
@@ -515,6 +515,312 @@ fn the_negative_controls(dir: &str) {
 }
 
 // ---------------------------------------------------------------------------
+// THE LAYOUT ARRIVES FROM AN UNTRUSTED PEER (docs/SPEC-TABLES.md §3.4). It is
+// the one structure a reader must parse before it knows anything at all, so
+// every rule it is held to refuses under ITS OWN NAME, before a single record
+// byte is touched. docs/FIXED-FORM-ALGORITHM.md §1.1 names SEVEN of them, and
+// A VALIDATION NOBODY WATCHED FAIL IS A VALIDATION NOBODY HAS — so there is one
+// case per named rule, each taking a layout this reader ACCEPTS and breaking
+// EXACTLY ONE THING in it. The C++ reference asserts the same twelve under the
+// same names in test/tables/fixedform_main.cpp `layout_validation()`, and this
+// is its Rust twin: the shared conformance set reads the same on every leg.
+//
+// THE REFUSAL IS ASSERTED BY ITS VARIANT NAME AND NOT BY THE ENUM VALUE, and
+// that is a deliberate design call rather than a shortcut.
+// `tblfx1::TableFixedReason::LayoutCountMismatch` DOES NOT EXIST in this
+// runtime yet, so naming it in Rust source is a COMPILE ERROR that takes the
+// whole leg down and measures NOTHING per case. The enum derives `Debug`, so
+// `format!("{:?}", report.reason)` IS the variant's name: comparing that string
+// against "LayoutCountMismatch" is EXACTLY AS STRONG as comparing the value, it
+// passes UNCHANGED the moment the runtime card adds the variants, and it is
+// written this way so each of the twelve cases gives its OWN red instead of one
+// build failure that says nothing about which rule is missing. THE ENUM-VALUE
+// COMPARISON IS THE EVENTUAL FORM: once the seven names exist these lines
+// should say `report.reason == tblfx1::TableFixedReason::LayoutCountMismatch`,
+// and the strings below are that comparison's spelling in the meantime.
+//
+// The file is the HEADER (docs/SPEC-TABLES.md §3: the form byte, seven reserved
+// zero bytes, the layout hash at 8, the body at 16), then `u32 layout length,
+// layout, records` — so the layout starts at byte 20, the entry count is the
+// four bytes there, and entry k is the seventeen bytes at 20 + 4 + 17k: id
+// (u64), kind (u8), size (u32), children (u32), every number little-endian.
+//
+// AND THE HEADER HASH IS LEFT LYING, WHICH IS CORRECT AND NOT SLOPPY. Every
+// break below is INSIDE the layout, so the hash at byte 8 is no longer the hash
+// of the layout behind it. docs/FIXED-FORM-ALGORITHM.md §2 step 5 checks the
+// header hash LAST precisely so a broken layout refuses under its own name
+// first — and THIS RUNTIME DOES THAT: the emitted loader parses the layout and
+// compiles the plan before it compares the hash (internal/codegen/rusttable/
+// fixedform.go: "THE HEADER NAMES THE LAYOUT ONCE, and it is checked LAST of
+// the three"). VERIFIED, so no hash is recomputed for cases 1-10 and what they
+// measure is the layout's own rules and never layout_malformed-on-a-lying
+// -header. The three hand-built files carry their own true hash regardless.
+// ---------------------------------------------------------------------------
+
+/// The first layout entry: the entry count sits at `LAYOUT_AT`, the seventeen
+/// byte entries back to back behind it.
+const ENTRY0: usize = LAYOUT_AT + 4;
+
+fn put32(b: &mut [u8], at: usize, v: u32) {
+    b[at..at + 4].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put64(b: &mut [u8], at: usize, v: u64) {
+    b[at..at + 8].copy_from_slice(&v.to_le_bytes());
+}
+
+/// Entry `k` of the layout inside a whole file, as its seventeen bytes.
+fn entry_at(f: &mut [u8], k: usize) -> &mut [u8] {
+    let at = ENTRY0 + k * 17;
+    &mut f[at..at + 17]
+}
+
+/// An entry appended to a HAND-BUILT layout, for the two rules that no single
+/// break of a layout this reader accepts can reach.
+fn put_entry(layout: &mut Vec<u8>, id: u64, kind: u8, size: u32, children: u32) {
+    let at = layout.len();
+    layout.resize(at + 17, 0);
+    put64(layout, at, id);
+    layout[at + 8] = kind;
+    put32(layout, at + 9, size);
+    put32(layout, at + 13, children);
+}
+
+/// A FILE around a hand-built layout: the form byte, the layout's own fnv1a64
+/// hash, the layout's byte length, the layout, and NO RECORDS — every rule
+/// below refuses before a record is reached. The twin of the reference's
+/// `file_of`.
+fn file_of(layout: &[u8]) -> Vec<u8> {
+    let mut f = vec![0u8; LAYOUT_AT];
+    f[0] = 3; // the fixed form's byte
+    put64(&mut f, HASH_AT, tblfx1::table_fixed_hash(layout));
+    put32(&mut f, HEADER_BYTES, layout.len() as u32);
+    f.extend_from_slice(layout);
+    f
+}
+
+/// Loads `file` and holds the refusal to ITS NAME — see the section note above
+/// for why the name is a string and why that is the same assertion as the enum
+/// comparison that will replace it.
+fn refuses(file: &[u8], want_name: &str, what: &str) {
+    // THE LOAD IS CAUGHT, for the same reason the name is a string: a hostile
+    // layout that PANICS this reader would take the other eleven cases down
+    // with it and measure nothing. A refusal by name is the only acceptable
+    // answer to a stranger's bytes — an abort is its own finding and gets its
+    // own line rather than ending the run.
+    let outcome = std::panic::catch_unwind(|| {
+        let mut values = [tblfx1::FxRootRow::default(); 8];
+        let mut plan = [tblfx1::TableFixedEntry::default(); 1024];
+        let mut remap = [0u16; 1024];
+        let mut report = tblfx1::TableFixedReport::default();
+        let n = tblfx1::fx_root_fixed_load(&mut values, file, &mut plan, &mut remap, &mut report);
+        (n, report)
+    });
+    let (n, report) = match outcome {
+        Ok(pair) => pair,
+        Err(_) => {
+            check(
+                false,
+                &format!("{what}: expected {want_name}, got a PANIC on a stranger's layout"),
+            );
+            return;
+        }
+    };
+    check(n.is_none() && report.refused, &format!("{what}: refused"));
+    let got = format!("{:?}", report.reason);
+    check(
+        got == want_name,
+        &format!("{what}: REFUSED BY NAME — expected {want_name}, got {got}"),
+    );
+    // NOTHING WAS DECODED AND NOTHING WAS COUNTED. A refusal that half-read a
+    // record would be the damage the refusal exists to prevent.
+    check(
+        report.unknown == 0
+            && report.kind_mismatch == 0
+            && report.widened == 0
+            && report.clamped == 0
+            && !report.malformed,
+        &format!("{what}: a layout refusal sets nothing and counts nothing"),
+    );
+}
+
+fn the_layout_validation() {
+    // THE LAYOUT THIS READER ACCEPTS, which every case below breaks exactly
+    // once. FX2 writes it and FX1 reads it through a plan compiled from it, so
+    // the break is the one thing that moved.
+    let two = [tblfx2::FxRootRow::default(); 1];
+    let mut good = vec![0u8; tblfx2::fx_root_fixed_measure(1)];
+    check(
+        tblfx2::fx_root_fixed_save(&two, &mut good) == Some(good.len()),
+        "layout validation: the unbroken file saves",
+    );
+    {
+        // AND IT READS. NEGATIVE CONTROL: without this line every refusal below
+        // could be the file rather than the break.
+        let mut values = [tblfx1::FxRootRow::default(); 8];
+        let mut plan = [tblfx1::TableFixedEntry::default(); 1024];
+        let mut remap = [0u16; 1024];
+        let mut report = tblfx1::TableFixedReport::default();
+        check(
+            tblfx1::fx_root_fixed_load(&mut values, &good, &mut plan, &mut remap, &mut report)
+                == Some(1)
+                && !report.refused,
+            "layout validation: the unbroken file reads, so the breaks below are the breaks",
+        );
+    }
+
+    // 1. THE ENTRY COUNT FITS THE LAYOUT'S LENGTH EXACTLY
+    {
+        let mut f = good.clone();
+        let count = u32_at(&f, LAYOUT_AT);
+        put32(&mut f, LAYOUT_AT, count + 1);
+        refuses(
+            &f,
+            "LayoutCountMismatch",
+            "RULE: the entry count fits the layout length exactly",
+        );
+    }
+    {
+        // a count of ZERO is not a layout either: there is no root to walk
+        let mut f = good.clone();
+        put32(&mut f, LAYOUT_AT, 0);
+        refuses(
+            &f,
+            "LayoutCountMismatch",
+            "RULE: an entry count of zero is not a layout",
+        );
+    }
+
+    // 2. EVERY KIND IS IN THE CLOSED SET. A fixed form's kind set is CLOSED, so
+    //    a kind outside it means a NEWER FORM BYTE — a different form — and not
+    //    a newer layout of this one. It is refused, never stepped over.
+    {
+        let mut f = good.clone();
+        entry_at(&mut f, 1)[8] = 200; // a kind no form byte this build carries defines
+        refuses(
+            &f,
+            "LayoutKindUnknown",
+            "RULE: a kind outside the closed set is REFUSED, not skipped",
+        );
+    }
+
+    // 3. A KIND IS USED AS ITS DEFINITION ALLOWS — here, the ROOT is a table
+    {
+        let mut f = good.clone();
+        entry_at(&mut f, 0)[8] = 14; // an array as the root of a record
+        refuses(&f, "LayoutKindInvalid", "RULE: the root entry is a TABLE");
+    }
+
+    // 4. A CONSTANT SIZE MATCHES ITS KIND
+    {
+        // entry 1 of FX2's FxRoot layout is `keep uint32`: kind 8, size 4, no
+        // children — so five bytes is a width its kind does not admit.
+        let mut f = good.clone();
+        put32(entry_at(&mut f, 1), 9, 5);
+        refuses(
+            &f,
+            "LayoutSizeMismatch",
+            "RULE: a constant size its kind does not admit",
+        );
+    }
+    {
+        // and a TABLE's size is the SUM of its children's, not a number of its own
+        let mut f = good.clone();
+        let body = u32_at(entry_at(&mut f, 0), 9);
+        put32(entry_at(&mut f, 0), 9, body + 4);
+        refuses(
+            &f,
+            "LayoutSizeMismatch",
+            "RULE: a table's size is the sum of its fields'",
+        );
+    }
+
+    // 5. THE PRE-ORDER CHILD WALK CONSUMES EXACTLY THE ENTRIES
+    {
+        let mut f = good.clone();
+        let kids = u32_at(entry_at(&mut f, 0), 13);
+        put32(entry_at(&mut f, 0), 13, kids + 1);
+        refuses(
+            &f,
+            "LayoutTreeUnclosed",
+            "RULE: the tree runs out of layout",
+        );
+    }
+    {
+        // THE OTHER DIRECTION: a tree that closes EARLY leaves entries no walk
+        // reaches. It takes a hand-built layout to reach, and that is itself
+        // worth stating: dropping a child of a TABLE is caught one rule sooner,
+        // by the size that no longer sums, so the only subtree whose loss the
+        // size rule cannot see is one that contributes NO size — an enum's
+        // variants, at kind 32 and size 0.
+        let mut layout = vec![0u8; 4];
+        put32(&mut layout, 0, 4);
+        put_entry(&mut layout, 1, 13, 4, 1); // a table of one field
+        put_entry(&mut layout, 2, 30, 4, 0); // an enum, its TWO variants unreached
+        put_entry(&mut layout, 3, 32, 0, 0);
+        put_entry(&mut layout, 4, 32, 0, 0);
+        refuses(
+            &file_of(&layout),
+            "LayoutTreeUnclosed",
+            "RULE: the layout outlasts the tree",
+        );
+    }
+
+    // 6. THE TOTAL RECORD SIZE IS WITHIN 65536 AND DOES NOT OVERFLOW
+    {
+        let mut f = good.clone();
+        put32(entry_at(&mut f, 0), 9, 65537);
+        refuses(
+            &f,
+            "LayoutRecordTooLarge",
+            "RULE: a record size past 65536",
+        );
+    }
+    {
+        // A SIZE THAT WOULD WRAP. The children's sizes are summed in 64 bits
+        // precisely so a u32 that overflows is CAUGHT rather than wrapped into a
+        // small number that then agrees with a parent.
+        let mut f = good.clone();
+        put32(entry_at(&mut f, 1), 9, 0xFFFF_FFFF);
+        refuses(
+            &f,
+            "LayoutRecordTooLarge",
+            "RULE: a size that would overflow the sum",
+        );
+    }
+
+    // 7. NOTHING NESTED PAST THE READER'S WALK BOUND. A BOUND ON THE WALK AND
+    //    NOT ON THE WIRE: the validation recurses, so a layout of a thousand
+    //    entries each claiming one child would spend a reader's stack before any
+    //    other rule could fire. Nothing in §3.4 fixes the number.
+    {
+        let depth: u32 = 4096; // far past any reader's own bound
+        let mut layout = vec![0u8; 4];
+        put32(&mut layout, 0, depth + 1);
+        for i in 0..depth {
+            // a table, then optional wrappers all the way down
+            put_entry(&mut layout, 1, if i == 0 { 13 } else { 35 }, depth - i, 1);
+        }
+        put_entry(&mut layout, 2, 1, 1, 0); // a bool at the bottom
+        refuses(
+            &file_of(&layout),
+            "LayoutTooDeep",
+            "RULE: a nesting depth past the walk's own bound",
+        );
+    }
+
+    // AND THE RESIDUE: bytes that are not a layout at all, which is the one case
+    // the seven named rules never reach.
+    {
+        refuses(
+            &file_of(&[0u8; 2]),
+            "LayoutMalformed",
+            "RULE: fewer bytes than a header is layout_malformed",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // THE UNION, ON THE REFERENCE'S OWN BENCH CORPUS (docs/SPEC-TABLES.md §15)
 //
 // bench/paired/corpus/bench_fixed.bin is 64 records of BenchMixed written by
@@ -1638,6 +1944,7 @@ fn main() {
     the_text_under_an_arm();
     the_enum_extent();
     the_negative_controls(&dir);
+    the_layout_validation();
     the_union_controls(&bench);
     the_guard_is_the_whole_tag();
     the_declared_range();


### PR DESCRIPTION
## The seven hostile-layout refusals, as SHARED fixtures — RED FIRST

`docs/FIXED-FORM-ALGORITHM.md` §1.1 names seven refusals a fixed-form reader raises on a hostile
LAYOUT, before it touches a single record byte. The C++ reference asserts all seven by name
(`test/tables/fixedform_main.cpp`, `layout_validation()`), and so do C#, Java and Dart. **JS, Rust
and C asserted none of them; Elixir asserted five, one of them weakly.** A rule a port got wrong
was a rule no other leg would catch.

The house rule is that a bug found by one port becomes a fixture in the SHARED conformance set. So
these are the reference's own twelve cases — the seven rules, four in both directions, plus the
residue `layout_malformed` — ported to every leg that lacked them, **fixtures before runtime fixes**.
The reds below are not a regression. They ARE the measurement of the gap.

**This PR touches no runtime and no emitter.** Go is another worker's card; JS and Rust runtime
fixes are cards of their own. One line of wiring only: the C leg's new translation unit into
`C_FIXEDFORM_SOURCES`.

### Leg by rule

| # | rule | refusal | C++ | **C** | **Elixir** | **JS** | **Rust** |
|---|---|---|---|---|---|---|---|
| 1 | count fits the length exactly | `layout_count_mismatch` | name | PASS | PASS | **RED** | **RED** |
| 1 | a count of zero is not a layout | `layout_count_mismatch` | name | PASS | PASS | **RED** | **RED** |
| 2 | every kind in the closed set | `layout_kind_unknown` | name | PASS | PASS | **RED — DECODED** | **RED** |
| 4 | the root entry is a TABLE | `layout_kind_invalid` | name | PASS | PASS | **RED — DECODED** | **RED** |
| 3 | a size its kind does not admit | `layout_size_mismatch` | name | PASS | PASS | **RED — DECODED** | **RED** |
| 3 | a table's size is the sum | `layout_size_mismatch` | name | PASS | PASS | **RED** | **RED** |
| 5 | the tree runs out of layout | `layout_tree_unclosed` | name | PASS | PASS | **RED** | **RED** |
| 5 | the layout outlasts the tree | `layout_tree_unclosed` | name | PASS | PASS | **RED** | **RED** |
| 6 | a record size past 65536 | `layout_record_too_large` | name | PASS | PASS | **RED** | **RED** |
| 6 | a size that would wrap the sum | `layout_record_too_large` | name | PASS | PASS | **RED — DECODED** | **RED — PANIC** |
| 7 | nesting past the walk's bound | `layout_too_deep` | name | PASS | PASS | **RED — DECODED** | **RED** |
| — | the residue | `layout_malformed` | name | PASS | PASS | PASS | **RED** |

C: **12/12 PASS** — the C runtime already carried all ten layout reasons; only the fixture was
missing. Elixir: **12/12 PASS**, with `layout_record_too_large` and `layout_too_deep` newly asserted
and the weak three-name check tightened to one name. JS: **18 failures**. Rust: **17 failures**.

### Two findings worse than a wrong name

**JS ACCEPTS a hostile layout and decodes records.** Rules 2, 3, 4 and 6 are not implemented at all,
so five cases do not refuse under the wrong name — they do not refuse. The reader reports `None`,
returns a decoded record, and moves §4 counters on bytes whose layout is a forgery:

```
FAILED: RULE: a kind outside the closed set is REFUSED, not skipped — expected LayoutKindUnknown, got None and a read of 1 record(s)
FAILED: RULE: a kind outside the closed set is REFUSED, not skipped: a layout refusal sets nothing and counts nothing (unknown 2, kindMismatch 2, widened 0, clamped 0, malformed false)
FAILED: RULE: the root entry is a TABLE — expected LayoutKindInvalid, got None and a read of 1 record(s)
FAILED: RULE: a constant size its kind does not admit — expected LayoutSizeMismatch, got None and a read of 1 record(s)
FAILED: RULE: a size that would overflow the sum — expected LayoutRecordTooLarge, got None and a read of 1 record(s)
FAILED: RULE: a nesting depth past the walk's own bound — expected LayoutTooDeep, got None and a read of 0 record(s)
```

**Rust PANICS on a stranger's layout**, on the very case the reference wrote to prevent it — rule 6's
wrapping sum. §1.1 says the children's sizes are summed in 64 bits *precisely so* a `u32` that
overflows is caught rather than wrapped into a small number that then agrees with its parent:

```
thread 'main' panicked at build/tables-generated-rust/tblfx1/src/fixed_runtime.rs:743:13:
attempt to add with overflow
FAIL: RULE: a size that would overflow the sum: expected LayoutRecordTooLarge, got a PANIC on a stranger's layout
```

That is the debug build. **A release build does not panic — it wraps**, which is the accepted-forgery
path the rule exists to close. The debug panic also aborts the run, so `cargo run --release` (the
target's second line) never executed.

### The rest of the red, verbatim

Rust collapses every rule into `BlockMalformed` — and note it says *Block* where the doc says
*Layout* (`NoBlock`/`BlockMalformed` against `no_layout`/`layout_malformed`), a naming divergence
beyond the seven:

```
FAIL: RULE: the entry count fits the layout length exactly: REFUSED BY NAME — expected LayoutCountMismatch, got BlockMalformed
FAIL: RULE: an entry count of zero is not a layout: REFUSED BY NAME — expected LayoutCountMismatch, got BlockMalformed
FAIL: RULE: a kind outside the closed set is REFUSED, not skipped: REFUSED BY NAME — expected LayoutKindUnknown, got BlockMalformed
FAIL: RULE: the root entry is a TABLE: REFUSED BY NAME — expected LayoutKindInvalid, got BlockMalformed
FAIL: RULE: a constant size its kind does not admit: REFUSED BY NAME — expected LayoutSizeMismatch, got BlockMalformed
FAIL: RULE: a table's size is the sum of its fields': REFUSED BY NAME — expected LayoutSizeMismatch, got BlockMalformed
FAIL: RULE: the tree runs out of layout: REFUSED BY NAME — expected LayoutTreeUnclosed, got BlockMalformed
FAIL: RULE: the layout outlasts the tree: REFUSED BY NAME — expected LayoutTreeUnclosed, got BlockMalformed
FAIL: RULE: a record size past 65536: REFUSED BY NAME — expected LayoutRecordTooLarge, got BlockMalformed
FAIL: RULE: a nesting depth past the walk's own bound: REFUSED BY NAME — expected LayoutTooDeep, got BlockMalformed
FAIL: RULE: fewer bytes than a header is layout_malformed: REFUSED BY NAME — expected LayoutMalformed, got BlockMalformed
rust fixed form: 17 FAILED
```

JS, where a name does exist but is the wrong one:

```
FAILED: RULE: the entry count fits the layout length exactly — expected LayoutCountMismatch, got LayoutMalformed
FAILED: RULE: an entry count of zero is not a layout — expected LayoutCountMismatch, got LayoutMalformed
FAILED: RULE: a table's size is the sum of its fields' — expected LayoutSizeMismatch, got None
FAILED: RULE: the tree runs out of layout — expected LayoutTreeUnclosed, got LayoutMalformed
FAILED: RULE: the layout outlasts the tree — expected LayoutTreeUnclosed, got LayoutMalformed
FAILED: RULE: a record size past 65536 — expected LayoutRecordTooLarge, got None
```

### How the assertion is written on JS and Rust, and why

On JS and Rust the doc's names **do not exist** as enum members. Naming them directly would be one
opaque red on JS (`undefined`) and a compile error on Rust that takes the whole leg down and measures
nothing per case. So both legs assert the refusal's **own member name as a string** — JS via a
reverse map over the frozen `TableFixedRefusal`, Rust via `format!("{:?}", report.reason)`, which the
derived `Debug` makes the variant name. This is exactly as strong as comparing the enum value, it
gives each of the twelve cases its own red, and **it passes unchanged once the runtime cards add the
members** — at which point it can be tightened to the enum value itself. Flagged for a reviewer: it
is a deliberate departure from "an enum in Rust".

Every case also carries the reference's second check — a layout refusal sets nothing and counts
nothing — and each leg asserts the UNBROKEN file reads clean first, so every red is the one break and
not the file.

### Targets and times

No new targets. All four are already reached by `make test` (via `test-c`, `test-js`, `test-rust`,
`test-elixir`), which `certify.yml` runs on both OSes, so these reds are visible without wiring.
The `conformance` matrix job in `ci.yml` does *not* run them — it runs `build/conformance-*` only.

| command | cold | warm | result |
|---|---|---|---|
| `make tables-c-fixedform` | 3.86s | 0.43s | PASS (strict + ASAN) |
| `make tables-js-fixed-form` | 3.79s | 0.24s | **18 FAILED** |
| `make tables-elixir-fixed-form` | 3.03s | 2.27s | PASS |
| `make tables-rust-fixedform` | — | 0.53s | **17 FAILED** |

Nothing near the two-minute rule.

### Notes for the reviewer

- **The C leg needed its own buffer.** Case 11 is 4097 entries — 69,673 bytes of file, past
  `fixedform_main.c`'s 65,536-byte `g_buffer`. A static array in the new TU, no malloc, ASAN clean.
  `kTableFixedMaxDepth` is 64, so the walk bails at depth 65.
- **Hash-last was verified, not assumed.** Breaking bytes inside a good layout only measures the rule
  if the header's hash is checked after validation (§2 step 5). Confirmed in
  `internal/codegen/ctable/fixedform.go`; Elixir's existing `refuse` helper rebuilds the header hash
  anyway.
- **Case 12 reaches a different code path on C** than the reference's prose implies: a 2-byte layout
  trips the layout-header check (`length < 4`), not the file-length check. Same name, same reason,
  different test — worth knowing for a leg that splits the two.
- **Case 5 is pinned.** The C fixture asserts entry 1 really is a 4-byte `uint32` leaf, so the case
  cannot silently stop exercising the size rule if a field moves.
- **The Rust leg does not build from a clean clone**, before any change here:
  `build/tables-generated-rust/benchfixed/Cargo.toml` wants `serialize = { package =
  "serialize-official", path = ".../serialize.rs" }` and the sibling checkout declares `name =
  "serialize"`. CI clones that sibling at a pinned `SERIALIZE_RS_TAG`, so the pin evidently renames
  it. Worked around **only in a scratch sibling** to get the measurement; no repo file touched. If
  CI's Rust row is green on this branch, the pin is fine and only local checkouts drift.
