### PR TITLE
docs: the bill, spec §21 and algorithm §5; the fixed table reads backward, never forward

### DIFF
--- a/docs/FIXED-FORM-ALGORITHM.md
+++ b/docs/FIXED-FORM-ALGORITHM.md
@@ -314,25 +314,121 @@ clamp on every clean read. A type that bounds nothing emits no pass at all.
   this wire: a variant is identified by the hash of its name, so a value with no name has no meaning here, and the
   compiler refuses a headroom enum the moment a table reaches it (Glenn, 2026-09-10: dead text, not a rule).
 
-## 5. Evolution
+## 5. Evolution: the fixed table reads backward, never forward
 
-Every decision below is the PLAN COMPILER's, made once per peer.
+The bill is `docs/FIXED-FORM-BILL-READS-BACKWARD.md`; the spec is SPEC-TABLES §21. This section is the
+algorithm. Glenn, 2026-09-10: "Newer versions of the fixed table should be able to read OLD versions. But
+old versions CANNOT read new versions, and complain loudly and refuse." The order of work: basic versioning
+on the fixed table first (this section), then the bitpacked fixed form; the variable table is HELD.
 
-| the edit | what the reader does | counter |
-|---|---|---|
-| a field APPENDED | a reader that lacks it emits no entry for it | — |
-| a field DEPRECATED | the slot keeps its size; the writer emits the declared default, the reader yields it | — |
-| a field REMOVED | every byte behind it moves; the hash catches that and the plan compiler absorbs it, at the cost of a plan per peer | — |
-| a field RENAMED under `was =` | it arrives under the id `was` names and resolves like any other (§5) | — |
-| a variant or arm INSERTED mid-list | remapped BY NAME, so it costs nothing | — |
-| a field WIDENED | an integer into a wider integer of the SAME signedness, or `f32` into `f64`, lands exactly. The signed ladder is `2,3,4,5,18`, the unsigned one `6,7,8,9,19`, `10` into `11` the float rung; **every other pair is a kind mismatch** | `widened` |
-| a field's KIND MOVED | not decoded; the field takes its declared default. A field moved between `?T` and a plain nesting IS one on this form, where on form `1` it is silent | `kind_mismatch` |
-| a field or NESTED TYPE this reader cannot name | stepped over by the size its entry states — one entry's worth of `src` advance | `unknown` |
-| a value outside the reader's range | clamped to the bound | `clamped` |
+Three procedures. `BASELINE` runs at commit and holds the law; `COMPILE` runs at build time from the lock and
+lays down one plan per supported version as static data; `LOAD` runs per file and selects a plan by hash.
+Nothing parses a stranger's layout at run time.
 
-**The compile-time guard is the tables baseline (§18, §18.2), not the wire.** (note c) The wire reports what it can
-see; `tables.baseline` refuses the edits it cannot — a changed specified default, a moved `flags` variant, a
-fixed field's `F` moved under one kind, a referent that cannot stand in. It is opt-in: no file, no check.
+### 5.1 BASELINE(old, new): the monotone law, at commit
+
+`old` is the last locked shape of the unit (SPEC §18); `new` is the unit being committed. For every fixed
+table `T` in `new` and every definition `D` in `T`'s closure (§5.4), with `D0` the same definition in `old`
+where it existed:
+
+```
+BASELINE(old, new):
+  for T in new.fixed_tables:
+    if T not in old:                    continue            -- a new table is a new lineage
+    if old[T] is not fixed:             REFUSE "T: fixed added" -- a different form, not a version
+    for D in closure(T):
+      D0 := old.lookup(D.name); if none: continue           -- added: allowed
+      WIDENS(D0, D) or REFUSE "T: D: <rule> (<old> -> <new>)"
+  for T in old.fixed_tables:
+    if T not in new or new[T] is not fixed: REFUSE "T: fixed removed"  -- deprecate; remove only when nothing live speaks it
+
+WIDENS(a, b):                            -- b may replace a
+  kind(a) == kind(b)                     or FAIL "kind changed"       -- includes string/wstring/bytes, [N]/[..N]/[Enum]
+  match kind:
+    table, type:   fields(a) is a PREFIX of fields(b) by (name, position); every a-field WIDENS into its b-field;
+                   a deprecated field keeps its place          or FAIL "field removed | inserted | reordered | modified"
+    enum:          variants(a) prefix of variants(b) by name   or FAIL "variant removed | inserted | reordered | renamed"
+    union:         arms(a) prefix of arms(b) by name; each payload WIDENS   or FAIL "arm ..."
+    flags:         flags(a) prefix of flags(b)                 or FAIL "flag removed | moved"
+    [N], [..N], string(N), wstring(N), bytes(N):  N(a) <= N(b) or FAIL "bound narrowed"; element WIDENS
+    [Enum]T:       Enum WIDENS (its own rule); element WIDENS
+    int, float:    width(a) <= width(b), same ladder, same signedness   or FAIL "narrowed | ladder | signedness"
+    ranged:        range(b) ⊇ range(a), or b unranged               or FAIL "range narrowed | added"
+    bits(N):       N(a) <= N(b)
+    fixed(I,F):    I(a) <= I(b) and F(a) == F(b)                     or FAIL "F changed"
+    ?T vs T:       optional(a) implies optional(b)                     or FAIL "optional removed"
+    default:       default(a) == default(b)                            or FAIL "default changed"   -- SPEC §18
+    reader limit:  limit(a) <= limit(b)
+```
+
+Every FAIL names the table, the definition, the rule, and both values. The compiler refuses to generate
+against a lock the schema contradicts; CI runs the same check.
+
+### 5.2 COMPILE(lock, T): one plan per supported version, at build time
+
+```
+COMPILE(lock, T):
+  y := T.layout                                   -- the current layout, its hash H(y)
+  for each older layout x in lock.lineage(T) with index >= T.floor:
+    plans[H(x)] := PLAN(x, y); known[H(x)] := bytes(x)
+  plans[H(y)] := IDENTITY; known[H(y)] := bytes(y)
+  emit plans, known as static data
+
+PLAN(x, y):                                        -- x older, y the reader's own; x WIDENS into y by §5.1
+  walk x and y side by side, entry by entry (x is a prefix of y at every level; where a merge reordered a
+  list, match by NAME and emit a remap, identity when the lists agree):
+    same width:            copy
+    wider in y:            widen / widenf   (COUNT widened)
+    enum, prefix:          copy (the ordinals are the reader's); reordered: ordinal remap by name
+    absent in x:           default            (a field y added)
+    deprecated in y:       skip x's bytes     (COUNT unknown, once per plan)
+    text, bytes, arrays:   copy the writer's extent; the reader's slack is template zeros
+    ?T where x has T:      present := 1, then the value
+  the plan is a straight-line list of ops; no per-record decision
+```
+
+Because §5.1 held at every commit, PLAN never fails at build time; a lineage that is not monotone is a bug
+in the lock, refused by name at build.
+
+### 5.3 LOAD(R, file): select by hash, never parse a stranger
+
+```
+LOAD(R, file):                                     -- R the reader's static data for T
+  h := file.layout_hash
+  if h not in R.known:
+    if h in lock.lineage(T) below floor:  REFUSE layout_unsupported
+    else:                                 REFUSE layout_newer      -- an older reader given a newer file
+  if file.layout_bytes != R.known[h]:     REFUSE layout_malformed  -- a lie about a known version
+  if file.record_bytes != size(R.known[h]) or rest % record_bytes != 0: REFUSE layout_malformed
+  for each record: run R.plans[h] (§4), then the hostile pass (§4.5, §4.6: a forged count past the WRITER'S
+    OWN bound, an ordinal past the writer's own variant count, a tag past its arm count, a bool byte not 0/1)
+```
+
+REFUSE is total: no counter moves, nothing decoded. `layout_newer` carries the file's hash; the refusal text
+names, where the language has text, the first definition the reader could not hold, read off the file's
+layout against the reader's own (this is the one walk over a stranger's layout, and it happens only inside a
+refusal, after the decision, with the seven §1.1 checks applied to it first).
+
+### 5.4 The closure
+
+`closure(T)` is `T`, every `table` or `type` it reaches by value, every enum, union, flags and constant any
+of them names, recursively. Every table or type in it is declared `fixed`; a pointer, map or unbounded array
+in it is a compile refusal; `T` is never in its own closure.
+
+### 5.5 What is retired by this section
+
+The plan compiler at run time (§4.1–§4.4 become the build-time PLAN of §5.2); reading a layout the lock has
+never seen; the count clamp across bounds, the range clamp across versions, the remap of an unknown variant
+to `None`, the drop-and-count of an unknown field (all forward reads, now `layout_newer`). The seven §1.1
+checks stay as the lock's validation of what it records and as the walk inside a refusal. Every hostile
+check on a KNOWN layout's records stays (§4.5, §4.6).
+
+### 5.6 The tests
+
+One test per row of §5.1, red first, in the compiler: the baseline REFUSES the narrowing and names it, and
+ACCEPTS the widening. One fixture per row of §5.2 in the reference (an older file read by the current
+build, the landed values and counters asserted), ported to every leg. One fixture per refusal of §5.3
+(`layout_newer`, `layout_unsupported`, `layout_malformed` on a known hash), reference first, every leg.
 
 ## 6. The bounds
 

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -186,7 +186,10 @@ Adding but never removing?" Three.
    means). None of it breaks a read; it is the price. The escape, in Glenn's order: "You would just create a
    new table if it got too large. Then deprecate the old, clean out the cruft, and upgrade the backend first
    to read the new table and the old. Deploy it, then deploy the client." A new table is a fresh lineage
-   with its own lock entry; the old one stays readable for as long as its files exist.
+   with its own lock entry; the old one stays readable for as long as its files exist, "and once no clients
+   are live talking the old table, remove the old table that is deprecated." The layout hash is the
+   per-table version; the new table is the explicit bump (Glenn: "you can see in network next how I would
+   do this with per-table versions").
 
 ## 9. Open, for the cold read
 

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -183,8 +183,10 @@ Adding but never removing?" Three.
    first. Stated in §7.
 3. **Growth has no reset.** Deprecated fields ride forever, every record carries them, the record-size and
    leaf caps eventually bind, and a default, once chosen, can never change (it defines what every old file
-   means). None of it breaks a read; it is the price. The escape is a NEW TABLE NAME, a fresh lineage the
-   new build reads beside the old, the same move a database makes.
+   means). None of it breaks a read; it is the price. The escape, in Glenn's order: "You would just create a
+   new table if it got too large. Then deprecate the old, clean out the cruft, and upgrade the backend first
+   to read the new table and the old. Deploy it, then deploy the client." A new table is a fresh lineage
+   with its own lock entry; the old one stays readable for as long as its files exist.
 
 ## 9. Open, for the cold read
 

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -32,6 +32,20 @@ The table's own law, additions and deprecation only, extends to every definition
 | an integer or float width | at most the reader's, same signedness ladder | wider, or a different kind |
 | a field's kind | the same | different |
 | field order | any | never (by name) |
+| a fixed-size array `[N]` | N at most the reader's (the reader defaults the rest) | larger |
+| an enum-keyed array `[Enum]T` | its enum a prefix of the reader's | the enum has a name the reader lacks |
+| `bits(N)` | N at most the reader's | larger |
+| `fixed(I,F)` / `ufixed(I,F)` | I at most the reader's, F equal | I larger, or F different (the scale moves, incompatible) |
+| an optional | `T` where the reader has `?T` (landed present) | `?T` where the reader has `T` |
+| a nested table or type by value | the table's own law, recursively | anything else |
+| `flags` | bits a prefix of the reader's | a moved or missing bit |
+| a compressed float | any quantization (it rides as the float) | never |
+| the `fixed` keyword | the same | a variable table where the reader has a fixed one, or the reverse: a different form, not a version |
+
+Glenn: "wstring/strings/bytes can be widened only, not narrowed, because a narrowed string/array cannot read
+the old." The principle behind every row: a newer reader must be able to hold every value an older writer
+could produce, exactly. Where widening keeps that true it is allowed; where it cannot, the change is
+incompatible and the baseline (§6) refuses it at commit.
 
 Widening an int or a float, or an enum's ordinal width, is a read: the reader lands it exactly. That is the
 one asymmetry the bill keeps, and it is Glenn's: "you can take an enum and widen it, but you cannot narrow."

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -177,6 +177,19 @@ Readers first, always. A writer ships only after every reader that will meet its
 can roll a reader back across (§8a.2). Getting the order wrong is a `layout_newer` refusal at the first
 file, not a truncated array in production.
 
+## 7a. What the versioning does, and what a person still does
+
+Glenn: "in practice this is the delta between the live clients and the backend"; "We did stuff like, if
+version is > x, read these vars, otherwise set to default, which i think is what you are doing here, so it
+SHOULD work"; "it's not 100% 'i don't have to think at all the versioning does this for me'."
+
+The versioning does the bytes: a file is never read wrong, and never read silently wrong. The compiler writes
+the `if version > x` chain from the lineage, one plan per supported version, the file's hash picking the
+branch. A person still does five things: append and never modify (the baseline catches the slip); choose a
+default once, because it defines every old file forever; ship readers before writers, by a margin a reader
+can roll back across; set the floor to the real delta between live clients and the backend; start a new
+table when the old one has grown past sense, and retire it when nothing live speaks it.
+
 ## 8. What changes on the board (#876)
 
 - E1 (unknown field): becomes `layout_newer`; the deprecated-field drop is its own item.

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -243,7 +243,7 @@ Adding but never removing?" Three.
 - Whether a writer's *deprecated* field (older writer, still writing it) needs any rule: the reader is newer
   and has the name, so it reads or drops by the reader's own deprecation; it seems to need none.
 
-## 10. The variable table, for a separate decision
+## 10. The variable table: HELD, for a separate decision (Glenn: "I don't know yet. Hold this for later.")
 
 Glenn: "I think the reads backwards rule is going to be required for the variable table too." The same law
 holds; the difference is where "newer" is detected. Form 1 has no layout, so today it finds out PER RECORD

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -42,6 +42,19 @@ The table's own law, additions and deprecation only, extends to every definition
 | a compressed float | any quantization (it rides as the float) | never |
 | the `fixed` keyword | the same | a variable table where the reader has a fixed one, or the reverse: a different form, not a version |
 
+| a range or constraint | absent on the writer where the reader has none, or inside the reader's | ADDED where none was (old values would clamp); a constraint added to a text field |
+| a text kind (`string`, `wstring`, `bytes`) | the same | any change between the three (old bytes stop being valid under the new content rules) |
+| an array's shape (`[N]`, `[..N]`, `[Enum]`) and its key enum | the same shape and key | a shape change or a swapped key; an element type follows the widening ladder, an element narrowed is refused |
+| a reader-side limit a table declares (a record count, a batch size) | at most the reader's | smaller; where the limit is a compiler flag it is outside the law and the doc says so |
+| a deprecated field | still written, still in its place | leaving the layout (that is a removal); undeprecating is allowed |
+| a rename | through `was` | without it (the baseline's identity is by name, the fixed wire's by position) |
+
+**The invariant that makes widening safe** (Glenn: "widening with default values is what saves us here"):
+every widening is defined by the default it fills. A new field takes its default; a grown array's new slots
+take the element default; `T` to `?T` lands every old value present; a widened range, width or list changes
+nothing an old value held. A change with no default to fill is not a widening, and that is the test for any
+case not in this table.
+
 Glenn: "wstring/strings/bytes can be widened only, not narrowed, because a narrowed string/array cannot read
 the old." The principle behind every row: a newer reader must be able to hold every value an older writer
 could produce, exactly. Where widening keeps that true it is allowed; where it cannot, the change is

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -149,8 +149,9 @@ nobody guarantees old ever reads new.")
 
 ## 7. The deployment rule
 
-Readers first, always. A writer ships only after every reader that will meet its files has. Getting the
-order wrong is a `layout_newer` refusal at the first file, not a truncated array in production.
+Readers first, always. A writer ships only after every reader that will meet its files has, by a margin you
+can roll a reader back across (§8a.2). Getting the order wrong is a `layout_newer` refusal at the first
+file, not a truncated array in production.
 
 ## 8. What changes on the board (#876)
 
@@ -162,6 +163,28 @@ order wrong is a `layout_newer` refusal at the first file, not a truncated array
 - The seven layout refusals, W10, W6, W16, the byte pins against the reference, FU in the oracle: untouched.
 - New items: `layout_newer` asserted by name on every leg for each row of §2; the baseline's monotone law
   with a fixture per row; the deployment rule in the doc's §5.
+
+## 8a. What breaks it, and what the bill does about each
+
+Glenn: "Is there any case you can find that breaks this approach? The widening approach to versioning?
+Adding but never removing?" Three.
+
+1. **Two branches both append.** A hotfix appends field A while main appends field B; each commit passes
+   its own baseline; after the merge one is reordered, and a reader that matches BY POSITION refuses every
+   file the pre-merge hotfix build wrote. Append-only assumes one linear history and git does not give one.
+   **Ruling in this bill:** the baseline enforces append-at-end on each branch (§6, the discipline), but the
+   READER accepts a writer whose definitions are a SUBSET of its own BY NAME, each compatible under §2, in
+   any order (the tolerance). Fields, variants and arms keep the remap by name that exists today, with the
+   forward-reading half removed; when the writer is a true prefix the remap is the identity and costs
+   nothing. §6's "what appending buys" is therefore the common case, not the rule.
+2. **Readers cannot roll back.** Once a newer writer has produced files, the previous reader build refuses
+   them by name. That is the contract working, and it makes a reader rollback a data event. Rule: writers
+   ship after readers by a margin you can roll back across; a build that must go down migrates its files
+   first. Stated in §7.
+3. **Growth has no reset.** Deprecated fields ride forever, every record carries them, the record-size and
+   leaf caps eventually bind, and a default, once chosen, can never change (it defines what every old file
+   means). None of it breaks a read; it is the price. The escape is a NEW TABLE NAME, a fresh lineage the
+   new build reads beside the old, the same move a database makes.
 
 ## 9. Open, for the cold read
 

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -1,5 +1,8 @@
 # Bill: the fixed form reads backward, never forward
 
+Purpose, in Glenn's words: "this is not perfect and does not do everything, but it does work, and extends
+from a pattern coded by one person that is a footgun, to something that could work on a larger team."
+
 Glenn, 2026-09-10, in Rowan's window, after walking three cases (an old reader sent a new enum variant, an
 old reader sent a longer array, an old reader sent a layout whose definitions moved): "The only correct is
 reject." "Newer versions of the fixed table should be able to read OLD versions." "But old versions CANNOT
@@ -239,3 +242,13 @@ Adding but never removing?" Three.
   one integer) or as text (readable, per language).
 - Whether a writer's *deprecated* field (older writer, still writing it) needs any rule: the reader is newer
   and has the name, so it reads or drops by the reader's own deprecation; it seems to need none.
+
+## 10. The variable table, for a separate decision
+
+Glenn: "I think the reads backwards rule is going to be required for the variable table too." The same law
+holds; the difference is where "newer" is detected. Form 1 has no layout, so today it finds out PER RECORD
+(an unknown field id, an unknown variant, a count past the bound), each tolerated and counted (SPEC §4). To
+refuse forward as form 3 does, form 1's header carries the writer's closure hash, and the decision is one
+comparison at the top of the file, before any record. §4's tolerance was form 1's selling point and it is
+the same footgun under a friendlier name. This is its own bill: it changes every leg's form-1 reader, the
+wire header, and the packet form's model, and must not ride in on the fixed table's ruling.

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -147,6 +147,30 @@ says the versions only ever grew. A human-readable number beside it for release 
 on the wire reads it. (Glenn: "So you DEPLOY the backend with the new schema, and it reads old and new. But
 nobody guarantees old ever reads new.")
 
+## 6b. The floor, and what it buys: no plan compiler at run time
+
+Glenn: "i would consider, only versions in the past to x would be supported, where current version might be
+y." The lock keeps the LINEAGE per fixed table: every layout the table has had, in order, each with its
+hash and its layout bytes. A floor is one number per table: the reader accepts lineage entries from x to y
+(its own) and refuses older ones by name, `layout_unsupported`.
+
+What that buys: the set of layouts a reader accepts is FINITE AND KNOWN AT BUILD TIME. So:
+
+- the plan for reading each supported version is compiled AT BUILD TIME by the compiler, from the lock,
+  and shipped as static data, one plan per version, the identity plan for y;
+- the RUNTIME PLAN COMPILER GOES. A file arrives; its hash is looked up in the table's supported set; the
+  file's layout bytes are compared to the known layout bytes for that hash; the precompiled plan runs;
+- hash not in the set: refuse (`layout_unsupported` if it is in the lineage below the floor, `layout_newer`
+  if the reader has never seen it); layout bytes differ from the known ones under that hash: refuse
+  (`layout_malformed`, a lie about a known version);
+- the seven layout refusals of §1.1 collapse to one byte comparison, because the reader NEVER PARSES A
+  STRANGER'S LAYOUT to decide whether it is well formed. No validation walk, no depth bound, no size
+  arithmetic on untrusted input. Faster, and much safer, than what exists;
+- the branch case (§8a.1) is settled by the lineage: a merge appends both sides' layouts, and both are
+  supported.
+
+The floor's syntax is Glenn's to name (§9). Without a floor, x is the table's first layout.
+
 ## 7. The deployment rule
 
 Readers first, always. A writer ships only after every reader that will meet its files has, by a margin you
@@ -192,6 +216,10 @@ Adding but never removing?" Three.
    do this with per-table versions").
 
 ## 9. Open, for the cold read
+
+- The floor's syntax: on the table (`fixed table Foo | floor = 3`?), in the lock, or a compiler flag per project.
+- Whether §6b (build-time plans from the lineage, no runtime plan compiler) is the shape, which retires §1.1's
+  seven refusals as runtime code (they stay as the lock's own validation of what it records).
 
 - Whether a deprecated field on the reader should count under `unknown` at all, or be silent.
 - Whether `layout_newer` should carry the offending entry as an index into the writer's layout (portable,

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -50,6 +50,15 @@ incompatible and the baseline (§6) refuses it at commit.
 Widening an int or a float, or an enum's ordinal width, is a read: the reader lands it exactly. That is the
 one asymmetry the bill keeps, and it is Glenn's: "you can take an enum and widen it, but you cannot narrow."
 
+## 2a. The closure rule
+
+Glenn: "fixed tables must only allow other fixed tables to be included in them, and not recursively include
+themselves." A fixed table's closure is a TREE of fixed things: every table or type it reaches by value is
+itself declared `fixed` and carries its own locked layout under §6; a pointer, a map, or an unbounded array
+makes a table variable and is refused in a fixed closure, so a fixed table cannot reach itself by any path.
+The compiler holds both halves today (a plain nested table is a closure break; `check_fixed.go` refuses the
+variable kinds); the bill makes them the law and the lock records the closure.
+
 ## 3. What the reader does with an older file
 
 - a field the reader added since: the reader's declared default;

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -31,14 +31,14 @@ The table's own law, additions and deprecation only, extends to every definition
 | a ranged scalar's bounds | inside the reader's | wider on either end |
 | an integer or float width | at most the reader's, same signedness ladder | wider, or a different kind |
 | a field's kind | the same | different |
-| field order | any | never (by name) |
+| field order | a prefix of the reader's: fields are ADDED AT THE END, deprecated in place, never modified or removed (Glenn) | a field out of order, changed, or missing where the reader has one |
 | a fixed-size array `[N]` | N at most the reader's (the reader defaults the rest) | larger |
 | an enum-keyed array `[Enum]T` | its enum a prefix of the reader's | the enum has a name the reader lacks |
 | `bits(N)` | N at most the reader's | larger |
 | `fixed(I,F)` / `ufixed(I,F)` | I at most the reader's, F equal | I larger, or F different (the scale moves, incompatible) |
 | an optional | `T` where the reader has `?T` (landed present) | `?T` where the reader has `T` |
-| a nested table or type by value | the table's own law, recursively | anything else |
-| `flags` | bits a prefix of the reader's | a moved or missing bit |
+| a nested table or type by value | the table's own law, recursively: fields added at the end, deprecated in place (Glenn) | a field modified, removed, or inserted elsewhere |
+| `flags` | bits a prefix of the reader's: new flags added, old flags never removed (Glenn) | a moved or missing bit |
 | a compressed float | any quantization (it rides as the float) | never |
 | the `fixed` keyword | the same | a variable table where the reader has a fixed one, or the reverse: a different form, not a version |
 
@@ -107,6 +107,12 @@ is neither older nor newer.
 reader's ordinal: no remap table, no lookup per record; an enum lands as a `copy`, or a `widen` when its
 width grew. The plan-time check for an enum is "the writer's list is a prefix of mine", one comparison per
 enum, and the same for a union's arms. Faster than the remap by name, and nothing to get wrong.
+
+**What append-only everywhere buys at plan time.** With every list a prefix of the reader's, the plan check
+is one shape at every level: walk the writer's layout and the reader's side by side; the writer's must be a
+prefix of the reader's entry by entry, widening where a width grew, defaulting the reader's tail. No matching
+by name at plan time, no remap tables, one comparison per entry. The compiler that reads old files gets
+smaller than the one that exists.
 
 ## 6a. Versions: the hash is the version, the lock holds the law
 

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -1,0 +1,102 @@
+# Bill: the fixed form reads backward, never forward
+
+Glenn, 2026-09-10, in Rowan's window, after walking three cases (an old reader sent a new enum variant, an
+old reader sent a longer array, an old reader sent a layout whose definitions moved): "The only correct is
+reject." "Newer versions of the fixed table should be able to read OLD versions." "But old versions CANNOT
+read new versions, and complain loudly and refuse. Nothing else makes sense." "You can take an enum and widen
+it, but you cannot narrow, or incompatible."
+
+This is step 1 of THE PROCESS (the bill). Nothing in the reference moves until it has been read cold. The
+algorithm doc (§5), the oracle, the matrix and the properties follow it, then the reference, then the ports.
+
+## 1. The rule
+
+A reader accepts a file only if the file's layout is **older or equal** to the reader's own. A file whose
+layout is newer than the reader **refuses by name, loudly, before any record is read**. There is no partial
+read, no clamp across versions, no value landed as `None` because the reader had no name for it.
+
+"Older or equal" is decided once per peer at plan time and is a property of the schema pair, never of a
+record's values. A pair either reads or it does not.
+
+## 2. What "older or equal" means, per thing that inputs into a table
+
+The table's own law, additions and deprecation only, extends to every definition that inputs into it.
+
+| definition | the writer's may be | refuse when the writer's is |
+|---|---|---|
+| a field | present on the reader by name, or deprecated on the reader | a name the reader lacks (the writer is newer) |
+| an array bound, a string or `bytes` size, a constant behind either | at most the reader's | larger |
+| an enum's variants, a union's arms | a subset of the reader's, by name | a name the reader lacks |
+| an enum's ordinal width, a union's tag width | at most the reader's | wider |
+| a ranged scalar's bounds | inside the reader's | wider on either end |
+| an integer or float width | at most the reader's, same signedness ladder | wider, or a different kind |
+| a field's kind | the same | different |
+| field order | any | never (by name) |
+
+Widening an int or a float, or an enum's ordinal width, is a read: the reader lands it exactly. That is the
+one asymmetry the bill keeps, and it is Glenn's: "you can take an enum and widen it, but you cannot narrow."
+
+## 3. What the reader does with an older file
+
+- a field the reader added since: the reader's declared default;
+- a field the reader deprecated since: dropped, counted once under `unknown` per plan (the reader chose not
+  to need it; the count is information, not a fault);
+- a narrower int or float: widened, `COUNT widened` as today;
+- everything else: copied, the plan being the identity plan whenever the hashes agree.
+
+## 4. What the reader does with a newer file
+
+Refuse, at plan time, by name. Proposed name: **`layout_newer`**. "Loudly" means the refusal carries what
+the reader could not hold: the first offending entry, as the reader can name it (a field name, a bound pair,
+a variant hash), through the report's reason where the language has one and through the reason's text where
+it has text. No counter moves; REFUSE stays total.
+
+`layout_newer` sits beside `newer_form` (a form byte past the reader's) and the seven layout refusals of
+§1.1, which are for a layout that is not a layout. `layout_newer` is for a layout that is a layout and is
+not the reader's to read.
+
+## 5. What leaves the reference
+
+Everything that existed to read a newer file with an older struct:
+
+- the count clamp across bounds (`count` lands the writer's count; a writer's bound larger than the reader's
+  is `layout_newer`, so the clamp can never fire on a legal peer);
+- the ranged-scalar clamp across versions (same reason);
+- the remap of a variant the reader lacks to `None` (it is `layout_newer`);
+- the drop-and-count of a field the reader lacks (it is `layout_newer`; deprecated fields keep the drop).
+
+What stays, unchanged: every hostile check. A forged count past the WRITER'S OWN bound, an ordinal past the
+writer's own variant count, a tag past the writer's own arm count, a bool byte that is not 0 or 1: those
+remain the reader's straight-line validation on every build, and they still land `None` or clamp and
+`COUNT clamped`, because they are a lie about the writer's own layout, not a version.
+
+## 6. What holds it up: the baseline
+
+`tables.baseline` already refuses the edits the wire cannot see. It gains the monotone law for definitions:
+a bound or size that shrinks, a variant or arm removed (deprecate instead), a range that narrows, an int or
+float that narrows, a kind that changes. A schema that breaks the law fails at commit, so no reader ever
+meets a pair that is neither older nor newer.
+
+## 7. The deployment rule
+
+Readers first, always. A writer ships only after every reader that will meet its files has. Getting the
+order wrong is a `layout_newer` refusal at the first file, not a truncated array in production.
+
+## 8. What changes on the board (#876)
+
+- E1 (unknown field): becomes `layout_newer`; the deprecated-field drop is its own item.
+- C1/C2 (count clamp): hostile half stays (forged past the writer's own bound); the cross-version half goes.
+- C7 (ranged scalar clamp): hostile half stays; cross-version half goes.
+- C9/C10 (tag/ordinal past top): hostile only, as today.
+- Card 18 (an unknown variant counted nowhere): superseded; it refuses.
+- The seven layout refusals, W10, W6, W16, the byte pins against the reference, FU in the oracle: untouched.
+- New items: `layout_newer` asserted by name on every leg for each row of §2; the baseline's monotone law
+  with a fixture per row; the deployment rule in the doc's §5.
+
+## 9. Open, for the cold read
+
+- Whether a deprecated field on the reader should count under `unknown` at all, or be silent.
+- Whether `layout_newer` should carry the offending entry as an index into the writer's layout (portable,
+  one integer) or as text (readable, per language).
+- Whether a writer's *deprecated* field (older writer, still writing it) needs any rule: the reader is newer
+  and has the name, so it reads or drops by the reader's own deprecation; it seems to need none.

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -77,6 +77,17 @@ a bound or size that shrinks, a variant or arm removed (deprecate instead), a ra
 float that narrows, a kind that changes. A schema that breaks the law fails at commit, so no reader ever
 meets a pair that is neither older nor newer.
 
+## 6a. Versions: the hash is the version, the lock holds the law
+
+There is no version number to increment. A fixed table's layout hash is derived from its content, so any
+change to a definition that inputs into it changes the hash by itself, and "older or equal" is decided
+structurally at plan time (§2), never by comparing numbers. What `schema.lock` needs is the SHAPE: one entry
+per fixed table carrying its layout hash and the layout itself, so that `tables.baseline` can hold §6's
+monotone law against the last locked layout at commit time. The hash says which version a file is; the lock
+says the versions only ever grew. A human-readable number beside it for release notes is allowed and nothing
+on the wire reads it. (Glenn: "So you DEPLOY the backend with the new schema, and it reads old and new. But
+nobody guarantees old ever reads new.")
+
 ## 7. The deployment rule
 
 Readers first, always. A writer ships only after every reader that will meet its files has. Getting the

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -70,12 +70,29 @@ writer's own variant count, a tag past the writer's own arm count, a bool byte t
 remain the reader's straight-line validation on every build, and they still land `None` or clamp and
 `COUNT clamped`, because they are a lie about the writer's own layout, not a version.
 
-## 6. What holds it up: the baseline
+## 6. The monotone law, guaranteed by the lock
 
-`tables.baseline` already refuses the edits the wire cannot see. It gains the monotone law for definitions:
-a bound or size that shrinks, a variant or arm removed (deprecate instead), a range that narrows, an int or
-float that narrows, a kind that changes. A schema that breaks the law fails at commit, so no reader ever
-meets a pair that is neither older nor newer.
+Glenn: "how do we guarantee ONLY widening is allowed (enums can have entries added at end, no shuffling of
+entries for meaning, new entries at end...)". The lock records the last shape and the baseline refuses any
+commit that is not a widening of it. Per definition:
+
+| definition | the lock records | the baseline refuses |
+|---|---|---|
+| enum, union | the variants or arms IN ORDER, each with its name hash | insert not at the end, reorder, rename, remove; deprecate is allowed and keeps its place |
+| array bound, string or `bytes` size, a constant behind either | the number | a smaller number |
+| ranged scalar | both ends | either end moving inward |
+| int, float, ordinal or tag width | the width and signedness | narrower, or the other ladder |
+| a field's kind | the kind | a different kind |
+| a table's fields | the list | anything but append and deprecate (today's law) |
+
+The compiler refuses to generate against a lock the schema contradicts; CI runs the same check; the refusal
+names the definition and the rule. So the law holds on every machine, and no reader ever meets a pair that
+is neither older nor newer.
+
+**What appending buys on the wire.** With variants and arms append-only, the writer's ordinal IS the
+reader's ordinal: no remap table, no lookup per record; an enum lands as a `copy`, or a `widen` when its
+width grew. The plan-time check for an enum is "the writer's list is a prefix of mine", one comparison per
+enum, and the same for a union's arms. Faster than the remap by name, and nothing to get wrong.
 
 ## 6a. Versions: the hash is the version, the lock holds the law
 

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -16365,3 +16365,73 @@ a second digest.
   field's offset in the compiler's model and BOTH backends go red; that is
   §19.3's test obligation, now owed for every record in the closure and not
   only for blocks and rows.
+
+## 21. The fixed table reads backward, never forward
+
+**A fixed table's file is read by a build at least as new as the one that wrote it, and by no other.**
+A newer reader reads every older file. An older reader given a newer file refuses it by name, before any
+record, and reads nothing. There is no partial read of a fixed table: no clamp across versions, no value
+landed as `None` for want of a name, no field dropped because the reader lacked it. (Glenn, 2026-09-10:
+"Newer versions of the fixed table should be able to read OLD versions. But old versions CANNOT read new
+versions, and complain loudly and refuse. Nothing else makes sense." The bill is
+`docs/FIXED-FORM-BILL-READS-BACKWARD.md`; the algorithm is `docs/FIXED-FORM-ALGORITHM.md` §5.)
+
+### 21.1 The law: everything that inputs into a fixed table only widens
+
+A fixed table's closure is a tree of fixed things (§21.4), and every definition in it may only WIDEN over
+time. The baseline (§18) refuses any commit that narrows, naming the definition and the rule. Widening is
+defined by the default it fills: a change with no default to fill is not a widening.
+
+| definition | widens by | never |
+|---|---|---|
+| a fixed table, a `type` or `table` in its closure | a field ADDED AT THE END; a field deprecated in place | a field modified, removed, or inserted elsewhere |
+| an enum | a variant ADDED AT THE END; deprecated in place | a variant removed, reordered, inserted mid-list, or renamed without `was` |
+| a union | an arm ADDED AT THE END | an arm removed, reordered, or its payload changed |
+| `flags` | a flag ADDED | a flag removed or moved |
+| an array `[N]`, `[..N]`, a `string(N)`, `wstring(N)`, `bytes(N)`, and any constant behind them | a LARGER N | a smaller N; a shape change (`[N]` to `[..N]`, a key enum swapped); a text kind change |
+| an element type | the widening ladder, as a field | narrowed |
+| an integer or float | wider, same ladder, same signedness (`int32` to `int64`, `f32` to `f64`) | narrower, the other ladder, the other signedness |
+| a ranged scalar | a range moved OUTWARD, or REMOVED | moved inward; a range ADDED where none was |
+| `bits(N)` | a larger N | smaller |
+| `fixed(I,F)` | a larger I | F changed |
+| an optional | `T` to `?T` (old values land present) | `?T` to `T` |
+| a field's kind | — | changed |
+| a specified default | — | changed (§18: it defines what every old file means) |
+| the `fixed` keyword | — | added or removed (a different form, not a version) |
+| a reader-side limit a table declares | larger | smaller |
+| a deprecated field | stays written, in its place; may be undeprecated | leaving the layout |
+
+### 21.2 What a newer reader does with an older file
+
+A field the reader added: its declared default. A field the reader deprecated: dropped, counted once under
+`unknown` per plan. A narrower integer or float: widened exactly, `widened` counts. A shorter array or
+string: landed, the reader's slack is template zeros. An older enum: its ordinals are the reader's, the
+list being a prefix. Everything else: copied.
+
+### 21.3 What an older reader does with a newer file
+
+Refuses, by name, at load, before any record: **`layout_newer`**. No counter moves. REFUSE is total. The
+refusal carries what the reader could not hold, as its language can name it.
+
+### 21.4 The closure rule
+
+Every table or type a fixed table reaches by value is itself declared `fixed`, with its own layout and its
+own lineage. A pointer, a map, or an unbounded array in the closure is refused, so a fixed table never
+reaches itself.
+
+### 21.5 The lineage, the floor, and the plans
+
+`schema.lock` keeps each fixed table's LINEAGE: every layout it has had, in order, with its hash and its
+layout bytes. The layout hash is the version; nothing on the wire carries a number. A FLOOR per table names
+the oldest supported entry; the reader accepts the lineage from the floor to its own layout and refuses
+older ones as `layout_unsupported`. Because the accepted set is finite and known at build time, the plan
+for each supported version is compiled at build time from the lock and shipped as static data; at load the
+file's hash selects a plan, the file's layout bytes are compared to the known bytes for that hash, and a
+mismatch is `layout_malformed`. The reader never parses a layout it has not seen before.
+
+### 21.6 The deployment rule, and the lifecycle
+
+Readers ship before writers, by a margin a reader can roll back across; the floor is the delta between the
+live clients and the backend. When a table has grown past sense: create a new table, deprecate the old,
+clean out the cruft, ship the backend reading both, then the client, and when nothing live speaks the old
+table, remove it.


### PR DESCRIPTION
The bill, step 1 of THE PROCESS, for the contract Glenn set tonight in Rowan's window: a fixed table reads backward, never forward. A newer reader reads an older file; an older reader refuses a newer file by name (proposed: layout_newer), at plan time, before any record; definitions that input into a table (bounds, sizes, constants, variants, arms, ranges, widths) only grow, enforced by tables.baseline. The count clamp across bounds, the range clamp across versions, the remap to None and the drop of an unknown field leave the reference; every hostile check stays. Docs only. Wants a cold read before the algorithm doc, the oracle, the reference and the ports move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
