### PR TITLE
gotable: the thirteen form-1 probes are one cause, and the first one reads through the region

### DIFF
--- a/internal/codegen/gotable/open_distinctness_test.go
+++ b/internal/codegen/gotable/open_distinctness_test.go
@@ -53,20 +53,27 @@ func TestGoTableOpenDistinctnessVerdict(t *testing.T) {
 	}
 	src := strings.ReplaceAll(openDistinctnessVerdictTest, "COLLIDE_A", fmt.Sprint(collideA))
 	src = strings.ReplaceAll(src, "COLLIDE_B", fmt.Sprint(collideB))
-	runGenerated(t, "package probe\nfixed table Root { x uint32 }\n", src)
+	runGenerated(t, "package probe\ntable Root { x uint32 }\n", src)
 }
 
 const openDistinctnessVerdictTest = `package probe
-import ("encoding/binary"; "testing")
+import ("encoding/binary"; "testing"; "unsafe")
 
+// tableOpen's distinctness walk is form 1's, and form 1 is the VARIABLE wire
+// (#823): the region Load is the only reader that still reaches it, so the
+// probe hands its hand-built vocabulary to that one. A damaged file has no
+// measurable region, so the region is sized for the widest case the probe
+// builds and the verdict is read from the report, as before.
 func loadIds(ids []uint64) (ok bool, report TableReport) {
 	buf := []byte{1, 0}
 	for _, id := range ids {
 		buf = binary.LittleEndian.AppendUint64(buf, id)
 	}
 	buf = binary.LittleEndian.AppendUint64(buf, uint64(len(ids)))
-	var value Root
-	ok = RootLoad(&value, buf, &report)
+	raw := make([]byte, 1<<16)
+	off := (-uintptr(unsafe.Pointer(&raw[0]))) & 15
+	region := raw[off : off+(1<<15)]
+	ok = RootLoad(region, buf, &report) != nil
 	return
 }
 


### PR DESCRIPTION
## The thirteen are one cause

The tip (f12b974c) left thirteen red in `internal/codegen/gotable` outside `-run TestFixedForm`, diagnosed there as "form-1 probes whose schemas main keyworded". That is the symptom. The cause is two lines, and neither is in a test:

1. **`refusesForm1` is now `hasFixedForm`.** `hasFixedForm` consults `isVarTable` → `ir.VariableTables`, which since #823 is exactly `ir.Struct.FixedDeclared`'s complement. So `refusesForm1(st) = hasFixedForm(st) && st.FixedDeclared` is `hasFixedForm(st)`, and read.go's `if g.hasFixedForm(st)` branch below the refusal — the one whose comment says "DERIVED into the fixed mode, not declared fixed … this reader still reads form 1" — is a state no unit can be in. The conjunction is still right to keep (a backend may carry the form for fewer types, never more); the branch it guards is what is now empty.

2. **`regional` is per UNIT.** `regional := len(variableTableNames(u)) > 0`, and a plain `table` is variable now, so **one** plain table makes the whole unit regional, and a regional unit emits no by-value form-1 Load for any table in it and no fixed form at all.

Together: the surface all thirteen probes were written against — a by-value `Root` whose `RootLoad(&v, wire, &report) bool` **reads** form 1 — is not reachable in any unit on this leg. Keyword the schema and you get the by-value surface with a Load that refuses form 1 by name (`previous_form`); leave it plain and you get a working form-1 Load on the region/builder surface (`RootBuilder`, `RootLoad(region, wire, report) *Root`), which is what `TestForm1OfVariableTableStillLoads` already uses. There is no third door, so de-keywording alone turns every one of them from `previous_form` into a build failure against `RootRow`.

Verified both ways: de-keywording all thirteen schemas leaves thirteen red, `previous_form` replaced by `cannot use &loaded (*Root) as []byte in argument to RootLoad` and `[]ChildRow` vs `[]Child`. `TestEndsEarlyShape` stays red on **either** setting — its `before := *report` is in the by-value form-1 Load, which is emitted for nothing.

## What is in here

One probe, the smallest, moved onto the reader that still exists. `TestGoTableOpenDistinctnessVerdict`'s subject is `tableOpen`'s 512-slot distinctness walk, which is form 1's and is the same shared-runtime code on either surface, so it hands its hand-built vocabulary to the region Load. The region is sized for the widest vocabulary the probe builds (257 ids) because a damaged file has no measurable region; the verdict still comes off the report. The SHAPE half next door (`TestGoTableOpenDistinctnessIsBounded`) keeps its `fixed table` and every assertion unchanged.

    go test ./internal/codegen/gotable/   82s, 12 red (was 13)
    gofmt -l .                            empty

## What is not, and why

The other twelve are the same cause, each needing its probe moved onto the region surface field by field — a rewrite per probe, not a keyword. Two of them should not be rewritten before Glenn answers a contract question:

- `TestEndsEarlyShape` asserts the shape of the by-value form-1 root Load, and `TestArithMeasureBodyShape` the shape of `LeafMeasureBody` — both emitted for nothing now.
- The reason they are emitted for nothing is that **a declared fixed table still emits a form-1 `<T>Save`** that writes form byte 1, whose own `<T>Load` refuses it. A writer with no reader. Either the form-1 `Save` of a declared fixed table goes (and the twelve move to the region surface), or the form-1 Load survives beside form 3 (which contradicts the 2026-09-09 ruling). That is the wire's shape, so it is Glenn's call, not a test edit.

Still red, one line each — all twelve are `Reason:previous_form` on a by-value form-1 round trip, and the subject each one loses its reader for:

| test | subject |
|---|---|
| `TestArrayLengthCacheWire` | array length cache, shared scratch, reused load targets |
| `TestEndsEarlyShape` | the root read answering its own early end |
| `TestLebOneByteFastPathShape` | LEB one-byte fast path on the wire |
| `TestMatchedScalarWidthShape` | matched scalar width, widening arm, mismatch skip |
| `TestArithMeasureBodyShape` | `MeasureBody` arithmetic vs `Save` |
| `TestPutLebAssemblesOnce` | `PutLeb` assembling once |
| `TestRefAtShape` | `RefAt` first use and default elision |
| `TestRefAtSharedFieldAndEnumKeyId` | shared field and enum key ids |
| `TestDefaultsAndOptionalArrays` | defaults, optional arrays, renamed variant ids |
| `TestWideValues` | int128/uint128/fixed-point text and wire |
| `TestWireLargeVocabularyAndZeroId` | large vocabulary, zero id, array count crossing the body, form verdicts |
| `TestWireSignalingNaNWideningAndLEBOverflow` | signalling NaN, tenth-byte LEB overflow |

Draft: the contract question above should be settled before the remaining twelve are rewritten, because the answer decides whether they move to the region surface or stay where they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)