### PR TITLE
monotone law, lists: the baseline refuses what a fixed record cannot survive

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -14516,6 +14516,25 @@ of the map field moves no line. Its two fields are judged as any table's are,
 which is what puts a changed key kind, a moved key bound and a retyped value
 under the verdicts of §18.2.
 
+**THE `fixed` KEYWORD RIDES AT THE END OF THE TABLE LINE, as `fixed=true`**
+(§2.2), because the two forms are under two different LIST laws and the file
+has to say which one a member is under: the id-table wire finds a field by its
+id, so a removal is absorbed and a reorder moves no byte, while a FIXED record
+is walked by offset and the order IS the contract (§2.10). The monotone law of
+the fixed form reads it — a field, variant or arm removed, inserted before the
+end, reordered or renamed without `was` inside a fixed closure is a REFUSAL
+(docs/FIXED-FORM-BILL-READS-BACKWARD.md §6) — and so is the keyword itself
+moving: a fixed table that becomes variable, or a variable one that becomes
+fixed, is A DIFFERENT FORM AND NOT A VERSION, and compaction is a new table
+under a new name. A map's generated ENTRY carries no keyword: it is declared by
+nobody (§2.8), and a map makes its holder variable, so an entry is never inside
+a fixed closure. **AND IT BUMPS NO RENDERING VERSION**, by the bump rule's own
+test: the token sits at the END of a line every older file still parses, and
+the law reads it on the COMMITTED side, so a baseline written before this
+rendering carries it nowhere and judges nothing — the price being that such a
+unit is unguarded against the keyword moving until its next `--update`, which
+is what writes the fact down.
+
 **Every line in it is a WIRE fact.** The block form's layout — the
 projection's offsets, each row's size, each pitch — is not recorded and not
 judged here (§19.3): **the baseline guards what the wire cannot report, and

--- a/examples-wide/tables.baseline
+++ b/examples-wide/tables.baseline
@@ -1,7 +1,7 @@
 schema-tables-baseline 7
 package wide
 
-table Caption
+table Caption fixed=true
     field title id=0xda31296c0c1b6029 kind=33 size=7
     field line id=0xbf4ba5ad694f5907 kind=13 type=Line
     field lines id=0x5ce3f9a9f1d5001c kind=14 elem=13 type=Line array=bounded bound=3
@@ -10,14 +10,14 @@ table Caption
 table Line
     field text id=0xfa04f4ef1995407e kind=33 size=4
 
-table Stamp
+table Stamp fixed=true
     field label id=0x39f7fcec8fcb623d kind=33 size=4
     field seq id=0x823b8a195ce2133c kind=8
 
 union Body
     arm wide id=0xa633f1f655715cca kind=33 size=4
     arm narrow id=0x96569b06f223c29a kind=12 size=4
-    arm count id=0xb1e5e28e4479a274 kind=4
+    arm tally id=0xb1e5e28e4479a274 kind=4 was=count
 
 ## history
 ### 2026-09-06 (UTC) — the wstring(N) table unit: kind 33's sites (schema#522)

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -102,6 +102,21 @@ type Table struct {
 	// DOES NOT CARRY beyond `name=`: [Render] fills it on the live projection
 	// alone, where the chain refusal reads it (§18.2).
 	Was string
+
+	// Fixed is the `fixed` KEYWORD (docs/SPEC-TABLES.md §2.2), rendered as
+	// `fixed=true` at the END of the table line. It is the one fact the
+	// monotone law of the fixed form needs and the projection did not carry
+	// (docs/FIXED-FORM-BILL-READS-BACKWARD.md §2, §6): a fixed record is
+	// walked by offset, so its list law is stricter than the id-table wire's,
+	// and the file has to say which law a member is under.
+	//
+	// IT BUMPS NO RENDERING VERSION, by §18.1's own test: the token sits at
+	// the END of a line every older file still parses, and the rules below
+	// read the token on the COMMITTED side — a baseline written before this
+	// rendering carries it nowhere, so it says nothing about an untouched
+	// schema and greets it with no diagnostic. The first `--update` after
+	// this lands is what locks a unit's forms in.
+	Fixed bool
 }
 
 // A Field is one field of a closure member: its declared name, its EFFECTIVE
@@ -211,7 +226,13 @@ func Render(u *ir.Unit) *Unit {
 		// spelling, and a `was` rename moves that while moving no byte — so
 		// the entry is keyed by the holder's wire id and the field's, and a
 		// rename moves nothing in this file.
-		t := Table{Name: ir.ProjectionMemberName(u, name), Declared: name, Was: st.WasName}
+		// THE KEYWORD RIDES ON A DECLARATION. A map's generated ENTRY is
+		// declared by nobody (§2.8) — it takes the class its own body can
+		// hold — so no `fixed` token rides on its line and the monotone law
+		// of the fixed form (monotone_lists.go) does not root on it: a map
+		// makes its holder variable, so an entry is never inside a fixed
+		// closure to begin with.
+		t := Table{Name: ir.ProjectionMemberName(u, name), Declared: name, Was: st.WasName, Fixed: st.FixedDeclared && st.MapEntryOf == ""}
 		if st.MapEntryOf != "" {
 			t.Declared = t.Name
 		}
@@ -467,11 +488,17 @@ func (u *Unit) Text() string {
 	fmt.Fprintf(&b, "package %s\n", u.Package)
 
 	for _, t := range u.Tables {
+		// the TABLE LINE's tokens, in column order: the declared name of a
+		// renamed table, then the `fixed` keyword at the END (§18.1's rule
+		// for a new token, see Table.Fixed)
+		fmt.Fprintf(&b, "\ntable %s", t.Name)
 		if t.Declared != "" && t.Declared != t.Name {
-			fmt.Fprintf(&b, "\ntable %s name=%s\n", t.Name, t.Declared)
-		} else {
-			fmt.Fprintf(&b, "\ntable %s\n", t.Name)
+			fmt.Fprintf(&b, " name=%s", t.Declared)
 		}
+		if t.Fixed {
+			b.WriteString(" fixed=true")
+		}
+		b.WriteString("\n")
 		for _, f := range t.Fields {
 			fmt.Fprintf(&b, "    field %s id=0x%016x", f.Name, f.Id)
 			for _, tok := range f.Tokens {
@@ -559,9 +586,18 @@ func Parse(path string, data []byte) (*Unit, error) {
 		if !strings.HasPrefix(line, " ") {
 			// a section opener; a table line may carry `name=<declared>`, the
 			// declared name of a table renamed under `was` (§18.1)
-			declared := ""
-			if fields[0] == "table" && len(fields) == 3 && strings.HasPrefix(fields[2], "name=") {
-				declared = strings.TrimPrefix(fields[2], "name=")
+			declared, fixed := "", false
+			if fields[0] == "table" && len(fields) > 2 {
+				for _, tok := range fields[2:] {
+					switch k, val, _ := strings.Cut(tok, "="); k {
+					case "name":
+						declared = val
+					case "fixed":
+						fixed = val == "true"
+					default:
+						return nil, fmt.Errorf("%s:%d: unknown table token %q", path, i+1, tok)
+					}
+				}
 				fields = fields[:2]
 			}
 			if len(fields) != 2 {
@@ -571,7 +607,7 @@ func Parse(path string, data []byte) (*Unit, error) {
 			case "package":
 				u.Package = fields[1]
 			case "table":
-				u.Tables = append(u.Tables, Table{Name: fields[1], Declared: declared})
+				u.Tables = append(u.Tables, Table{Name: fields[1], Declared: declared, Fixed: fixed})
 			case "enum":
 				u.Enums = append(u.Enums, Enum{Name: fields[1]})
 			case "flags":

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1420,9 +1420,14 @@ func TestWasChainIsRefused(t *testing.T) {
 	if ctrl := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, right)), baseline.DefaultTokenPolicy); len(ctrl) != 0 {
 		t.Errorf("carrying the first wire name forward is the whole point of `was`; it must be silent, got:%s", summary(ctrl))
 	}
-	// the ATTRIBUTION control
-	if got := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, edited)), without("was-chain")); len(got) != 0 {
-		t.Errorf("with the \"was-chain\" rule removed the edit passes as it did before, got:%s", summary(got))
+	// the ATTRIBUTION control. The `was-chain` row is what names the chain; a
+	// second `was` aimed at the intermediate spelling also hashes a NEW id,
+	// so on a FIXED table the monotone law of the fixed form sees the locked
+	// id gone and refuses on its own (monotone_lists.go, bill §6) — which is
+	// the rule working, not this one. The control is that the CHAIN refusal
+	// is the only thing the row was holding up.
+	if got := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, edited)), without("was-chain")); find(got, baseline.Refuse, "ShipConfig.max_speed", "FIRST wire name") {
+		t.Errorf("with the \"was-chain\" rule removed the chain refusal must not fire, got:%s", summary(got))
 	}
 }
 

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -208,6 +208,7 @@ func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
 	out = append(out, d.diffEnums()...)
 	out = append(out, d.diffFlags()...)
 	out = append(out, d.diffUnions()...)
+	out = append(out, monotoneListFindings(base, live)...) // monotone law, lists (bill §6)
 	return out
 }
 

--- a/internal/baseline/monotone_lists.go
+++ b/internal/baseline/monotone_lists.go
@@ -55,17 +55,34 @@ func monotoneLists(old, new *Unit) []string {
 	out = append(out, monotoneForm(old, new)...)
 
 	oldTables, newTables := byName(old.Tables), byName(new.Tables)
+	// ONE LINE PER BREAK, not one per fixed table that reaches it. A `type`,
+	// an enum or a union is commonly in the closure of several fixed tables —
+	// a unit of twenty of them is ordinary (tables/vocab9) — and one edit
+	// inside it is ONE edit to fix: the output is bounded by the number of
+	// definitions that moved, never by the size of the unit. The root named in
+	// the line is the first fixed table, in sorted order, that reaches it.
+	seen := map[string]bool{}
+	add := func(lines []string) {
+		for _, line := range lines {
+			_, rule, _ := strings.Cut(line, ": ")
+			if seen[rule] {
+				continue
+			}
+			seen[rule] = true
+			out = append(out, line)
+		}
+	}
 	for _, root := range fixedRoots(new) {
 		// the definitions this fixed table inputs into, by the SAME walk the
 		// compiler's closure uses: by value, through types, arms and keys
 		for _, def := range closureOf(new, root) {
 			switch {
 			case def.enum != "":
-				out = append(out, monotoneEnum(root, def.enum, findEnum(old, def.enum), findEnum(new, def.enum))...)
+				add(monotoneEnum(root, def.enum, findEnum(old, def.enum), findEnum(new, def.enum)))
 			case def.union != "":
-				out = append(out, monotoneUnion(root, def.union, findUnion(old, def.union), findUnion(new, def.union))...)
+				add(monotoneUnion(root, def.union, findUnion(old, def.union), findUnion(new, def.union)))
 			default:
-				out = append(out, monotoneFields(root, def.table, oldTables[def.table], newTables[def.table])...)
+				add(monotoneFields(root, def.table, oldTables[def.table], newTables[def.table]))
 			}
 		}
 	}

--- a/internal/baseline/monotone_lists.go
+++ b/internal/baseline/monotone_lists.go
@@ -1,0 +1,389 @@
+// THE MONOTONE LAW, LISTS (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6): every
+// LIST that inputs into a `fixed table` only ever GROWS AT THE END, and the
+// baseline refuses any commit that is not a widening of the list it holds.
+//
+// The owner's words are the law, and each one is a rule below:
+//
+//	"types or tables referenced in a fixed table can only have new fields
+//	 added at end, not existing entries modified or removed (they can be
+//	 deprecated sure)"
+//	"enums can have entries added at end, no shuffling of entries for meaning,
+//	 new entries at end"
+//	"Flags can only ever have new flags added. Old flags cannot be removed"
+//	"fixed tables must only allow other fixed tables to be included in them,
+//	 and not recursively include themselves"
+//	— Glenn Fiedler, 2026-09-10
+//
+// WHY THE BASELINE IS STRICTER HERE THAN ANYWHERE ELSE IN THIS PACKAGE. The
+// id-table wire finds a field by its id, so on a VARIABLE table a removal is
+// absorbed and a reorder moves no byte — this package warns about those and
+// does not refuse them (§18.2). A FIXED record has no ids in it at all: it is
+// walked by OFFSET, so the ORDER is the contract (docs/SPEC-TABLES.md §2.10),
+// an enum's PLACE is stored rather than its name, and a reader holding an
+// older record reads one field as another with nothing to report. Those are
+// refusals, and the law applies to the FIXED CLOSURE only: a unit with no
+// fixed table keeps the rules it had.
+//
+// WHAT IS NOT HERE. The NUMBERS half of §6 — a bound, a size, a width, a
+// range, a `frac` — is `monotoneNumbers`, in its own file beside this one.
+// `flags` is also not here: bit i is variant i on every wire, so this
+// package's `flags-position` row ALREADY refuses a flag removed, inserted or
+// moved for fixed and variable alike, and the fixed closure adds nothing to
+// it; monotone_lists_test.go holds that rule to Glenn's sentence where it
+// lives rather than refusing it twice.
+package baseline
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// the two citations every refusal here carries: the bill, and the section of
+// the spec that says what a fixed record is walked by.
+const monotoneCite = "docs/FIXED-FORM-BILL-READS-BACKWARD.md §6, docs/SPEC-TABLES.md §2.10"
+
+// monotoneLists judges the LIST monotonicity of every definition in the fixed
+// closure. It returns one line per refusal, each reading
+//
+//	fixed <Table>: <definition>: <rule>
+//
+// — the fixed table the definition inputs into, the definition that moved, and
+// the rule it broke with the remedy. An empty result is the pass.
+func monotoneLists(old, new *Unit) []string {
+	var out []string
+	out = append(out, monotoneForm(old, new)...)
+
+	oldTables, newTables := byName(old.Tables), byName(new.Tables)
+	for _, root := range fixedRoots(new) {
+		// the definitions this fixed table inputs into, by the SAME walk the
+		// compiler's closure uses: by value, through types, arms and keys
+		for _, def := range closureOf(new, root) {
+			switch {
+			case def.enum != "":
+				out = append(out, monotoneEnum(root, def.enum, findEnum(old, def.enum), findEnum(new, def.enum))...)
+			case def.union != "":
+				out = append(out, monotoneUnion(root, def.union, findUnion(old, def.union), findUnion(new, def.union))...)
+			default:
+				out = append(out, monotoneFields(root, def.table, oldTables[def.table], newTables[def.table])...)
+			}
+		}
+	}
+	return out
+}
+
+// monotoneListFindings is monotoneLists as the package's own verdict type: a
+// list refusal is a Refuse, and the line's first colon splits the fixed table
+// it names from the rule.
+func monotoneListFindings(old, new *Unit) []Finding {
+	var out []Finding
+	for _, line := range monotoneLists(old, new) {
+		where, what, ok := strings.Cut(line, ": ")
+		if !ok {
+			where, what = "", line
+		}
+		out = append(out, Finding{Refuse, where, what})
+	}
+	return out
+}
+
+// ---- the `fixed` keyword itself ----
+
+// monotoneForm holds the KEYWORD: a fixed table does not become a variable one
+// and a variable one does not become fixed. The bill's own row —
+// "the `fixed` keyword | the same | a variable table where the reader has a
+// fixed one, or the reverse: A DIFFERENT FORM, NOT A VERSION" (§2) — so there
+// is no version of the one that reads the other, and compaction is a NEW table
+// under a NEW name (docs/SPEC-TABLES.md §2.10).
+//
+// It is judged only where the COMMITTED file speaks the fact: a baseline
+// written before `fixed=true` existed carries it nowhere, and reading its
+// silence as "every table was variable" would refuse every fixed table in
+// every committed baseline at once. The first `--update` locks a unit's forms
+// in; see Table.Fixed.
+func monotoneForm(old, new *Unit) []string {
+	if !formKnown(old) {
+		return nil
+	}
+	newTables := byName(new.Tables)
+	var out []string
+	for _, bt := range old.Tables {
+		lt, ok := newTables[bt.Name]
+		if !ok {
+			continue // the member's own vanished/rename walk reports that
+		}
+		switch {
+		case bt.Fixed && !lt.Fixed:
+			out = append(out, fmt.Sprintf("fixed %s: the `fixed` keyword: dropped — a fixed table's layout is a promise to every record already written, and the variable wire is A DIFFERENT FORM, NOT A VERSION of it: no reader of one reads the other; keep `fixed` and append, or make a NEW table under a NEW name (%s)", bt.Name, monotoneCite))
+		case !bt.Fixed && lt.Fixed:
+			out = append(out, fmt.Sprintf("fixed %s: the `fixed` keyword: added — every record already written rode the id-table wire, and the fixed form is A DIFFERENT FORM, NOT A VERSION of it: a reader at an offset would read an id for a value; make a NEW fixed table under a NEW name (%s)", bt.Name, monotoneCite))
+		}
+	}
+	return out
+}
+
+// formKnown reports whether the committed projection speaks the `fixed` fact at
+// all. One `fixed=true` anywhere is the evidence: a unit whose closure holds no
+// fixed table is under none of this law until its baseline is regenerated.
+func formKnown(u *Unit) bool {
+	for _, t := range u.Tables {
+		if t.Fixed {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- a table's fields ----
+
+// monotoneFields is Glenn's first sentence: "types or tables referenced in a
+// fixed table can only have new fields added at end, not existing entries
+// modified or removed (they can be deprecated sure)".
+//
+// THE SHAPE OF THE CHECK IS THE PREFIX WALK (§6): the committed list must be a
+// PREFIX of the declared one, entry by entry, and the declaration's tail is
+// the append. The FIRST differing entry is the one reported — the one a person
+// can fix — and a list of every consequence of one reorder teaches nothing it
+// did not.
+//
+// A field DEPRECATED IN PLACE keeps its entry and every wire fact it had
+// (docs/SPEC-TABLES.md §2.10), so it is a prefix of itself and passes here,
+// which is the whole of "they can be deprecated sure".
+func monotoneFields(root, name string, old, new *Table) []string {
+	if old == nil || new == nil {
+		return nil
+	}
+	var out []string
+	for i, bf := range old.Fields {
+		switch {
+		case i >= len(new.Fields):
+			// REMOVED FROM THE END: the declaration stops before an entry the
+			// baseline holds.
+			out = append(out, monotoneLine(root, fieldWhere(name, bf.Name),
+				fmt.Sprintf("entry %d, id=0x%016x, is in the baseline and gone from the declaration — a fixed table evolves APPEND-ONLY: a field is DEPRECATED IN PLACE, never removed, because the record has no ids in it and every field after a removed one slides", i+1, bf.Id),
+				"restore it and mark it `| deprecated`"))
+		case new.Fields[i].Id != bf.Id:
+			// INSERTED NOT AT THE END, REORDERED, RENAMED WITHOUT `was` (the
+			// id is the hash of the wire name, §5), or REMOVED FROM THE
+			// MIDDLE — which lands here rightly: the entry the baseline names
+			// now holds the field that FOLLOWED it, which is exactly what a
+			// reader at that offset would find (docs/SPEC-TABLES.md §2.10).
+			out = append(out, monotoneLine(root, fieldWhere(name, bf.Name),
+				fmt.Sprintf("entry %d is %s in the declaration — a fixed table evolves APPEND-ONLY: a new field goes at the BOTTOM, never inserted, moved or removed, because the record has no ids in it and a reader at this offset would read one field as the other", i+1, entryName(new.Fields, i)),
+				"put the new field at the END of the table"))
+		default:
+			out = append(out, monotoneFieldKind(root, name, bf, new.Fields[i], i)...)
+		}
+	}
+	return out
+}
+
+// monotoneFieldKind is the one MODIFY case this file holds: the field's KIND.
+// Every other modifiable fact a field has — a width, a bound, a size, a range,
+// a `frac` — is the numbers half of §6 and lives in monotoneNumbers; the kind
+// is here because it is the one that makes the prefix walk of the LIST a lie:
+// the entry is in its place and is not the thing it was.
+func monotoneFieldKind(root, name string, bf, lf Field, i int) []string {
+	was, hadKind := bf.Get("kind")
+	now, hasKind := lf.Get("kind")
+	if !hadKind || !hasKind || was == now {
+		return nil
+	}
+	return []string{monotoneLine(root, fieldWhere(name, lf.Name),
+		fmt.Sprintf("entry %d is kind %s in the baseline and kind %s in the declaration — a field already in a fixed table's closure keeps its type: every record already written holds the old one, and a fixed record carries nothing that says which", i+1, was, now),
+		"deprecate this field and append a new one")}
+}
+
+// ---- an enum's variants, and a union's arms ----
+
+// monotoneEnum is Glenn's second sentence: "enums can have entries added at
+// end, no shuffling of entries for meaning, new entries at end".
+//
+// A fixed record stores the PLACE and not the name (docs/SPEC-TABLES.md
+// §2.10), so the prefix walk of a table's fields is the prefix walk of a
+// variant list, one citation over. A RENAME is a moved entry here: a variant
+// rides under the hash of its wire name, so renaming it without `was` puts a
+// name no stored value was ever written under at that place, and `was` keeps
+// the id and passes.
+func monotoneEnum(root, name string, old, new *Enum) []string {
+	if old == nil || new == nil {
+		return nil
+	}
+	return monotoneVariants(root, "enum "+name, "variant", variantEntries(old.Variants), variantEntries(new.Variants))
+}
+
+// monotoneUnion is the same five for a union's ARMS: an arm is a field line
+// (docs/SPEC-TABLES.md §2.6) and a union's tag is its arm's PLACE.
+func monotoneUnion(root, name string, old, new *Union) []string {
+	if old == nil || new == nil {
+		return nil
+	}
+	return monotoneVariants(root, "union "+name, "arm", armEntries(old.Arms), armEntries(new.Arms))
+}
+
+// an entry of a value list: the name on the line and the id it rides under.
+type entry struct {
+	name string
+	id   uint64
+}
+
+func variantEntries(vs []Variant) []entry {
+	out := make([]entry, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, entry{v.Name, v.Id})
+	}
+	return out
+}
+
+func armEntries(as []Field) []entry {
+	out := make([]entry, 0, len(as))
+	for _, a := range as {
+		out = append(out, entry{a.Name, a.Id})
+	}
+	return out
+}
+
+func monotoneVariants(root, where, noun string, old, new []entry) []string {
+	var out []string
+	for i, be := range old {
+		switch {
+		case i >= len(new):
+			out = append(out, monotoneLine(root, where,
+				fmt.Sprintf("%s %d, %s, is in the baseline and gone from the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: every entry keeps its place forever, because a fixed record stores the PLACE and not the name", noun, i+1, be.name),
+				"restore it, and add the new one at the END"))
+		case new[i].id != be.id:
+			out = append(out, monotoneLine(root, where,
+				fmt.Sprintf("%s %d, %s, is %s in the declaration — an enum, a flags mask or a union a fixed table reaches evolves APPEND-ONLY: a new entry goes at the END, and one already in the baseline is never inserted, moved or renamed, because a fixed record stores the PLACE and a reader would read one value as the other", noun, i+1, be.name, entryAt(new, i)),
+				"restore it, and add the new one at the END"))
+		}
+	}
+	return out
+}
+
+// ---- the lines, and the closure walk ----
+
+// monotoneLine is the one shape every refusal here takes:
+// "fixed <Table>: <definition>: <rule>; <remedy> (<citation>)".
+func monotoneLine(root, where, rule, remedy string) string {
+	return fmt.Sprintf("fixed %s: %s: %s; %s (%s)", root, where, rule, remedy, monotoneCite)
+}
+
+func fieldWhere(table, field string) string { return table + "." + field }
+
+func entryName(fs []Field, i int) string {
+	if i >= len(fs) {
+		return "nothing — the declaration ends before it"
+	}
+	return fmt.Sprintf("field %s (id=0x%016x)", fs[i].Name, fs[i].Id)
+}
+
+func entryAt(es []entry, i int) string {
+	if i >= len(es) {
+		return "nothing — the declaration ends before it"
+	}
+	return es[i].name
+}
+
+// a member of a fixed table's closure: exactly one of the three is set.
+type closureDef struct {
+	table string
+	enum  string
+	union string
+}
+
+// fixedRoots is every table of the projection declared `fixed`, sorted, so the
+// refusals do not shuffle run to run.
+func fixedRoots(u *Unit) []string {
+	var out []string
+	for _, t := range u.Tables {
+		if t.Fixed {
+			out = append(out, t.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// closureOf walks one fixed table's BY-VALUE closure over the PROJECTION —
+// every table, enum and union it reaches through a field's referent, an arm's
+// payload and a keyed array's key enum. The fixed form admits nothing else: a
+// pointer, a map and an unbounded array are refused in a fixed closure by the
+// compiler (internal/check/check_fixed.go), which is also why this walk cannot
+// meet the same table twice by value and needs no depth limit beyond the seen
+// set. The root itself is the first member.
+//
+// `flags` is deliberately not collected: the `flags-position` rule already
+// refuses a moved or removed bit for every table (see this file's header).
+func closureOf(u *Unit, root string) []closureDef {
+	tables := byName(u.Tables)
+	seen := map[string]bool{}
+	var out []closureDef
+	var walkTable func(name string)
+	var walkFields func(fs []Field)
+	var walkUnion func(name string)
+
+	refs := func(f Field) {
+		for _, tok := range f.Tokens {
+			switch tok.Key {
+			case "type", "payload":
+				// a BLOB's `type=` names the blob's shape, not a member, and a
+				// blob cannot be in a fixed closure at all (§2.5)
+				if tok.Value != "string" && tok.Value != "bytes" {
+					walkTable(tok.Value)
+				}
+			case "enum", "key":
+				if !seen["enum "+tok.Value] {
+					seen["enum "+tok.Value] = true
+					out = append(out, closureDef{enum: tok.Value})
+				}
+			case "union":
+				walkUnion(tok.Value)
+			}
+		}
+	}
+	walkFields = func(fs []Field) {
+		for _, f := range fs {
+			refs(f)
+		}
+	}
+	walkTable = func(name string) {
+		if seen["table "+name] {
+			return
+		}
+		seen["table "+name] = true
+		out = append(out, closureDef{table: name})
+		if t, ok := tables[name]; ok {
+			walkFields(t.Fields)
+		}
+	}
+	walkUnion = func(name string) {
+		if seen["union "+name] {
+			return
+		}
+		seen["union "+name] = true
+		out = append(out, closureDef{union: name})
+		if un := findUnion(u, name); un != nil {
+			walkFields(un.Arms)
+		}
+	}
+
+	walkTable(root)
+	return out
+}
+
+func byName(ts []Table) map[string]*Table {
+	out := make(map[string]*Table, len(ts))
+	for i := range ts {
+		out[ts[i].Name] = &ts[i]
+	}
+	return out
+}
+
+func findEnum(u *Unit, name string) *Enum {
+	for i := range u.Enums {
+		if u.Enums[i].Name == name {
+			return &u.Enums[i]
+		}
+	}
+	return nil
+}

--- a/internal/baseline/monotone_lists_test.go
+++ b/internal/baseline/monotone_lists_test.go
@@ -1,0 +1,369 @@
+// THE MONOTONE LAW, LISTS (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6), one
+// test per forbidden change and one per change the law allows. THE TEST NAMES
+// ARE THE OWNER'S WORDS, verbatim, because the words are the law:
+//
+//	"types or tables referenced in a fixed table can only have new fields
+//	 added at end, not existing entries modified or removed (they can be
+//	 deprecated sure)"
+//	"enums can have entries added at end, no shuffling of entries for meaning,
+//	 new entries at end"
+//	"Flags can only ever have new flags added. Old flags cannot be removed"
+//	"fixed tables must only allow other fixed tables to be included in them,
+//	 and not recursively include themselves"
+//	— Glenn Fiedler, 2026-09-10
+//
+// Every refusal is asserted two ways: that it FIRES, and that it NAMES the
+// definition and the rule — a refusal nobody can act on is a refusal that
+// teaches nothing (docs/SPEC-TABLES.md §18.2).
+package baseline_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/baseline"
+)
+
+// the fixture: one FIXED table whose closure holds a nested `type`, an enum, a
+// flags mask and a union, and one VARIABLE table beside it, so every case can
+// be spelled on the fixed half where it is refused.
+const monotoneSrc = `package monotone
+
+enum Hull { Interceptor, Gunship, Freighter }
+
+flags Perks { Shielded, Cloaked }
+
+type Vec
+{
+    x float32
+    y float32
+    z float32
+}
+
+type Buff
+{
+    multiplier float32 = 1.0
+}
+
+type Debuff
+{
+    penalty float32 = 1.0
+}
+
+type Boost
+{
+    amount float32 = 1.0
+}
+
+union Effect
+{
+    buff   Buff
+    debuff Debuff
+}
+
+fixed table Vessel
+{
+    hull   Hull = Gunship
+    perks  Perks
+    effect Effect
+    offset Vec
+    speed  float32 = 1.0
+}
+
+table Fleet
+{
+    ships []Vessel
+}
+`
+
+// monotone judges one edit of the fixture under the shipping policy.
+func monotone(t *testing.T, old, new string) []baseline.Finding {
+	t.Helper()
+	return baseline.Diff(committed(t, old), baseline.Render(unit(t, new)), baseline.DefaultTokenPolicy)
+}
+
+// refuses asserts the refusal fires and names both the definition and the rule.
+func refuses(t *testing.T, fs []baseline.Finding, where, rule string) {
+	t.Helper()
+	if !find(fs, baseline.Refuse, where, rule) {
+		t.Errorf("the baseline must refuse, naming %s and %q, got:%s", where, rule, summary(fs))
+	}
+	for _, f := range fs {
+		if f.Verdict == baseline.Refuse && strings.Contains(f.Where, where) && !strings.Contains(f.What, "FIXED-FORM-BILL") {
+			continue
+		}
+	}
+}
+
+// allows asserts the edit draws no refusal at all. A WARNING is left alone:
+// the variable-table rules are unchanged by this law, and they are what warn.
+func allows(t *testing.T, fs []baseline.Finding) {
+	t.Helper()
+	if refusals, _ := baseline.Split(fs); len(refusals) != 0 {
+		t.Errorf("the law allows this edit and the baseline refused it:%s", summary(fs))
+	}
+}
+
+// ---- "not existing entries modified or removed (they can be deprecated sure)" ----
+
+// TestAFieldRemovedFromAFixedTablesClosureIsRefused: a fixed record is walked
+// by OFFSET, so every field after a removed one slides and a reader holding an
+// older record reads one field as the next.
+func TestAFieldRemovedFromAFixedTablesClosureIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    y float32\n    z float32\n", "    y float32\n")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "gone from the declaration")
+	refuses(t, fs, "fixed Vessel", "DEPRECATED IN PLACE, never removed")
+	if !find(fs, baseline.Refuse, "fixed Vessel", "Vec.z") {
+		t.Errorf("the refusal must name the field that is gone:%s", summary(fs))
+	}
+	// the field removed from the FIXED TABLE itself, not only from a `type`
+	// it reaches
+	dropped := editOf(t, monotoneSrc, "    offset Vec\n    speed  float32 = 1.0\n", "    offset Vec\n")
+	refuses(t, monotone(t, monotoneSrc, dropped), "fixed Vessel", "Vessel.speed")
+}
+
+// TestAFieldInsertedNotAtTheEndIsRefused: "a field is added at the BOTTOM, and
+// nowhere else."
+func TestAFieldInsertedNotAtTheEndIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    x float32\n    y float32", "    x float32\n    w float32\n    y float32")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "entry 2 is field w")
+	refuses(t, fs, "fixed Vessel", "never inserted, moved or removed")
+}
+
+// TestFieldsReorderedAreRefused: the ORDER is the contract, and a swap moves
+// no byte in the file while moving every value in the record.
+func TestFieldsReorderedAreRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    x float32\n    y float32", "    y float32\n    x float32")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "Vec.x")
+	refuses(t, fs, "fixed Vessel", "a reader at this offset would read one field as the other")
+}
+
+// TestAFieldsKindModifiedIsRefused is the one representative MODIFY case this
+// file holds — the field's KIND. A width, a bound, a size, a range and a
+// `frac` are the numbers half of §6 and live next door.
+func TestAFieldsKindModifiedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    x float32\n", "    x int32\n")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "Vec.x")
+	refuses(t, fs, "fixed Vessel", "keeps its type")
+}
+
+// TestAFieldDeprecatedInPlaceIsAllowed is "they can be deprecated sure": the
+// slot stays exactly where it is, every wire fact on it is unchanged, and the
+// marker is a statement about MEANING (docs/SPEC-TABLES.md §2.10).
+func TestAFieldDeprecatedInPlaceIsAllowed(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    z float32\n", "    z float32 | deprecated\n")
+	allows(t, monotone(t, monotoneSrc, edited))
+}
+
+// TestAFieldAppendedAtTheEndIsAllowed is the owner's own example, both
+// directions: "vec {x,y,z}" to "vec {x,y,z,w}" passes, and to "vec {x,y}"
+// refuses.
+func TestAFieldAppendedAtTheEndIsAllowed(t *testing.T) {
+	grown := editOf(t, monotoneSrc, "    z float32\n", "    z float32\n    w float32\n")
+	allows(t, monotone(t, monotoneSrc, grown))
+	narrowed := editOf(t, monotoneSrc, "    y float32\n    z float32\n", "    y float32\n")
+	if refusals, _ := baseline.Split(monotone(t, monotoneSrc, narrowed)); len(refusals) == 0 {
+		t.Errorf("vec {x,y,z} narrowed to vec {x,y} must refuse")
+	}
+	// and the same append on the FIXED TABLE's own bottom
+	appended := editOf(t, monotoneSrc, "    speed  float32 = 1.0\n", "    speed  float32 = 1.0\n    armor  int32 = 0\n")
+	allows(t, monotone(t, monotoneSrc, appended))
+}
+
+// ---- "enums can have entries added at end, no shuffling of entries for meaning" ----
+
+// TestAnEnumVariantRemovedIsRefused: a fixed record stores the PLACE, not the
+// name, so a dropped variant is every later variant's place moving.
+func TestAnEnumVariantRemovedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Interceptor, Gunship }")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "enum Hull")
+	refuses(t, fs, "fixed Vessel", "variant 3, Freighter, is in the baseline and gone")
+}
+
+// TestAnEnumVariantInsertedMidListIsRefused: "new entries at end."
+func TestAnEnumVariantInsertedMidListIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Interceptor, Scout, Gunship, Freighter }")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "variant 2, Gunship, is Scout in the declaration")
+	refuses(t, fs, "fixed Vessel", "a new entry goes at the END")
+}
+
+// TestEnumVariantsReorderedAreRefused: "no shuffling of entries for meaning."
+func TestEnumVariantsReorderedAreRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Gunship, Interceptor, Freighter }")
+	refuses(t, monotone(t, monotoneSrc, edited), "fixed Vessel", "variant 1, Interceptor, is Gunship in the declaration")
+}
+
+// TestAnEnumVariantRenamedWithoutWasIsRefused: a variant rides under the hash
+// of its wire name, so a rename with no `was` puts a name no stored value was
+// ever written under at that place.
+func TestAnEnumVariantRenamedWithoutWasIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Interceptor, Gunship, Hauler }")
+	refuses(t, monotone(t, monotoneSrc, edited), "fixed Vessel", "variant 3, Freighter, is Hauler in the declaration")
+}
+
+// TestAnEnumVariantAppendedIsAllowed, and the note the other half of Glenn's
+// sentence needs: THIS LANGUAGE HAS NO PER-VARIANT DEPRECATION MARKER —
+// `| deprecated` is a FIELD tag (docs/SPEC-TABLES.md §2.10) — so the allowed
+// edits to an enum in a fixed closure are exactly one: append at the end.
+func TestAnEnumVariantAppendedIsAllowed(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Interceptor, Gunship, Freighter, Hauler }")
+	allows(t, monotone(t, monotoneSrc, edited))
+}
+
+// ---- a union's arms: the same five ----
+
+func TestAUnionArmRemovedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "union Effect")
+	refuses(t, fs, "fixed Vessel", "arm 2, debuff, is in the baseline and gone")
+}
+
+func TestAUnionArmInsertedNotAtTheEndIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n    boost  Boost\n    debuff Debuff\n")
+	refuses(t, monotone(t, monotoneSrc, edited), "fixed Vessel", "arm 2, debuff, is boost in the declaration")
+}
+
+func TestUnionArmsReorderedAreRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    buff   Buff\n    debuff Debuff\n", "    debuff Debuff\n    buff   Buff\n")
+	refuses(t, monotone(t, monotoneSrc, edited), "fixed Vessel", "arm 1, buff, is debuff in the declaration")
+}
+
+func TestAUnionArmRenamedWithoutWasIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    debuff Debuff\n", "    curse  Debuff\n")
+	refuses(t, monotone(t, monotoneSrc, edited), "fixed Vessel", "arm 2, debuff, is curse in the declaration")
+}
+
+func TestAUnionArmAppendedIsAllowed(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "    debuff Debuff\n", "    debuff Debuff\n    boost  Boost\n")
+	allows(t, monotone(t, monotoneSrc, edited))
+}
+
+// ---- "Flags can only ever have new flags added. Old flags cannot be removed" ----
+
+// TestAFlagRemovedIsRefused and TestAFlagMovedIsRefused hold Glenn's sentence
+// where the law already lives: bit i is variant i on EVERY wire, so this
+// package's `flags-position` rule refuses a removed or moved bit for a fixed
+// and a variable table alike (docs/SPEC-TABLES.md §18.2), and the monotone law
+// of the fixed form adds nothing to it rather than refusing it twice.
+func TestAFlagRemovedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "flags Perks { Shielded, Cloaked }", "flags Perks { Shielded }")
+	fs := monotone(t, monotoneSrc, edited)
+	if !find(fs, baseline.Refuse, "flags Perks", "variant Cloaked removed from bit 1") {
+		t.Errorf("an old flag removed must be refused:%s", summary(fs))
+	}
+	if !find(fs, baseline.Refuse, "flags Perks", "a spent bit stays spent") {
+		t.Errorf("the refusal must name the rule:%s", summary(fs))
+	}
+}
+
+func TestAFlagMovedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "flags Perks { Shielded, Cloaked }", "flags Perks { Cloaked, Shielded }")
+	fs := monotone(t, monotoneSrc, edited)
+	if !find(fs, baseline.Refuse, "flags Perks", "moved from bit") {
+		t.Errorf("a flag moved must be refused:%s", summary(fs))
+	}
+}
+
+func TestAFlagAppendedIsAllowed(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "flags Perks { Shielded, Cloaked }", "flags Perks { Shielded, Cloaked, Stealthed }")
+	allows(t, monotone(t, monotoneSrc, edited))
+}
+
+// ---- the `fixed` keyword: a different FORM, not a version ----
+
+// TestTheFixedKeywordDroppedIsRefused: a fixed table's layout is a promise to
+// every record already written, and the variable wire is not a later version
+// of it — no reader of one reads the other (bill §2).
+func TestTheFixedKeywordDroppedIsRefused(t *testing.T) {
+	edited := editOf(t, monotoneSrc, "fixed table Vessel", "table Vessel")
+	fs := monotone(t, monotoneSrc, edited)
+	refuses(t, fs, "fixed Vessel", "the `fixed` keyword: dropped")
+	refuses(t, fs, "fixed Vessel", "A DIFFERENT FORM, NOT A VERSION")
+}
+
+// TestTheFixedKeywordAddedToALockedVariableTableIsRefused is the other
+// direction: every record already written rode the id-table wire, and a reader
+// at an offset would read an id for a value.
+func TestTheFixedKeywordAddedToALockedVariableTableIsRefused(t *testing.T) {
+	// Fleet holds an unbounded array, which cannot be fixed at all; the
+	// variable table this case needs is one whose body a fixed table could
+	// hold, so the baseline's refusal is about the KEYWORD and nothing else.
+	src := editOf(t, monotoneSrc, "table Fleet\n{\n    ships []Vessel\n}", "table Fleet\n{\n    ships [..4]Vessel\n}")
+	edited := editOf(t, src, "table Fleet", "fixed table Fleet")
+	fs := monotone(t, src, edited)
+	refuses(t, fs, "fixed Fleet", "the `fixed` keyword: added")
+	refuses(t, fs, "fixed Fleet", "A DIFFERENT FORM, NOT A VERSION")
+}
+
+// TestTheProjectionRecordsTheFixedKeyword is the format addition itself: the
+// token rides at the END of the table line, so every baseline written before
+// it still parses and an untouched unit regenerates with one token added and
+// no rendering version moved (docs/SPEC-TABLES.md §18.1).
+func TestTheProjectionRecordsTheFixedKeyword(t *testing.T) {
+	text := baseline.Render(unit(t, monotoneSrc)).Text()
+	if !strings.Contains(text, "table Vessel fixed=true\n") {
+		t.Errorf("the fixed table's line must carry fixed=true:\n%s", text)
+	}
+	if !strings.Contains(text, "table Fleet\n") {
+		t.Errorf("a variable table's line carries no fixed token:\n%s", text)
+	}
+	// a baseline written before the token existed still parses, and says
+	// nothing about a unit that has not moved
+	older := strings.ReplaceAll(text, " fixed=true", "")
+	parsed, err := baseline.Parse("tables.baseline", []byte(older))
+	if err != nil {
+		t.Fatalf("a baseline written before the token must still parse: %v", err)
+	}
+	if fs := baseline.Diff(parsed, baseline.Render(unit(t, monotoneSrc)), baseline.DefaultTokenPolicy); len(fs) != 0 {
+		t.Errorf("a baseline from before the token must greet an untouched schema in silence:%s", summary(fs))
+	}
+	// and the token round-trips
+	back, err := baseline.Parse("tables.baseline", []byte(text))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.Text() != text {
+		t.Errorf("the table line does not round-trip:\n--- got ---\n%s\n--- want ---\n%s", back.Text(), text)
+	}
+}
+
+// TestAVariableOnlyUnitKeepsItsOwnRules is the law's SCOPE (the bill's §6 is
+// the fixed form's): the same edits on a unit with no fixed table in it are
+// judged exactly as they were — the id-table wire finds a field by its id, so
+// a removal is absorbed and a reorder moves no byte.
+func TestAVariableOnlyUnitKeepsItsOwnRules(t *testing.T) {
+	const variableSrc = `package variableonly
+
+type Vec
+{
+    x float32
+    y float32
+    z float32
+}
+
+table Fleet
+{
+    offset Vec
+    speed  float32 = 1.0
+}
+`
+	for _, tc := range []struct{ name, old, new string }{
+		{"a field removed", "    y float32\n    z float32\n", "    y float32\n"},
+		{"fields reordered", "    x float32\n    y float32", "    y float32\n    x float32"},
+		{"a field inserted", "    x float32\n    y float32", "    x float32\n    w float32\n    y float32"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			edited := editOf(t, variableSrc, tc.old, tc.new)
+			if refusals, _ := baseline.Split(monotone(t, variableSrc, edited)); len(refusals) != 0 {
+				t.Errorf("a variable-only unit keeps the rules it had:%s", summary(monotone(t, variableSrc, edited)))
+			}
+		})
+	}
+}

--- a/internal/baseline/monotone_lists_test.go
+++ b/internal/baseline/monotone_lists_test.go
@@ -367,3 +367,50 @@ table Fleet
 		})
 	}
 }
+
+// TestOneLinePerBreakNotOnePerFixedTable is the output's BOUND. A `type`, an
+// enum or a union is commonly in the closure of many fixed tables — twenty of
+// them in one unit is ordinary — and one edit inside it is ONE edit to fix. The
+// count of refusals is the count of definitions that moved, never the size of
+// the unit.
+func TestOneLinePerBreakNotOnePerFixedTable(t *testing.T) {
+	const sharedSrc = `package shared
+
+enum Hull { Interceptor, Gunship, Freighter }
+
+type Vec
+{
+    x float32
+    y float32
+    z float32
+}
+
+fixed table One
+{
+    offset Vec
+    hull   Hull = Gunship
+}
+
+fixed table Two
+{
+    offset Vec
+    hull   Hull = Gunship
+}
+
+fixed table Three
+{
+    offset Vec
+    hull   Hull = Gunship
+}
+`
+	edited := editOf(t, sharedSrc, "    y float32\n    z float32\n", "    y float32\n")
+	refusals, _ := baseline.Split(monotone(t, sharedSrc, edited))
+	if len(refusals) != 1 {
+		t.Errorf("one field removed from a shared `type` is one refusal, got %d:%s", len(refusals), summary(refusals))
+	}
+	both := editOf(t, edited, "enum Hull { Interceptor, Gunship, Freighter }", "enum Hull { Interceptor, Gunship }")
+	refusals, _ = baseline.Split(monotone(t, sharedSrc, both))
+	if len(refusals) != 2 {
+		t.Errorf("two definitions moved is two refusals, got %d:%s", len(refusals), summary(refusals))
+	}
+}

--- a/internal/baseline/monotone_lists_test.go
+++ b/internal/baseline/monotone_lists_test.go
@@ -88,10 +88,10 @@ func refuses(t *testing.T, fs []baseline.Finding, where, rule string) {
 	if !find(fs, baseline.Refuse, where, rule) {
 		t.Errorf("the baseline must refuse, naming %s and %q, got:%s", where, rule, summary(fs))
 	}
-	for _, f := range fs {
-		if f.Verdict == baseline.Refuse && strings.Contains(f.Where, where) && !strings.Contains(f.What, "FIXED-FORM-BILL") {
-			continue
-		}
+	// AND IT CITES THE LAW. A refusal a person cannot look up is a refusal
+	// that teaches nothing, so every line this file asserts carries the bill.
+	if !find(fs, baseline.Refuse, where, "FIXED-FORM-BILL-READS-BACKWARD.md") && !find(fs, baseline.Refuse, where, "SPEC-TABLES.md") {
+		t.Errorf("the refusal cites no law:%s", summary(fs))
 	}
 }
 

--- a/internal/baseline/was_test.go
+++ b/internal/baseline/was_test.go
@@ -65,7 +65,7 @@ func TestTableRenamedUnderWasMovesNothing(t *testing.T) {
 	// the file keeps the wire name on every line, and records the declared
 	// name beside it so a later rename can be told which spelling is right
 	text := live.Text()
-	for _, want := range []string{"table Vessel name=Ship\n", "type=Vessel", "table Fleet\n"} {
+	for _, want := range []string{"table Vessel name=Ship fixed=true\n", "type=Vessel", "table Fleet\n"} {
 		if !strings.Contains(text, want) {
 			t.Errorf("the rendered baseline lacks %q:\n%s", want, text)
 		}

--- a/internal/check/fixedtable_test.go
+++ b/internal/check/fixedtable_test.go
@@ -171,3 +171,48 @@ func TestTheDeclaredClassReachesTheIr(t *testing.T) {
 		t.Errorf("VariableTables is not the flag's complement: %v", v)
 	}
 }
+
+// TestAFixedTableCannotReachItself is the owner's fourth sentence, its second
+// half: "fixed tables must only allow other fixed tables to be included in
+// them, and not recursively include themselves"
+// (docs/FIXED-FORM-BILL-READS-BACKWARD.md §2a). A fixed closure is a TREE of
+// fixed things, and there are exactly two paths by which a table could reach
+// itself — BY VALUE, which is an infinite record, and THROUGH A POINTER, which
+// is what a cyclic structure actually needs. Both are refused, and the first
+// half of the sentence (every member of the closure is itself fixed) is
+// TestFixedTableClosureRefusals above, a row per construct.
+func TestAFixedTableCannotReachItself(t *testing.T) {
+	for _, tc := range []struct{ name, want, src string }{
+		{
+			name: "itself by value", want: "cycle",
+			src: "package t\nfixed table Node { again Node }\n",
+		},
+		{
+			// through a `type` the path does not even exist: a table cannot
+			// ride in a `type` at all, which is a stronger refusal than the
+			// cycle and is the reason the closure is a tree of `type`s and
+			// fixed tables rather than a graph.
+			name: "itself by value, through a type", want: "not a wire type",
+			src: "package t\ntype Wrap { node Node }\nfixed table Node { wrap Wrap }\n",
+		},
+		{
+			name: "itself through a fixed array", want: "cycle",
+			src: "package t\nfixed table Node { kids [2]Node }\n",
+		},
+		{
+			// the one spelling that is not an infinite record is the one a
+			// cyclic structure wants, and a pointer is refused in a fixed
+			// closure on its own account (§2.2) — which is WHY a fixed table
+			// cannot reach itself by any path.
+			name: "itself through a pointer", want: "is a pointer",
+			src: "package t\nfixed table Node { next *Node }\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refuse(t, tc.src)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("the refusal must say %q: %s", tc.want, got)
+			}
+		})
+	}
+}

--- a/tables/arms/tables.baseline
+++ b/tables/arms/tables.baseline
@@ -24,10 +24,10 @@ table Nest
     field outer id=0x30e6ed678f5e1bd4 kind=15 union=Outer
     field tail id=0xd94c56ef0798d723 kind=14 elem=4 array=unbounded
 
-table Node
+table Node fixed=true
     field v id=0xaf63eb4c86020609 kind=4
 
-table Only
+table Only fixed=true
     field w id=0xaf63ea4c86020456 kind=4
 
 table Rack

--- a/tables/backend/tables.baseline
+++ b/tables/backend/tables.baseline
@@ -1,22 +1,25 @@
 schema-tables-baseline 7
 package backenddemo
 
-table LoginRequest
+table Envelope fixed=true
+    field payload id=0xcfb8a9d063b5e9e5 kind=15 union=Payload
+
+table LoginRequest fixed=true
     field player_id id=0xc14ae3ff748dc438 kind=9 default=0
     field session_token id=0x26860f8b6834fa0d kind=14 elem=6 size=32
     field client_build id=0xb865d537bd0b08f9 kind=8 default=0
     field region id=0xc755a623f50a24dd kind=7 enum=Region
 
-table MatchResult
+table MatchResult fixed=true
     field match_id id=0xf336e379ba146826 kind=9 default=0
     field players id=0x98e3ac7518558b29 kind=14 elem=13 type=PlayerRow array=fixed bound=10
 
-table PlayerRow
+table PlayerRow fixed=true
     field player_id id=0xc14ae3ff748dc438 kind=9 default=0
     field score id=0xc10e63fbe7f624f5 kind=4 min=0 max=100000 default=0
     field placement id=0x98a3024830754a20 kind=6 min=1 max=10 default=1
 
-table StorePurchase
+table StorePurchase fixed=true
     field player_id id=0xc14ae3ff748dc438 kind=9 default=0
     field sku id=0x82429a195ce84d1a kind=12 size=32
     field quantity id=0xa3768bf56b809718 kind=6 min=1 max=99 default=1
@@ -34,6 +37,11 @@ enum Region
     variant EU id=0x08fb5f07b5965acf
     variant APAC id=0x0b38df8be8d23c24
     variant SA id=0x09460f07b5d5be59
+
+union Payload
+    arm login id=0x03c75db6e18f29d2 payload=LoginRequest
+    arm result id=0x9b51cd7cd76778c4 payload=MatchResult
+    arm purchase id=0x0ba8e96f5598f0c2 payload=StorePurchase
 
 ## history
 ### 2026-09-04 — first baseline: the message form's corpus (docs/SPEC-TABLES.md §3.3)

--- a/tables/block/tables.baseline
+++ b/tables/block/tables.baseline
@@ -1,13 +1,13 @@
 schema-tables-baseline 7
 package blockdemo
 
-table PaddedFrame
+table PaddedFrame fixed=true
     field marker id=0xeddcb72b15486e77 kind=6
     field stamp id=0xee7ba9ad45c64144 kind=9
     field rows id=0xa3a7061ff10a8138 kind=14 elem=13 type=PaddedRow array=bounded bound=64
     field blob id=0xc573b39bc29148ca kind=14 elem=6 size=12
 
-table PaddedRow
+table PaddedRow fixed=true
     field tag id=0x56d7ab194448a4f3 kind=6
     field value id=0x7ce4fd9430e80cea kind=11
     field flag id=0xd5f2d079088c0b17 kind=1
@@ -17,7 +17,7 @@ table PaddedRow
     field teams id=0xbaaeb048a5a8fa6d kind=16 elem=6 array=keyed bound=4 key=Team
     field counter id=0x77976c7416517c63 kind=4 optional=true
 
-table RenderCamera
+table RenderCamera fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field camera_id id=0x9f61700f084ab92e kind=8
@@ -25,7 +25,7 @@ table RenderCamera
     field target_object_id id=0x6a0c6a156952b9c2 kind=8
     field fov id=0xdcb27c18fed9e15c kind=10
 
-table RenderCosmeticProp
+table RenderCosmeticProp fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field scale id=0x6aacb9fbb71a1d91 kind=11
@@ -35,7 +35,7 @@ table RenderCosmeticProp
     field prop_type id=0xe5626f155e4c5dad kind=7 enum=PropType
     field team id=0xfa23d9ef19afc32c kind=7 enum=Team
 
-table RenderDynamicProp
+table RenderDynamicProp fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field flags id=0x17a3a1a985f75aec kind=9
@@ -44,7 +44,7 @@ table RenderDynamicProp
     field prop_type id=0xe5626f155e4c5dad kind=7 enum=PropType
     field team id=0xfa23d9ef19afc32c kind=7 enum=Team
 
-table RenderExplosion
+table RenderExplosion fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field t id=0xaf63e94c860202a3 kind=11
@@ -53,7 +53,7 @@ table RenderExplosion
     field explosion_type id=0xdc89eb9cd3393be5 kind=7 enum=ExplosionType
     field team id=0xfa23d9ef19afc32c kind=7 enum=Team
 
-table RenderFrame
+table RenderFrame fixed=true
     field version id=0xbb62c62c9808ea37 kind=9
     field cameras id=0x0f9222d2ba7aa2a7 kind=14 elem=13 type=RenderCamera array=bounded bound=1
     field ships id=0x294a5c4913e1ad44 kind=14 elem=13 type=RenderShip array=bounded bound=4096
@@ -65,7 +65,7 @@ table RenderFrame
     field lasers id=0xd982b77b3e92d16d kind=14 elem=13 type=RenderLaser array=bounded bound=32000
     field explosions id=0x876a8c1a85806a69 kind=14 elem=13 type=RenderExplosion array=bounded bound=32000
 
-table RenderLaser
+table RenderLaser fixed=true
     field start id=0xee5d97ad45ad251f kind=13 type=RenderVector3
     field finish id=0x6917a5bab91540f2 kind=13 type=RenderVector3
     field t id=0xaf63e94c860202a3 kind=11
@@ -73,7 +73,7 @@ table RenderLaser
     field laser_type id=0x96b593c242133841 kind=7 enum=LaserType
     field team id=0xfa23d9ef19afc32c kind=7 enum=Team
 
-table RenderMissile
+table RenderMissile fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field flags id=0x17a3a1a985f75aec kind=9
@@ -88,7 +88,7 @@ table RenderQuaternion
     field z id=0xaf63f74c86021a6d kind=11
     field w id=0xaf63ea4c86020456 kind=11 default=1.0
 
-table RenderShip
+table RenderShip fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field flags id=0x17a3a1a985f75aec kind=9 flags=ShipFlags
@@ -101,7 +101,7 @@ table RenderShip
     field has_target_lock id=0x1554fa45a1220171 kind=1
     field predicted_explode id=0x4d5be97ba1b9cb81 kind=1
 
-table RenderStaticProp
+table RenderStaticProp fixed=true
     field position id=0x4cbf3a26fca1d74a kind=13 type=RenderVector3
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field scale id=0x6aacb9fbb71a1d91 kind=11
@@ -110,7 +110,7 @@ table RenderStaticProp
     field prop_type id=0xe5626f155e4c5dad kind=7 enum=PropType
     field team id=0xfa23d9ef19afc32c kind=7 enum=Team
 
-table RenderTurret
+table RenderTurret fixed=true
     field rotation id=0xb51afb05cd34709f kind=13 type=RenderQuaternion
     field flags id=0x17a3a1a985f75aec kind=9
     field object_id id=0x0bdab42c07f19812 kind=8

--- a/tables/blockhome/tables.baseline
+++ b/tables/blockhome/tables.baseline
@@ -22,11 +22,11 @@ table GunnerSettings
     field reload_seconds id=0xad9b64728ea52486 kind=10
     field gunner_id id=0xbd9be53180256e02 kind=8
 
-table PartFrame
+table PartFrame fixed=true
     field version id=0xbb62c62c9808ea37 kind=9
     field parts id=0x0c519da7a1f958c5 kind=14 elem=13 type=PartRow array=bounded bound=32
 
-table PartRow
+table PartRow fixed=true
     field armor id=0xd19988b67e699194 kind=13 type=ArmorConfig
     field gunner id=0x40dbb648c0cd44aa kind=13 type=GunnerSettings
     field part_id id=0x04d6206b33415104 kind=8

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -1,7 +1,7 @@
 schema-tables-baseline 7
 package tabledemo
 
-table ArchiveConfig
+table ArchiveConfig fixed=true
     field root id=0xa354fd1ff0c467c5 kind=13 type=RootConfig
     field count id=0xb1e5e28e4479a274 kind=4 min=0 max=100 default=1
 
@@ -15,32 +15,32 @@ table Buff
 table Debuff
     field amount id=0x8113fe7ea2b16969 kind=4 min=0 max=100 default=0
 
-table GlobalSettings
+table GlobalSettings fixed=true
     field tick_rate id=0xa65f859b617deaf3 kind=8 min=1 max=240 default=60
     field difficulty id=0x467f35a74c6e4a70 kind=7 enum=Difficulty default=Normal
     field build_note id=0x14ec921cc2549d60 kind=12 size=48
     field spawn_delays id=0x09ae5613b0051271 kind=14 elem=10 array=fixed bound=3
 
-table GunnerConfig
+table GunnerConfig fixed=true
     field reaction id=0xb75aa3662201646a kind=10 default=0.2
     field tracking id=0xa6bf719a4602b0bc kind=1
 
-table GunnerSettings
+table GunnerSettings fixed=true
     field reaction id=0xb75aa3662201646a kind=10 default=0.2
     field tracking id=0xa6bf719a4602b0bc kind=1
     field callsign id=0x5bc44627b9848818 kind=12 size=24
 
-table HullConfig
+table HullConfig fixed=true
     field health id=0x7f69d4b5288ba9cf kind=10 default=100.0
     field mass id=0x1f3757a2ce7b0ab1 kind=10 default=1.0
     field turrets id=0x84f8260bc283608c kind=16 elem=13 type=TurretConfig array=keyed bound=3 key=Weapon
 
-table KeyedConfig
+table KeyedConfig fixed=true
     field teams id=0xbaaeb048a5a8fa6d kind=16 elem=13 type=TeamConfig array=keyed bound=3 key=Team
     field hulls id=0xce0ac3c25694d8ff kind=16 elem=13 type=HullConfig array=keyed bound=3 key=Hull
     field scores id=0x01986b0b27400fb2 kind=13 type=ScoreBoard
 
-table LoadoutConfig
+table LoadoutConfig fixed=true
     field grade id=0x32a89b2977c48ad4 kind=7 enum=Grade default=Silver
     field grades id=0xd90a4e7682f799c5 kind=14 elem=7 enum=Grade array=bounded bound=4
     field podium id=0xb46ff45a23d72549 kind=14 elem=7 enum=Grade array=fixed bound=3
@@ -49,7 +49,7 @@ table LoadoutConfig
     field backups id=0xde28f0f5118acc24 kind=14 elem=13 type=WeaponConfig array=fixed bound=2
     field attachments id=0xf901aa0340249a41 kind=14 elem=13 type=Attachment array=bounded bound=8
 
-table PackConfig
+table PackConfig fixed=true
     field version id=0xbb62c62c9808ea37 kind=8 default=1
     field global id=0x7fb43557b54149ce kind=13 type=GlobalSettings
     field ships id=0x294a5c4913e1ad44 kind=16 elem=13 type=ShipEntry array=keyed bound=3 key=ShipType
@@ -64,7 +64,7 @@ table Patrol
     field wander id=0xb8c758d8bd1845d4 kind=10 default=0.5
     field note id=0x3bf8fbbad1587cdd kind=12 size=8
 
-table ProfileConfig
+table ProfileConfig fixed=true
     field name id=0xc4bcadba8e631b86 kind=12 size=32
     field icon id=0xdbff4cc56c2092f0 kind=14 elem=6 size=16
     field experience id=0xab8b6d521f80b969 kind=8 default=0
@@ -79,7 +79,7 @@ table ProfileConfig
     field has_loadout id=0xa06f5e0a148e253c kind=1
     field loadout id=0x5759ce7586bbb5a3 kind=13 type=LoadoutConfig
 
-table RangedSigned
+table RangedSigned fixed=true
     field i8_span id=0x48121511bf702eb5 kind=2 min=-128 max=127
     field i8_low id=0x942bfe3168090f7d kind=2 min=-128 max=126
     field i8_high id=0xd182acd105b55dd1 kind=2 min=-127 max=127
@@ -98,7 +98,7 @@ table RangedSigned
     field i64_inside id=0xd308fcb98ece5d23 kind=5 min=-9223372036854775807 max=9223372036854775806
     field edges id=0xc70cde6b85b6197d kind=14 elem=3 array=bounded bound=4 min=-32768 max=32767
 
-table RangedUnsigned
+table RangedUnsigned fixed=true
     field u8_span id=0x0f8897557f37c021 kind=6 min=0 max=255
     field u8_low id=0x2e17553f8200a2a1 kind=6 min=0 max=254
     field u8_high id=0xa0e5c60df9301b7d kind=6 min=1 max=255 default=1
@@ -117,7 +117,7 @@ table RangedUnsigned
     field u64_inside id=0x713e12017eebcaf7 kind=9 min=1 max=18446744073709551614 default=1
     field counts id=0xc341febe5aae51e5 kind=14 elem=9 array=bounded bound=4 min=0 max=18446744073709551615
 
-table RangedWidths
+table RangedWidths fixed=true
     field b8 id=0x08a60c07b54d8dc7 kind=6
     field b16 id=0xff95701912ad97be kind=7
     field b32 id=0xff9c5c1912b39470 kind=8
@@ -125,7 +125,7 @@ table RangedWidths
     field b12 id=0xff95741912ad9e8a kind=7
     field b48 id=0xff8b681912a535a1 kind=9
 
-table RootConfig
+table RootConfig fixed=true
     field version_note id=0x8a67c9728746d394 kind=12 size=16
     field weapons id=0x41cbd901b87fabb6 kind=14 elem=13 type=WeaponConfig array=bounded bound=8
     field profiles id=0x8181e61fc0436767 kind=14 elem=13 type=ProfileConfig array=bounded bound=4
@@ -133,23 +133,23 @@ table RootConfig
 table ScoreBoard
     field per_team id=0xf10fad739a0e1660 kind=16 elem=4 array=keyed bound=3 key=Team min=0 max=100000
 
-table ShipEntry
+table ShipEntry fixed=true
     field display_name id=0x2d21d7cd66bd5a5d kind=12 size=32
     field health id=0x7f69d4b5288ba9cf kind=10 default=100.0
     field mass id=0x1f3757a2ce7b0ab1 kind=10 default=1.0
     field hardpoints id=0x95d0cce09ca82b73 kind=14 elem=4 array=bounded bound=4 min=0 max=8
     field gunner id=0x40dbb648c0cd44aa kind=13 type=GunnerSettings optional=true
 
-table TeamConfig
+table TeamConfig fixed=true
     field spawn_count id=0xceec99e2d65db674 kind=4 min=0 max=64 default=4
     field banner id=0xbca0dab1c7a00ccf kind=12 size=16
 
-table TurretConfig
+table TurretConfig fixed=true
     field damage id=0x7f6308be8ab37fc0 kind=10 default=10.0
     field cooldown id=0xdc2cbe6953343d48 kind=10 default=0.5
     field gunner id=0x40dbb648c0cd44aa kind=13 type=GunnerConfig optional=true
 
-table WeaponConfig
+table WeaponConfig fixed=true
     field damage id=0x7f6308be8ab37fc0 kind=10 default=21.0
     field speed id=0x1733055702acb1d2 kind=10 default=500.0 was=velocity
     field penetration id=0x4f31c5309e13e932 kind=4 min=0 max=10 default=1
@@ -157,7 +157,7 @@ table WeaponConfig
     field homing id=0xad6587bc602e3f59 kind=1
     field effect id=0x36c1c83b51f24394 kind=15 union=Effect
 
-table WideBlob
+table WideBlob fixed=true
     field label id=0x39f7fcec8fcb623d kind=12 size=70000
     field payload id=0xcfb8a9d063b5e9e5 kind=14 elem=6 size=70000
     field samples id=0xe3b1ca6a3b48dddc kind=14 elem=7 array=bounded bound=70000

--- a/tables/lists/tables.baseline
+++ b/tables/lists/tables.baseline
@@ -9,7 +9,7 @@ table Army
     field squads id=0x7848019b0c02a926 kind=14 elem=13 type=Squad array=unbounded
     field after id=0xbf82010f6f71eae9 kind=4
 
-table Bounded
+table Bounded fixed=true
     field items id=0x3e7884bf4f412c6f kind=14 elem=13 type=Unit array=bounded bound=8
     field tag id=0x56d7ab194448a4f3 kind=4
 
@@ -29,10 +29,10 @@ table Ints
     field values id=0x21277bcf1a4d67fb kind=14 elem=4 array=unbounded
     field after id=0xbf82010f6f71eae9 kind=4
 
-table Item
+table Item fixed=true
     field count id=0xb1e5e28e4479a274 kind=4
 
-table LogEntry
+table LogEntry fixed=true
     field tick id=0x1e7683ef2ebc7684 kind=8
 
 table Mixed
@@ -41,16 +41,16 @@ table Mixed
     field hits id=0x732dfbcc9b0cf0bb kind=14 elem=15 union=Hit array=unbounded
     field bounds id=0x52f60c4caef0b768 kind=14 elem=4 array=unbounded min=0 max=100
 
-table Photo
+table Photo fixed=true
     field width id=0xdbdacd932fd1e9bf kind=8
     field height id=0x17720bf67d347222 kind=8
 
-table Placement
+table Placement fixed=true
     field x id=0xaf63f54c86021707 kind=10
     field y id=0xaf63f44c86021554 kind=10
     field model id=0x9de543933e6e703a kind=8
 
-table Point
+table Point fixed=true
     field x id=0xaf63f54c86021707 kind=4
     field y id=0xaf63f44c86021554 kind=4
 
@@ -58,7 +58,7 @@ table Row
     field items id=0x3e7884bf4f412c6f kind=14 elem=13 type=Sample array=unbounded
     field label id=0x39f7fcec8fcb623d kind=4
 
-table Sample
+table Sample fixed=true
     field v id=0xaf63eb4c86020609 kind=4
 
 table Save
@@ -78,7 +78,7 @@ table Unbounded
     field items id=0x3e7884bf4f412c6f kind=14 elem=13 type=Unit array=unbounded
     field tag id=0x56d7ab194448a4f3 kind=4
 
-table Unit
+table Unit fixed=true
     field v id=0xaf63eb4c86020609 kind=4
 
 table ec07a2f760550a91.1c84390d304f4f42

--- a/tables/maps/tables.baseline
+++ b/tables/maps/tables.baseline
@@ -88,7 +88,7 @@ table Fleet
     field loadouts id=0x294fa1b3f0f5f070 kind=14 elem=13 array=map keykind=12 keybound=16
     field tiers id=0x6dd8dc6c5fdae3ce kind=14 elem=13 array=map keykind=3
 
-table Item
+table Item fixed=true
     field count id=0xb1e5e28e4479a274 kind=4
 
 table Pairs
@@ -103,7 +103,7 @@ table Runs
     field spans id=0x437dfc8ab2566816 kind=14 elem=13 array=map keykind=7
     field after id=0xbf82010f6f71eae9 kind=4
 
-table ShipConfig
+table ShipConfig fixed=true
     field name id=0xc4bcadba8e631b86 kind=12 size=64
     field health id=0x7f69d4b5288ba9cf kind=4
 

--- a/tables/messages/tables.baseline
+++ b/tables/messages/tables.baseline
@@ -5,18 +5,18 @@ table Cursor
     field line id=0xbf4ba5ad694f5907 kind=8
     field column id=0x5f531287628bf287 kind=8
 
-table Edit
+table Edit fixed=true
     field revision id=0xd6a4dbc46c8e8658 kind=8
     field body id=0xcd4de79bc6c93295 kind=15 union=EditBody
 
-table InsertText
+table InsertText fixed=true
     field at id=0x089c4e07b545a968 kind=13 type=Cursor
     field text id=0xfa04f4ef1995407e kind=12 size=32
     field origin id=0xb9eae4fe785a14cf kind=15 union=Origin
     field origins id=0x4437d86681113b74 kind=14 elem=15 union=Origin array=bounded bound=2
     field modes id=0x9de526933e6e3ef3 kind=14 elem=7 enum=Mode optional=true array=bounded bound=2
 
-table OpenDocument
+table OpenDocument fixed=true
     field path id=0x03c52d0debd70676 kind=12 size=64
     field mode id=0x0d3deba2c41dadb2 kind=7 enum=Mode default=Read
     field cursor id=0xf927453fbe6252ef kind=13 type=Cursor
@@ -24,36 +24,36 @@ table OpenDocument
 table Ping
     field nonce id=0x73a94c71d60dc0d8 kind=8
 
-table RemoveText
+table RemoveText fixed=true
     field span id=0x8b7dc019093cd0e1 kind=13 type=Selection
 
-table SaveDocument
+table SaveDocument fixed=true
     field path id=0x03c52d0debd70676 kind=12 size=64
     field force id=0xe75ad8afb3eeebe4 kind=1
 
-table Script
+table Script fixed=true
     field path id=0x03c52d0debd70676 kind=12 size=64
     field line id=0xbf4ba5ad694f5907 kind=8
 
-table Selection
+table Selection fixed=true
     field start id=0xee5d97ad45ad251f kind=13 type=Cursor
     field end id=0xc2f00318f053500a kind=13 type=Cursor
 
-table ToolMessage
+table ToolMessage fixed=true
     field sequence id=0xaa38aca481f528a8 kind=8
     field body id=0xcd4de79bc6c93295 kind=15 union=ToolBody
     field history id=0x33428945bbd5f2ff kind=14 elem=15 union=ToolBody array=bounded bound=2
     field trace id=0xdec59ea6c4eb9aee kind=14 elem=13 type=Script optional=true array=bounded bound=3
     field marks id=0x9077d4a4e1726e29 kind=14 elem=7 enum=Mode optional=true array=fixed bound=2
 
-table Transaction
+table Transaction fixed=true
     field reason id=0x65e8d7f3474f2639 kind=12 size=16
     field edits id=0x9478d06b697549e6 kind=14 elem=13 type=Edit array=bounded bound=3
     field pending id=0x52dea0d6eeb5083c kind=14 elem=15 union=EditBody array=fixed bound=2
     field checkpoints id=0x028afa1c4d757704 kind=14 elem=8 optional=true array=fixed bound=2
     field snapshots id=0x99dc6354a681403a kind=14 elem=13 type=Selection optional=true array=fixed bound=2
 
-table User
+table User fixed=true
     field name id=0xc4bcadba8e631b86 kind=12 size=16
 
 enum Mode

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -33,7 +33,7 @@ table Marker
     field label id=0x39f7fcec8fcb623d kind=12 size=8
     field note id=0x3bf8fbbad1587cdd kind=17 type=Tally
 
-table Meta
+table Meta fixed=true
     field build id=0x802517e298c70b03 kind=4 min=0 max=1000 default=1
     field tag id=0x56d7ab194448a4f3 kind=12 size=8
 
@@ -48,15 +48,15 @@ table Scene
     field layers id=0x4554e34a747022df kind=14 elem=13 type=Layer array=bounded bound=4
     field meta id=0x4320e9a2e32eac38 kind=13 type=Meta
 
-table Settings
+table Settings fixed=true
     field quality id=0x7a8060916400fe66 kind=4 min=0 max=4 default=2
     field label id=0x39f7fcec8fcb623d kind=12 size=16
 
-table Stamp
+table Stamp fixed=true
     field tag id=0x56d7ab194448a4f3 kind=12 size=8
     field seq id=0x823b8a195ce2133c kind=4 min=0 max=1000 default=0
 
-table Tally
+table Tally fixed=true
     field hits id=0x732dfbcc9b0cf0bb kind=4 min=0 max=10000 default=0
 
 table TreeNode

--- a/tables/scalars/tables.baseline
+++ b/tables/scalars/tables.baseline
@@ -6,7 +6,7 @@ table Pose
     field y id=0xaf63f44c86021554 kind=23 frac=16 min=-30000 max=30000
     field heading id=0xb128829190ca0f75 kind=27 frac=16 min=0 max=360
 
-table SimState
+table SimState fixed=true
     field tilt id=0x1e5088ef2e9bafc6 kind=20 frac=4 min=-8 max=7
     field angle id=0x401ab8cd06158638 kind=22 frac=16 min=-180 max=180
     field position id=0x4cbf3a26fca1d74a kind=23 frac=16 min=-30000 max=30000

--- a/tables/stream/tables.baseline
+++ b/tables/stream/tables.baseline
@@ -12,7 +12,7 @@ table Feed
     field parts id=0x0c519da7a1f958c5 kind=14 elem=17 type=Chunk array=bounded bound=4
     field pair id=0x0369250deb889a31 kind=14 elem=17 type=Chunk array=fixed bound=2
 
-table Header
+table Header fixed=true
     field name id=0xc4bcadba8e631b86 kind=12 size=16
 
 union Frame

--- a/tables/vocab/tables.baseline
+++ b/tables/vocab/tables.baseline
@@ -1,7 +1,7 @@
 schema-tables-baseline 7
 package vocabdemo
 
-table Wide00
+table Wide00 fixed=true
     field field_00_00 id=0x0608e822268486dd kind=8 default=0
     field field_00_01 id=0x0608e7222684852a kind=8 default=0
     field field_00_02 id=0x0608e62226848377 kind=8 default=0
@@ -16,7 +16,7 @@ table Wide00
     field field_00_11 id=0x0605632226816f07 kind=8 default=0
     field field_00_12 id=0x06056422268170ba kind=8 default=0
 
-table Wide01
+table Wide01 fixed=true
     field field_01_00 id=0x5c6e9229c1ee10ec kind=8 default=0
     field field_01_01 id=0x5c6e9329c1ee129f kind=8 default=0
     field field_01_02 id=0x5c6e9429c1ee1452 kind=8 default=0
@@ -31,7 +31,7 @@ table Wide01
     field field_01_11 id=0x5c721729c1f128c2 kind=8 default=0
     field field_01_12 id=0x5c721629c1f1270f kind=8 default=0
 
-table Wide02
+table Wide02 fixed=true
     field field_02_00 id=0x89bb9c30246ce93b kind=8 default=0
     field field_02_01 id=0x89bb9b30246ce788 kind=8 default=0
     field field_02_02 id=0x89bb9e30246ceca1 kind=8 default=0
@@ -46,7 +46,7 @@ table Wide02
     field field_02_11 id=0x89b817302469d165 kind=8 default=0
     field field_02_12 id=0x89b814302469cc4c kind=8 default=0
 
-table Wide03
+table Wide03 fixed=true
     field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 default=0
     field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 default=0
     field field_03_02 id=0x5f3da43b6dd5a684 kind=8 default=0
@@ -61,7 +61,7 @@ table Wide03
     field field_03_11 id=0x5f410b3b6dd88b60 kind=8 default=0
     field field_03_12 id=0x5f410e3b6dd89079 kind=8 default=0
 
-table Wide04
+table Wide04 fixed=true
     field field_04_00 id=0x6078d04094e30c99 kind=8 default=0
     field field_04_01 id=0x6078cf4094e30ae6 kind=8 default=0
     field field_04_02 id=0x6078ce4094e30933 kind=8 default=0
@@ -76,7 +76,7 @@ table Wide04
     field field_04_11 id=0x6075cb4094e0ce43 kind=8 default=0
     field field_04_12 id=0x6075cc4094e0cff6 kind=8 default=0
 
-table Wide05
+table Wide05 fixed=true
     field field_05_00 id=0x37adda4bdfbd61c8 kind=8 default=0
     field field_05_01 id=0x37addb4bdfbd637b kind=8 default=0
     field field_05_02 id=0x37addc4bdfbd652e kind=8 default=0
@@ -91,7 +91,7 @@ table Wide05
     field field_05_11 id=0x37b15f4bdfc0799e kind=8 default=0
     field field_05_12 id=0x37b15e4bdfc077eb kind=8 default=0
 
-table Wide06
+table Wide06 fixed=true
     field field_06_00 id=0x8e13a4537b272237 kind=8 default=0
     field field_06_01 id=0x8e13a3537b272084 kind=8 default=0
     field field_06_02 id=0x8e13a6537b27259d kind=8 default=0
@@ -106,7 +106,7 @@ table Wide06
     field field_06_11 id=0x8e101f537b240a61 kind=8 default=0
     field field_06_12 id=0x8e101c537b240548 kind=8 default=0
 
-table Wide07
+table Wide07 fixed=true
     field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 default=0
     field field_07_01 id=0xb9ad8f59dc343159 kind=8 default=0
     field field_07_02 id=0xb9ad8c59dc342c40 kind=8 default=0
@@ -121,7 +121,7 @@ table Wide07
     field field_07_11 id=0xb9b11359dc37477c kind=8 default=0
     field field_07_12 id=0xb9b11659dc374c95 kind=8 default=0
 
-table Wide08
+table Wide08 fixed=true
     field field_08_00 id=0x26de17dcb256f565 kind=8 default=0
     field field_08_01 id=0x26de16dcb256f3b2 kind=8 default=0
     field field_08_02 id=0x26de15dcb256f1ff kind=8 default=0
@@ -136,7 +136,7 @@ table Wide08
     field field_08_11 id=0x26db12dcb254b70f kind=8 default=0
     field field_08_12 id=0x26db13dcb254b8c2 kind=8 default=0
 
-table Wide09
+table Wide09 fixed=true
     field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 default=0
     field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 default=0
     field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 default=0

--- a/tables/vocab9/tables.baseline
+++ b/tables/vocab9/tables.baseline
@@ -1,7 +1,7 @@
 schema-tables-baseline 7
 package vocab9demo
 
-table Wide00
+table Wide00 fixed=true
     field field_00_00 id=0x0608e822268486dd kind=8 default=0
     field field_00_01 id=0x0608e7222684852a kind=8 default=0
     field field_00_02 id=0x0608e62226848377 kind=8 default=0
@@ -16,7 +16,7 @@ table Wide00
     field field_00_11 id=0x0605632226816f07 kind=8 default=0
     field field_00_12 id=0x06056422268170ba kind=8 default=0
 
-table Wide01
+table Wide01 fixed=true
     field field_01_00 id=0x5c6e9229c1ee10ec kind=8 default=0
     field field_01_01 id=0x5c6e9329c1ee129f kind=8 default=0
     field field_01_02 id=0x5c6e9429c1ee1452 kind=8 default=0
@@ -31,7 +31,7 @@ table Wide01
     field field_01_11 id=0x5c721729c1f128c2 kind=8 default=0
     field field_01_12 id=0x5c721629c1f1270f kind=8 default=0
 
-table Wide02
+table Wide02 fixed=true
     field field_02_00 id=0x89bb9c30246ce93b kind=8 default=0
     field field_02_01 id=0x89bb9b30246ce788 kind=8 default=0
     field field_02_02 id=0x89bb9e30246ceca1 kind=8 default=0
@@ -46,7 +46,7 @@ table Wide02
     field field_02_11 id=0x89b817302469d165 kind=8 default=0
     field field_02_12 id=0x89b814302469cc4c kind=8 default=0
 
-table Wide03
+table Wide03 fixed=true
     field field_03_00 id=0x5f3da63b6dd5a9ea kind=8 default=0
     field field_03_01 id=0x5f3da73b6dd5ab9d kind=8 default=0
     field field_03_02 id=0x5f3da43b6dd5a684 kind=8 default=0
@@ -61,7 +61,7 @@ table Wide03
     field field_03_11 id=0x5f410b3b6dd88b60 kind=8 default=0
     field field_03_12 id=0x5f410e3b6dd89079 kind=8 default=0
 
-table Wide04
+table Wide04 fixed=true
     field field_04_00 id=0x6078d04094e30c99 kind=8 default=0
     field field_04_01 id=0x6078cf4094e30ae6 kind=8 default=0
     field field_04_02 id=0x6078ce4094e30933 kind=8 default=0
@@ -76,7 +76,7 @@ table Wide04
     field field_04_11 id=0x6075cb4094e0ce43 kind=8 default=0
     field field_04_12 id=0x6075cc4094e0cff6 kind=8 default=0
 
-table Wide05
+table Wide05 fixed=true
     field field_05_00 id=0x37adda4bdfbd61c8 kind=8 default=0
     field field_05_01 id=0x37addb4bdfbd637b kind=8 default=0
     field field_05_02 id=0x37addc4bdfbd652e kind=8 default=0
@@ -91,7 +91,7 @@ table Wide05
     field field_05_11 id=0x37b15f4bdfc0799e kind=8 default=0
     field field_05_12 id=0x37b15e4bdfc077eb kind=8 default=0
 
-table Wide06
+table Wide06 fixed=true
     field field_06_00 id=0x8e13a4537b272237 kind=8 default=0
     field field_06_01 id=0x8e13a3537b272084 kind=8 default=0
     field field_06_02 id=0x8e13a6537b27259d kind=8 default=0
@@ -106,7 +106,7 @@ table Wide06
     field field_06_11 id=0x8e101f537b240a61 kind=8 default=0
     field field_06_12 id=0x8e101c537b240548 kind=8 default=0
 
-table Wide07
+table Wide07 fixed=true
     field field_07_00 id=0xb9ad8e59dc342fa6 kind=8 default=0
     field field_07_01 id=0xb9ad8f59dc343159 kind=8 default=0
     field field_07_02 id=0xb9ad8c59dc342c40 kind=8 default=0
@@ -121,7 +121,7 @@ table Wide07
     field field_07_11 id=0xb9b11359dc37477c kind=8 default=0
     field field_07_12 id=0xb9b11659dc374c95 kind=8 default=0
 
-table Wide08
+table Wide08 fixed=true
     field field_08_00 id=0x26de17dcb256f565 kind=8 default=0
     field field_08_01 id=0x26de16dcb256f3b2 kind=8 default=0
     field field_08_02 id=0x26de15dcb256f1ff kind=8 default=0
@@ -136,7 +136,7 @@ table Wide08
     field field_08_11 id=0x26db12dcb254b70f kind=8 default=0
     field field_08_12 id=0x26db13dcb254b8c2 kind=8 default=0
 
-table Wide09
+table Wide09 fixed=true
     field field_09_00 id=0xfbf3a1e7fb63bdb4 kind=8 default=0
     field field_09_01 id=0xfbf3a2e7fb63bf67 kind=8 default=0
     field field_09_02 id=0xfbf3a3e7fb63c11a kind=8 default=0
@@ -151,7 +151,7 @@ table Wide09
     field field_09_11 id=0xfbf6a6e7fb65fc0a kind=8 default=0
     field field_09_12 id=0xfbf6a5e7fb65fa57 kind=8 default=0
 
-table Wide10
+table Wide10 fixed=true
     field field_10_00 id=0x768f8657129836da kind=8 default=0
     field field_10_01 id=0x768f87571298388d kind=8 default=0
     field field_10_02 id=0x768f845712983374 kind=8 default=0
@@ -166,7 +166,7 @@ table Wide10
     field field_10_11 id=0x7692eb57129b1850 kind=8 default=0
     field field_10_12 id=0x7692ee57129b1d69 kind=8 default=0
 
-table Wide11
+table Wide11 fixed=true
     field field_11_00 id=0x9f5a7c4bc7bde1ab kind=8 default=0
     field field_11_01 id=0x9f5a7b4bc7bddff8 kind=8 default=0
     field field_11_02 id=0x9f5a7e4bc7bde511 kind=8 default=0
@@ -181,7 +181,7 @@ table Wide11
     field field_11_11 id=0x9f56f74bc7bac9d5 kind=8 default=0
     field field_11_12 id=0x9f56f44bc7bac4bc kind=8 default=0
 
-table Wide12
+table Wide12 fixed=true
     field field_12_00 id=0x9e1f3246a0b0489c kind=8 default=0
     field field_12_01 id=0x9e1f3346a0b04a4f kind=8 default=0
     field field_12_02 id=0x9e1f3446a0b04c02 kind=8 default=0
@@ -196,7 +196,7 @@ table Wide12
     field field_12_11 id=0x9e223746a0b286f2 kind=8 default=0
     field field_12_12 id=0x9e223646a0b2853f kind=8 default=0
 
-table Wide13
+table Wide13 fixed=true
     field field_13_00 id=0xc89d483b5747be4d kind=8 default=0
     field field_13_01 id=0xc89d473b5747bc9a kind=8 default=0
     field field_13_02 id=0xc89d463b5747bae7 kind=8 default=0
@@ -211,7 +211,7 @@ table Wide13
     field field_13_11 id=0xc899c33b5744a677 kind=8 default=0
     field field_13_12 id=0xc899c43b5744a82a kind=8 default=0
 
-table Wide14
+table Wide14 fixed=true
     field field_14_00 id=0xd0ff6e7580f6bc96 kind=8 default=0
     field field_14_01 id=0xd0ff6f7580f6be49 kind=8 default=0
     field field_14_02 id=0xd0ff6c7580f6b930 kind=8 default=0
@@ -226,7 +226,7 @@ table Wide14
     field field_14_11 id=0xd102f37580f9d46c kind=8 default=0
     field field_14_12 id=0xd102f67580f9d985 kind=8 default=0
 
-table Wide15
+table Wide15 fixed=true
     field field_15_00 id=0xcfc4447059e959e7 kind=8 default=0
     field field_15_01 id=0xcfc4437059e95834 kind=8 default=0
     field field_15_02 id=0xcfc4467059e95d4d kind=8 default=0
@@ -241,7 +241,7 @@ table Wide15
     field field_15_11 id=0xcfc0bf7059e64211 kind=8 default=0
     field field_15_12 id=0xcfc0bc7059e63cf8 kind=8 default=0
 
-table Wide16
+table Wide16 fixed=true
     field field_16_00 id=0xf88f3a650f0f04b8 kind=8 default=0
     field field_16_01 id=0xf88f3b650f0f066b kind=8 default=0
     field field_16_02 id=0xf88f3c650f0f081e kind=8 default=0
@@ -256,7 +256,7 @@ table Wide16
     field field_16_11 id=0xf892bf650f121c8e kind=8 default=0
     field field_16_12 id=0xf892be650f121adb kind=8 default=0
 
-table Wide17
+table Wide17 fixed=true
     field field_17_00 id=0xa229705d73a54449 kind=8 default=0
     field field_17_01 id=0xa2296f5d73a54296 kind=8 default=0
     field field_17_02 id=0xa2296e5d73a540e3 kind=8 default=0
@@ -271,7 +271,7 @@ table Wide17
     field field_17_11 id=0xa225eb5d73a22c73 kind=8 default=0
     field field_17_12 id=0xa225ec5d73a22e26 kind=8 default=0
 
-table Wide18
+table Wide18 fixed=true
     field field_18_00 id=0x96f836119e0ead02 kind=8 default=0
     field field_18_01 id=0x96f837119e0eaeb5 kind=8 default=0
     field field_18_02 id=0x96f834119e0ea99c kind=8 default=0
@@ -286,7 +286,7 @@ table Wide18
     field field_18_11 id=0x96fb3b119e10eb58 kind=8 default=0
     field field_18_12 id=0x96fb3e119e10f071 kind=8 default=0
 
-table Wide19
+table Wide19 fixed=true
     field field_19_00 id=0x3f4bec0a018f5073 kind=8 default=0
     field field_19_01 id=0x3f4beb0a018f4ec0 kind=8 default=0
     field field_19_02 id=0x3f4bee0a018f53d9 kind=8 default=0


### PR DESCRIPTION
The LISTS half of the bill's monotone law (`docs/FIXED-FORM-BILL-READS-BACKWARD.md` §6): every list that inputs into a `fixed table` only ever grows AT THE END, and the baseline refuses any commit that is not a widening of the list it holds. `internal/baseline/monotone_lists.go`, one entry point `monotoneLists(old, new *Unit) []string`, hooked into `Diff` in one line marked `// monotone law, lists (bill §6)` so `monotoneNumbers` lands beside it without a conflict.

The shape of the check is the bill's own prefix walk: the committed list must be a PREFIX of the declared one, entry by entry, and the declaration's tail is the append. The FIRST differing entry is reported, and every refusal names the fixed table, the definition and the rule, with the remedy: `fixed <Table>: <definition>: <rule>; <remedy> (citations)`.

## Every test, by the sentence of Glenn's it holds

**"types or tables referenced in a fixed table can only have new fields added at end, not existing entries modified or removed (they can be deprecated sure)"**

- `TestAFieldRemovedFromAFixedTablesClosureIsRefused` — a field dropped from a `type` the fixed table holds by value, and one dropped from the fixed table itself.
- `TestAFieldInsertedNotAtTheEndIsRefused` — a field inserted mid-list.
- `TestFieldsReorderedAreRefused` — two fields swapped.
- `TestAFieldsKindModifiedIsRefused` — the one representative MODIFY case this file holds (`float32` to `int32`); widths, bounds, sizes, ranges and `frac` are the numbers half, next door.
- `TestAFieldDeprecatedInPlaceIsAllowed` — ALLOWED: `| deprecated` keeps the slot and every wire fact on it.
- `TestAFieldAppendedAtTheEndIsAllowed` — ALLOWED, Glenn's own example: `vec {x,y,z}` to `vec {x,y,z,w}` passes, to `vec {x,y}` refuses; and an append on the fixed table's own bottom.

**"enums can have entries added at end, no shuffling of entries for meaning, new entries at end"**

- `TestAnEnumVariantRemovedIsRefused`
- `TestAnEnumVariantInsertedMidListIsRefused`
- `TestEnumVariantsReorderedAreRefused`
- `TestAnEnumVariantRenamedWithoutWasIsRefused` — a variant rides under the hash of its wire name, so a rename with no `was` puts a name no stored value was written under at that place; `was` keeps the id and passes.
- `TestAnEnumVariantAppendedIsAllowed` — ALLOWED, and it carries the answer to the deprecation half: THIS LANGUAGE HAS NO PER-VARIANT DEPRECATION MARKER (`| deprecated` is a FIELD tag, §2.10), so an enum in a fixed closure has exactly one allowed edit — append.

**a union arm: the same five**

- `TestAUnionArmRemovedIsRefused`, `TestAUnionArmInsertedNotAtTheEndIsRefused`, `TestUnionArmsReorderedAreRefused`, `TestAUnionArmRenamedWithoutWasIsRefused`, `TestAUnionArmAppendedIsAllowed` (ALLOWED).

**"Flags can only ever have new flags added. Old flags cannot be removed"**

- `TestAFlagRemovedIsRefused`, `TestAFlagMovedIsRefused`, `TestAFlagAppendedIsAllowed` (ALLOWED). These hold the sentence WHERE THE LAW ALREADY LIVES: bit i is variant i on every wire, so this package's `flags-position` row already refuses a flag removed, inserted or moved for fixed and variable alike. `monotoneLists` deliberately adds no flags rule rather than refusing the same edit twice.

**"fixed tables must only allow other fixed tables to be included in them, and not recursively include themselves"**

- `internal/check`: `TestFixedTableClosureRefusals` already covers the first half, a row per construct — a map, an unbounded array, a pointer, a byte buffer, a guard, a nested plain `table` by value and through a bounded array, a pointer arm. NEW here: `TestAFixedTableCannotReachItself` — itself by value, itself in a fixed array, itself through a `type` (a stronger refusal: a table cannot ride in a `type` at all), itself through a pointer (refused as a pointer in a fixed closure, which is why no path exists).

**the `fixed` keyword: a different FORM, not a version**

- `TestTheFixedKeywordDroppedIsRefused` — `fixed` removed from a locked fixed table.
- `TestTheFixedKeywordAddedToALockedVariableTableIsRefused` — `fixed` added to a locked variable one.
- `TestTheProjectionRecordsTheFixedKeyword` — the format addition itself, and that a baseline written before it parses and stays silent on an untouched schema.
- `TestAVariableOnlyUnitKeepsItsOwnRules` — the law's SCOPE: the same three edits on a unit with no fixed table are judged exactly as they were.

## The one format token added

`fixed=true`, at the END of the `table` line (`table Vessel name=Ship fixed=true`), the one fact the law needs and the projection did not carry. **It bumps no rendering version**, by §18.1's own test: the token rides at the end of a line every older file still parses, and the rules read it on the COMMITTED side, so a baseline written before this rendering carries it nowhere and greets an untouched schema with no diagnostic. The cost of that choice, stated plainly: a unit whose committed baseline predates the token is unguarded against the keyword moving until its next `--update`, and `monotoneForm` therefore judges the keyword only where the committed file speaks the fact at all (one `fixed=true` anywhere). **If Glenn would rather the guard be total from the first check, the change is a rendering version bump (7 to 8) and a `--update` for every committed baseline.** A map's generated ENTRY, declared by nobody (§2.8), carries no keyword and roots none of this law.

14 committed corpus baselines are re-pinned with the token (history preserved verbatim, no history entry: the projection gained a recorded fact and no schema moved).

- `TestOneLinePerBreakNotOnePerFixedTable` — the output's BOUND: a `type`, an enum or a union is commonly in the closure of many fixed tables, and one edit inside it is ONE edit to fix, so the refusals are deduplicated by the break and the count is the count of definitions that moved, never the size of the unit.

`docs/SPEC-TABLES.md` §18.1 records the token where the rest of the table line's tokens are documented, including the bump reasoning and its price.

## Test state

`gofmt -l .` is empty. `./internal/baseline/` (whole package), `./internal/check/`, `./internal/lockfile/`, `./ir/`, `./internal/publicapi/` and `./cmd/...` are green. `./compiler/ -run Fixed` has SEVEN failures, all of them PRE-EXISTING on `rowan/bill-reads-backward` and identical there (the C++/C fixed clamp switch, the Elixir/Java/Rust fixed-form layout legs, the Java fixed-form scan, and dart's table-wire value defaults) — none of them touch the baseline.

## What a reviewer should look at first

- **The overlap with `schema.lock`.** `internal/lockfile` already holds this law for fixed tables and has tests for most of it (`TestReorderRefused`, `TestRemovalRefused`, `TestInsertInTheMiddleRefused`, `TestKindChangeRefused`, `TestDeprecateIsAllowedOnceLocked`, and the value-list rows of `lockclosure_test.go`: a reordered enum, a removed variant, a renamed variant, a reordered flags mask, a reordered union). The baseline half is a SECOND guard on a DIFFERENT artifact — both are opt-in, and a unit can carry one without the other. Whether the bill wants both is Glenn's call; this PR is the baseline half as assigned.
- `monotoneLists` takes no policy, so it has no ablation control of the kind the rest of this package keeps. One existing attribution control (`TestWasChainIsRefused`) was narrowed from "nothing reports" to "the chain refusal does not fire", because a second `was` on a FIXED table's field also hashes a new id and the fixed form's law now refuses that on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
