### PR TITLE
baseline: the monotone law, numbers and kinds (bill §6)

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -102,6 +102,17 @@ type Table struct {
 	// DOES NOT CARRY beyond `name=`: [Render] fills it on the live projection
 	// alone, where the chain refusal reads it (§18.2).
 	Was string
+
+	// Fixed is the DECLARED fixed class (`fixed table`, docs/SPEC-TABLES.md
+	// §2.2), and it is a fact of the LIVE projection alone: [Render] fills it,
+	// the file does not carry it, and nothing parses it. The monotone law of
+	// docs/FIXED-FORM-BILL-READS-BACKWARD.md §6 is gated on it, and the gate
+	// reads the LIVE side on purpose — a table that has just become fixed
+	// comes under the law at that commit, and one that is not fixed keeps the
+	// §18 verdicts it always had. So the committed file needs no new fact for
+	// it: asking the old file whether a table used to be fixed would only
+	// weaken the law on every baseline written before the keyword.
+	Fixed bool
 }
 
 // A Field is one field of a closure member: its declared name, its EFFECTIVE
@@ -211,7 +222,12 @@ func Render(u *ir.Unit) *Unit {
 		// spelling, and a `was` rename moves that while moving no byte — so
 		// the entry is keyed by the holder's wire id and the field's, and a
 		// rename moves nothing in this file.
-		t := Table{Name: ir.ProjectionMemberName(u, name), Declared: name, Was: st.WasName}
+		// A GENERATED MAP ENTRY is never `fixed` for the law's purposes even
+		// when its own body could be: nothing declares one, the checker answers
+		// the class from the body (§2.8), and the map that reaches it makes its
+		// HOLDER variable — so an entry is not a fixed table anyone deployed,
+		// and the monotone law has no business with its key's capacity.
+		t := Table{Name: ir.ProjectionMemberName(u, name), Declared: name, Was: st.WasName, Fixed: st.FixedDeclared && st.MapEntryOf == ""}
 		if st.MapEntryOf != "" {
 			t.Declared = t.Name
 		}
@@ -424,6 +440,27 @@ func renderField(f *ir.Field) Field {
 	}
 	if f.WasName != "" {
 		add("was", f.WasName)
+	}
+	// `bits(N)`'s N, AT THE END OF THE LINE, and the one fact this rendering
+	// adds (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6, docs/SPEC-TABLES.md
+	// §18.1). A `bits(N)` field rides under the KIND its storage width gives
+	// it — bits(12) and bits(10) are both kind 7 — so N was nowhere in this
+	// file, and the bill's law over it ("bits(N) shrunk refused") had no fact
+	// to stand on: narrowing one is a value the old writer could produce and
+	// the new reader cannot hold, with no token to see it by.
+	//
+	// It is written LAST so a baseline committed before it still parses
+	// byte-identically: the token set on a line is unordered to the parser,
+	// and a file that lacks this one states no N, which is no fact and judged
+	// on nothing. That is also why it moves no RENDERING VERSION: §18.1's bump
+	// rule exists because an added JUDGED token would greet an untouched
+	// schema with a diagnostic per field through the added-token branch of
+	// diffTokens, and this token has no row in [DefaultTokenPolicy] at all —
+	// it is read by the monotone law alone, which treats an absent fact as
+	// silence. A committed baseline regenerated once carries it and the law
+	// holds from there.
+	if f.Type.Kind == ir.TBits {
+		add("bits", strconv.Itoa(f.Type.Width))
 	}
 	return out
 }

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1241,9 +1241,15 @@ func TestCheckRefusesAForeignBaseline(t *testing.T) {
 // them, so a case can move one range and leave the rest still. Every default
 // sits well inside its bounds, so an edit here moves the range and nothing
 // else.
+// It is a PLAIN `table`, the variable wire, on purpose: the warn class is the
+// variable wire's answer, where the reader still clamps a stored value to its
+// own bounds and counts it (§4). A FIXED table has no cross-version clamp left
+// (docs/FIXED-FORM-BILL-READS-BACKWARD.md §5), so the same edit there is a
+// REFUSAL under the monotone law and is held by its own gate
+// (monotone_numbers_test.go).
 const rangeSrc = `package ranged
 
-fixed table Ship
+table Ship
 {
     hull  int32 = 50          | min = 0, max = 1000
     angle fixed(16, 16) = 0   | min = -180, max = 180

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -208,6 +208,8 @@ func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
 	out = append(out, d.diffEnums()...)
 	out = append(out, d.diffFlags()...)
 	out = append(out, d.diffUnions()...)
+	// monotone law, numbers (bill §6)
+	out = append(out, monotoneFindings(monotoneNumbers(base, live))...)
 	return out
 }
 

--- a/internal/baseline/monotone_numbers.go
+++ b/internal/baseline/monotone_numbers.go
@@ -1,0 +1,309 @@
+// THE MONOTONE LAW, NUMBERS AND KINDS
+// (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6).
+//
+// Glenn, 2026-09-10: "Newer versions of the fixed table should be able to read
+// OLD versions. But old versions CANNOT read new versions, and complain loudly
+// and refuse." "You can take an enum and widen it, but you cannot narrow, or
+// incompatible." "wstring/strings/bytes can be widened only, not narrowed,
+// because a narrowed string/array cannot read the old." "same with arrays and
+// strings etc."
+//
+// A FIXED TABLE READS BACKWARD, so every definition that inputs into one may
+// only GROW. The principle behind every row of the bill's §2 table is one
+// sentence: a newer reader must be able to hold every value an older writer
+// could produce, exactly. Where a widening keeps that true it is allowed;
+// where it cannot, the edit is incompatible and this file refuses it at
+// commit, which is what makes the reader's `layout_newer` refusal a thing no
+// legal peer ever meets.
+//
+// WHAT THIS FILE IS, NEXT TO §18. The tables baseline asks a save game's
+// question: what does an old FILE mean to a new reader, and the answers are
+// the three verdicts of §18.2, where a shrunk bound WARNS because the runtime
+// counts the clamp. A fixed table has no such middle: the clamp is gone from
+// the reference (bill §5), so the same edit has no runtime report left and the
+// only correct answer is REFUSE. So this law does not change a §18 row — it
+// adds refusals, and only ever for a table whose live declaration says `fixed
+// table`. A variable-only unit keeps every verdict it had.
+//
+// IT ONLY EVER ADDS. Nothing here turns a §18 refusal into a pass, and that
+// asymmetry is deliberate: the bill ALLOWS an int widened along its ladder
+// (the reader lands it exactly, `COUNT widened`), while §18's `kind` row
+// refuses every kind change for the save-game reason. Loosening that row is a
+// decision about the whole baseline and it belongs to the bill's §8 backport,
+// not to this file. So a widening the law allows may still be refused by the
+// `kind` row above it — monotoneNumbers says only that the LAW has no
+// complaint, which is what its tests assert.
+//
+// THE GATE IS THE LIVE DECLARATION, and [Table.Fixed] is a live-only fact
+// (see its comment): a table that has just become fixed comes under the law at
+// that commit, and the committed file needs no new token to say what it used
+// to be.
+package baseline
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// monotoneNumbers holds the bill's §6 law over the NUMBERS and the KINDS of
+// the fields of every FIXED table, and returns one line per edit that is not a
+// widening: "fixed <Table>: <field>: <rule> (<old> -> <new>)".
+//
+// old is the committed baseline, new the live projection. Fields are matched
+// BY WIRE ID, as every walk in this package matches them: the id is the
+// identity a reader keys on, and a field whose id is gone was removed, which
+// is the bill's field row and not a number's (an older writer still sending it
+// is `layout_newer`'s business at plan time, and the lists half of the law
+// holds the append-only field order at commit).
+//
+// Tables are matched BY NAME and nothing else. A renamed table is paired by
+// [pairMembers] for §18's walks, and pairing it here too would make the law's
+// refusals depend on a heuristic; a `was` rename keeps the WIRE name, which is
+// the name on both lines, so the case that matters is not a rename at all.
+func monotoneNumbers(old, new *Unit) []string {
+	live := map[string]Table{}
+	for _, t := range new.Tables {
+		live[t.Name] = t
+	}
+	var out []string
+	for _, bt := range old.Tables {
+		lt, ok := live[bt.Name]
+		// THE GATE: the law is the FIXED form's. A plain `table` is the
+		// variable wire whatever its fields happen to be (§2.2), and it keeps
+		// §18's verdicts.
+		if !ok || !lt.Fixed {
+			continue
+		}
+		liveFields := map[uint64]Field{}
+		for _, f := range lt.Fields {
+			liveFields[f.Id] = f
+		}
+		for _, bf := range bt.Fields {
+			lf, still := liveFields[bf.Id]
+			if !still {
+				continue
+			}
+			out = append(out, monotoneFieldNumbers(lt.Name, lf.Name, bf, lf)...)
+		}
+	}
+	return out
+}
+
+// monotoneFieldNumbers judges one field's numbers and kinds, old against new.
+func monotoneFieldNumbers(table, field string, was, now Field) []string {
+	var out []string
+	say := func(rule, before, after string) {
+		out = append(out, fmt.Sprintf("fixed %s: %s: %s (%s -> %s)", table, field, rule, before, after))
+	}
+
+	// ---- the extents that may only GROW ----
+	//
+	// An array bound, a string/wstring/bytes capacity, and `bits(N)`. The
+	// baseline's values are EVALUATED (§18.1), so a constant behind any of
+	// them is judged here by the number it now produces and needs no rule of
+	// its own: `[..Slots]` with Slots moved from 8 to 4 is a bound of 8 against
+	// a bound of 4, exactly as a hand-written 4 would be.
+	for _, key := range growOnly {
+		before, had := was.Get(key.token)
+		after, has := now.Get(key.token)
+		if !had || !has {
+			// A TOKEN THAT ARRIVES OR LEAVES is not a number moving. `bound=`
+			// appearing or vanishing is the unbounded array's capacity fact
+			// (§18.1), and an unbounded array cannot sit in a fixed closure at
+			// all — the compiler refuses it (§2.2) — so there is nothing here
+			// for this loop to say about either.
+			continue
+		}
+		// A KEYED ARRAY'S BOUND IS ITS KEY ENUM'S SIZE (§3.2), not a capacity
+		// anyone declared: it shrinks only when a variant goes, which is the
+		// enum's own row of the law and is reported there, by name.
+		if shape, _ := was.Get("array"); key.token == "bound" && shape == "keyed" {
+			continue
+		}
+		if tightened(RuleShrink, before, after) {
+			say(key.rule, before, after)
+		}
+	}
+
+	// ---- a ranged scalar: neither end may move INWARD ----
+	//
+	// A fixed table's reader has no cross-version clamp left (bill §5), so a
+	// stored value outside the new range is a value the reader cannot hold and
+	// cannot report. Moving either end OUTWARD is a widening and passes: every
+	// value already written still fits.
+	monotoneRange(say, was, now)
+
+	// ---- the kind: the same ladder, never narrower ----
+	//
+	// `elem` is the same vocabulary one level in — an array's element kind —
+	// and is judged by the same rule, because an element narrowed loses
+	// exactly what a scalar narrowed loses.
+	for _, key := range []string{"kind", "elem"} {
+		before, had := was.Get(key)
+		after, has := now.Get(key)
+		if !had || !has || before == after {
+			continue
+		}
+		if rule, refused := kindMove(key, before, after); refused {
+			say(rule, before, after)
+		}
+	}
+
+	// ---- an optional only ever APPEARS ----
+	//
+	// `T` where the reader has `?T` lands present (bill §2); `?T` where the
+	// reader has `T` has no way to land an absence, so dropping the `?` is
+	// refused. The token itself is judged on nothing by §18 — T, ?T and *T are
+	// one framing on the wire (§3.1) — and this is the one place the fixed
+	// form's read makes the direction matter.
+	if _, had := was.Get("optional"); had {
+		if _, has := now.Get("optional"); !has {
+			say("an optional only appears: a reader with no presence companion cannot land a stored absence (bill §2)", "?T", "T")
+		}
+	}
+	return out
+}
+
+// growOnly is the extents that may only grow, and the rule each one states
+// when it shrinks. One row per definition the bill's §2 table names, in the
+// words of the row.
+var growOnly = []struct {
+	token string
+	rule  string
+}{
+	{"bound", "an array bound only grows: a narrowed array cannot read the old, and a fixed table has no clamp left to report it (bill §2, §5)"},
+	{"size", "a string/wstring/bytes capacity only grows: a narrowed string cannot read the old (bill §2)"},
+	{"bits", "a bits(N) width only grows: a narrower N cannot hold every value the old writer could produce (bill §2)"},
+}
+
+// monotoneRange judges a declared range's two ends. Raising a minimum and
+// lowering a maximum are the same edit from opposite sides, and DECLARING a
+// range where the field had none is the same edit from the kind's whole
+// domain — the bill's row reads "inside the reader's", and a range the old
+// writer never had was the kind's own extent.
+func monotoneRange(say func(rule, before, after string), was, now Field) {
+	for _, end := range []struct {
+		token string
+		rule  TokenRule
+		words string
+	}{
+		{"min", RuleRaise, "a declared minimum only moves outward: a stored value below it has nowhere to land and no clamp to count it (bill §2, §5)"},
+		{"max", RuleShrink, "a declared maximum only moves outward: a stored value above it has nowhere to land and no clamp to count it (bill §2, §5)"},
+	} {
+		before, had := was.Get(end.token)
+		after, has := now.Get(end.token)
+		switch {
+		case had && has:
+			if tightened(end.rule, before, after) {
+				say(end.words, before, after)
+			}
+		case !had && has:
+			// A RANGE DECLARED WHERE THERE WAS NONE is an extent tightened
+			// from the kind's whole domain onto a narrower one — §18.2 warns
+			// on it for that reason, and in a fixed closure the warning has no
+			// runtime report behind it any more.
+			say(end.words, "none", after)
+		}
+		// a range REMOVED is the largest widening there is, and passes.
+	}
+}
+
+// kindMove judges one kind change, and is the bill's row "an integer or float
+// width: at most the reader's, SAME SIGNEDNESS LADDER; refuse wider, or a
+// different kind". It answers (rule, refused): a widening along one ladder is
+// silent, because the reader lands it exactly and counts `widened` (bill §3).
+func kindMove(token, before, after string) (string, bool) {
+	noun := "a field's kind"
+	if token == "elem" {
+		noun = "an array's element kind"
+	}
+	from, okFrom := kindLadders[atoiOr(before, 0)]
+	to, okTo := kindLadders[atoiOr(after, 0)]
+	switch {
+	case !okFrom || !okTo:
+		// One side is not on a numeric ladder at all — a string, a nested
+		// table, a union, an array, a pointer. There is no widening between a
+		// number and one of those, or between two of those: it is a different
+		// definition wearing the same field id.
+		return noun + " is fixed: a kind change is a different definition, not a version of one (bill §2)", true
+	case from.ladder != to.ladder:
+		return fmt.Sprintf("%s is fixed: the %s ladder and the %s ladder are different kinds, not widths of one (bill §2)", noun, from.ladder, to.ladder), true
+	case to.rung < from.rung:
+		return fmt.Sprintf("%s only widens: a narrower %s cannot hold every value the old writer could produce (bill §2)", noun, from.ladder), true
+	}
+	return "", false
+}
+
+// kindLadders is the four numeric ladders of the table wire (§3), and the
+// SIGNEDNESS is part of the ladder's identity, not a step along it: int32 to
+// uint32 moves no byte and changes what every stored negative value means, so
+// it is a different kind and not a width.
+//
+// `fixed(I,F)` and `ufixed(I,F)` ride as their RAW scaled storage integer, one
+// kind per storage width (§3), so widening I moves a fixed field UP its own
+// ladder and is a widening here. F is the scale, it is not a width at all, and
+// it is already held fixed by `frac=` (§4.1, §18.1) — a moved F reads every
+// stored raw value as a different number, and nothing can report it.
+//
+// `bits(N)` has no ladder of its own: it rides under the unsigned kind its
+// storage width gives it, and its N is the `bits=` token.
+var kindLadders = map[int]struct {
+	ladder string
+	rung   int
+}{
+	ir.TableKindI8:   {"int", 1},
+	ir.TableKindI16:  {"int", 2},
+	ir.TableKindI32:  {"int", 3},
+	ir.TableKindI64:  {"int", 4},
+	ir.TableKindI128: {"int", 5},
+
+	ir.TableKindU8:   {"uint", 1},
+	ir.TableKindU16:  {"uint", 2},
+	ir.TableKindU32:  {"uint", 3},
+	ir.TableKindU64:  {"uint", 4},
+	ir.TableKindU128: {"uint", 5},
+
+	ir.TableKindF32: {"float", 1},
+	ir.TableKindF64: {"float", 2},
+
+	ir.TableKindFixed8:   {"fixed", 1},
+	ir.TableKindFixed16:  {"fixed", 2},
+	ir.TableKindFixed32:  {"fixed", 3},
+	ir.TableKindFixed64:  {"fixed", 4},
+	ir.TableKindFixed128: {"fixed", 5},
+
+	ir.TableKindUFixed8:   {"ufixed", 1},
+	ir.TableKindUFixed16:  {"ufixed", 2},
+	ir.TableKindUFixed32:  {"ufixed", 3},
+	ir.TableKindUFixed64:  {"ufixed", 4},
+	ir.TableKindUFixed128: {"ufixed", 5},
+}
+
+// monotoneFindings turns the law's lines into the refusals the check already
+// carries, so a fixed table's monotone break arrives where every other
+// refusal does: as an error on the compile, named, with the old value, the new
+// one and the rule. The line's own first segment is its `Where`, which keeps
+// [Finding.String] byte-identical to the line.
+func monotoneFindings(lines []string) []Finding {
+	out := make([]Finding, 0, len(lines))
+	for _, line := range lines {
+		where, what, found := strings.Cut(line, ": ")
+		if !found {
+			where, what = line, ""
+		}
+		out = append(out, Finding{Refuse, where, what})
+	}
+	return out
+}
+
+// atoiOr reads a token's integer value, or a fallback for a value this
+// rendering did not write.
+func atoiOr(s string, fallback int) int {
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return fallback
+}

--- a/internal/baseline/monotone_numbers_test.go
+++ b/internal/baseline/monotone_numbers_test.go
@@ -1,0 +1,451 @@
+// The MONOTONE LAW's gate, numbers and kinds
+// (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6): one test per forbidden change,
+// one per allowed widening, each named by GLENN'S OWN SENTENCE for the rule it
+// holds.
+//
+// It is an INTERNAL test file (package baseline) because the law's entry point
+// is monotoneNumbers, and the law is what these cases are about: every case
+// states an old baseline — rendered and taken through the file's own text form,
+// so the old side is a PARSED baseline exactly as a committed one is — against
+// the unit as it now stands, and asserts the law's line or its silence. The two
+// cases that go through [Diff] instead say where the law lands: in the refusal
+// path the check already fails a compile with.
+package baseline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// monotoneSrc is the fixture: ONE FIXED TABLE whose fields carry every number
+// and kind the bill's §6 table names — a bound behind a constant, a fixed-size
+// array, the three capacities, a declared range, a bits width, a fixed-point
+// scale, an optional, and one field of each numeric ladder.
+const monotoneSrc = `package fixture
+
+const Slots = 8
+
+type Buff
+{
+    multiplier float32 = 1.0
+}
+
+// another body of the same shape-less kind: a nested type swapped for this one
+// is not a widening of anything
+type Debuff
+{
+    amount int32 = 0
+}
+
+fixed table Ship
+{
+    hull    int32
+    plain   uint32
+    speed   float32
+    drag    float64
+    score   int32 | min = 0, max = 1000
+    channel bits(12)
+    angle   fixed(16, 16) | min = -180, max = 180
+    heading ufixed(16, 16) | min = 0, max = 360
+    name    string(32)
+    label   wstring(16)
+    blob    bytes(64)
+    slots   [..Slots]int32
+    cells   [4]int32
+    boost   Buff
+    gunner  ?Buff
+}
+`
+
+// variableSrc is the SAME table on the variable wire: the law's gate is the
+// `fixed` keyword, and this fixture is what proves the gate is not a no-op.
+var variableSrc = strings.Replace(monotoneSrc, "fixed table Ship", "table Ship", 1)
+
+func monotoneUnit(t *testing.T, src string) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Fixture.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Fixture.schema", Name: "Fixture.schema", Base: "Fixture", Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+// monotoneCommitted is the OLD side: rendered, written as the file writes it,
+// and parsed back, so every case runs against a committed baseline's own facts.
+func monotoneCommitted(t *testing.T, src string) *Unit {
+	t.Helper()
+	text := Render(monotoneUnit(t, src)).Text()
+	b, err := Parse("tables.baseline", []byte(text))
+	if err != nil {
+		t.Fatalf("a rendered baseline does not parse: %v\n%s", err, text)
+	}
+	return b
+}
+
+// monotoneEdit is the fixture edit: exactly one substitution, or the case is
+// lying about what it changed.
+func monotoneEdit(t *testing.T, src, old, new string) string {
+	t.Helper()
+	if strings.Count(src, old) != 1 {
+		t.Fatalf("fixture edit %q does not appear exactly once in the fixture", old)
+	}
+	return strings.Replace(src, old, new, 1)
+}
+
+// law runs the monotone law over one edit of one fixture.
+func law(t *testing.T, base, edited string) []string {
+	t.Helper()
+	return monotoneNumbers(monotoneCommitted(t, base), Render(monotoneUnit(t, edited)))
+}
+
+// TestMonotoneNumbersRefused is one case per FORBIDDEN change: the law refuses,
+// and the line names the definition, the old value, the new value and the rule.
+func TestMonotoneNumbersRefused(t *testing.T) {
+	cases := []struct {
+		// name is GLENN'S SENTENCE for the rule, then the edit it holds
+		name  string
+		old   string
+		new   string
+		field string // "Ship: slots"
+		rule  string // a fragment of the rule the line must state
+		move  string // "(8 -> 4)"
+	}{
+		{
+			name:  "same with arrays and strings etc. — a bounded array's bound shrunk THROUGH A CONSTANT (the baseline records the EVALUATED value)",
+			old:   "const Slots = 8",
+			new:   "const Slots = 4",
+			field: "Ship: slots",
+			rule:  "an array bound only grows",
+			move:  "(8 -> 4)",
+		},
+		{
+			name:  "same with arrays and strings etc. — a bounded array's bound shrunk",
+			old:   "slots   [..Slots]int32",
+			new:   "slots   [..2]int32",
+			field: "Ship: slots",
+			rule:  "an array bound only grows",
+			move:  "(8 -> 2)",
+		},
+		{
+			name:  "same with arrays and strings etc. — a FIXED-SIZE array's N shrunk",
+			old:   "cells   [4]int32",
+			new:   "cells   [2]int32",
+			field: "Ship: cells",
+			rule:  "an array bound only grows",
+			move:  "(4 -> 2)",
+		},
+		{
+			name:  "wstring/strings/bytes can be widened only, not narrowed — string(N) shrunk",
+			old:   "name    string(32)",
+			new:   "name    string(16)",
+			field: "Ship: name",
+			rule:  "capacity only grows",
+			move:  "(32 -> 16)",
+		},
+		{
+			name:  "wstring/strings/bytes can be widened only, not narrowed — wstring(N) shrunk",
+			old:   "label   wstring(16)",
+			new:   "label   wstring(8)",
+			field: "Ship: label",
+			rule:  "capacity only grows",
+			move:  "(16 -> 8)",
+		},
+		{
+			name:  "wstring/strings/bytes can be widened only, not narrowed — bytes(N) shrunk",
+			old:   "blob    bytes(64)",
+			new:   "blob    bytes(32)",
+			field: "Ship: blob",
+			rule:  "capacity only grows",
+			move:  "(64 -> 32)",
+		},
+		{
+			name:  "a narrowed string/array cannot read the old — a ranged scalar's MAX moved inward",
+			old:   "score   int32 | min = 0, max = 1000",
+			new:   "score   int32 | min = 0, max = 500",
+			field: "Ship: score",
+			rule:  "a declared maximum only moves outward",
+			move:  "(1000 -> 500)",
+		},
+		{
+			name:  "a narrowed string/array cannot read the old — a ranged scalar's MIN moved inward",
+			old:   "score   int32 | min = 0, max = 1000",
+			new:   "score   int32 = 10 | min = 10, max = 1000",
+			field: "Ship: score",
+			rule:  "a declared minimum only moves outward",
+			move:  "(0 -> 10)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — an integer NARROWED",
+			old:   "hull    int32",
+			new:   "hull    int16",
+			field: "Ship: hull",
+			rule:  "only widens: a narrower int cannot hold every value",
+			move:  "(4 -> 3)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — a float NARROWED",
+			old:   "drag    float64",
+			new:   "drag    float32",
+			field: "Ship: drag",
+			rule:  "only widens: a narrower float cannot hold every value",
+			move:  "(11 -> 10)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — SIGNEDNESS changed (int32 to uint32)",
+			old:   "hull    int32",
+			new:   "hull    uint32",
+			field: "Ship: hull",
+			rule:  "the int ladder and the uint ladder are different kinds",
+			move:  "(4 -> 8)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — A DIFFERENT LADDER (int32 to float32)",
+			old:   "hull    int32",
+			new:   "hull    float32",
+			field: "Ship: hull",
+			rule:  "the int ladder and the float ladder are different kinds",
+			move:  "(4 -> 10)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — bits(N) shrunk",
+			old:   "channel bits(12)",
+			new:   "channel bits(10)",
+			field: "Ship: channel",
+			rule:  "a bits(N) width only grows",
+			move:  "(12 -> 10)",
+		},
+		{
+			name:  "you cannot narrow, or incompatible — an ARRAY's ELEMENT narrowed",
+			old:   "slots   [..Slots]int32",
+			new:   "slots   [..Slots]int16",
+			field: "Ship: slots",
+			rule:  "an array's element kind only widens",
+			move:  "(4 -> 3)",
+		},
+		{
+			name:  "a field's kind changed — a scalar respelled as a string",
+			old:   "plain   uint32",
+			new:   "plain   string(8)",
+			field: "Ship: plain",
+			rule:  "a field's kind is fixed",
+			move:  "(8 -> 12)",
+		},
+		{
+			name:  "a field's kind changed — a scalar respelled as a NESTED TYPE",
+			old:   "plain   uint32",
+			new:   "plain   Buff",
+			field: "Ship: plain",
+			rule:  "a field's kind is fixed",
+			move:  "(8 -> 13)",
+		},
+		{
+			name:  "?T to T is refused — an optional dropped",
+			old:   "gunner  ?Buff",
+			new:   "gunner  Buff",
+			field: "Ship: gunner",
+			rule:  "an optional only appears",
+			move:  "(?T -> T)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lines := law(t, monotoneSrc, monotoneEdit(t, monotoneSrc, c.old, c.new))
+			if len(lines) != 1 {
+				t.Fatalf("the law states one refusal for one edit; it stated %d:\n  %s", len(lines), strings.Join(lines, "\n  "))
+			}
+			line := lines[0]
+			for _, want := range []string{"fixed " + c.field, c.rule, c.move} {
+				if !strings.Contains(line, want) {
+					t.Errorf("the refusal must name %q:\n  %s", want, line)
+				}
+			}
+			// THE GATE: the very same edit on the VARIABLE wire is no business
+			// of this law — it keeps the §18 verdict it always had.
+			if loose := law(t, variableSrc, monotoneEdit(t, variableSrc, c.old, c.new)); len(loose) != 0 {
+				t.Errorf("the law is the FIXED form's; a plain `table` drew:\n  %s", strings.Join(loose, "\n  "))
+			}
+		})
+	}
+}
+
+// TestMonotoneNumbersAllowed is one case per ALLOWED WIDENING: the law is
+// silent, because a newer reader can hold every value an older writer wrote.
+//
+// Silence HERE is the law's silence, not the whole baseline's: §18's own `kind`
+// row still refuses a kind change for the save-game reason, and loosening that
+// row for a fixed closure belongs to the bill's §8 backport (see this file's
+// package comment).
+func TestMonotoneNumbersAllowed(t *testing.T) {
+	cases := []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{
+			name: "you can take an enum and widen it — a bounded array's bound GROWN through a constant",
+			old:  "const Slots = 8",
+			new:  "const Slots = 32",
+		},
+		{
+			name: "same with arrays and strings etc. — a FIXED-SIZE array's N grown",
+			old:  "cells   [4]int32",
+			new:  "cells   [8]int32",
+		},
+		{
+			name: "wstring/strings/bytes can be widened only — string(N) grown",
+			old:  "name    string(32)",
+			new:  "name    string(64)",
+		},
+		{
+			name: "wstring/strings/bytes can be widened only — wstring(N) grown",
+			old:  "label   wstring(16)",
+			new:  "label   wstring(64)",
+		},
+		{
+			name: "wstring/strings/bytes can be widened only — bytes(N) grown",
+			old:  "blob    bytes(64)",
+			new:  "blob    bytes(128)",
+		},
+		{
+			name: "you can take an enum and widen it — a ranged scalar's ends moved OUTWARD",
+			old:  "score   int32 | min = 0, max = 1000",
+			new:  "score   int32 | min = -50, max = 5000",
+		},
+		{
+			name: "you can take an enum and widen it — a declared range REMOVED, the largest widening there is",
+			old:  "score   int32 | min = 0, max = 1000",
+			new:  "score   int32",
+		},
+		{
+			name: "you can take an enum and widen it — int32 to int64",
+			old:  "hull    int32",
+			new:  "hull    int64",
+		},
+		{
+			name: "you can take an enum and widen it — float32 to float64",
+			old:  "speed   float32",
+			new:  "speed   float64",
+		},
+		{
+			name: "you can take an enum and widen it — bits(N) grown",
+			old:  "channel bits(12)",
+			new:  "channel bits(16)",
+		},
+		{
+			name: "you can take an enum and widen it — fixed(I,F)'s I widened, F untouched",
+			old:  "angle   fixed(16, 16) | min = -180, max = 180",
+			new:  "angle   fixed(48, 16) | min = -180, max = 180",
+		},
+		{
+			name: "T to ?T is allowed — an optional added",
+			old:  "boost   Buff",
+			new:  "boost   ?Buff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if lines := law(t, monotoneSrc, monotoneEdit(t, monotoneSrc, c.old, c.new)); len(lines) != 0 {
+				t.Errorf("a widening the bill allows drew a refusal:\n  %s", strings.Join(lines, "\n  "))
+			}
+		})
+	}
+}
+
+// TestMonotoneNumbersLandsInTheRefusalPath is WHERE the law lands: [Diff]'s
+// refusals, which are what [Check] fails a compile with. The same edit on the
+// variable wire stays the WARNING §18 has always given it — the law adds
+// refusals to the fixed form and takes nothing away from anyone else.
+func TestMonotoneNumbersLandsInTheRefusalPath(t *testing.T) {
+	shrink := func(src string) []Finding {
+		return Diff(monotoneCommitted(t, src), Render(monotoneUnit(t, monotoneEdit(t, src, "name    string(32)", "name    string(16)"))), DefaultTokenPolicy)
+	}
+
+	refusals, warnings := Split(shrink(monotoneSrc))
+	var found bool
+	for _, r := range refusals {
+		if strings.Contains(r.String(), "fixed Ship: name: a string/wstring/bytes capacity only grows") && strings.Contains(r.What, "(32 -> 16)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a fixed table's shrunk capacity must REFUSE, by name:%s", monotoneSummary(append(refusals, warnings...)))
+	}
+
+	refusals, warnings = Split(shrink(variableSrc))
+	if len(refusals) != 0 {
+		t.Errorf("the variable wire keeps its own verdicts; it refused:%s", monotoneSummary(refusals))
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0].What, "capacity 32 -> 16") {
+		t.Errorf("the variable wire's shrunk capacity stays §18's one warning:%s", monotoneSummary(warnings))
+	}
+}
+
+// TestMonotoneFixedScaleAndNestedBodyAlreadyRefuse are the two rows of the
+// bill's §6 table a check ALREADY held, asserted over a FIXED closure so the
+// law's coverage is not claimed twice and not left assumed:
+//
+//   - `fixed(I,F)`'s F CHANGED — §4.1's one wire-invisible fact on a wide kind,
+//     refused by the `frac` row. The scale moves, every stored raw value reads
+//     as a different number, and no counter can fire.
+//   - a NESTED TYPE swapped for another — refused by the referent rule, which
+//     asks whether the replacement can stand in for data already written.
+func TestMonotoneFixedScaleAndNestedBodyAlreadyRefuse(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   string
+		new   string
+		where string
+		what  string
+	}{
+		{
+			name:  "you cannot narrow, or incompatible — fixed(I,F)'s F changed (the storage width held still)",
+			old:   "angle   fixed(16, 16) | min = -180, max = 180",
+			new:   "angle   fixed(24, 8) | min = -180, max = 180",
+			where: "Ship.angle",
+			what:  "fractional bits 16 -> 8",
+		},
+		{
+			name:  "a field's kind changed — a nested type swapped for another",
+			old:   "boost   Buff",
+			new:   "boost   Debuff",
+			where: "Ship.boost",
+			what:  "nested table Buff -> Debuff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			edited := monotoneEdit(t, monotoneSrc, c.old, c.new)
+			refusals, _ := Split(Diff(monotoneCommitted(t, monotoneSrc), Render(monotoneUnit(t, edited)), DefaultTokenPolicy))
+			var found bool
+			for _, r := range refusals {
+				if strings.Contains(r.Where, c.where) && strings.Contains(r.What, c.what) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("a fixed closure must refuse %s: %s:%s", c.where, c.what, monotoneSummary(refusals))
+			}
+		})
+	}
+}
+
+func monotoneSummary(fs []Finding) string {
+	if len(fs) == 0 {
+		return " (no findings)"
+	}
+	var b strings.Builder
+	for _, f := range fs {
+		b.WriteString("\n  [" + f.Verdict.String() + "] " + f.String())
+	}
+	return b.String()
+}

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -118,12 +118,12 @@ table RangedUnsigned
     field counts id=0xc341febe5aae51e5 kind=14 elem=9 array=bounded bound=4 min=0 max=18446744073709551615
 
 table RangedWidths
-    field b8 id=0x08a60c07b54d8dc7 kind=6
-    field b16 id=0xff95701912ad97be kind=7
-    field b32 id=0xff9c5c1912b39470 kind=8
-    field b64 id=0xff92701912ab61e7 kind=9
-    field b12 id=0xff95741912ad9e8a kind=7
-    field b48 id=0xff8b681912a535a1 kind=9
+    field b8 id=0x08a60c07b54d8dc7 kind=6 bits=8
+    field b16 id=0xff95701912ad97be kind=7 bits=16
+    field b32 id=0xff9c5c1912b39470 kind=8 bits=32
+    field b64 id=0xff92701912ab61e7 kind=9 bits=64
+    field b12 id=0xff95741912ad9e8a kind=7 bits=12
+    field b48 id=0xff8b681912a535a1 kind=9 bits=48
 
 table RootConfig
     field version_note id=0x8a67c9728746d394 kind=12 size=16
@@ -153,7 +153,7 @@ table WeaponConfig
     field damage id=0x7f6308be8ab37fc0 kind=10 default=21.0
     field speed id=0x1733055702acb1d2 kind=10 default=500.0 was=velocity
     field penetration id=0x4f31c5309e13e932 kind=4 min=0 max=10 default=1
-    field channel id=0xa5013e9ad5caeda4 kind=6
+    field channel id=0xa5013e9ad5caeda4 kind=6 bits=6
     field homing id=0xad6587bc602e3f59 kind=1
     field effect id=0x36c1c83b51f24394 kind=15 union=Effect
 
@@ -228,3 +228,6 @@ union Effect
 
 ### 2026-09-04 — the id-table wire: sixty-four-bit identity, the enum kind, and rendering version 7 (docs/SPEC-TABLES.md §3, §5, §18.1)
 - baseline REGENERATED over an unreadable one (baseline version 6, this compiler writes 7); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow
+
+### 2026-09-11 (UTC) — the baseline records bits(N)'s N at the end of the line, the one fact the monotone law of the fixed form needs and the kind cannot carry (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6)
+- no compatibility-affecting edits; the wire absorbs the rest


### PR DESCRIPTION
My half of the bill's monotone law (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6): the
NUMBERS and the KINDS, for units whose closure holds a `fixed table`. Variable-only
units keep every §18 verdict they had.

One entry point, `monotoneNumbers(old, new *Unit) []string`, in the new
`internal/baseline/monotone_numbers.go`, returning one line per edit that is not a
widening — `fixed <Table>: <field>: <rule> (<old> -> <new>)` — called from `diff.go`'s
refusal path on ONE line marked `// monotone law, numbers (bill §6)`, so `monotoneLists`
lands beside it without a conflict.

## Forbidden, one test each, named by Glenn's sentence it holds

"same with arrays and strings etc."

- a bounded array `[..N]`'s bound SHRUNK — `an array bound only grows` (8 -> 2)
- the same bound shrunk THROUGH A CONSTANT (`const Slots` 8 -> 4) — the baseline records
  the EVALUATED value, so it is the same check, and the test goes through the constant to
  prove it
- a fixed-size array `[N]`'s N SHRUNK (4 -> 2), the same rule

"wstring/strings/bytes can be widened only, not narrowed, because a narrowed
string/array cannot read the old"

- `string(32)` -> `string(16)`, `wstring(16)` -> `wstring(8)`, `bytes(64)` -> `bytes(32)`
  — `a string/wstring/bytes capacity only grows`
- a ranged scalar's MAX moved inward (1000 -> 500) and its MIN moved inward (0 -> 10) —
  `a declared maximum/minimum only moves outward`. A range DECLARED where the field had
  none is the same edit from the kind's whole domain and refuses too

"You can take an enum and widen it, but you cannot narrow, or incompatible"

- an integer NARROWED (int32 -> int16) and a float NARROWED (float64 -> float32) —
  `only widens: a narrower int/float cannot hold every value the old writer could produce`
- SIGNEDNESS changed (int32 -> uint32) and A DIFFERENT LADDER (int32 -> float32) —
  `the int ladder and the uint/float ladder are different kinds, not widths of one`
- `bits(N)` shrunk (12 -> 10) — `a bits(N) width only grows`
- an ARRAY's ELEMENT narrowed (elem 4 -> 3) — the same rule one level in

a field's kind changed

- a scalar respelled as a `string(8)` (kind 8 -> 12) and as a NESTED TYPE (8 -> 13) —
  `a field's kind is fixed: a kind change is a different definition, not a version of one`
- a NESTED TYPE swapped for another (`Buff` -> `Debuff`): asserted over a FIXED closure
  against the EXISTING referent refusal, which already carries it
- `fixed(I,F)`'s F CHANGED, with the storage width held still (`fixed(16,16)` ->
  `fixed(24,8)`): asserted over a FIXED closure against the EXISTING `frac` row
  (§4.1, §18.1), which already carries it

an optional

- `?T` -> `T` refused — `an optional only appears: a reader with no presence companion
  cannot land a stored absence`

Every forbidden case also asserts THE GATE: the very same edit on a plain `table` draws
nothing from this law.

## Allowed, one test each

a bound GROWN through a constant (8 -> 32); a fixed-size array grown ([4] -> [8]);
`string` 32 -> 64, `wstring` 16 -> 64, `bytes` 64 -> 128; a range's ends moved OUTWARD;
a range REMOVED (the largest widening there is); int32 -> int64; float32 -> float64;
`bits(12)` -> `bits(16)`; `fixed(16,16)` -> `fixed(48,16)` (I widened, F untouched);
`T` -> `?T`.

With the law stubbed to `return nil`, all seventeen forbidden cases go red and every
widening stays green. 31 subtests, `go test ./internal/baseline/` green.

## The format token added, and why

`bits=N`, AT THE END OF THE FIELD LINE, and it is the only fact added. A `bits(N)` field
rides under the KIND its storage width gives it — bits(12) and bits(10) are both kind 7 —
so N was nowhere in this file, and "bits(N) shrunk refused" had no fact to stand on. With
the token reverted and the law in place, exactly the bits case goes red, which is the
proof it was missing.

- Old baselines still parse: the token set on a line is unordered to the parser, and a
  file that lacks this one states no N, which is no fact and judged on nothing.
- It moves NO RENDERING VERSION. §18.1's bump rule exists because an added JUDGED token
  reads as an addition on every older file and the added-token branch of `diffTokens`
  would greet an untouched schema with a diagnostic per field. This token has no row in
  `DefaultTokenPolicy` at all — the monotone law alone reads it, and an absent fact is
  silence. `tables/examples/tables.baseline` regenerates with it by `--update`, history
  intact.
- Follow-on, not done here: §18.1's token list in docs/SPEC-TABLES.md should name `bits=`
  once the bill's algorithm doc lands, so the file's columns and the spec agree.

`Table.Fixed` is the other fact, and it needs NO file token: it is the live projection's
(`Render` fills it, as it fills `Was` and `JsonKey`), and the gate reads the LIVE side on
purpose — a table that has just become fixed comes under the law at that commit, and
asking the old file what a table used to be would weaken the law on every baseline
written before the keyword. A GENERATED map entry is never fixed for the law: nothing
declares one, and the map that reaches it makes its holder variable.

## What this law does not touch, and one asymmetry left for the backport

- AN ENUM'S ORDINAL WIDTH AND A UNION'S TAG WIDTH CANNOT BE SET BY HAND IN THIS LANGUAGE
  — both derive from the variant count (an enum value rides as the u16 hash of its
  variant NAME, a union opens with its arm name hash) — so there is no edit to refuse and
  NO TEST for those two rows.
- An ENUM-KEYED array's `bound=` is its key enum's size, not a capacity anyone declared:
  it shrinks only when a variant goes, which is the enum's row of the law and is reported
  there, by name. Skipped here so it is not judged twice.
- IT ONLY EVER ADDS REFUSALS. §18's `kind` row still refuses every kind change for the
  save-game reason, including int32 -> int64, which the bill ALLOWS in a fixed closure
  (the reader lands it exactly and counts `widened`). So the allowed-widening tests assert
  that THE LAW has no complaint, not that the whole baseline passes. Loosening that row for
  a fixed closure is a decision about the whole file and belongs to the bill's §8 backport.
- §18's own range fixture (`rangeSrc`) becomes a plain `table`: the warn class is the
  VARIABLE wire's answer, where the clamp still exists and the read counts it. The fixed
  form's answer to the same edit is this law's refusal, held by its own gate.

## Green

`gofmt -l .` empty. `go vet ./internal/baseline/` clean. `go test ./internal/baseline/`
green (whole package). `go test ./...` shows 44 failures in 6 packages
(compiler, ctable, elixirtable, gotable, javatable, goldens) — IDENTICAL test names
before and after this branch's changes, i.e. pre-existing on `rowan/bill-reads-backward`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
