### PR TITLE
dart fixed form: the writer copies the live span and zeroes the slack (Emma)

### DIFF
--- a/internal/codegen/darttable/fixeddart.go
+++ b/internal/codegen/darttable/fixeddart.go
@@ -538,9 +538,10 @@ func (g *fixedGen) emitTextDefaultBytes(f *ir.Field, ind, target string) {
 //
 // A COUNTED ARRAY WRITES ITS LIVE COUNT. Decode walks Count, so unused
 // slots still hold constructor defaults; writing the bound would put those
-// on the wire. Slack stays the template's zeros (SPEC §3.4). A string's N
-// bytes still ride as the storage holds them: decode copies the whole
-// declared span from the image, so that slack is the peer's.
+// on the wire. Slack stays the template's zeros (SPEC §3.4). A string,
+// wstring, or bytes writes its live length and zeroes slack (SPEC §3.4);
+// decode copies the whole declared span from the image, so that slack is
+// the peer's.
 //
 // AN ABSENT OPTIONAL'S PAYLOAD IS THE ONE EXCEPTION, and it is §3.4's own:
 // under a present flag of `0` the payload is SLACK, and slack is ZERO ON
@@ -607,8 +608,13 @@ func (g *fixedGen) emitWritePayload(f *ir.Field, base string, at int64, val, nam
 			[]string{fixedOff(base, at), val + "." + name + "Length", "Endian.little"}, ";")
 		g.call(ind, "", "bytes.setRange", []string{
 			fixedOff(base, at+fixedCountBytes),
-			fixedOff(base, at+fixedCountBytes+f.Type.Size),
+			fixedOff(base, at+fixedCountBytes) + " + " + val + "." + name + "Length",
 			val + "." + name,
+		}, ";")
+		g.call(ind, "", "bytes.fillRange", []string{
+			fixedOff(base, at+fixedCountBytes) + " + " + val + "." + name + "Length",
+			fixedOff(base, at+fixedCountBytes+f.Type.Size),
+			"0",
 		}, ";")
 	case f.Type.Kind == ir.TWString:
 		// the length in CODE UNITS, then 2N bytes
@@ -616,10 +622,15 @@ func (g *fixedGen) emitWritePayload(f *ir.Field, base string, at int64, val, nam
 		g.pf("%sassert(%s.%sLength <= %d);\n", ind, val, name, f.Type.Size)
 		g.call(ind, "", "view.setInt32",
 			[]string{fixedOff(base, at), val + "." + name + "Length", "Endian.little"}, ";")
-		g.pf("%sfor (var i = 0; i < %d; i++) {\n", ind, f.Type.Size)
+		g.pf("%sfor (var i = 0; i < %s.%sLength; i++) {\n", ind, val, name)
 		g.call(ind+"  ", "", "view.setUint16",
 			[]string{fixedOff(base, at+fixedCountBytes) + " + i * 2", val + "." + name + "[i]", "Endian.little"}, ";")
 		g.pf("%s}\n", ind)
+		g.call(ind, "", "bytes.fillRange", []string{
+			fixedOff(base, at+fixedCountBytes) + " + " + val + "." + name + "Length * 2",
+			fixedOff(base, at+fixedCountBytes+2*f.Type.Size),
+			"0",
+		}, ";")
 	default:
 		g.emitWriteElement(f, base, at, val+"."+name, ind)
 	}

--- a/internal/codegen/darttable/fixedform_test.go
+++ b/internal/codegen/darttable/fixedform_test.go
@@ -288,6 +288,76 @@ table LiveRoot
 	}
 }
 
+// A STRING, BYTES, OR WSTRING WRITE COPIES LENGTH AND ZEROES SLACK
+// (docs/SPEC-TABLES.md §3.4). Writing all N units would put unwritten or
+// stale storage onto the wire instead of the used length. Slack is zeroed.
+func TestWriteStringAndBytesCopiesLengthAndZeroesSlack(t *testing.T) {
+	u := unitFrom(t, `package probe
+
+table SpanRoot
+{
+    label string(8)
+    blob  bytes(6)
+    wide  wstring(4)
+}
+`)
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var src string
+	for _, b := range files {
+		s := string(b)
+		if strings.Contains(s, "void spanRootFixedWriteBody(") {
+			src = s
+			break
+		}
+	}
+	if src == "" {
+		t.Fatal("no spanRootFixedWriteBody in the generated unit")
+	}
+	body := src
+	if i := strings.Index(src, "void spanRootFixedWriteBody("); i >= 0 {
+		body = src[i:]
+		if j := strings.Index(body[1:], "\nvoid "); j >= 0 {
+			body = body[:j+1]
+		}
+	}
+
+	// string(8): copies length bytes, not bound 8; zeroes slack
+	if !strings.Contains(body, "bytes.setRange(at + 4, at + 4 + value.labelLength, value.label);") {
+		t.Fatalf("string write must copy length bytes:\n%s", body)
+	}
+	if strings.Contains(body, "bytes.setRange(at + 4, at + 12, value.label);") {
+		t.Fatalf("string write still copies declared bound:\n%s", body)
+	}
+	if !strings.Contains(body, "bytes.fillRange(at + 4 + value.labelLength, at + 12, 0);") {
+		t.Fatalf("string write must zero slack:\n%s", body)
+	}
+
+	// bytes(6): copies length bytes, not bound 6; zeroes slack
+	if !strings.Contains(body, "bytes.setRange(at + 16, at + 16 + value.blobLength, value.blob);") {
+		t.Fatalf("bytes write must copy length bytes:\n%s", body)
+	}
+	if strings.Contains(body, "bytes.setRange(at + 16, at + 22, value.blob);") {
+		t.Fatalf("bytes write still copies declared bound:\n%s", body)
+	}
+	if !strings.Contains(body, "bytes.fillRange(at + 16 + value.blobLength, at + 22, 0);") {
+		t.Fatalf("bytes write must zero slack:\n%s", body)
+	}
+
+	// wstring(4): loops length code units, not bound 4; zeroes slack
+	if !strings.Contains(body, "for (var i = 0; i < value.wideLength; i++) {") {
+		t.Fatalf("wstring write must loop length code units:\n%s", body)
+	}
+	if strings.Contains(body, "for (var i = 0; i < 4; i++) {") {
+		t.Fatalf("wstring write still loops declared bound:\n%s", body)
+	}
+	if !strings.Contains(body, "bytes.fillRange(at + 26 + value.wideLength * 2, at + 34, 0);") {
+		t.Fatalf("wstring write must zero slack:\n%s", body)
+	}
+}
+
 // THE PREFILL IS THE DECLARED DEFAULTS, and the one this corpus carries is
 // `has_extra bool = true` — the byte that would silently read false if the
 // prefill were a zero fill.


### PR DESCRIPTION
Emma's branch, opened as a draft by Rowan so the read and the merge have a number. Her account (emma-35e7563b943e): the Dart writer copies the live length of string, bytes and wstring and zeroes the slack to the declared size (W1: write slack is template zeros); unit test TestWriteStringAndBytesCopiesLengthAndZeroesSlack; tables-dart-fixed-form and its negative control green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
