### PR TITLE
go test: the fixed-form probes declare the class the keyword now selects

### DIFF
--- a/compiler/fixedleafcap_test.go
+++ b/compiler/fixedleafcap_test.go
@@ -44,7 +44,7 @@ func leafCapUnit(t *testing.T, src string) *ir.Unit {
 // the count and the run. This is the control for the cases below: without it
 // they would be measuring the array bound rather than the fold.
 func TestFlatElementArrayCostsOneLeaf(t *testing.T) {
-	u := leafCapUnit(t, "package probe\n\ntable Flat\n{\n    marks [..8192]int32\n}\n")
+	u := leafCapUnit(t, "package probe\n\nfixed table Flat\n{\n    marks [..8192]int32\n}\n")
 	st := u.Tables["Flat"]
 	if st == nil {
 		t.Fatal("the probe declares Flat")
@@ -63,54 +63,69 @@ func TestFlatElementArrayCostsOneLeaf(t *testing.T) {
 
 // AN ARRAY OF A WALKED ELEMENT SPENDS A LEAF PER ELEMENT, which is what reaches
 // the cap. `Cell` carries a `string(4)`, so this form cannot fold it into a run.
-func TestWalkedElementArrayPastTheCapWarnsAndDropsTheForm(t *testing.T) {
-	src := fmt.Sprintf("package probe\n\ntype Cell\n{\n    label string(4)\n}\n\ntable Wide\n{\n    cells [..%d]Cell\n}\n", ir.TableFixedLeafCap)
-	u := leafCapUnit(t, src)
-	st := u.Tables["Wide"]
-	if st == nil {
-		t.Fatal("the probe declares Wide")
+//
+// THE KEYWORD IS WHAT THE CAP ANSWERS TO (#823, docs/SPEC-TABLES.md §2.2). A
+// DECLARED `fixed table` past the cap is a REFUSAL BY NAME and the unit does not
+// compile — a fixed table never silently falls back to form 1. A plain `table`
+// is the variable wire by declaration and never a fixed root at all, so the cap
+// has nothing to say about it and says nothing.
+func TestWalkedElementArrayPastTheCapIsRefusedByName(t *testing.T) {
+	src := fmt.Sprintf("package probe\n\ntype Cell\n{\n    label string(4)\n}\n\nfixed table Wide\n{\n    cells [..%d]Cell\n}\n", ir.TableFixedLeafCap)
+
+	// DECLARED: the unit does not compile, and the refusal names the table, the
+	// leaf count, the cap and the section.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Probe.schema"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	leaves := ir.TableFixedLeafCount(u, st)
-	if leaves <= ir.TableFixedLeafCap {
-		t.Fatalf("the probe must be past the cap to measure anything; %d leaves", leaves)
+	paths, err := GatherPaths([]string{dir})
+	if err != nil {
+		t.Fatal(err)
 	}
-	// DERIVED: a warning naming the table and the count, and the unit compiles.
-	warns, errs := ir.TableFixedLeafCapRefusals(u)
-	if len(errs) != 0 || len(warns) != 1 {
-		t.Fatalf("a DERIVED fixed table past the cap warns and compiles: warns=%v errs=%v", warns, errs)
-	}
-	for _, want := range []string{"Wide", fmt.Sprint(leaves), fmt.Sprint(ir.TableFixedLeafCap), "§3.4"} {
-		if !strings.Contains(warns[0], want) {
-			t.Errorf("the warning must carry %q: %s", want, warns[0])
+	var warns []string
+	c := New()
+	c.OnWarn = func(msg string) { warns = append(warns, msg) }
+	if _, err := c.Load(paths); err == nil {
+		t.Fatal("a DECLARED fixed table past the cap must not compile")
+	} else {
+		for _, want := range []string{"Wide", fmt.Sprint(ir.TableFixedLeafCap), "leaves", "§3.4", "DECLARED"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the refusal must carry %q: %s", want, err)
+			}
 		}
 	}
-	if ir.TableFixedEmitted(u, st) {
-		t.Error("and the fixed form is not emitted for it")
+	// A REFUSAL REPLACES THE CAP'S WARNING rather than joining it. The record-size
+	// advisory (§3.4's other bound) is a different sentence about a different
+	// number and is expected here, so only the cap's own warning is read.
+	for _, w := range warns {
+		if strings.Contains(w, "leaf cap") || strings.Contains(w, "leaves") {
+			t.Errorf("the cap warned as well as refused: %s", w)
+		}
 	}
 
-	// DECLARED: a refusal BY NAME, and no warning pretending the form was kept.
-	// The `fixed table` keyword lives on branch `fixed-table-keyword` and is
-	// not merged, so this sets the IR marker the keyword will set — the same
-	// half the record ceiling's own declared case sets.
-	st.FixedDeclared = true
-	warns, errs = ir.TableFixedLeafCapRefusals(u)
-	if len(errs) != 1 {
-		t.Fatalf("a DECLARED fixed table past the cap must not compile: warns=%v errs=%v", warns, errs)
+	// THE SAME SHAPE ON A PLAIN `table` IS THE VARIABLE WIRE BY DECLARATION: no
+	// refusal, no warning, and no fixed form to drop.
+	plain := leafCapUnit(t, strings.Replace(src, "fixed table Wide", "table Wide", 1))
+	pst := plain.Tables["Wide"]
+	if pst == nil {
+		t.Fatal("the plain probe declares Wide")
 	}
-	if len(warns) != 0 {
-		t.Errorf("a refusal replaces the warning rather than joining it: %v", warns)
+	if pst.FixedDeclared {
+		t.Fatal("a plain `table` came out of the IR declared fixed")
 	}
-	for _, want := range []string{"Wide", fmt.Sprint(leaves), fmt.Sprint(ir.TableFixedLeafCap), "§3.4", "DECLARED"} {
-		if !strings.Contains(errs[0].Error(), want) {
-			t.Errorf("the refusal must carry %q: %s", want, errs[0])
-		}
+	pwarns, perrs := ir.TableFixedLeafCapRefusals(plain)
+	if len(pwarns) != 0 || len(perrs) != 0 {
+		t.Fatalf("a plain table is not a fixed root, so the cap says nothing: warns=%v errs=%v", pwarns, perrs)
+	}
+	if ir.TableFixedEmitted(plain, pst) {
+		t.Error("a plain table got the fixed form")
 	}
 }
 
 // AND UNDER THE CAP THE SAME SHAPE IS SILENT: the cap is what fires, not the
 // walked element.
 func TestWalkedElementArrayUnderTheCapIsSilent(t *testing.T) {
-	src := "package probe\n\ntype Cell\n{\n    label string(4)\n}\n\ntable Narrow\n{\n    cells [..16]Cell\n}\n"
+	src := "package probe\n\ntype Cell\n{\n    label string(4)\n}\n\nfixed table Narrow\n{\n    cells [..16]Cell\n}\n"
 	u := leafCapUnit(t, src)
 	warns, errs := ir.TableFixedLeafCapRefusals(u)
 	if len(warns) != 0 || len(errs) != 0 {

--- a/compiler/packetvaluedefaults_test.go
+++ b/compiler/packetvaluedefaults_test.go
@@ -88,11 +88,11 @@ type Loose
 		edge  string
 		form1 bool // form-1 / variable tables still refuse; the fixed form does not
 	}{
-		{"direct", "table", "", false},
-		{"nested_type", "type", "type Middle { badge Badge }\ntable Root { middle Middle }", false},
-		{"fixed_array", "type", "table Root { badges [2]Badge }", false},
-		{"counted_array", "type", "table Root { badges [..2]Badge }", false},
-		{"union_arm", "type", "union Choice { badge Badge }\ntable Root { choice Choice }", false},
+		{"direct", "fixed table", "", false},
+		{"nested_type", "type", "type Middle { badge Badge }\nfixed table Root { middle Middle }", false},
+		{"fixed_array", "type", "fixed table Root { badges [2]Badge }", false},
+		{"counted_array", "type", "fixed table Root { badges [..2]Badge }", false},
+		{"union_arm", "type", "union Choice { badge Badge }\nfixed table Root { choice Choice }", false},
 		{"union_array_arm", "type", "union Choice { badges [2]Badge }\ntable Root { choice Choice }", true},
 		{"pointer", "table", "table Root { badge *Badge }", true},
 		{"map_value", "type", "table Root { badges map[uint8]Badge }", true},

--- a/compiler/tablefixedclamp_test.go
+++ b/compiler/tablefixedclamp_test.go
@@ -28,7 +28,7 @@ union Effect
     ward  Ward
 }
 
-table Cfg
+fixed table Cfg
 {
     a      int32 = 5 | min = 0, max = 1000
     effect Effect
@@ -53,7 +53,7 @@ union Effect
     ward  Ward
 }
 
-table Cfg
+fixed table Cfg
 {
     a      int32 = 5 | min = 0, max = 1000
     effect Effect

--- a/compiler/tableselixir_test.go
+++ b/compiler/tableselixir_test.go
@@ -278,7 +278,7 @@ enum Slot { Alpha, Beta, Gamma }
 
 flags Mark { One, Two }
 
-table Leaf
+fixed table Leaf
 {
     a int32 = 7 | min = 0, max = 1000
     b uint16 = 3
@@ -300,7 +300,7 @@ union Effect
     ward  Ward
 }
 
-table FixedProbe
+fixed table FixedProbe
 {
     small    uint8 = 5
     wide     uint64 = 9

--- a/compiler/tablesjava_test.go
+++ b/compiler/tablesjava_test.go
@@ -431,13 +431,13 @@ union Effect
     ward  Ward
 }
 
-table Leaf
+fixed table Leaf
 {
     a int32 = 7 | min = 0, max = 1000
     b uint16 = 3
 }
 
-table FixedProbe
+fixed table FixedProbe
 {
     small    uint8 = 5
     wide     uint64 = 9

--- a/compiler/tablesrust_test.go
+++ b/compiler/tablesrust_test.go
@@ -194,13 +194,13 @@ enum Slot { Alpha, Beta, Gamma }
 
 flags Mark { One, Two }
 
-table Leaf
+fixed table Leaf
 {
     a int32 = 7 | min = 0, max = 1000
     b uint16 = 3
 }
 
-table FixedProbe
+fixed table FixedProbe
 {
     small   uint8 = 5
     wide    uint64 = 9

--- a/compiler/valuedefaults_test.go
+++ b/compiler/valuedefaults_test.go
@@ -205,7 +205,7 @@ const fixedValueDefaultsUnit = `package vdef
 
 flags Caps { Jump, Crouch }
 
-table Ship
+fixed table Ship
 {
     name string(32) = "untitled"
     tag  bytes(4) = "ab"

--- a/internal/codegen/ctable/identity_test.go
+++ b/internal/codegen/ctable/identity_test.go
@@ -23,21 +23,21 @@ import (
 // says gcc, and requiring that word dropped the flags on CI.
 
 const identityFlatSchema = `package probe
-table Flat {
+fixed table Flat {
     a uint32
     b uint32
 }
 `
 
 const identityHeldSchema = `package probe
-table Held {
+fixed table Held {
     marks [..4]int32
     label string(8)
 }
 `
 
 const identityPadSchema = `package probe
-table Pad {
+fixed table Pad {
     a uint8
     b uint32
 }

--- a/internal/codegen/elixirtable/fixedform_test.go
+++ b/internal/codegen/elixirtable/fixedform_test.go
@@ -68,7 +68,7 @@ func TestFixedLayoutMatchesTheCppReference(t *testing.T) {
 func TestBytesNDstRowIsAnArray(t *testing.T) {
 	u := unitFrom(t, `package probe
 
-table Probe
+fixed table Probe
 {
     label string(8)
     blob  bytes(6)
@@ -189,7 +189,7 @@ type Inner
     y float32
 }
 
-table Everything
+fixed table Everything
 {
     a      uint32
     b      bool
@@ -234,7 +234,7 @@ table Everything
 func TestNoPlanClampOp(t *testing.T) {
 	out, err := Generate(unitFrom(t, `package probe
 
-table Cfg
+fixed table Cfg
 {
     a      int32 = 5 | min = 0, max = 1000
     marks  [..4]int32 | min = 0, max = 10
@@ -275,7 +275,7 @@ func TestIdentityDecodeCountsLiveElementsOnly(t *testing.T) {
 
 enum Grade { Bronze, Gold }
 
-table Live
+fixed table Live
 {
     marks  [..4]int32 | min = 0, max = 10
     grades [..4]Grade
@@ -319,7 +319,7 @@ type Inner
     y float32
 }
 
-table Plain
+fixed table Plain
 {
     a uint32
     b bool
@@ -344,7 +344,7 @@ table Plain
 func TestFixedFormSkipsWhatItCannotCarry(t *testing.T) {
 	u := unitFrom(t, `package probe
 
-table Fine
+fixed table Fine
 {
     a int32
 }
@@ -396,13 +396,13 @@ func TestFixedGenerationIsDeterministic(t *testing.T) {
 
 enum Slot { Alpha, Beta }
 
-table Leaf
+fixed table Leaf
 {
     a int32 = 7 | min = 0, max = 1000
     s string(8)
 }
 
-table Root
+fixed table Root
 {
     leaf   Leaf
     slots  [Slot]Leaf
@@ -468,7 +468,7 @@ type Wide
     o int32
 }
 
-table Root
+fixed table Root
 {
     cells [..80]Cell
     wides [..8]Wide
@@ -498,7 +498,7 @@ table Root
 func TestFixedRuntimeUtf8IsOneWalk(t *testing.T) {
 	out, err := Generate(unitFrom(t, `package probe
 
-table Root
+fixed table Root
 {
     label string(15)
 }

--- a/internal/codegen/javatable/fixedform_test.go
+++ b/internal/codegen/javatable/fixedform_test.go
@@ -21,7 +21,7 @@ import (
 func TestBytesNDstRowIsAnArray(t *testing.T) {
 	u := unitFrom(t, `package probe
 
-table Probe
+fixed table Probe
 {
     label string(8)
     blob  bytes(6)
@@ -70,7 +70,7 @@ table Probe
 func TestFixedLoadPrefillsHolesOnly(t *testing.T) {
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -98,7 +98,7 @@ table ByRoot
 func TestWriteAndScatterWalkLiveCount(t *testing.T) {
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -129,7 +129,7 @@ func TestIdentityCompiledBytesN(t *testing.T) {
 	}
 	files, err := Generate(unitFrom(t, `package probe
 
-table ByRoot
+fixed table ByRoot
 {
     blob bytes(6)
     marks [..4]int32
@@ -335,7 +335,7 @@ enum Grade
     Gold
 }
 
-table LiveRoot
+fixed table LiveRoot
 {
     grades [1..4]Grade
 }

--- a/internal/codegen/rusttable/rusttable_test.go
+++ b/internal/codegen/rusttable/rusttable_test.go
@@ -288,7 +288,7 @@ union Effect
     ward  Ward
 }
 
-table Holder
+fixed table Holder
 {
     effect Effect
     tail   int32
@@ -308,7 +308,7 @@ union Note
     tally int32
 }
 
-table Holder
+fixed table Holder
 {
     note Note
 }
@@ -456,7 +456,7 @@ func keysOf(out map[string][]byte) []string {
 // wide_key, flux and ping).
 const wideKinds = `package probe
 
-table Wide
+fixed table Wide
 {
     server_time fixed(24, 8)  | min = 0, max = 65535
     ping        ufixed(8, 8)  | min = 0, max = 250
@@ -551,7 +551,7 @@ func TestWideKindsAreRefusedByTheAcceleratorsAndCarriedByTheWire(t *testing.T) {
 // skipped the field if it had.
 const wideTextFixed = `package probe
 
-table Caption
+fixed table Caption
 {
     lead  int32
     wide  wstring(8)
@@ -677,7 +677,7 @@ func TestFixedFormLoadPrefillsThePlanHoles(t *testing.T) {
 // compiled both call it.
 const liveWriteSrc = `package probe
 
-table Probe
+fixed table Probe
 {
     marks [..4]int32
     blob  bytes(6)


### PR DESCRIPTION
`go test ./...` on `fixed-table-form` went red when main's #823 landed (merge
8d69cf77): the `fixed table` keyword became the selection point for form 3
(`ir.TableFixedRoots` reads `ir.Struct.FixedDeclared`, docs/SPEC-TABLES.md §2.2,
§3.4), and the probe schemas in the fixed-form tests still said plain `table`.
They asked the emitters for form 3 on declared VARIABLE tables and were handed
form 1, so every assertion about the form's surface failed.

This is a test-only change: no emitter, runtime, IR or golden moved. Nothing
under `internal/codegen/gotable` is touched — another line owns that package.

## (a) the probe intends the fixed form — the probe now declares it

Thirty-odd probe schemas took the keyword. `fixed table Name { … }`, confirmed
against `internal/parser/parser.go:241`.

| package | probes |
| --- | --- |
| `internal/codegen/rusttable` | `unionReaching`, `unionWithTextArm`, `wideKinds`, `wideTextFixed`, `liveWriteSrc` |
| `internal/codegen/javatable` | the five `fixedform_test.go` probes |
| `internal/codegen/ctable` | `identityFlatSchema`, `identityHeldSchema`, `identityPadSchema` |
| `internal/codegen/elixirtable` | the ten `fixedform_test.go` probes |
| `compiler` | `clampSrc`, `clampRangedArmSrc`, `elixirFixedSrc`, the java and rust fixed-form probes, `fixedValueDefaultsUnit`, the five `form1: false` edges of `TestPacketValueDefaultsRefuseTableClosure` |

Tests back green by this route:

- rusttable: `TestFixedFormWriteIsLiveCountAndLength`, `TestFixedFormCarriesWideText`,
  `TestWideKindsAreRefusedByTheAcceleratorsAndCarriedByTheWire`,
  `TestFixedFormIsEmittedForAFixedRootAndForNothingElse`
- javatable: `TestScatterCountedArrayWalksLiveCount`, `TestIdentityCompiledBytesN`,
  `TestWriteAndScatterWalkLiveCount`, `TestFixedLoadPrefillsHolesOnly`
- ctable: `TestIdentityLoadIsOneLoop`, `TestIdentityFlatIsThePlanNotMemcpy`,
  `TestIdentityPaddedDoesNotMemcpyTheStruct`, `TestIdentityHeldRoundTripAndClamp`,
  `TestIdentityFlatRoundTripFromDirty`
- elixirtable: `TestIdentityPlanOfEverythingIsOneRun`, `TestNoPlanClampOp`,
  `TestIdentityDecodeCountsLiveElementsOnly`, `TestFixedFormSkipsWhatItCannotCarry`,
  `TestFixedGenerationIsDeterministic`, `TestFixedListWalkUnrollsSmallRecords`,
  `TestFixedRuntimeUtf8IsOneWalk`
- compiler: `TestCppNoPlanClamps`, `TestCNoPlanClamps`,
  `TestCppTableFixedClampOmitsEmptyUnionSwitch`,
  `TestCTableFixedClampOmitsEmptyUnionSwitch`,
  `TestElixirFixedFormLayoutIsTheCppReferenceByteForByte`,
  `TestJavaFixedFormLayoutIsTheCppReferenceByteForByte`,
  `TestJavaFixedFormIsEmittedForAFixedRootAndForNothingElse`,
  `TestRustFixedFormLayoutIsIrsByteForByte`, `TestFixedTableValueDefaultsEveryLeg`,
  `TestPacketValueDefaultsRefuseTableClosure` (all five `form1: false` subtests),
  `TestFlatElementArrayCostsOneLeaf`, `TestWalkedElementArrayUnderTheCapIsSilent`

Two rules decided where the keyword did NOT go:

- A pointer, a map or an unbounded array makes a table VARIABLE and `fixed` on
  one is a compile error (`internal/check/check_fixed.go`). So rusttable's
  `pointered` and `wideKindsNoFixedRoot`, elixirtable's `Pointered`, and
  packetvaluedefaults' `pointer` / `map_value` / `nested_map_value` /
  `union_array_arm` edges stay plain — each asserts the ABSENCE of the form, and
  still does.
- A nested plain `table` is one of the six closure breaks, so `Leaf` takes the
  keyword wherever its holder does: Root cannot be fixed unless Leaf is.

`unionWithTextArm` is now a DECLARED fixed table on purpose. The refusal it
tests is §3.4's own layout law about an arm needing a companion beside it, and
on a plain `table` it was being refused for the wrong reason.

## (b) the test intends form-1 behaviour — none

No assertion was bent. Nothing turned out to be a form-1 test wearing a
fixed-form expectation.

## (c) something else — the leaf cap's DERIVED half is gone from the language

`compiler/fixedleafcap_test.go` was written while the keyword was still on an
unmerged branch: it set `st.FixedDeclared = true` by hand and held a DERIVED
case — a table the compiler *inferred* into the fixed mode, which warned and
kept form 1. #823 removed that case: `ir.TableFixedRoots` selects by the
keyword, so every root is DECLARED and `ir.TableFixedLeafCapRefusals`' warning
branch (`ir/fixedform.go:1006`) is unreachable.

`TestWalkedElementArrayPastTheCapWarnsAndDropsTheForm` is replaced by
`TestWalkedElementArrayPastTheCapIsRefusedByName`, which holds the law that
survives:

- DECLARED past the cap: the unit does not compile, and the refusal names the
  table, the leaf count, the cap and §3.4. Asserted through `compiler.Load`,
  because a refusal is what a user meets.
- the same shape on a plain `table`: no refusal, no warning, no fixed form.

The dead warning branch in `ir/fixedform.go` is left alone — it is unreachable,
not wrong, and that file is not this change's subject.

## Still red

`compiler/TestTableClosureCountDefaults/go`. Not a keyword-staleness failure and
not mine to fix: the probe is already `fixed table Root`, the wire the test
writes is form 1 (`tablewire.Encode`, and the test's own `empty` is the form
byte 1), the C++ and C legs accept it, and the generated Go loader refuses it
`previous_form`. That refusal lives in `internal/codegen/gotable/fixedform.go`
(`refusesForm1`, commit f2d3e5e7) — the Go backend is ahead of the reference on
form-1 fallback for a declared fixed table, and the two have to be reconciled in
the package this PR does not touch.

## Goldens and pins

None regenerated, and none needed: every change is inside a `_test.go` probe
string or assertion. The goldens are driven by the `tables/` corpora, which #823
updated itself. The `pins` job was failing on the rusttable test, which is green
here.

## Verification

- `gofmt -l .` empty
- `go test ./...` run whole, 229 s wall: green everywhere except
  `compiler/TestTableClosureCountDefaults/go` (above) and
  `internal/codegen/gotable`, which is out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
