### PR TITLE
gotable: the form-1 refusal belongs to FixedLoad, not to Load

### DIFF
--- a/generated/bench/paired/go/FixedTableTable.go
+++ b/generated/bench/paired/go/FixedTableTable.go
@@ -154,17 +154,16 @@ func FixedTableLoadBody(r *TableReader, value *FixedTable) bool {
 	}
 }
 
+// FixedTable also carries the FIXED form (form 3): FixedTableFixedLoad reads that one and
+// names a form-1 file `previous_form`. This Load is the VARIABLE form's entry
+// point and reads form 1, whether or not the table was DECLARED fixed
+// (docs/SPEC-TABLES.md §3.4, §15).
 func FixedTableLoad(value *FixedTable, data []byte, report *TableReport) bool {
 	if report == nil {
 		var ignored TableReport
 		report = &ignored
 	}
-	FixedTableReset(value)
-	if len(data) > 0 && data[0] == 1 {
-		tableFixedRefuse(report, "previous_form")
-		return false
-	}
-	_, verdict := tableOpen(data, report)
+	r, verdict := tableOpen(data, report)
 	report.Verdict = verdict
 	report.Reason = ""
 	if verdict == TableOpenRefused {
@@ -173,10 +172,48 @@ func FixedTableLoad(value *FixedTable, data []byte, report *TableReport) bool {
 			report.Reason = "message form requires an announced vocabulary and a message reader"
 		}
 	}
-	if verdict == TableOpenDamaged {
-		report.Malformed = true
+	if verdict != TableOpenOk {
+		FixedTableReset(value)
+		if verdict == TableOpenDamaged {
+			report.Malformed = true
+		}
+		return false
 	}
-	return false
+	// The root read answers its own early end after the walk, not before it.
+	// A body that returned at its zero reference left the cursor on the byte
+	// after that reference. Every field leaves the cursor where skip would, so
+	// r.Offset != len(r.Buffer) is the old EndsEarly on the true path.
+	// Nothing is decoded on the damaged path: the value goes back to defaults
+	// and the report goes back to what the caller handed in, so an early end
+	// counts no unknown, no kind mismatch and no clamp — as when the framing
+	// walk refused before the reader had seen one byte.
+	before := *report
+	if !FixedTableLoadBody(&r, value) {
+		// The reading walk stops on rules the framing walk has no opinion about
+		// — a reserved id in a file body is the one that matters — so a body
+		// that stopped is still asked the framing question from the start of
+		// the body, and a body whose framing ends early is damage whatever else
+		// was wrong with it.
+		probe := r
+		probe.Offset = 0
+		if probe.EndsEarly() {
+			FixedTableReset(value)
+			*report = before
+			report.Malformed = true
+			report.Verdict = TableOpenDamaged
+			return false
+		}
+		report.Verdict = TableOpenBodyStopped
+		return false
+	}
+	if r.Offset != int64(len(r.Buffer)) {
+		FixedTableReset(value)
+		*report = before
+		report.Malformed = true
+		report.Verdict = TableOpenDamaged
+		return false
+	}
+	return true
 }
 
 const FixedTableLoadRetainBuilder = "FixedTable: retention requires a region round trip through the VARIABLE form"

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -3380,17 +3380,16 @@ func TableEntityLoadBody(r *TableReader, value *TableEntity) bool {
 	}
 }
 
+// TableEntity also carries the FIXED form (form 3): TableEntityFixedLoad reads that one and
+// names a form-1 file `previous_form`. This Load is the VARIABLE form's entry
+// point and reads form 1, whether or not the table was DECLARED fixed
+// (docs/SPEC-TABLES.md §3.4, §15).
 func TableEntityLoad(value *TableEntity, data []byte, report *TableReport) bool {
 	if report == nil {
 		var ignored TableReport
 		report = &ignored
 	}
-	TableEntityReset(value)
-	if len(data) > 0 && data[0] == 1 {
-		tableFixedRefuse(report, "previous_form")
-		return false
-	}
-	_, verdict := tableOpen(data, report)
+	r, verdict := tableOpen(data, report)
 	report.Verdict = verdict
 	report.Reason = ""
 	if verdict == TableOpenRefused {
@@ -3399,10 +3398,48 @@ func TableEntityLoad(value *TableEntity, data []byte, report *TableReport) bool 
 			report.Reason = "message form requires an announced vocabulary and a message reader"
 		}
 	}
-	if verdict == TableOpenDamaged {
-		report.Malformed = true
+	if verdict != TableOpenOk {
+		TableEntityReset(value)
+		if verdict == TableOpenDamaged {
+			report.Malformed = true
+		}
+		return false
 	}
-	return false
+	// The root read answers its own early end after the walk, not before it.
+	// A body that returned at its zero reference left the cursor on the byte
+	// after that reference. Every field leaves the cursor where skip would, so
+	// r.Offset != len(r.Buffer) is the old EndsEarly on the true path.
+	// Nothing is decoded on the damaged path: the value goes back to defaults
+	// and the report goes back to what the caller handed in, so an early end
+	// counts no unknown, no kind mismatch and no clamp — as when the framing
+	// walk refused before the reader had seen one byte.
+	before := *report
+	if !TableEntityLoadBody(&r, value) {
+		// The reading walk stops on rules the framing walk has no opinion about
+		// — a reserved id in a file body is the one that matters — so a body
+		// that stopped is still asked the framing question from the start of
+		// the body, and a body whose framing ends early is damage whatever else
+		// was wrong with it.
+		probe := r
+		probe.Offset = 0
+		if probe.EndsEarly() {
+			TableEntityReset(value)
+			*report = before
+			report.Malformed = true
+			report.Verdict = TableOpenDamaged
+			return false
+		}
+		report.Verdict = TableOpenBodyStopped
+		return false
+	}
+	if r.Offset != int64(len(r.Buffer)) {
+		TableEntityReset(value)
+		*report = before
+		report.Malformed = true
+		report.Verdict = TableOpenDamaged
+		return false
+	}
+	return true
 }
 
 const TableEntityLoadRetainBuilder = "TableEntity: retention requires a region round trip through the VARIABLE form"
@@ -4332,17 +4369,16 @@ func TableStatLoadBody(r *TableReader, value *TableStat) bool {
 	}
 }
 
+// TableStat also carries the FIXED form (form 3): TableStatFixedLoad reads that one and
+// names a form-1 file `previous_form`. This Load is the VARIABLE form's entry
+// point and reads form 1, whether or not the table was DECLARED fixed
+// (docs/SPEC-TABLES.md §3.4, §15).
 func TableStatLoad(value *TableStat, data []byte, report *TableReport) bool {
 	if report == nil {
 		var ignored TableReport
 		report = &ignored
 	}
-	TableStatReset(value)
-	if len(data) > 0 && data[0] == 1 {
-		tableFixedRefuse(report, "previous_form")
-		return false
-	}
-	_, verdict := tableOpen(data, report)
+	r, verdict := tableOpen(data, report)
 	report.Verdict = verdict
 	report.Reason = ""
 	if verdict == TableOpenRefused {
@@ -4351,10 +4387,48 @@ func TableStatLoad(value *TableStat, data []byte, report *TableReport) bool {
 			report.Reason = "message form requires an announced vocabulary and a message reader"
 		}
 	}
-	if verdict == TableOpenDamaged {
-		report.Malformed = true
+	if verdict != TableOpenOk {
+		TableStatReset(value)
+		if verdict == TableOpenDamaged {
+			report.Malformed = true
+		}
+		return false
 	}
-	return false
+	// The root read answers its own early end after the walk, not before it.
+	// A body that returned at its zero reference left the cursor on the byte
+	// after that reference. Every field leaves the cursor where skip would, so
+	// r.Offset != len(r.Buffer) is the old EndsEarly on the true path.
+	// Nothing is decoded on the damaged path: the value goes back to defaults
+	// and the report goes back to what the caller handed in, so an early end
+	// counts no unknown, no kind mismatch and no clamp — as when the framing
+	// walk refused before the reader had seen one byte.
+	before := *report
+	if !TableStatLoadBody(&r, value) {
+		// The reading walk stops on rules the framing walk has no opinion about
+		// — a reserved id in a file body is the one that matters — so a body
+		// that stopped is still asked the framing question from the start of
+		// the body, and a body whose framing ends early is damage whatever else
+		// was wrong with it.
+		probe := r
+		probe.Offset = 0
+		if probe.EndsEarly() {
+			TableStatReset(value)
+			*report = before
+			report.Malformed = true
+			report.Verdict = TableOpenDamaged
+			return false
+		}
+		report.Verdict = TableOpenBodyStopped
+		return false
+	}
+	if r.Offset != int64(len(r.Buffer)) {
+		TableStatReset(value)
+		*report = before
+		report.Malformed = true
+		report.Verdict = TableOpenDamaged
+		return false
+	}
+	return true
 }
 
 const TableStatLoadRetainBuilder = "TableStat: retention requires a region round trip through the VARIABLE form"
@@ -6163,17 +6237,16 @@ func TableMixedLoadBody(r *TableReader, value *TableMixed) bool {
 	}
 }
 
+// TableMixed also carries the FIXED form (form 3): TableMixedFixedLoad reads that one and
+// names a form-1 file `previous_form`. This Load is the VARIABLE form's entry
+// point and reads form 1, whether or not the table was DECLARED fixed
+// (docs/SPEC-TABLES.md §3.4, §15).
 func TableMixedLoad(value *TableMixed, data []byte, report *TableReport) bool {
 	if report == nil {
 		var ignored TableReport
 		report = &ignored
 	}
-	TableMixedReset(value)
-	if len(data) > 0 && data[0] == 1 {
-		tableFixedRefuse(report, "previous_form")
-		return false
-	}
-	_, verdict := tableOpen(data, report)
+	r, verdict := tableOpen(data, report)
 	report.Verdict = verdict
 	report.Reason = ""
 	if verdict == TableOpenRefused {
@@ -6182,10 +6255,48 @@ func TableMixedLoad(value *TableMixed, data []byte, report *TableReport) bool {
 			report.Reason = "message form requires an announced vocabulary and a message reader"
 		}
 	}
-	if verdict == TableOpenDamaged {
-		report.Malformed = true
+	if verdict != TableOpenOk {
+		TableMixedReset(value)
+		if verdict == TableOpenDamaged {
+			report.Malformed = true
+		}
+		return false
 	}
-	return false
+	// The root read answers its own early end after the walk, not before it.
+	// A body that returned at its zero reference left the cursor on the byte
+	// after that reference. Every field leaves the cursor where skip would, so
+	// r.Offset != len(r.Buffer) is the old EndsEarly on the true path.
+	// Nothing is decoded on the damaged path: the value goes back to defaults
+	// and the report goes back to what the caller handed in, so an early end
+	// counts no unknown, no kind mismatch and no clamp — as when the framing
+	// walk refused before the reader had seen one byte.
+	before := *report
+	if !TableMixedLoadBody(&r, value) {
+		// The reading walk stops on rules the framing walk has no opinion about
+		// — a reserved id in a file body is the one that matters — so a body
+		// that stopped is still asked the framing question from the start of
+		// the body, and a body whose framing ends early is damage whatever else
+		// was wrong with it.
+		probe := r
+		probe.Offset = 0
+		if probe.EndsEarly() {
+			TableMixedReset(value)
+			*report = before
+			report.Malformed = true
+			report.Verdict = TableOpenDamaged
+			return false
+		}
+		report.Verdict = TableOpenBodyStopped
+		return false
+	}
+	if r.Offset != int64(len(r.Buffer)) {
+		TableMixedReset(value)
+		*report = before
+		report.Malformed = true
+		report.Verdict = TableOpenDamaged
+		return false
+	}
+	return true
 }
 
 const TableMixedLoadRetainBuilder = "TableMixed: retention requires a region round trip through the VARIABLE form"

--- a/internal/codegen/gotable/fixedform.go
+++ b/internal/codegen/gotable/fixedform.go
@@ -321,17 +321,6 @@ func (g *tableGen) hasFixedForm(st *ir.Struct) bool {
 	return g.fixedLeafCount(st) <= fixedLeafCap
 }
 
-// refusesForm1 is the OTHER question, and Glenn 2026-09-09 is that they are
-// two: a form-1 file handed to <T>Load is a named refusal when the AUTHOR
-// DECLARED the table fixed, never merely because the compiler could lay it
-// out fixed. hasFixedForm above is shape; this is the keyword. Nothing sets
-// [ir.Struct.FixedDeclared] until #823's `fixed table` lands, so today every
-// table in this tree keeps its form-1 Load and the shared wire oracle reads
-// what it always read.
-func (g *tableGen) refusesForm1(st *ir.Struct) bool {
-	return g.hasFixedForm(st) && st.FixedDeclared
-}
-
 func (g *tableGen) fixedRoots(members []*ir.Struct) []*ir.Struct {
 	var out []*ir.Struct
 	for _, st := range members {
@@ -933,26 +922,6 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, tabs int) {
 			g.pf("%sif %s > %d { %s = %d; (*clamped)++ }\n", ind, expr, maxv, expr, maxv)
 		}
 	}
-}
-
-// emitFixedForm1Load is the form-1 file reader for a DECLARED fixed table
-// (#823's keyword, [ir.Struct.FixedDeclared]) — see [tableGen.refusesForm1].
-// Form 1 is previous_form; the slow tableOpen walk never runs. Other bytes
-// keep the form-1 Load's existing refusal names. The C++ reference still
-// accepts form 1 on this type (cpptable/fixedform.go:19); Glenn says refuse.
-func (g *tableGen) emitFixedForm1Load(st *ir.Struct) {
-	n := st.Name
-	g.pf("func %sLoad(value *%s, data []byte, report *TableReport) bool {\n", n, g.storageName(n))
-	g.pf("\tif report == nil { var ignored TableReport; report = &ignored }\n")
-	g.pf("\t%sReset(value)\n", n)
-	g.pf("\tif len(data) > 0 && data[0] == 1 {\n")
-	g.pf("\t\ttableFixedRefuse(report, \"previous_form\")\n")
-	g.pf("\t\treturn false\n")
-	g.pf("\t}\n")
-	g.pf("\t_, verdict := tableOpen(data, report); report.Verdict = verdict; report.Reason = \"\"\n")
-	g.pf("\tif verdict == TableOpenRefused { report.Reason = \"unsupported wire form\"; if len(data) > 0 && data[0] == 2 { report.Reason = \"message form requires an announced vocabulary and a message reader\" } }\n")
-	g.pf("\tif verdict == TableOpenDamaged { report.Malformed = true }\n")
-	g.pf("\treturn false\n}\n\n")
 }
 
 func (g *tableGen) emitByteArray(b []byte) {

--- a/internal/codegen/gotable/fixedform_test.go
+++ b/internal/codegen/gotable/fixedform_test.go
@@ -84,11 +84,16 @@ table Point {
 	}
 }
 
-// TestFixedFormForm1RefusalIsByTheKeyword is the other half of the surface
-// above, and the difference is #823's `fixed table`: a DECLARED fixed table
-// encodes as form 3 always, so a form-1 file handed to its Load is a named
-// refusal and never a slower read of the same records (Glenn 2026-09-09).
-func TestFixedFormForm1RefusalIsByTheKeyword(t *testing.T) {
+// TestFixedFormForm1RefusalLivesInFixedLoad is the other half of the surface
+// above, and it is #823's `fixed table` keyword that makes it worth pinning:
+// the keyword decides what a WRITER emits (form 3, always) and which ENTRY
+// POINT names a form-1 file `previous_form` — <T>FixedLoad — and it does NOT
+// turn <T>Load, the variable form's own entry point, into a refusal. The
+// shared corpus pins `v1_cfg_as_v2` at `read` over a form-1 file of a DECLARED
+// fixed root and the C++ reference reads it there, so a Go <T>Load that
+// refused would be the one leg disagreeing with the reference
+// (docs/SPEC-TABLES.md §3.4, §15).
+func TestFixedFormForm1RefusalLivesInFixedLoad(t *testing.T) {
 	files := generateFixed(t, `package probe
 table Point {
     x int32
@@ -105,11 +110,15 @@ table Point {
 	if load == "" {
 		t.Fatal("PointLoad was not emitted")
 	}
-	if !strings.Contains(load, "previous_form") || !strings.Contains(load, "tableFixedRefuse") {
-		t.Error("PointLoad of a DECLARED fixed table is not a named form-1 refusal")
+	if !strings.Contains(load, "PointLoadBody") {
+		t.Error("PointLoad of a DECLARED fixed table must still walk form 1")
 	}
-	if strings.Contains(load, "PointLoadBody") {
-		t.Error("PointLoad still walks a form-1 file of a declared fixed table")
+	if strings.Contains(load, "previous_form") {
+		t.Error("PointLoad, the form-1 entry point, refuses form 1")
+	}
+	fixedLoad := funcSource(body, "func PointFixedLoad(")
+	if !strings.Contains(fixedLoad, "previous_form") || !strings.Contains(fixedLoad, "tableFixedRefuse") {
+		t.Error("PointFixedLoad does not name a form-1 file previous_form")
 	}
 }
 
@@ -424,7 +433,9 @@ func writeUnit(t *testing.T, out, pkg, schema, runtime string) {
 	}
 }
 
-func TestForm1OfFixedTableRefused(t *testing.T) {
+// TestForm1OfFixedTableReadsAndFixedLoadRefuses is the runtime half: the two
+// entry points of a DECLARED fixed table, each over the other's form byte.
+func TestForm1OfFixedTableReadsAndFixedLoadRefuses(t *testing.T) {
 	runGeneratedFixed(t, `package probe
 table Point {
     x int32 = 1
@@ -433,7 +444,7 @@ table Point {
 `, `package probe
 import ("testing")
 
-func TestForm1LoadIsNamedRefusal(t *testing.T) {
+func TestForm1LoadReadsAndFixedLoadRefuses(t *testing.T) {
 	one := Point{X: 4242, Y: -7}
 	need := PointMeasure(&one)
 	if need < 0 {
@@ -448,14 +459,14 @@ func TestForm1LoadIsNamedRefusal(t *testing.T) {
 	}
 	var got Point
 	var r TableReport
-	if PointLoad(&got, form1, &r) {
-		t.Fatalf("form-1 Load of a DECLARED fixed table succeeded: %+v seq=%+v", r, got)
+	if !PointLoad(&got, form1, &r) {
+		t.Fatalf("form-1 Load of a DECLARED fixed table refused: %+v", r)
 	}
-	if r.Reason != "previous_form" || r.Verdict != TableOpenRefused || r.Malformed {
-		t.Fatalf("want named previous_form, got %+v", r)
+	if r.Reason != "" || r.Verdict != TableOpenOk || r.Malformed {
+		t.Fatalf("form-1 Load of a DECLARED fixed table is not a clean read: %+v", r)
 	}
-	if got.X == 4242 || got.Y == -7 {
-		t.Fatalf("form-1 Load of a DECLARED fixed table was a slow read: %+v", got)
+	if got.X != 4242 || got.Y != -7 {
+		t.Fatalf("form-1 Load of a DECLARED fixed table lost the record: %+v", got)
 	}
 	batch := make([]Point, 1)
 	r = TableReport{}

--- a/internal/codegen/gotable/read.go
+++ b/internal/codegen/gotable/read.go
@@ -67,18 +67,22 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	if g.retain || st.IsMapEntry() || g.regional && ir.VariableTables(g.unit)[st.Name] {
 		return
 	}
-	if g.refusesForm1(st) {
-		g.emitFixedForm1Load(st)
-		return
-	}
 	if g.hasFixedForm(st) {
-		// DERIVED into the fixed mode, not declared fixed (§2.2 vs §3.4). It
-		// carries FixedSave/FixedLoad for form 3 AND keeps the form-1 Load it
-		// never lost. When #823's `fixed table` keyword marks it declared,
-		// this Load becomes the `previous_form` refusal above.
-		g.pf("// %s also carries the fixed form (form 3), because its closure lays out\n", n)
-		g.pf("// fixed — but nobody DECLARED it fixed, so this reader still reads form 1.\n")
-		g.pf("// A `fixed table` (docs/SPEC-TABLES.md §3.4, #823) refuses form 1 by name.\n")
+		// IT CARRIES BOTH FORMS AND EACH ENTRY POINT CARRIES ONE (§3.4, §15).
+		// <T>FixedLoad reads form 3 and names a form-1 file `previous_form`;
+		// this <T>Load reads form 1 and names a form-3 file `newer_form`. The
+		// `fixed table` keyword (#823) decides what a WRITER emits, not which
+		// bytes a reader of the variable form can still be handed: the shared
+		// corpus pins `v1_cfg_as_v2` at `read` over a form-1 file of a DECLARED
+		// fixed root, the C++ reference reads it there (cpptable/fixedform.go's
+		// header: "a fixed-table type's reader accepts both, by the form byte"),
+		// and a leg that refused it alone would be the one leg disagreeing with
+		// the reference. The dispatch §15 names as the follow-on is what would
+		// let one entry point answer both; it is not this one refusing.
+		g.pf("// %s also carries the FIXED form (form 3): %sFixedLoad reads that one and\n", n, n)
+		g.pf("// names a form-1 file `previous_form`. This Load is the VARIABLE form's entry\n")
+		g.pf("// point and reads form 1, whether or not the table was DECLARED fixed\n")
+		g.pf("// (docs/SPEC-TABLES.md §3.4, §15).\n")
 	}
 	g.pf("func %sLoad(value *%s, data []byte, report *TableReport) bool {\n", n, g.storageName(n))
 	g.pf("\tif report == nil { var ignored TableReport; report = &ignored }\n")


### PR DESCRIPTION
## The red

`conformance (go)` on the tip of `fixed-table-form`: wire **0/96**, json-write **0/92**, cook-write **0/92**, report **38/59**, and every one of them on the same line —

```
driver: wire: v1_cfg: load refused testdata/wire/tables/v1_cfg.bin
```

The driver stops on the first case of the tables corpus, so three surfaces read zero; `report` does not stop, it just prints `refused` where the pin says `read` (24 bytes out, 21 expected — `1,1,0,1,0,false,refused` against `1,1,0,1,0,false,read`). One cause, four surfaces.

## The cause

f2d3e5e7 taught the Go emitter to replace a DECLARED fixed table's `<T>Load` — the **variable** form's entry point — with a `previous_form` refusal, gated on `ir.Struct.FixedDeclared`, and named its own assumption:

> Nothing sets `[ir.Struct.FixedDeclared]` until #823's `fixed table` lands, so today every table in this tree keeps its form-1 Load and the shared wire oracle reads what it always read.

Tonight's merge of main (8d69cf77) landed #823 and gave fourteen schemas the keyword, `test/tables/V1.schema`'s `Cfg` among them. The latent switch threw, and from that moment the Go leg alone refused a form-1 file of a fixed root.

## Why the leg moves and not the corpus

- The shared pin is `v1_cfg_as_v2  1,1,0,1,0,false,read` (`testdata/conformance/tables/reports.txt`) over `testdata/wire/tables/v1_cfg.bin`, which is **form 1**.
- The C++ reference **reads** it there — `CfgLoad` is the form-1 entry point — and refuses form 1 in `CfgFixedLoad`. `internal/codegen/cpptable/fixedform.go`'s header: *"Nothing here touches form 1: a fixed-table type's reader accepts both, by the form byte."*
- SPEC-TABLES §15 names exactly this shape and calls the remaining work the DISPATCH, not the refusal: *"`<T>Load` for form `1` and `<T>FixedLoad` for form `3` — and each refuses the other's byte."*

The reference is the byte authority, so **no corpus byte and no pin is touched in this PR**. `make conformance-pin` was not run and `testdata/` is unchanged.

## The change, minimally

In `internal/codegen/gotable`:

- `read.go`, **`(*tableGen).emitTableRead`** — the `refusesForm1` branch that swapped in the refusal is gone; a declared fixed table keeps the ordinary form-1 `Load`.
- `fixedform.go` — **`(*tableGen).refusesForm1`** and **`(*tableGen).emitFixedForm1Load`** deleted (one path, no dead emitter).
- `fixedform.go`'s `FixedLoad` is untouched: it still answers `previous_form` for `1`, `message_form_as_file` for `2`, `newer_form` for a byte no form defines.

The two tests that pinned the divergence now pin the pair, one per entry point — `TestFixedFormForm1RefusalLivesInFixedLoad` on the emitted text, `TestForm1LoadReadsAndFixedLoadRefuses` on the generated runtime (a form-1 file reads the record back through `Load`, and is refused by name through `FixedLoad`).

`generated/bench/tables/go/BenchTableTable.go` and `generated/bench/paired/go/FixedTableTable.go` re-emitted from their own make targets. `go test ./internal/goldens -run TestGolden` is green without `-update`, so `testdata/golden` never carried the refusal.

## What it was measured against

| | before | after |
|---|---|---|
| wire | FAIL 0/96 | pass 96/96 |
| report | FAIL 38/59 | pass 59/59 |
| json-write | FAIL 0/92 | pass 0→92/92 |
| cook-write | FAIL 0/92 | pass 92/92 |

`./build/conformance-harness run --only go`: **every registered surface passes**, 18 surfaces, **2.1 s** wall.

Also green: `make conformance-negative-control-go` and `conformance-negative-control-go-walk` (both still *detect* their sabotage — the two targets `negative controls (base-conformance)` fails on at make/go.mk:283 and :287), `make tables-go-fuzz` (100 000 mutants plain and under `-race`), `gofmt -l .` empty.

## One ruling this needs

f2d3e5e7's note says *"The C++ reference still accepts form 1 on this type (cpptable/fixedform.go:19); Glenn says refuse."* This PR puts the Go leg back beside the reference, because a leg cannot diverge from the byte authority while the shared pin says `read`. If the ruling is that a `fixed table`'s form-1 file is refused **everywhere**, that is the reference's change first — cpptable, the fourteen schemas' corpus instances moving to form 3, and the pins re-taken from C++ — and nine legs follow it. That is not this PR, and it is not something a Go child should do by regenerating the reference's bytes to match Go.

Pre-existing and NOT touched here: `go test ./internal/codegen/gotable` is also red at HEAD (`TestFixedFormEmitsSurface`, `TestFixedFormClampPassShape`, `TestFixedFormClampLiveCount` — the fixed form is no longer emitted for a table nobody declared fixed). Verified identical on a clean worktree of `c6bbaf22`; another child owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)