### PR TITLE
bill §12: the implementer's read and the lock survey, twelve rulings

### DIFF
--- a/docs/FIXED-FORM-ALGORITHM.md
+++ b/docs/FIXED-FORM-ALGORITHM.md
@@ -327,7 +327,7 @@ Nothing parses a stranger's layout at run time.
 
 ### 5.1 BASELINE(old, new): the monotone law, at commit
 
-`old` is the last locked shape of the unit (SPEC §18); `new` is the unit being committed. For every fixed
+`old` is the last locked shape of the unit (`schema.lock`, SPEC §2.10 as superseded by the bill's §6 and §12.1; the comparison is MONOTONE per row, on EVALUATED values); `new` is the unit being committed. For every fixed
 table `T` in `new` and every definition `D` in `T`'s closure (§5.4), with `D0` the same definition in `old`
 where it existed:
 
@@ -343,7 +343,9 @@ BASELINE(old, new):                      -- at a merge commit, run once per pare
     if T not in new or new[T] is not fixed: REFUSE "T: fixed removed"  -- deprecate; remove only when nothing live speaks it
 
 WIDENS(a, b):                            -- b may replace a
-  kind(a) == kind(b)                     or FAIL "kind changed"       -- includes string/wstring/bytes, [N]/[..N]/[Enum]
+  LADDER(a, b) or kind(a) == kind(b)     or FAIL "kind changed"       -- LADDER: int into wider int same signedness, f32 into f64,
+                                                                       -- ordinal/tag width wider, bits(N) into wider storage (bill §12.2);
+                                                                       -- string/wstring/bytes and [N]/[..N]/[Enum] never cross
   match kind:
     table, type:   fields(a) is a SUBSET of fields(b) by NAME and a SUBSEQUENCE of it by position (append-only per
                    branch, any interleaving after a merge; bill §11.3); every a-field WIDENS into its b-field;
@@ -355,11 +357,14 @@ WIDENS(a, b):                            -- b may replace a
     [Enum]T:       Enum WIDENS (its own rule); element WIDENS
     int, float:    width(a) <= width(b), same ladder, same signedness   or FAIL "narrowed | ladder | signedness"
     ranged:        range(b) ⊇ range(a), or b unranged               or FAIL "range narrowed | added"
-    bits(N):       N(a) <= N(b)
+    bits(N):       N(a) <= N(b)                                     or FAIL "bits narrowed"
     fixed(I,F):    I(a) <= I(b) and F(a) == F(b)                     or FAIL "F changed"
     ?T vs T:       optional(a) implies optional(b)                     or FAIL "optional removed"
     default:       default(a) == default(b)                            or FAIL "default changed"   -- SPEC §18
     reader limit:  limit(a) <= limit(b)
+    plan cap:      for every supported older entry x, PLAN(x, b) fits plan_too_large and the leaf cap
+                                                                    or FAIL "plan too large for lineage entry x" (bill §12.10)
+    deprecated:    deprecated(a) implies deprecated(b)                 or FAIL "undeprecated" (one way, bill §12.3)
 ```
 
 Every FAIL names the table, the definition, the rule, and both values. The compiler refuses to generate
@@ -380,11 +385,16 @@ PLAN(x, y):                                        -- x older, y the reader's ow
   list, match by NAME and emit a remap, identity when the lists agree):
     same width:            copy
     wider in y:            widen / widenf   (COUNT widened)
-    enum, prefix:          copy (the ordinals are the reader's); reordered: ordinal remap by name
-    absent in x:           default            (a field y added)
-    deprecated in y:       skip x's bytes     (COUNT unknown, once per plan)
-    text, bytes, arrays:   copy the writer's extent; the reader's slack is template zeros
-    ?T where x has T:      present := 1, then the value
+    enum, prefix:          copy when the width is equal, widen when the writer's ordinal width is narrower
+                           (the ordinals are the reader's); reordered after a merge: ordinal remap by name
+    absent in x:           default            (a field y added; the reader's FRESH IMAGE, recursing into a
+                                               nested type's and an element's own defaults, bill §12.6)
+    deprecated in y:       copy               (read on every plan, identity included; nothing dropped, bill §12.3)
+    text, bytes, [..N]:    copy the writer's extent; the slack past the count is zeros
+    [N] grown:             copy x's N elements; the reader's remaining elements take the ELEMENT DEFAULT
+    ?T where x has T:      present (an unguarded constant 1 into the present byte, its own op), then the value
+    bounds for the hostile pass: the plan carries x's bound, variant count, arm count and range (the
+                           WRITER's own), and §4.5/§4.6 clamp against those, per plan (bill §12.5)
   the plan is a straight-line list of ops; no per-record decision
 ```
 
@@ -400,15 +410,14 @@ LOAD(R, file):                                     -- R the reader's static data
     if h in R.retired:                    REFUSE layout_unsupported   -- COMPILE emits the retired hashes (bill §11.4)
     else:                                 REFUSE layout_newer      -- an older reader given a newer file
   if file.layout_bytes != R.known[h]:     REFUSE layout_malformed  -- a lie about a known version
-  if file.record_bytes != size(R.known[h]) or rest % record_bytes != 0: REFUSE layout_malformed
-  for each record: run R.plans[h] (§4), then the hostile pass (§4.5, §4.6: a forged count past the WRITER'S
-    OWN bound, an ordinal past the writer's own variant count, a tag past its arm count, a bool byte not 0/1)
+  framing as §2: the form byte, the header length, 20 + L, the per-record hash (no_layout), batch_too_large,
+    a ragged tail (malformed); nothing here parses the layout
+  for each record: run R.plans[h] (§4), then the hostile pass (§4.5, §4.6) against the bounds THE PLAN
+    CARRIES (the writer's own, bill §12.5); a bool or present byte not 0/1 is normalised and counts nothing
 ```
 
-REFUSE is total: no counter moves, nothing decoded. `layout_newer` carries the file's hash; the refusal text
-names, where the language has text, the first definition the reader could not hold, read off the file's
-layout against the reader's own (this is the one walk over a stranger's layout, and it happens only inside a
-refusal, after the decision, with the seven §1.1 checks applied to it first).
+REFUSE is total: no counter moves, nothing decoded. `layout_newer` carries the file's hash and NOTHING ELSE
+(bill §12.4): no walk over a stranger's layout anywhere in LOAD, on any path.
 
 ### 5.4 The closure
 
@@ -421,7 +430,8 @@ in it is a compile refusal; `T` is never in its own closure.
 The plan compiler at run time (§4.1–§4.4 become the build-time PLAN of §5.2); reading a layout the lock has
 never seen; the count clamp across bounds, the range clamp across versions, the remap of an unknown variant
 to `None`, the drop-and-count of an unknown field (all forward reads, now `layout_newer`). The seven §1.1
-checks stay as the lock's validation of what it records and as the walk inside a refusal. Every hostile
+checks stay as the lock's validation of what it records and the oracle's validation of the corpus; at run
+time a known hash is a byte comparison and an unknown hash is a refusal (bill §12.4). Every hostile
 check on a KNOWN layout's records stays (§4.5, §4.6).
 
 ### 5.6 The tests

--- a/docs/FIXED-FORM-BILL-READS-BACKWARD.md
+++ b/docs/FIXED-FORM-BILL-READS-BACKWARD.md
@@ -49,7 +49,7 @@ The table's own law, additions and deprecation only, extends to every definition
 | a text kind (`string`, `wstring`, `bytes`) | the same | any change between the three (old bytes stop being valid under the new content rules) |
 | an array's shape (`[N]`, `[..N]`, `[Enum]`) and its key enum | the same shape and key | a shape change or a swapped key; an element type follows the widening ladder, an element narrowed is refused |
 | a reader-side limit a table declares (a record count, a batch size) | at most the reader's | smaller; where the limit is a compiler flag it is outside the law and the doc says so |
-| a deprecated field | still written, still in its place | leaving the layout (that is a removal); undeprecating is allowed |
+| a deprecated field | still written, still in its place, read on every plan | leaving the layout (that is a removal); undeprecating (one way, §12.3) |
 | a rename | through `was` | without it (the baseline's identity is by name, the fixed wire's by position) |
 
 **The invariant that makes widening safe** (Glenn: "widening with default values is what saves us here"):
@@ -308,3 +308,58 @@ supported version per table per leg; at five hundred entries and thirty versions
 of layout bytes per table per leg in generated source. Java's 64 KB static-initializer limit and JS/Dart
 bundle size bite first; the legs carry layout bytes as a resource or a string constant where the language
 needs it. Bounded by §11.6 and the floor.
+
+## 12. The implementer's cold read and the lock survey: the rulings (2026-09-11 02:45Z)
+
+A second Fable reader read as the implementer who is blamed for a wrong read; a third child surveyed
+`internal/lockfile` row by row. Defaults, recorded on #898, Glenn's to reverse.
+
+1. **The lock's rule becomes MONOTONE, not equal.** Today the lock refuses every narrowing AND every
+   widening with one sentence ("keeps its width"), `schema lock` refuses the relock, and `bits(N)` is
+   recorded nowhere. Step 1 of #898 rewrites the comparison to §2's direction per row and records the facts
+   it lacks: each bound and capacity as a NUMBER, `bits=N`, `fixed`'s I and F, an int's width and
+   signedness ladder, a reader-side limit, and judges every constant by its EVALUATED use (a constant
+   behind `min =` widens by going DOWN). SPEC §2.10's "nothing is widened" is superseded by this bill.
+2. **"Kind" means the family.** WIDENS checks the ladder BEFORE kind equality: an int into a wider int of
+   the same signedness, `f32` into `f64`, an enum's or tag's ordinal width into a wider one, `bits(N)`
+   into a wider storage, are widenings although the wire kind byte changes. Every other kind change refuses.
+3. **Deprecation is one way, and a deprecated field is READ on every plan.** §2.10's reason stands
+   ("what would come back is not data"): undeprecating is refused; §2's row is corrected. And a deprecated
+   field keeps its slot and is landed by every plan, identity included; nothing is dropped and `unknown`
+   does not move for it. The application ignores it. One answer for one field on every version.
+4. **`layout_newer` carries the hash and nothing else.** The refusal walk over a stranger's layout is
+   REMOVED from LOAD: no parse, no names, no depth bound, no size arithmetic on untrusted bytes, anywhere.
+   The seven §1.1 checks are the lock's validation of what it records and the oracle's validation of the
+   corpus; at run time a known hash is a byte comparison and an unknown hash is a refusal. The design's
+   OLD-REFUSES-NEW column asserts the hash, not a name.
+5. **The plan carries the writer's bounds, and the hostile pass is per plan.** For lineage entry x, the
+   plan's `count`, `ordinal`, tag and range checks use x's bound, x's variant count, x's arm count and x's
+   range (the writer's own), never the reader's; a forged value past the WRITER's bound clamps or lands
+   `None` and counts, exactly as §4.5 and §4.6 say, with the bound taken from the plan, not from the
+   reader's type. One pass over storage per plan, laid down at build time.
+6. **A grown `[N]` fills the ELEMENT DEFAULT, never zeros.** The prefill recurses into the reader's fresh
+   image (a nested type's own defaults, an element's own), so a reader-added field of a nested type and a
+   grown fixed-size array both land what a fresh value holds. `[..N]`'s slack past the count is zeros.
+7. **A grown ordinal width is a `widen`, and the guard compares at the tag's width.** An enum crossing
+   255 variants, a union crossing 255 arms: the plan widens, and every leg's guard/arg lane is full width
+   (card 14 on #876 becomes a rule: no byte lane anywhere).
+8. **`T` to `?T` is a `present` op**, an unguarded constant 1 into the present byte, then the value; named
+   as its own op so no leg invents it.
+9. **LOAD keeps every framing and file check.** Form byte, header length, `20 + L`, the per-record hash
+   (`no_layout`), `batch_too_large`, the ragged tail as `malformed`; the vacuous record-bytes clause is
+   dropped; the retired hashes are emitted for `layout_unsupported`.
+10. **PLAN can fail at build, so BASELINE has a cap row.** A widening whose plan for ANY supported older
+    entry exceeds `plan_too_large` or the leaf cap is refused at commit, naming the entry; the remedy is
+    the floor or a new table.
+11. **The default row is in §6's table.** A changed specified default is refused (SPEC §18 was built for
+    it); it was in prose only.
+12. **Smaller.** A bool or present byte not 0 or 1 is normalised and counts nothing (ALG §4.5 stands; the
+    hostile list is corrected). `unknown` counts for a deprecated writer field that the reader lacks
+    entirely: none, by ruling 3, so the counter is removed from PLAN. `bits(N)` refuses with text. The
+    headroom sentence at ALG §1.1 (`>= key.children`) goes with C11. `ufixed` is in the spec's table. A
+    compressed float's quantization never refuses. §6's law is judged on evaluated uses, stated. The bill's
+    line saying the baseline "can hold" the law is deleted; the lock holds it (§6).
+
+The implementer's verdict was "not ready to build from"; with §11 and §12 applied it is the bill a stranger
+can implement, and the tests in `FIXED-FORM-VERSIONING-TESTS.md` are corrected to match (the refusal
+carries the hash; `[N]` lands defaults; deprecated fields read).

--- a/docs/FIXED-FORM-VERSIONING-TESTS.md
+++ b/docs/FIXED-FORM-VERSIONING-TESTS.md
@@ -10,7 +10,7 @@ The bill is `FIXED-FORM-BILL-READS-BACKWARD.md`; the law is its §2 and §6; the
 | **LOCK-REFUSES** | the narrowing does not compile against the lock; the refusal names the table, the definition, the rule, the old and the new value | `internal/lockfile` (Go), one test per row | yes |
 | **LOCK-ALLOWS** | the widening compiles and the lock's lineage gains one entry | `internal/lockfile` | no (a positive) |
 | **NEW-READS-OLD** | the widened reader reads the older writer's file: every old value lands exactly, the reader's tail is the default, the counters are what §5.2 says | the C++ reference first (`test/tables/fixedform_main.cpp`, a lineage pair per row written by the dump), then every leg | yes, per leg |
-| **OLD-REFUSES-NEW** | the older reader given the widened writer's file refuses `layout_newer` before any record, no counter moves, nothing decoded; the refusal names the row's definition where the language has text | the C++ reference first, then every leg | yes, per leg |
+| **OLD-REFUSES-NEW** | the older reader given the widened writer's file refuses `layout_newer` before any record, no counter moves, nothing decoded; the refusal carries the file's hash and nothing else (bill §12.4) | the C++ reference first, then every leg | yes, per leg |
 
 The two read columns share one corpus: for each row, `fixedform_dump.cpp` writes the OLD file (`vN_<row>.bin`)
 and the NEW file (`vN1_<row>.bin`) from two schemas that differ by exactly that row. Each leg then has two
@@ -26,16 +26,16 @@ Naming: `V_<row>`; the Go test is `TestLock<Row>Refuses` / `TestLock<Row>Allows`
 | row | old | new (the widening) | the narrowing LOCK-REFUSES (new = the reverse) | NEW-READS-OLD lands | OLD-REFUSES-NEW names |
 |---|---|---|---|---|---|
 | `field_append` | `vec {x,y,z}` | `vec {x,y,z,w}` | `{x,y}`: "field removed"; `{x,w,y,z}`: "field inserted not at the end"; `{y,x,z}`: "fields reordered" | x,y,z exact; w = default | the field w |
-| `field_deprecate` | `{a,b,c}` | `{a,b deprecated,c}` | `{a,c}` (removed instead of deprecated): "field removed" | a,c exact; b dropped, `unknown` += 1 per plan | (a deprecation is not newer: the OLD reader READS the new file, b landing as written) |
-| `field_undeprecate` | `{a,b deprecated}` | `{a,b}` | — (allowed both ways; a test that both compile) | a,b exact | reads |
+| `field_deprecate` | `{a,b,c}` | `{a,b deprecated,c}` | `{a,c}` (removed instead of deprecated): "field removed" | a,b,c exact; b read on every plan, no counter (bill §12.3) | (a deprecation is not newer: the OLD reader READS the new file) |
+| `field_undeprecate` | `{a,b deprecated}` | — | `{a,b}`: "undeprecated" (one way, bill §12.3) | — | — |
 | `field_modify` | `{a int32}` | — | `{a int64}` is `int_widen`; `{a string(8)}`: "kind changed" | — | — |
 | `enum_append` | `Tier {bronze silver gold}` | `+ platinum` | `{bronze gold silver}`: "variant reordered"; `{bronze silver}`: "variant removed"; `{bronze platinum silver gold}`: "variant inserted mid-list"; `{bronze silver golden}`: "variant renamed without was" | ordinals equal; a gold record reads gold | the variant platinum |
-| `enum_width` | 255 variants | 256 variants (width 1 → 2)... per the ordinal width rule | a width cannot be set by hand: covered by `enum_append` at the boundary | width 1 ordinal widened into width 2, `widened` += 1 | the layout's enum width |
+| `enum_width` | 255 variants | 256 variants (width 1 → 2) | a width cannot be set by hand: covered by `enum_append` at the boundary | width 1 ordinal WIDENED into width 2, `widened` += 1; a union crossing 255 arms the same, and the guard compares at the tag's width (bill §12.7) | the hash |
 | `union_append` | `Pick {a b}` | `+ c` | reordered / removed / inserted / payload changed: four refusals | an `a` record lands a; the tag width equal | the arm c |
 | `union_arm_payload_widen` | arm `a: {x}` | arm `a: {x,y}` | arm `a: {}`: "field removed" | x exact, y default | the field y under arm a |
 | `flags_append` | `F {a b}` | `F {a b c}` | `{b a}`: "flag moved"; `{a}`: "flag removed" | mask equal | the flag c |
 | `array_bounded_grow` | `[..4]int32` | `[..8]int32` | `[..2]`: "bound narrowed (4 -> 2)" | count and 4 elements exact; slots 4..7 default | the bound 8 |
-| `array_fixed_grow` | `[4]int32` | `[8]int32` | `[2]`: "bound narrowed" | 4 exact, 4 default | the bound |
+| `array_fixed_grow` | `[4]Vec` | `[8]Vec` | `[2]`: "bound narrowed" | 4 exact, 4 at the ELEMENT DEFAULT (a nested Vec's own defaults, bill §12.6) | the hash |
 | `array_shape` | `[4]T` | — | `[..4]T`: "shape changed"; `[Enum]T`: "shape changed" | — | — |
 | `array_elem_widen` | `[..4]int16` | `[..4]int32` | `[..4]int8`: "element narrowed" | 4 exact, widened | the element width |
 | `keyed_array_enum_append` | `[Tier]int32`, Tier 3 | Tier 4 | Tier reordered: "variant reordered" (the array follows) | 3 slots exact, slot 4 default | the variant |
@@ -85,3 +85,11 @@ only, and OLD-REFUSES-NEW for the other direction).
 33 rows × up to 4 columns, the floor and hash tests, on the reference and nine legs. The reference first,
 red first; then the legs from the corpus, algorithm not reference; the swarm takes the mechanical rows with
 the target and the corpus file named on the card.
+
+## Hostile rows, per plan (bill §12.5)
+
+For every bounded row above, one more test on the reference: a forged value in the OLD file past the OLD
+writer's bound (a count of 7 where the old writer declared `[..4]`, an ordinal 5 where the old enum had 3,
+a tag past the old arm count, a scalar past the old range), read by the NEW reader whose own bound is
+wider: it clamps or lands `None` against the WRITER's bound carried by the plan, and counts, never landing
+a value the old writer could not have written. Named `<row>_hostile_case()`.


### PR DESCRIPTION
The implementer's cold read (twelve contradictions, verdict not ready) and the lock survey (the lock is equality-based; every widening refused; bits(N) unrecorded; no lineage, floor or layout bytes) ruled as defaults under Glenn's 'run to completion without me': the lock's rule becomes monotone; kind means family; deprecation one way and deprecated fields read on every plan; layout_newer carries the hash only, no walk over a stranger's layout anywhere; the plan carries the writer's bounds for the hostile pass; a grown [N] fills element defaults; ordinal width growth is a widen and guards compare full width; a present op; LOAD keeps every framing check; a plan-cap row in BASELINE; the default row in §6. §5 and the test design corrected to match. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
