### PR TITLE
fixed form: the LIST rows' read columns on the C++ reference, red first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,35 @@ define tables_generate
 	# nested TYPE the older side has no name for
 	$(1) generate --lang cpp --out $(2)/fx1 test/tables/FX1.schema
 	$(1) generate --lang cpp --out $(2)/fx2 test/tables/FX2.schema
+	# ==== BEGIN rowan/cpp-versioning-lists ====
+	# THE LIST ROWS OF THE FIXED FORM'S VERSIONING LAW
+	# (docs/FIXED-FORM-VERSIONING-TESTS.md). One pair of schemas per row,
+	# the SAME table name on both sides (one lineage) and a package each, so
+	# both generations compile into one test binary — the FX1/FX2 precedent.
+	# The reference's two read columns are test/tables/versioning_lists.cpp.
+	$(1) generate --lang cpp --out $(2)/vold_field_append test/tables/VOLD_field_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_field_append test/tables/VNEW_field_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_field_deprecate test/tables/VOLD_field_deprecate.schema
+	$(1) generate --lang cpp --out $(2)/vnew_field_deprecate test/tables/VNEW_field_deprecate.schema
+	$(1) generate --lang cpp --out $(2)/vold_field_undeprecate test/tables/VOLD_field_undeprecate.schema
+	$(1) generate --lang cpp --out $(2)/vnew_field_undeprecate test/tables/VNEW_field_undeprecate.schema
+	$(1) generate --lang cpp --out $(2)/vold_enum_append test/tables/VOLD_enum_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_enum_append test/tables/VNEW_enum_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_enum_width test/tables/VOLD_enum_width.schema
+	$(1) generate --lang cpp --out $(2)/vnew_enum_width test/tables/VNEW_enum_width.schema
+	$(1) generate --lang cpp --out $(2)/vold_union_append test/tables/VOLD_union_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_union_append test/tables/VNEW_union_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_union_arm_payload_widen test/tables/VOLD_union_arm_payload_widen.schema
+	$(1) generate --lang cpp --out $(2)/vnew_union_arm_payload_widen test/tables/VNEW_union_arm_payload_widen.schema
+	$(1) generate --lang cpp --out $(2)/vold_flags_append test/tables/VOLD_flags_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_flags_append test/tables/VNEW_flags_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_keyed_array_enum_append test/tables/VOLD_keyed_array_enum_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_keyed_array_enum_append test/tables/VNEW_keyed_array_enum_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_nested_append test/tables/VOLD_nested_append.schema
+	$(1) generate --lang cpp --out $(2)/vnew_nested_append test/tables/VNEW_nested_append.schema
+	$(1) generate --lang cpp --out $(2)/vold_rename_without_was test/tables/VOLD_rename_without_was.schema
+	$(1) generate --lang cpp --out $(2)/vnew_rename_without_was test/tables/VNEW_rename_without_was.schema
+	# ==== END rowan/cpp-versioning-lists ====
 	$(1) generate --lang cpp --out $(2)/scalars tables/scalars
 	$(1) generate --lang cpp --out $(2)/maps tables/maps
 	$(1) generate --lang cpp --out $(2)/lists tables/lists
@@ -252,7 +281,7 @@ tables_includes = -I$(1)/examples -I$(1)/pointers -I$(1)/block -I$(1)/blockhome 
 	-I$(1)/v1 -I$(1)/v2 -I$(1)/p1 -I$(1)/p2 -I$(1)/p3 -I$(1)/jsonkeys \
 	-I$(1)/messages -I$(1)/stream -I$(1)/blobs -I$(1)/m1 -I$(1)/m2 -I$(1)/a1 -I$(1)/a2 -I$(1)/g1 -I$(1)/k1 -I$(1)/k2 -I$(1)/w1 -I$(1)/w2 -I$(1)/r1 -I$(1)/r2 -I$(1)/f1 -I$(1)/f2 -I$(1)/l1 -I$(1)/scalars -I$(1)/scalars2 -I$(1)/maps -I$(1)/lists -I$(1)/arms -I$(1)/backend -I$(1)/vocab -I$(1)/vocab9 -I$(1)/bases -I$(1)/rt1 -I$(1)/rt2 -I$(1)/rt3 -I$(1)/wide -I$(SERIALIZE)
 
-build/tables-generated/.stamp: bin/schema $(SCHEMAS_WIDE) $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) $(SCHEMAS_TABLES_BLOCK) $(SCHEMAS_TABLES_MESSAGES) $(SCHEMAS_TABLES_BLOBS) $(SCHEMAS_TABLES_SCALARS) $(SCHEMAS_TABLES_MAPS) $(SCHEMAS_TABLES_LISTS) $(SCHEMAS_TABLES_ARMS) $(SCHEMAS_TABLES_BACKEND) $(SCHEMAS_TABLES_VOCAB) $(SCHEMAS_TABLES_VOCAB9) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema test/tables/P3.schema test/tables/JsonKeys.schema test/tables/M1.schema test/tables/M2.schema test/tables/A1.schema test/tables/A2.schema test/tables/G1.schema test/tables/K1.schema test/tables/K2.schema test/tables/W1.schema test/tables/W2.schema test/tables/R1.schema test/tables/R2.schema test/tables/F1.schema test/tables/F2.schema test/tables/L1.schema test/tables/Scalars2.schema test/tables/Bases.schema test/tables/RT1.schema test/tables/RT2.schema test/tables/RT3.schema test/tables/FX1.schema test/tables/FX2.schema test/tables/UT1.schema test/tables/UT2.schema test/tables/FN1.schema test/tables/FN2.schema test/tables/FU1.schema test/tables/FU2.schema test/tables/FM1.schema test/tables/FM2.schema
+build/tables-generated/.stamp: bin/schema $(SCHEMAS_WIDE) $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) $(SCHEMAS_TABLES_BLOCK) $(SCHEMAS_TABLES_MESSAGES) $(SCHEMAS_TABLES_BLOBS) $(SCHEMAS_TABLES_SCALARS) $(SCHEMAS_TABLES_MAPS) $(SCHEMAS_TABLES_LISTS) $(SCHEMAS_TABLES_ARMS) $(SCHEMAS_TABLES_BACKEND) $(SCHEMAS_TABLES_VOCAB) $(SCHEMAS_TABLES_VOCAB9) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema test/tables/P3.schema test/tables/JsonKeys.schema test/tables/M1.schema test/tables/M2.schema test/tables/A1.schema test/tables/A2.schema test/tables/G1.schema test/tables/K1.schema test/tables/K2.schema test/tables/W1.schema test/tables/W2.schema test/tables/R1.schema test/tables/R2.schema test/tables/F1.schema test/tables/F2.schema test/tables/L1.schema test/tables/Scalars2.schema test/tables/Bases.schema test/tables/RT1.schema test/tables/RT2.schema test/tables/RT3.schema test/tables/FX1.schema test/tables/FX2.schema test/tables/UT1.schema test/tables/UT2.schema test/tables/FN1.schema test/tables/FN2.schema test/tables/FU1.schema test/tables/FU2.schema test/tables/FM1.schema test/tables/FM2.schema test/tables/VOLD_field_append.schema test/tables/VNEW_field_append.schema test/tables/VOLD_field_deprecate.schema test/tables/VNEW_field_deprecate.schema test/tables/VOLD_field_undeprecate.schema test/tables/VNEW_field_undeprecate.schema test/tables/VOLD_enum_append.schema test/tables/VNEW_enum_append.schema test/tables/VOLD_enum_width.schema test/tables/VNEW_enum_width.schema test/tables/VOLD_union_append.schema test/tables/VNEW_union_append.schema test/tables/VOLD_union_arm_payload_widen.schema test/tables/VNEW_union_arm_payload_widen.schema test/tables/VOLD_flags_append.schema test/tables/VNEW_flags_append.schema test/tables/VOLD_keyed_array_enum_append.schema test/tables/VNEW_keyed_array_enum_append.schema test/tables/VOLD_nested_append.schema test/tables/VNEW_nested_append.schema test/tables/VOLD_rename_without_was.schema test/tables/VNEW_rename_without_was.schema
 	@mkdir -p build/tables-generated
 	$(call tables_generate,./bin/schema,build/tables-generated)
 	@touch $@
@@ -5734,20 +5763,29 @@ toolchain-negative-control:
 # and the NEGATIVE CONTROLS — the wrong plan, a form byte this reader does not
 # carry, a plan that does not fit, and ONE CORRUPTED-LAYOUT CASE PER NAMED RULE
 # a reader holds an untrusted peer's layout to.
-build/schema_test_fixedform: build/tables-generated/.stamp test/tables/fixedform_main.cpp
+# ==== BEGIN rowan/cpp-versioning-lists ====
+# THE LIST ROWS' GENERATED PAIRS, as one variable so the three recipes that
+# need them keep one line each (docs/FIXED-FORM-VERSIONING-TESTS.md).
+VLISTS_INCLUDES = -Ibuild/tables-generated/vold_field_append -Ibuild/tables-generated/vnew_field_append -Ibuild/tables-generated/vold_field_deprecate -Ibuild/tables-generated/vnew_field_deprecate -Ibuild/tables-generated/vold_field_undeprecate -Ibuild/tables-generated/vnew_field_undeprecate -Ibuild/tables-generated/vold_enum_append -Ibuild/tables-generated/vnew_enum_append -Ibuild/tables-generated/vold_enum_width -Ibuild/tables-generated/vnew_enum_width -Ibuild/tables-generated/vold_union_append -Ibuild/tables-generated/vnew_union_append -Ibuild/tables-generated/vold_union_arm_payload_widen -Ibuild/tables-generated/vnew_union_arm_payload_widen -Ibuild/tables-generated/vold_flags_append -Ibuild/tables-generated/vnew_flags_append -Ibuild/tables-generated/vold_keyed_array_enum_append -Ibuild/tables-generated/vnew_keyed_array_enum_append -Ibuild/tables-generated/vold_nested_append -Ibuild/tables-generated/vnew_nested_append -Ibuild/tables-generated/vold_rename_without_was -Ibuild/tables-generated/vnew_rename_without_was
+# ==== END rowan/cpp-versioning-lists ====
+
+build/schema_test_fixedform: build/tables-generated/.stamp test/tables/fixedform_main.cpp \
+                               test/tables/versioning_lists.cpp
 	@mkdir -p build
 	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/tables-generated/fx1 -Ibuild/tables-generated/fx2 \
 	    -Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
 	    -Ibuild/tables-generated/p1 -Ibuild/tables-generated/p3 \
 	    -Ibuild/tables-generated/ut1 -Ibuild/tables-generated/ut2 \
 	    -Ibuild/tables-generated/fu1 -Ibuild/tables-generated/fu2 \
-	    -I$(SERIALIZE) test/tables/fixedform_main.cpp -o $@
+	    $(VLISTS_INCLUDES) \
+	    -I$(SERIALIZE) test/tables/fixedform_main.cpp test/tables/versioning_lists.cpp -o $@
 
 # THE SANITIZED TWIN, and it is the point of the byte-flip fuzz inside it. A
 # fixed record carries no lengths and no terminators, so every offset the
 # reader uses is arithmetic over sizes a STRANGER wrote down. "The reader never
 # leaves the buffer" is a claim only a sanitizer can hold.
-build/schema_test_fixedform_asan: build/tables-generated/.stamp test/tables/fixedform_main.cpp
+build/schema_test_fixedform_asan: build/tables-generated/.stamp test/tables/fixedform_main.cpp \
+                               test/tables/versioning_lists.cpp
 	@mkdir -p build
 	$(CXX) $(TABLES_CXXFLAGS) -fsanitize=address,undefined -fno-sanitize-recover=all \
 	    -fno-omit-frame-pointer -g \
@@ -5756,7 +5794,8 @@ build/schema_test_fixedform_asan: build/tables-generated/.stamp test/tables/fixe
 	    -Ibuild/tables-generated/p1 -Ibuild/tables-generated/p3 \
 	    -Ibuild/tables-generated/ut1 -Ibuild/tables-generated/ut2 \
 	    -Ibuild/tables-generated/fu1 -Ibuild/tables-generated/fu2 \
-	    -I$(SERIALIZE) test/tables/fixedform_main.cpp -o $@
+	    $(VLISTS_INCLUDES) \
+	    -I$(SERIALIZE) test/tables/fixedform_main.cpp test/tables/versioning_lists.cpp -o $@
 
 # THE RUN COPY'S BOUND, ON ITS OWN (test/tables/fixedform_runcopy.cpp). The
 # fixtures above check the VALUES a read produces; this one checks the single
@@ -5860,6 +5899,7 @@ build/schema_test_fixedform_dump: build/tables-generated/.stamp build/tables-gen
 	$(CXX) $(TABLES_CXXFLAGS) -Ibuild/tables-generated/fx1 -Ibuild/tables-generated/fx2 \
 	    -Ibuild/tables-generated/p1 -Ibuild/tables-generated/p3 \
 	    -Ibuild/tables-generated/examples -Ibuild/tables-generated-fxw/fxw \
+	    $(VLISTS_INCLUDES) \
 	    -I$(SERIALIZE) test/tables/fixedform_dump.cpp -o $@
 
 build/fixedform-corpus/.stamp: build/schema_test_fixedform_dump

--- a/test/tables/VNEW_enum_append.schema
+++ b/test/tables/VNEW_enum_append.schema
@@ -1,0 +1,19 @@
+// VNEW_enum_append.schema — the NEW side of the `enum_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one variant appended at the end of an enum — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_enum_append
+
+enum Tier { Bronze, Silver, Gold, Platinum }
+
+fixed table Lineage
+{
+    tier Tier
+    seq  int32 = 0
+}

--- a/test/tables/VNEW_enum_width.schema
+++ b/test/tables/VNEW_enum_width.schema
@@ -1,0 +1,22 @@
+// VNEW_enum_width.schema — the NEW side of the `enum_width` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — an enum crossing the 255/256 variant boundary, so its ordinal width goes 1 -> 2 — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_enum_width
+
+// 256 VARIANTS: the extent is 256 and the ordinal is TWO BYTES. One appended
+// variant moves every byte after it, which is the whole of why the reader's
+// plan has to widen the ordinal rather than copy it.
+enum Wide { V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37, V38, V39, V40, V41, V42, V43, V44, V45, V46, V47, V48, V49, V50, V51, V52, V53, V54, V55, V56, V57, V58, V59, V60, V61, V62, V63, V64, V65, V66, V67, V68, V69, V70, V71, V72, V73, V74, V75, V76, V77, V78, V79, V80, V81, V82, V83, V84, V85, V86, V87, V88, V89, V90, V91, V92, V93, V94, V95, V96, V97, V98, V99, V100, V101, V102, V103, V104, V105, V106, V107, V108, V109, V110, V111, V112, V113, V114, V115, V116, V117, V118, V119, V120, V121, V122, V123, V124, V125, V126, V127, V128, V129, V130, V131, V132, V133, V134, V135, V136, V137, V138, V139, V140, V141, V142, V143, V144, V145, V146, V147, V148, V149, V150, V151, V152, V153, V154, V155, V156, V157, V158, V159, V160, V161, V162, V163, V164, V165, V166, V167, V168, V169, V170, V171, V172, V173, V174, V175, V176, V177, V178, V179, V180, V181, V182, V183, V184, V185, V186, V187, V188, V189, V190, V191, V192, V193, V194, V195, V196, V197, V198, V199, V200, V201, V202, V203, V204, V205, V206, V207, V208, V209, V210, V211, V212, V213, V214, V215, V216, V217, V218, V219, V220, V221, V222, V223, V224, V225, V226, V227, V228, V229, V230, V231, V232, V233, V234, V235, V236, V237, V238, V239, V240, V241, V242, V243, V244, V245, V246, V247, V248, V249, V250, V251, V252, V253, V254, V255, V256 }
+
+fixed table Lineage
+{
+    tier Wide
+    seq  int32 = 0
+}

--- a/test/tables/VNEW_field_append.schema
+++ b/test/tables/VNEW_field_append.schema
@@ -1,0 +1,21 @@
+// VNEW_field_append.schema — the NEW side of the `field_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended at the end of the table — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_field_append
+
+fixed table Lineage
+{
+    x int32 = 0
+    y int32 = 0
+    z int32 = 0
+    // THE WIDENING. Its default is what makes the widening safe (the bill's
+    // invariant): a NEW reader given an OLD record lands 77 here.
+    w int32 = 77
+}

--- a/test/tables/VNEW_field_deprecate.schema
+++ b/test/tables/VNEW_field_deprecate.schema
@@ -1,0 +1,20 @@
+// VNEW_field_deprecate.schema — the NEW side of the `field_deprecate` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field retired in place with `| deprecated` — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_field_deprecate
+
+fixed table Lineage
+{
+    a int32 = 0
+    // RETIRED IN PLACE (SPEC-TABLES §2.10): the slot stays exactly where it is,
+    // so `c` does not slide, and a reader ignores what it finds here.
+    b int32 = 0 | deprecated
+    c int32 = 0
+}

--- a/test/tables/VNEW_field_undeprecate.schema
+++ b/test/tables/VNEW_field_undeprecate.schema
@@ -1,0 +1,18 @@
+// VNEW_field_undeprecate.schema — the NEW side of the `field_undeprecate` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field UN-deprecated (allowed in both directions) — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_field_undeprecate
+
+fixed table Lineage
+{
+    a int32 = 0
+    b int32 = 0
+    c int32 = 0
+}

--- a/test/tables/VNEW_flags_append.schema
+++ b/test/tables/VNEW_flags_append.schema
@@ -1,0 +1,19 @@
+// VNEW_flags_append.schema — the NEW side of the `flags_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one flag appended at the end of a flags declaration — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_flags_append
+
+flags Caps { Jump, Crouch, Fly }
+
+fixed table Lineage
+{
+    caps Caps
+    seq  int32 = 0
+}

--- a/test/tables/VNEW_keyed_array_enum_append.schema
+++ b/test/tables/VNEW_keyed_array_enum_append.schema
@@ -1,0 +1,19 @@
+// VNEW_keyed_array_enum_append.schema — the NEW side of the `keyed_array_enum_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one variant appended to the enum that KEYS an array, so the array gains a slot — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_keyed_array_enum_append
+
+enum Tier { Bronze, Silver, Gold, Platinum }
+
+fixed table Lineage
+{
+    slots [Tier]int32
+    seq   int32 = 0
+}

--- a/test/tables/VNEW_nested_append.schema
+++ b/test/tables/VNEW_nested_append.schema
@@ -1,0 +1,26 @@
+// VNEW_nested_append.schema — the NEW side of the `nested_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended at the end of a NESTED fixed table reached by value — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_nested_append
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 0
+    z int32 = 0
+    // the widening, INSIDE the nested table: Root's own field list did not move
+    w int32 = 88
+}
+
+fixed table Lineage
+{
+    v   Vec
+    seq int32 = 0
+}

--- a/test/tables/VNEW_rename_without_was.schema
+++ b/test/tables/VNEW_rename_without_was.schema
@@ -1,0 +1,20 @@
+// VNEW_rename_without_was.schema — the NEW side of the `rename_without_was` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field renamed THROUGH `was`, which is wire identity preserved and no version at all — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_rename_without_was
+
+fixed table Lineage
+{
+    // RENAMED THROUGH `was`. Wire identity is the hash of the name, and `was`
+    // keeps the OLD name's hash, so this edit moves no layout byte: the two
+    // layouts are BYTE-IDENTICAL and the pair reads in both directions.
+    b   int32 = 0 | was = "a"
+    seq int32 = 0
+}

--- a/test/tables/VNEW_union_append.schema
+++ b/test/tables/VNEW_union_append.schema
@@ -1,0 +1,28 @@
+// VNEW_union_append.schema — the NEW side of the `union_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one arm appended at the end of a union — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_union_append
+
+type Alpha { m int32 = 0 }
+type Beta  { n int32 = 0 }
+type Gamma { p int32 = 0 }
+
+union Pick
+{
+    alpha Alpha
+    beta  Beta
+    gamma Gamma
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}

--- a/test/tables/VNEW_union_arm_payload_widen.schema
+++ b/test/tables/VNEW_union_arm_payload_widen.schema
@@ -1,0 +1,32 @@
+// VNEW_union_arm_payload_widen.schema — the NEW side of the `union_arm_payload_widen` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended to the payload of a union's FIRST arm — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vnew_union_arm_payload_widen
+
+// THE ARM'S PAYLOAD WIDENS: `y` appended at the end of Alpha, its default the
+// value a NEW reader lands when an OLD writer's arm carried only `x`.
+type Alpha
+{
+    x int32 = 0
+    y int32 = 55
+}
+type Beta  { n int32 = 0 }
+
+union Pick
+{
+    alpha Alpha
+    beta  Beta
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}

--- a/test/tables/VOLD_enum_append.schema
+++ b/test/tables/VOLD_enum_append.schema
@@ -1,0 +1,20 @@
+// VOLD_enum_append.schema — the OLD side of the `enum_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one variant appended at the end of an enum — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_enum_append
+
+enum Tier { Bronze, Silver, Gold }
+
+fixed table Lineage
+{
+    tier Tier
+    // A SCALAR AFTER THE ENUM, so a mislaid ordinal width moves this too.
+    seq  int32 = 0
+}

--- a/test/tables/VOLD_enum_width.schema
+++ b/test/tables/VOLD_enum_width.schema
@@ -1,0 +1,21 @@
+// VOLD_enum_width.schema — the OLD side of the `enum_width` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — an enum crossing the 255/256 variant boundary, so its ordinal width goes 1 -> 2 — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_enum_width
+
+// 255 VARIANTS: with None = 0 implicit and the variants dense from 1 the extent
+// is 255, which is the last extent a ONE-BYTE ordinal holds.
+enum Wide { V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37, V38, V39, V40, V41, V42, V43, V44, V45, V46, V47, V48, V49, V50, V51, V52, V53, V54, V55, V56, V57, V58, V59, V60, V61, V62, V63, V64, V65, V66, V67, V68, V69, V70, V71, V72, V73, V74, V75, V76, V77, V78, V79, V80, V81, V82, V83, V84, V85, V86, V87, V88, V89, V90, V91, V92, V93, V94, V95, V96, V97, V98, V99, V100, V101, V102, V103, V104, V105, V106, V107, V108, V109, V110, V111, V112, V113, V114, V115, V116, V117, V118, V119, V120, V121, V122, V123, V124, V125, V126, V127, V128, V129, V130, V131, V132, V133, V134, V135, V136, V137, V138, V139, V140, V141, V142, V143, V144, V145, V146, V147, V148, V149, V150, V151, V152, V153, V154, V155, V156, V157, V158, V159, V160, V161, V162, V163, V164, V165, V166, V167, V168, V169, V170, V171, V172, V173, V174, V175, V176, V177, V178, V179, V180, V181, V182, V183, V184, V185, V186, V187, V188, V189, V190, V191, V192, V193, V194, V195, V196, V197, V198, V199, V200, V201, V202, V203, V204, V205, V206, V207, V208, V209, V210, V211, V212, V213, V214, V215, V216, V217, V218, V219, V220, V221, V222, V223, V224, V225, V226, V227, V228, V229, V230, V231, V232, V233, V234, V235, V236, V237, V238, V239, V240, V241, V242, V243, V244, V245, V246, V247, V248, V249, V250, V251, V252, V253, V254, V255 }
+
+fixed table Lineage
+{
+    tier Wide
+    seq  int32 = 0
+}

--- a/test/tables/VOLD_field_append.schema
+++ b/test/tables/VOLD_field_append.schema
@@ -1,0 +1,18 @@
+// VOLD_field_append.schema — the OLD side of the `field_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended at the end of the table — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_field_append
+
+fixed table Lineage
+{
+    x int32 = 0
+    y int32 = 0
+    z int32 = 0
+}

--- a/test/tables/VOLD_field_deprecate.schema
+++ b/test/tables/VOLD_field_deprecate.schema
@@ -1,0 +1,18 @@
+// VOLD_field_deprecate.schema — the OLD side of the `field_deprecate` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field retired in place with `| deprecated` — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_field_deprecate
+
+fixed table Lineage
+{
+    a int32 = 0
+    b int32 = 0
+    c int32 = 0
+}

--- a/test/tables/VOLD_field_undeprecate.schema
+++ b/test/tables/VOLD_field_undeprecate.schema
@@ -1,0 +1,18 @@
+// VOLD_field_undeprecate.schema — the OLD side of the `field_undeprecate` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field UN-deprecated (allowed in both directions) — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_field_undeprecate
+
+fixed table Lineage
+{
+    a int32 = 0
+    b int32 = 0 | deprecated
+    c int32 = 0
+}

--- a/test/tables/VOLD_flags_append.schema
+++ b/test/tables/VOLD_flags_append.schema
@@ -1,0 +1,19 @@
+// VOLD_flags_append.schema — the OLD side of the `flags_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one flag appended at the end of a flags declaration — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_flags_append
+
+flags Caps { Jump, Crouch }
+
+fixed table Lineage
+{
+    caps Caps
+    seq  int32 = 0
+}

--- a/test/tables/VOLD_keyed_array_enum_append.schema
+++ b/test/tables/VOLD_keyed_array_enum_append.schema
@@ -1,0 +1,19 @@
+// VOLD_keyed_array_enum_append.schema — the OLD side of the `keyed_array_enum_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one variant appended to the enum that KEYS an array, so the array gains a slot — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_keyed_array_enum_append
+
+enum Tier { Bronze, Silver, Gold }
+
+fixed table Lineage
+{
+    slots [Tier]int32
+    seq   int32 = 0
+}

--- a/test/tables/VOLD_nested_append.schema
+++ b/test/tables/VOLD_nested_append.schema
@@ -1,0 +1,24 @@
+// VOLD_nested_append.schema — the OLD side of the `nested_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended at the end of a NESTED fixed table reached by value — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_nested_append
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 0
+    z int32 = 0
+}
+
+fixed table Lineage
+{
+    v   Vec
+    seq int32 = 0
+}

--- a/test/tables/VOLD_rename_without_was.schema
+++ b/test/tables/VOLD_rename_without_was.schema
@@ -1,0 +1,17 @@
+// VOLD_rename_without_was.schema — the OLD side of the `rename_without_was` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field renamed THROUGH `was`, which is wire identity preserved and no version at all — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_rename_without_was
+
+fixed table Lineage
+{
+    a   int32 = 0
+    seq int32 = 0
+}

--- a/test/tables/VOLD_union_append.schema
+++ b/test/tables/VOLD_union_append.schema
@@ -1,0 +1,26 @@
+// VOLD_union_append.schema — the OLD side of the `union_append` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one arm appended at the end of a union — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_union_append
+
+type Alpha { m int32 = 0 }
+type Beta  { n int32 = 0 }
+
+union Pick
+{
+    alpha Alpha
+    beta  Beta
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}

--- a/test/tables/VOLD_union_arm_payload_widen.schema
+++ b/test/tables/VOLD_union_arm_payload_widen.schema
@@ -1,0 +1,26 @@
+// VOLD_union_arm_payload_widen.schema — the OLD side of the `union_arm_payload_widen` row of the fixed form's
+// versioning law (docs/FIXED-FORM-VERSIONING-TESTS.md, the LISTS rows; the bill
+// is docs/FIXED-FORM-BILL-READS-BACKWARD.md §2 and the procedures are
+// docs/FIXED-FORM-ALGORITHM.md §5).
+//
+// The pair differs by EXACTLY ONE definition change — one field appended to the payload of a union's FIRST arm — and
+// nothing else, so a read that goes wrong can only have gone wrong there. The
+// table name is the same on both sides, because the two layouts are ONE
+// LINEAGE; only the package differs, so both generations compile into one test
+// binary (the FX1/FX2 precedent).
+package vold_union_arm_payload_widen
+
+type Alpha { x int32 = 0 }
+type Beta  { n int32 = 0 }
+
+union Pick
+{
+    alpha Alpha
+    beta  Beta
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}

--- a/test/tables/fixedform_dump.cpp
+++ b/test/tables/fixedform_dump.cpp
@@ -27,6 +27,33 @@
 #include "PackTable.h"
 #include "FXWTable.h"
 
+// ==== BEGIN rowan/cpp-versioning-lists: the LIST rows lineage pairs ====
+// docs/FIXED-FORM-VERSIONING-TESTS.md: two schemas per row, one table name,
+// one package each, so both generations of one lineage compile into this binary.
+#include"VOLD_field_appendTable.h"
+#include "VNEW_field_appendTable.h"
+#include"VOLD_field_deprecateTable.h"
+#include "VNEW_field_deprecateTable.h"
+#include"VOLD_field_undeprecateTable.h"
+#include "VNEW_field_undeprecateTable.h"
+#include"VOLD_enum_appendTable.h"
+#include "VNEW_enum_appendTable.h"
+#include"VOLD_enum_widthTable.h"
+#include "VNEW_enum_widthTable.h"
+#include"VOLD_union_appendTable.h"
+#include "VNEW_union_appendTable.h"
+#include"VOLD_union_arm_payload_widenTable.h"
+#include "VNEW_union_arm_payload_widenTable.h"
+#include"VOLD_flags_appendTable.h"
+#include "VNEW_flags_appendTable.h"
+#include"VOLD_keyed_array_enum_appendTable.h"
+#include "VNEW_keyed_array_enum_appendTable.h"
+#include"VOLD_nested_appendTable.h"
+#include "VNEW_nested_appendTable.h"
+#include"VOLD_rename_without_wasTable.h"
+#include "VNEW_rename_without_wasTable.h"
+// ==== END rowan/cpp-versioning-lists ===================================
+
 static bool spill( const char * dir, const char * name, const std::vector<uint8_t> & data )
 {
     char path[1024];
@@ -267,11 +294,228 @@ static bool fxw_file( const char * dir )
     return emit( dir, "fxw.bin", v, tblfxw::FxWideFixedMeasure, tblfxw::FxWideFixedSave );
 }
 
+// ==== BEGIN rowan/cpp-versioning-lists: THE LISTS ROWS' LINEAGE PAIRS ======
+//
+// docs/FIXED-FORM-VERSIONING-TESTS.md, the LIST rows. One pair of files per
+// row: `old_<row>.bin` written by the OLD schema's writer and `new_<row>.bin`
+// by the NEW one's, the two schemas differing by EXACTLY the row's definition
+// change and nothing else. The reference's two read columns (NEW-READS-OLD and
+// OLD-REFUSES-NEW) live in test/tables/versioning_lists.cpp; every other leg
+// reads these same bytes, so the values below are set by hand and none of them
+// is a default.
+
+static bool vlists_files( const char * dir )
+{
+    // ---- field_append: {x,y,z} -> {x,y,z,w} --------------------------------
+    {
+        std::vector<vold_field_append::Lineage> o( 1 );
+        vold_field_append::LineageReset( o[0] );
+        o[0].x = 11; o[0].y = 22; o[0].z = 33;
+        if ( !emit( dir, "old_field_append.bin", o, vold_field_append::LineageFixedMeasure,
+                    vold_field_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_field_append::Lineage> n( 1 );
+        vnew_field_append::LineageReset( n[0] );
+        n[0].x = 44; n[0].y = 55; n[0].z = 66; n[0].w = 777;
+        if ( !emit( dir, "new_field_append.bin", n, vnew_field_append::LineageFixedMeasure,
+                    vnew_field_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- field_deprecate: {a,b,c} -> {a, b deprecated, c} ------------------
+    {
+        std::vector<vold_field_deprecate::Lineage> o( 1 );
+        vold_field_deprecate::LineageReset( o[0] );
+        o[0].a = 1; o[0].b = 2; o[0].c = 3;
+        if ( !emit( dir, "old_field_deprecate.bin", o, vold_field_deprecate::LineageFixedMeasure,
+                    vold_field_deprecate::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_field_deprecate::Lineage> n( 1 );
+        vnew_field_deprecate::LineageReset( n[0] );
+        n[0].a = 4; n[0].b = 5; n[0].c = 6;
+        if ( !emit( dir, "new_field_deprecate.bin", n, vnew_field_deprecate::LineageFixedMeasure,
+                    vnew_field_deprecate::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- field_undeprecate: {a, b deprecated, c} -> {a,b,c} ----------------
+    {
+        std::vector<vold_field_undeprecate::Lineage> o( 1 );
+        vold_field_undeprecate::LineageReset( o[0] );
+        o[0].a = 1; o[0].b = 2; o[0].c = 3;
+        if ( !emit( dir, "old_field_undeprecate.bin", o, vold_field_undeprecate::LineageFixedMeasure,
+                    vold_field_undeprecate::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_field_undeprecate::Lineage> n( 1 );
+        vnew_field_undeprecate::LineageReset( n[0] );
+        n[0].a = 4; n[0].b = 5; n[0].c = 6;
+        if ( !emit( dir, "new_field_undeprecate.bin", n, vnew_field_undeprecate::LineageFixedMeasure,
+                    vnew_field_undeprecate::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- enum_append: Tier {Bronze,Silver,Gold} -> + Platinum --------------
+    //
+    // THE NEW FILE LEADS WITH A VALUE THE OLD READER CAN NAME (Gold), because
+    // the refusal is a property of the LAYOUT and not of a record's values: an
+    // old reader must refuse this file even though its first record holds
+    // nothing it could not have held. The second record holds Platinum.
+    {
+        std::vector<vold_enum_append::Lineage> o( 1 );
+        vold_enum_append::LineageReset( o[0] );
+        o[0].tier = vold_enum_append::Tier::Gold; o[0].seq = 9;
+        if ( !emit( dir, "old_enum_append.bin", o, vold_enum_append::LineageFixedMeasure,
+                    vold_enum_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_enum_append::Lineage> n( 2 );
+        vnew_enum_append::LineageReset( n[0] );
+        n[0].tier = vnew_enum_append::Tier::Gold; n[0].seq = 10;
+        vnew_enum_append::LineageReset( n[1] );
+        n[1].tier = vnew_enum_append::Tier::Platinum; n[1].seq = 11;
+        if ( !emit( dir, "new_enum_append.bin", n, vnew_enum_append::LineageFixedMeasure,
+                    vnew_enum_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- enum_width: 255 variants -> 256, the ordinal 1 byte -> 2 ----------
+    {
+        std::vector<vold_enum_width::Lineage> o( 1 );
+        vold_enum_width::LineageReset( o[0] );
+        o[0].tier = vold_enum_width::Wide::V200; o[0].seq = 12;
+        if ( !emit( dir, "old_enum_width.bin", o, vold_enum_width::LineageFixedMeasure,
+                    vold_enum_width::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_enum_width::Lineage> n( 2 );
+        vnew_enum_width::LineageReset( n[0] );
+        n[0].tier = vnew_enum_width::Wide::V200; n[0].seq = 13;
+        vnew_enum_width::LineageReset( n[1] );
+        // the 256th variant: the ordinal the OLD side's byte cannot hold
+        n[1].tier = vnew_enum_width::Wide::V256; n[1].seq = 14;
+        if ( !emit( dir, "new_enum_width.bin", n, vnew_enum_width::LineageFixedMeasure,
+                    vnew_enum_width::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- union_append: Pick {alpha,beta} -> + gamma ------------------------
+    {
+        std::vector<vold_union_append::Lineage> o( 1 );
+        vold_union_append::LineageReset( o[0] );
+        o[0].pick.type = vold_union_append::PickType::Alpha;
+        o[0].pick.alpha.m = 7;
+        o[0].seq = 15;
+        if ( !emit( dir, "old_union_append.bin", o, vold_union_append::LineageFixedMeasure,
+                    vold_union_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_union_append::Lineage> n( 2 );
+        vnew_union_append::LineageReset( n[0] );
+        n[0].pick.type = vnew_union_append::PickType::Alpha;
+        n[0].pick.alpha.m = 8;
+        n[0].seq = 16;
+        vnew_union_append::LineageReset( n[1] );
+        n[1].pick.type = vnew_union_append::PickType::Gamma;
+        n[1].pick.gamma.p = 9;
+        n[1].seq = 17;
+        if ( !emit( dir, "new_union_append.bin", n, vnew_union_append::LineageFixedMeasure,
+                    vnew_union_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- union_arm_payload_widen: arm alpha {x} -> {x,y} -------------------
+    {
+        std::vector<vold_union_arm_payload_widen::Lineage> o( 1 );
+        vold_union_arm_payload_widen::LineageReset( o[0] );
+        o[0].pick.type = vold_union_arm_payload_widen::PickType::Alpha;
+        o[0].pick.alpha.x = 21;
+        o[0].seq = 18;
+        if ( !emit( dir, "old_union_arm_payload_widen.bin", o, vold_union_arm_payload_widen::LineageFixedMeasure,
+                    vold_union_arm_payload_widen::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_union_arm_payload_widen::Lineage> n( 1 );
+        vnew_union_arm_payload_widen::LineageReset( n[0] );
+        n[0].pick.type = vnew_union_arm_payload_widen::PickType::Alpha;
+        n[0].pick.alpha.x = 22;
+        n[0].pick.alpha.y = 23;
+        n[0].seq = 19;
+        if ( !emit( dir, "new_union_arm_payload_widen.bin", n, vnew_union_arm_payload_widen::LineageFixedMeasure,
+                    vnew_union_arm_payload_widen::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- flags_append: Caps {Jump,Crouch} -> + Fly -------------------------
+    {
+        std::vector<vold_flags_append::Lineage> o( 1 );
+        vold_flags_append::LineageReset( o[0] );
+        o[0].caps = vold_flags_append::Caps_Jump | vold_flags_append::Caps_Crouch;
+        o[0].seq = 20;
+        if ( !emit( dir, "old_flags_append.bin", o, vold_flags_append::LineageFixedMeasure,
+                    vold_flags_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_flags_append::Lineage> n( 1 );
+        vnew_flags_append::LineageReset( n[0] );
+        n[0].caps = vnew_flags_append::Caps_Jump | vnew_flags_append::Caps_Fly;
+        n[0].seq = 21;
+        if ( !emit( dir, "new_flags_append.bin", n, vnew_flags_append::LineageFixedMeasure,
+                    vnew_flags_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- keyed_array_enum_append: [Tier]int32, Tier gains Platinum --------
+    {
+        std::vector<vold_keyed_array_enum_append::Lineage> o( 1 );
+        vold_keyed_array_enum_append::LineageReset( o[0] );
+        o[0].slots[vold_keyed_array_enum_append::Tier::Bronze] = 101;
+        o[0].slots[vold_keyed_array_enum_append::Tier::Silver] = 102;
+        o[0].slots[vold_keyed_array_enum_append::Tier::Gold] = 103;
+        o[0].seq = 22;
+        if ( !emit( dir, "old_keyed_array_enum_append.bin", o, vold_keyed_array_enum_append::LineageFixedMeasure,
+                    vold_keyed_array_enum_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_keyed_array_enum_append::Lineage> n( 1 );
+        vnew_keyed_array_enum_append::LineageReset( n[0] );
+        n[0].slots[vnew_keyed_array_enum_append::Tier::Bronze] = 201;
+        n[0].slots[vnew_keyed_array_enum_append::Tier::Silver] = 202;
+        n[0].slots[vnew_keyed_array_enum_append::Tier::Gold] = 203;
+        n[0].slots[vnew_keyed_array_enum_append::Tier::Platinum] = 204;
+        n[0].seq = 23;
+        if ( !emit( dir, "new_keyed_array_enum_append.bin", n, vnew_keyed_array_enum_append::LineageFixedMeasure,
+                    vnew_keyed_array_enum_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- nested_append: Vec {x,y,z} -> {x,y,z,w}, inside Lineage -----------
+    {
+        std::vector<vold_nested_append::Lineage> o( 1 );
+        vold_nested_append::LineageReset( o[0] );
+        o[0].v.x = 1; o[0].v.y = 2; o[0].v.z = 3; o[0].seq = 24;
+        if ( !emit( dir, "old_nested_append.bin", o, vold_nested_append::LineageFixedMeasure,
+                    vold_nested_append::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_nested_append::Lineage> n( 1 );
+        vnew_nested_append::LineageReset( n[0] );
+        n[0].v.x = 4; n[0].v.y = 5; n[0].v.z = 6; n[0].v.w = 7; n[0].seq = 25;
+        if ( !emit( dir, "new_nested_append.bin", n, vnew_nested_append::LineageFixedMeasure,
+                    vnew_nested_append::LineageFixedSave ) ) { return false; }
+    }
+
+    // ---- rename_without_was: `a` -> `b was = "a"` -------------------------
+    {
+        std::vector<vold_rename_without_was::Lineage> o( 1 );
+        vold_rename_without_was::LineageReset( o[0] );
+        o[0].a = 31; o[0].seq = 26;
+        if ( !emit( dir, "old_rename_without_was.bin", o, vold_rename_without_was::LineageFixedMeasure,
+                    vold_rename_without_was::LineageFixedSave ) ) { return false; }
+
+        std::vector<vnew_rename_without_was::Lineage> n( 1 );
+        vnew_rename_without_was::LineageReset( n[0] );
+        n[0].b = 32; n[0].seq = 27;
+        if ( !emit( dir, "new_rename_without_was.bin", n, vnew_rename_without_was::LineageFixedMeasure,
+                    vnew_rename_without_was::LineageFixedSave ) ) { return false; }
+    }
+
+    return true;
+}
+
+// ==== END rowan/cpp-versioning-lists =======================================
+
 int main( int argc, char ** argv )
 {
     if ( argc != 2 ) { std::fprintf( stderr, "usage: %s <outdir>\n", argv[0] ); return 1; }
     const char * dir = argv[1];
     if ( !fx1_file( dir ) || !fx2_file( dir ) || !p1_file( dir ) || !p3_file( dir ) ||
          !keyed_file( dir ) || !pack_file( dir ) || !fxw_file( dir ) ) { return 1; }
+    // ==== BEGIN rowan/cpp-versioning-lists ====
+    if ( !vlists_files( dir ) ) { return 1; }
+    // ==== END rowan/cpp-versioning-lists =====
     return 0;
 }

--- a/test/tables/fixedform_main.cpp
+++ b/test/tables/fixedform_main.cpp
@@ -49,6 +49,12 @@
 
 static int failures = 0;
 
+// ==== BEGIN rowan/cpp-versioning-lists ====
+// the LIST rows' read columns, in their own translation unit; it returns its
+// own failure count and prints its own known-red report
+int versioning_lists_cases();
+// ==== END rowan/cpp-versioning-lists ====
+
 static void check( bool ok, const char * what )
 {
     if ( !ok ) { std::printf( "FAIL: %s\n", what ); failures++; }
@@ -1388,6 +1394,13 @@ int main()
     cache_case();
     layout_validation();
     fuzz_case();
+    // ==== BEGIN rowan/cpp-versioning-lists ====
+    // THE LIST ROWS OF THE FIXED FORM'S VERSIONING LAW, in their own
+    // translation unit (test/tables/versioning_lists.cpp) with their own
+    // known-red list: NEW-READS-OLD and OLD-REFUSES-NEW, one lineage pair per
+    // row (docs/FIXED-FORM-VERSIONING-TESTS.md).
+    failures += versioning_lists_cases();
+    // ==== END rowan/cpp-versioning-lists ====
     if ( failures != 0 ) { std::printf( "%d failure(s)\n", failures ); return 1; }
     std::printf( "fixed form: versioning conformance green\n" );
     return 0;

--- a/test/tables/versioning_lists.cpp
+++ b/test/tables/versioning_lists.cpp
@@ -1,0 +1,951 @@
+// THE FIXED FORM READS BACKWARD, NEVER FORWARD — THE LIST ROWS, ON THE C++
+// REFERENCE.
+//
+// The bill is docs/FIXED-FORM-BILL-READS-BACKWARD.md; the law is its §2; the
+// procedures are docs/FIXED-FORM-ALGORITHM.md §5; the test design is
+// docs/FIXED-FORM-VERSIONING-TESTS.md, and this file is that design's two READ
+// columns for the rows that are LISTS — a field list, an enum's variants, a
+// union's arms, a flags' bits, an enum-keyed array's slots, a nested table's
+// fields:
+//
+//   NEW-READS-OLD     the widened reader reads the older writer's file: every
+//                     old value lands EXACTLY, the reader's tail is its
+//                     declared default, and the counters are what §5.2 says.
+//   OLD-REFUSES-NEW   the older reader given the widened writer's file refuses
+//                     `layout_newer` BEFORE ANY RECORD: nothing decoded, no
+//                     counter moved, and the reason is this refusal's own.
+//
+// Glenn, 2026-09-10: "Newer versions of the fixed table should be able to read
+// OLD versions. But old versions CANNOT read new versions, and complain loudly
+// and refuse. Nothing else makes sense."
+//
+// RED FIRST IS THE POINT. `layout_newer` DOES NOT EXIST. This build's reader,
+// handed a newer file, compiles a plan from the stranger's layout and READS it
+// — which is the old contract, and is exactly what the bill retires. So every
+// OLD-REFUSES-NEW column below is RED today, by name, on the known-red list,
+// and the day the refusal lands they all go green together and the list has to
+// be emptied. A listed case that starts PASSING fails this target, which is how
+// the list is held from both ends (the convention is fixedform_properties.cpp's).
+//
+// THE PAIRS. One row is one definition change and nothing else. Each row has
+// two schemas, test/tables/VOLD_<row>.schema and VNEW_<row>.schema, carrying
+// the SAME table name `Lineage` — the two layouts are ONE LINEAGE — and
+// differing only in their package, so both generations compile into this one
+// binary. That is the FX1/FX2 precedent and it means no row needs `Old<Row>` /
+// `New<Row>` names.
+//
+// THE BYTES. test/tables/fixedform_dump.cpp writes `old_<row>.bin` and
+// `new_<row>.bin` into build/fixedform-corpus from the same two writers with
+// the same hand-set values, which is the corpus every other leg reads. The
+// cases below build those same bytes in memory rather than opening the files,
+// so this binary needs no corpus on disk — the same choice fixedform_main.cpp
+// makes, and each case names its corpus file so a leg can line the two up.
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "VOLD_field_appendTable.h"
+#include "VNEW_field_appendTable.h"
+#include "VOLD_field_deprecateTable.h"
+#include "VNEW_field_deprecateTable.h"
+#include "VOLD_field_undeprecateTable.h"
+#include "VNEW_field_undeprecateTable.h"
+#include "VOLD_enum_appendTable.h"
+#include "VNEW_enum_appendTable.h"
+#include "VOLD_enum_widthTable.h"
+#include "VNEW_enum_widthTable.h"
+#include "VOLD_union_appendTable.h"
+#include "VNEW_union_appendTable.h"
+#include "VOLD_union_arm_payload_widenTable.h"
+#include "VNEW_union_arm_payload_widenTable.h"
+#include "VOLD_flags_appendTable.h"
+#include "VNEW_flags_appendTable.h"
+#include "VOLD_keyed_array_enum_appendTable.h"
+#include "VNEW_keyed_array_enum_appendTable.h"
+#include "VOLD_nested_appendTable.h"
+#include "VNEW_nested_appendTable.h"
+#include "VOLD_rename_without_wasTable.h"
+#include "VNEW_rename_without_wasTable.h"
+
+// ---------------------------------------------------------------------------
+// the failure count of this translation unit, handed to fixedform_main.cpp's by
+// the one registration call at the bottom
+
+static int failures = 0;
+
+static void check( bool ok, const char * what )
+{
+    if ( !ok ) { std::printf( "FAIL: %s\n", what ); failures++; }
+}
+
+// ---------------------------------------------------------------------------
+// THE KNOWN-RED LIST, held from both ends (test/tables/fixedform_properties.cpp
+// is where this convention lives). A listed case may fail and the target still
+// ends green; a listed case that PASSES fails the target, so landing the fix
+// means deleting its line here.
+
+struct KnownRed
+{
+    const char * key;
+    const char * waits_on;
+    int reached;
+    int failed;
+};
+
+static KnownRed known_red[] = {
+    // The eight rows whose widening the reader must refuse. Every one of them
+    // is refused by the LAW and read by the CODE, which is the gap this list
+    // measures.
+    { "field_append/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "enum_append/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "enum_width/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "union_append/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "union_arm_payload_widen/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "keyed_array_enum_append/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    { "nested_append/OLD-REFUSES-NEW", "layout_newer (bill §4, algorithm §5.3)", 0, 0 },
+    // AND THE ROW WHOSE REFUSAL IS NOT EVEN REACHABLE YET. A flags append
+    // moves NO LAYOUT BYTE (ir/fixedform.go pushes a flags field as a plain
+    // 8-byte scalar, children = 0), so the two layouts hash the same, the
+    // reader takes the IDENTITY plan, and there is nothing for a version check
+    // to look at. The bill's "flags: bits a prefix of the reader's" row cannot
+    // be held on this wire until the layout entry carries the flag count the
+    // way an enum's carries its variant count.
+    { "flags_append/OLD-REFUSES-NEW",
+      "the layout recording a flags' bit count, THEN layout_newer", 0, 0 },
+    // The same shape of hole on the read side: `| deprecated` is a lock and
+    // reflection marker only (nothing in ir/ reads Field.Deprecated), so the
+    // deprecation moves no layout byte either, the pair hashes the same, and
+    // the reader cannot drop-and-count a field it was told to stop needing.
+    { "field_deprecate/NEW-READS-OLD",
+      "the layout recording `| deprecated`, so the plan can skip-and-count", 0, 0 },
+    // MEASURED, NOT PREDICTED. Two of the NEW-READS-OLD columns are red on
+    // this build as well, and neither is about `layout_newer`:
+    //
+    //   an enum ordinal that GREW is landed exactly and counted NOWHERE. §5.2
+    //   says "wider in y: widen (COUNT widened)" and names the ordinal as one
+    //   of the rows it is written for, so the value is right and the counter
+    //   owes one. Compare FU1/FU2's int16 -> int32, which does count.
+    { "enum_width/NEW-READS-OLD",
+      "COUNT widened on an enum ordinal that grew (algorithm §5.2)", 0, 0 },
+    //   a field appended UNDER A UNION ARM does not take its declared default
+    //   through a compiled plan: the prefill reaches a table's own appended
+    //   field (FX2's `added` lands 11) and does not reach one inside an arm's
+    //   payload. And it does not land ZERO either — it lands 1 on this build,
+    //   which is a byte from somewhere else in the record and not a default at
+    //   all, so this red is the sharper of the two. The landed value is printed
+    //   beside the assertion so it cannot drift silently.
+    { "union_arm_payload_widen/NEW-READS-OLD",
+      "the prefill reaching a field appended inside a union arm's payload", 0, 0 },
+};
+
+static KnownRed * find_red( const char * key )
+{
+    for ( KnownRed & r : known_red )
+    {
+        if ( std::strcmp( r.key, key ) == 0 ) { return &r; }
+    }
+    return NULL;
+}
+
+static void check_red( bool ok, const char * key, const char * what )
+{
+    KnownRed * r = find_red( key );
+    if ( r == NULL ) { check( ok, what ); return; }
+    r->reached++;
+    if ( !ok )
+    {
+        r->failed++;
+        std::printf( "KNOWN-RED [%s]: %s\n", r->key, what );
+    }
+}
+
+static int known_red_report()
+{
+    int bad = 0;
+    const int n = (int) ( sizeof( known_red ) / sizeof( known_red[0] ) );
+    std::printf( "versioning lists: KNOWN-RED, %d case(s), each waiting on a named fix:\n", n );
+    for ( const KnownRed & r : known_red )
+    {
+        std::printf( "  %-44s  %s  <- %s\n", r.key,
+                     r.failed > 0 ? "RED  " : ( r.reached > 0 ? "GREEN" : "UNRUN" ), r.waits_on );
+        if ( r.reached == 0 )
+        {
+            std::printf( "FAIL: KNOWN-RED case %s was never reached: the case that carries it is gone\n", r.key );
+            bad++;
+        }
+        else if ( r.failed == 0 )
+        {
+            std::printf( "FAIL: KNOWN-RED case %s PASSES now — delete it from known_red[] as part of landing %s\n",
+                         r.key, r.waits_on );
+            bad++;
+        }
+    }
+    return bad;
+}
+
+// ---------------------------------------------------------------------------
+// THE REFUSAL, SPELLED WITHOUT THE NAME IT DOES NOT HAVE YET.
+//
+// The bill names this refusal `layout_newer` and the runtime carries no such
+// enumerator, so no case can write it down. What a case CAN write down is
+// everything the name is worth, and all of it is observable today:
+//
+//   1. the read is refused and returns a negative count — before any record;
+//   2. no counter moved and nothing is marked malformed (REFUSE is total);
+//   3. the reason is NOT one this build already has — not a form byte, and not
+//      one of §1.1's eight broken-layout reasons: a newer layout IS a layout,
+//      and it is not this reader's to read;
+//   4. the destination is untouched, which each case asserts on its own fields.
+//
+// The reference exposes no TEXT for a reason (TableReport carries the
+// enumerator and nothing else), so "the refusal names the row's definition"
+// has nowhere to land on this leg yet; the per-row definition is named in the
+// case's own message instead, which is what a leg with text will assert.
+
+#define VL_OWN_REASON( NS, r )                                                                 \
+    ( ( r ).reason != NS::newer_form && ( r ).reason != NS::previous_form &&                    \
+      ( r ).reason != NS::no_vocabulary && ( r ).reason != NS::second_announcement &&           \
+      ( r ).reason != NS::vocabulary_too_large && ( r ).reason != NS::message_form_as_file &&   \
+      ( r ).reason != NS::batch_too_large && ( r ).reason != NS::no_layout &&                   \
+      ( r ).reason != NS::layout_malformed && ( r ).reason != NS::plan_too_large &&             \
+      ( r ).reason != NS::layout_count_mismatch && ( r ).reason != NS::layout_kind_unknown &&   \
+      ( r ).reason != NS::layout_kind_invalid && ( r ).reason != NS::layout_size_mismatch &&    \
+      ( r ).reason != NS::layout_tree_unclosed && ( r ).reason != NS::layout_too_deep &&        \
+      ( r ).reason != NS::layout_record_too_large )
+
+// the three assertions every OLD-REFUSES-NEW column shares. `definition` is the
+// row's own definition, named so the line says what the refusal owes.
+template <typename Report>
+static void refuses_newer( const char * key, const char * definition, int64_t n, const Report & r,
+                           bool own_reason )
+{
+    char what[320];
+    std::snprintf( what, sizeof( what ),
+                   "%s: refused before any record, naming %s", key, definition );
+    check_red( n < 0 && r.refused, key, what );
+    std::snprintf( what, sizeof( what ), "%s: REFUSE is total — no counter moved", key );
+    check_red( r.unknown == 0 && r.kind_mismatch == 0 && r.widened == 0 && r.clamped == 0 &&
+               !r.malformed, key, what );
+    std::snprintf( what, sizeof( what ),
+                   "%s: the reason is `layout_newer`'s own — not a form byte, not a broken layout", key );
+    check_red( r.refused && own_reason, key, what );
+}
+
+// the counters §5.2 says a clean NEW-READS-OLD moves, and the ones it does not
+template <typename Report>
+static void reads_clean( const char * row, const Report & r, int want_unknown, int want_widened )
+{
+    char what[320];
+    std::snprintf( what, sizeof( what ), "%s: NEW-READS-OLD — unknown == %d per §5.2", row, want_unknown );
+    check( r.unknown == want_unknown, what );
+    std::snprintf( what, sizeof( what ), "%s: NEW-READS-OLD — widened == %d per §5.2", row, want_widened );
+    check( r.widened == want_widened, what );
+    std::snprintf( what, sizeof( what ),
+                   "%s: NEW-READS-OLD — nothing clamped, no kind moved, no damage, no refusal", row );
+    check( r.clamped == 0 && r.kind_mismatch == 0 && !r.malformed && !r.refused, what );
+}
+
+// ---------------------------------------------------------------------------
+// field_append: vec {x,y,z} -> {x,y,z,w}   (old_field_append.bin / new_field_append.bin)
+
+static void field_append_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_field_append::LineageFixedMeasure( 1 ) );
+    {
+        vold_field_append::Lineage v;
+        vold_field_append::LineageReset( v );
+        v.x = 11; v.y = 22; v.z = 33;
+        check( vold_field_append::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "field_append: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_field_append::LineageFixedMeasure( 1 ) );
+    {
+        vnew_field_append::Lineage v;
+        vnew_field_append::LineageReset( v );
+        v.x = 44; v.y = 55; v.z = 66; v.w = 777;
+        check( vnew_field_append::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "field_append: the NEW file saves" );
+    }
+
+    // NEW-READS-OLD
+    {
+        vnew_field_append::Lineage back;
+        vnew_field_append::LineageReset( back );
+        vnew_field_append::TableReport r;
+        std::vector<vnew_field_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_field_append::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        check( n == 1, "field_append: NEW-READS-OLD — one record" );
+        check( back.x == 11 && back.y == 22 && back.z == 33,
+               "field_append: NEW-READS-OLD — every old value lands exactly" );
+        check( back.w == 77, "field_append: NEW-READS-OLD — the appended field `w` takes its declared default" );
+        reads_clean( "field_append", r, 0, 0 );
+    }
+
+    // OLD-REFUSES-NEW
+    {
+        vold_field_append::Lineage back;
+        vold_field_append::LineageReset( back );
+        vold_field_append::TableReport r;
+        std::vector<vold_field_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_field_append::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        refuses_newer( "field_append/OLD-REFUSES-NEW", "the field `w`", n, r,
+                       VL_OWN_REASON( vold_field_append, r ) );
+        check_red( back.x == 0 && back.y == 0 && back.z == 0, "field_append/OLD-REFUSES-NEW",
+                   "field_append/OLD-REFUSES-NEW: nothing was decoded — every field is still its default" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// field_deprecate: {a,b,c} -> {a, b deprecated, c}
+// (old_field_deprecate.bin / new_field_deprecate.bin)
+//
+// The second column of this row is NOT a refusal: a deprecation is not newer
+// (docs/FIXED-FORM-VERSIONING-TESTS.md names it so), and the OLD reader READS
+// the new file with `b` landing as written, because the new writer still writes
+// the slot. What the NEW reader owes is the other half: `b` dropped and counted
+// once under `unknown`.
+
+static void field_deprecate_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_field_deprecate::LineageFixedMeasure( 1 ) );
+    {
+        vold_field_deprecate::Lineage v;
+        vold_field_deprecate::LineageReset( v );
+        v.a = 1; v.b = 2; v.c = 3;
+        check( vold_field_deprecate::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "field_deprecate: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_field_deprecate::LineageFixedMeasure( 1 ) );
+    {
+        vnew_field_deprecate::Lineage v;
+        vnew_field_deprecate::LineageReset( v );
+        v.a = 4; v.b = 5; v.c = 6;
+        check( vnew_field_deprecate::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "field_deprecate: the NEW file saves" );
+    }
+
+    // NEW-READS-OLD: a and c exact, b dropped, `unknown` += 1 per plan (bill §3)
+    {
+        vnew_field_deprecate::Lineage back;
+        vnew_field_deprecate::LineageReset( back );
+        vnew_field_deprecate::TableReport r;
+        std::vector<vnew_field_deprecate::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_field_deprecate::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                                 plan.data(), 1024, NULL, &r );
+        check( n == 1, "field_deprecate: NEW-READS-OLD — one record" );
+        check( back.a == 1 && back.c == 3,
+               "field_deprecate: NEW-READS-OLD — the live fields land exactly and `c` did not slide" );
+        check_red( r.unknown == 1, "field_deprecate/NEW-READS-OLD",
+                   "field_deprecate/NEW-READS-OLD: the deprecated field `b` is dropped and counted once "
+                   "under `unknown` (bill §3)" );
+        check( r.clamped == 0 && r.kind_mismatch == 0 && !r.malformed && !r.refused,
+               "field_deprecate: NEW-READS-OLD — nothing else fired" );
+    }
+
+    // OLD-READS-NEW: a deprecation is not newer, so this is a READ
+    {
+        vold_field_deprecate::Lineage back;
+        vold_field_deprecate::LineageReset( back );
+        vold_field_deprecate::TableReport r;
+        std::vector<vold_field_deprecate::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_field_deprecate::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                                 plan.data(), 1024, NULL, &r );
+        check( n == 1, "field_deprecate: OLD-READS-NEW — a deprecation is not newer, so the old reader reads" );
+        check( back.a == 4 && back.b == 5 && back.c == 6,
+               "field_deprecate: OLD-READS-NEW — `b` lands as written, because the new writer still writes it" );
+        check( !r.refused && !r.malformed, "field_deprecate: OLD-READS-NEW — no refusal and no damage" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// field_undeprecate: {a, b deprecated, c} -> {a,b,c}
+// (old_field_undeprecate.bin / new_field_undeprecate.bin)
+//
+// Allowed in both directions, and the row's whole content is that BOTH reads
+// land (docs/FIXED-FORM-VERSIONING-TESTS.md: "reads" in both read columns).
+
+static void field_undeprecate_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_field_undeprecate::LineageFixedMeasure( 1 ) );
+    {
+        vold_field_undeprecate::Lineage v;
+        vold_field_undeprecate::LineageReset( v );
+        v.a = 1; v.b = 2; v.c = 3;
+        check( vold_field_undeprecate::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "field_undeprecate: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_field_undeprecate::LineageFixedMeasure( 1 ) );
+    {
+        vnew_field_undeprecate::Lineage v;
+        vnew_field_undeprecate::LineageReset( v );
+        v.a = 4; v.b = 5; v.c = 6;
+        check( vnew_field_undeprecate::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "field_undeprecate: the NEW file saves" );
+    }
+
+    {
+        vnew_field_undeprecate::Lineage back;
+        vnew_field_undeprecate::LineageReset( back );
+        vnew_field_undeprecate::TableReport r;
+        std::vector<vnew_field_undeprecate::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_field_undeprecate::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                                   plan.data(), 1024, NULL, &r );
+        check( n == 1, "field_undeprecate: NEW-READS-OLD — one record" );
+        check( back.a == 1 && back.b == 2 && back.c == 3,
+               "field_undeprecate: NEW-READS-OLD — a and b and c land exactly, the undeprecated field included" );
+        check( !r.refused && !r.malformed, "field_undeprecate: NEW-READS-OLD — no refusal and no damage" );
+    }
+    {
+        vold_field_undeprecate::Lineage back;
+        vold_field_undeprecate::LineageReset( back );
+        vold_field_undeprecate::TableReport r;
+        std::vector<vold_field_undeprecate::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_field_undeprecate::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                                   plan.data(), 1024, NULL, &r );
+        check( n == 1, "field_undeprecate: OLD-READS-NEW — undeprecating is not newer, so the old reader reads" );
+        check( back.a == 4 && back.c == 6, "field_undeprecate: OLD-READS-NEW — the live fields land exactly" );
+        check( !r.refused && !r.malformed, "field_undeprecate: OLD-READS-NEW — no refusal and no damage" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// enum_append: Tier {Bronze,Silver,Gold} -> + Platinum
+// (old_enum_append.bin / new_enum_append.bin)
+
+static void enum_append_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_enum_append::LineageFixedMeasure( 1 ) );
+    {
+        vold_enum_append::Lineage v;
+        vold_enum_append::LineageReset( v );
+        v.tier = vold_enum_append::Tier::Gold;
+        v.seq = 9;
+        check( vold_enum_append::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "enum_append: the OLD file saves" );
+    }
+    // TWO RECORDS, AND THE FIRST HOLDS A VALUE THE OLD READER COULD NAME. The
+    // refusal is a property of the LAYOUT, never of a record's values: `Gold`
+    // leading the file is what makes that the assertion.
+    std::vector<uint8_t> newf( (size_t) vnew_enum_append::LineageFixedMeasure( 2 ) );
+    {
+        vnew_enum_append::Lineage v[2];
+        vnew_enum_append::LineageReset( v[0] );
+        v[0].tier = vnew_enum_append::Tier::Gold; v[0].seq = 10;
+        vnew_enum_append::LineageReset( v[1] );
+        v[1].tier = vnew_enum_append::Tier::Platinum; v[1].seq = 11;
+        check( vnew_enum_append::LineageFixedSave( v, 2, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "enum_append: the NEW file saves" );
+    }
+
+    {
+        vnew_enum_append::Lineage back;
+        vnew_enum_append::LineageReset( back );
+        vnew_enum_append::TableReport r;
+        std::vector<vnew_enum_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_enum_append::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                             plan.data(), 1024, NULL, &r );
+        check( n == 1, "enum_append: NEW-READS-OLD — one record" );
+        check( back.tier == vnew_enum_append::Tier::Gold,
+               "enum_append: NEW-READS-OLD — a gold record reads gold: append-only means the writer's "
+               "ordinal IS the reader's" );
+        check( (int) vold_enum_append::Tier::Gold == (int) vnew_enum_append::Tier::Gold,
+               "enum_append: the ordinals are equal across the pair, which is what appending buys" );
+        check( back.seq == 9, "enum_append: NEW-READS-OLD — the scalar after the enum lands exactly" );
+        reads_clean( "enum_append", r, 0, 0 );
+    }
+
+    {
+        vold_enum_append::Lineage back[2];
+        vold_enum_append::LineageReset( back[0] );
+        vold_enum_append::LineageReset( back[1] );
+        vold_enum_append::TableReport r;
+        std::vector<vold_enum_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_enum_append::LineageFixedLoad( back, 2, newf.data(), (int64_t) newf.size(),
+                                                             plan.data(), 1024, NULL, &r );
+        refuses_newer( "enum_append/OLD-REFUSES-NEW", "the variant `Platinum`", n, r,
+                       VL_OWN_REASON( vold_enum_append, r ) );
+        check_red( back[0].seq == 0 && back[1].seq == 0, "enum_append/OLD-REFUSES-NEW",
+                   "enum_append/OLD-REFUSES-NEW: nothing was decoded, not even the record whose variant "
+                   "this reader could have named" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// enum_width: 255 variants -> 256, so the ordinal's width goes 1 -> 2
+// (old_enum_width.bin / new_enum_width.bin)
+//
+// The boundary is StorageBitsFor (ir/ir.go): with None = 0 implicit and the
+// variants dense from 1, 255 variants have extent 255 and ride in one byte, and
+// the 256th takes the extent to 256 and the ordinal to two. One appended
+// variant moves every byte after it.
+
+static void enum_width_case()
+{
+    check( (int) sizeof( vold_enum_width::Wide ) == 1,
+           "enum_width: the OLD side's ordinal is ONE byte (255 variants)" );
+    check( (int) sizeof( vnew_enum_width::Wide ) == 2,
+           "enum_width: the NEW side's ordinal is TWO bytes (256 variants)" );
+
+    std::vector<uint8_t> oldf( (size_t) vold_enum_width::LineageFixedMeasure( 1 ) );
+    {
+        vold_enum_width::Lineage v;
+        vold_enum_width::LineageReset( v );
+        v.tier = vold_enum_width::Wide::V200;
+        v.seq = 12;
+        check( vold_enum_width::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "enum_width: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_enum_width::LineageFixedMeasure( 2 ) );
+    {
+        vnew_enum_width::Lineage v[2];
+        vnew_enum_width::LineageReset( v[0] );
+        v[0].tier = vnew_enum_width::Wide::V200; v[0].seq = 13;
+        vnew_enum_width::LineageReset( v[1] );
+        v[1].tier = vnew_enum_width::Wide::V256; v[1].seq = 14; // the ordinal a byte cannot hold
+        check( vnew_enum_width::LineageFixedSave( v, 2, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "enum_width: the NEW file saves" );
+    }
+
+    {
+        vnew_enum_width::Lineage back;
+        vnew_enum_width::LineageReset( back );
+        vnew_enum_width::TableReport r;
+        std::vector<vnew_enum_width::TableFixedEntry> plan( 4096 );
+        const int64_t n = vnew_enum_width::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                            plan.data(), 4096, NULL, &r );
+        check( n == 1, "enum_width: NEW-READS-OLD — one record" );
+        check( back.tier == vnew_enum_width::Wide::V200,
+               "enum_width: NEW-READS-OLD — a width-1 ordinal widened into width 2, exactly" );
+        check( back.seq == 12, "enum_width: NEW-READS-OLD — the scalar behind the widened ordinal lands exactly" );
+        // §5.2: "wider in y: widen (COUNT widened)", and an enum's ordinal is
+        // the row this is written for. The counter is the red half of this
+        // column; the value above is the green half.
+        check_red( r.widened == 1, "enum_width/NEW-READS-OLD",
+                   "enum_width/NEW-READS-OLD: a widened ordinal COUNTS widened (§5.2)" );
+        check( r.unknown == 0 && r.clamped == 0 && r.kind_mismatch == 0 && !r.malformed && !r.refused,
+               "enum_width: NEW-READS-OLD — nothing else fired" );
+    }
+
+    {
+        vold_enum_width::Lineage back[2];
+        vold_enum_width::LineageReset( back[0] );
+        vold_enum_width::LineageReset( back[1] );
+        vold_enum_width::TableReport r;
+        std::vector<vold_enum_width::TableFixedEntry> plan( 4096 );
+        const int64_t n = vold_enum_width::LineageFixedLoad( back, 2, newf.data(), (int64_t) newf.size(),
+                                                            plan.data(), 4096, NULL, &r );
+        refuses_newer( "enum_width/OLD-REFUSES-NEW", "the layout's enum ordinal width (1 -> 2)", n, r,
+                       VL_OWN_REASON( vold_enum_width, r ) );
+        check_red( back[0].seq == 0 && back[1].seq == 0, "enum_width/OLD-REFUSES-NEW",
+                   "enum_width/OLD-REFUSES-NEW: nothing was decoded" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// union_append: Pick {alpha,beta} -> + gamma
+// (old_union_append.bin / new_union_append.bin)
+
+static void union_append_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_union_append::LineageFixedMeasure( 1 ) );
+    {
+        vold_union_append::Lineage v;
+        vold_union_append::LineageReset( v );
+        v.pick.type = vold_union_append::PickType::Alpha;
+        v.pick.alpha.m = 7;
+        v.seq = 15;
+        check( vold_union_append::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "union_append: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_union_append::LineageFixedMeasure( 2 ) );
+    {
+        vnew_union_append::Lineage v[2];
+        vnew_union_append::LineageReset( v[0] );
+        v[0].pick.type = vnew_union_append::PickType::Alpha;
+        v[0].pick.alpha.m = 8;
+        v[0].seq = 16;
+        vnew_union_append::LineageReset( v[1] );
+        v[1].pick.type = vnew_union_append::PickType::Gamma;
+        v[1].pick.gamma.p = 9;
+        v[1].seq = 17;
+        check( vnew_union_append::LineageFixedSave( v, 2, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "union_append: the NEW file saves" );
+    }
+
+    {
+        vnew_union_append::Lineage back;
+        vnew_union_append::LineageReset( back );
+        vnew_union_append::TableReport r;
+        std::vector<vnew_union_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_union_append::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        check( n == 1, "union_append: NEW-READS-OLD — one record" );
+        check( back.pick.type == vnew_union_append::PickType::Alpha,
+               "union_append: NEW-READS-OLD — an `alpha` record lands alpha" );
+        check( back.pick.alpha.m == 7, "union_append: NEW-READS-OLD — the arm's payload lands exactly" );
+        check( (int) vold_union_append::PickType::Beta == (int) vnew_union_append::PickType::Beta,
+               "union_append: the arms' tags are equal across the pair — append-only keeps every ordinal" );
+        check( back.seq == 15, "union_append: NEW-READS-OLD — the scalar behind the union lands exactly" );
+        reads_clean( "union_append", r, 0, 0 );
+    }
+
+    {
+        vold_union_append::Lineage back[2];
+        vold_union_append::LineageReset( back[0] );
+        vold_union_append::LineageReset( back[1] );
+        vold_union_append::TableReport r;
+        std::vector<vold_union_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_union_append::LineageFixedLoad( back, 2, newf.data(), (int64_t) newf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        refuses_newer( "union_append/OLD-REFUSES-NEW", "the arm `gamma`", n, r,
+                       VL_OWN_REASON( vold_union_append, r ) );
+        check_red( back[0].seq == 0 && back[1].seq == 0 &&
+                   back[0].pick.type == vold_union_append::PickType::None,
+                   "union_append/OLD-REFUSES-NEW",
+                   "union_append/OLD-REFUSES-NEW: nothing was decoded, tag included" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// union_arm_payload_widen: arm alpha {x} -> {x,y}
+// (old_union_arm_payload_widen.bin / new_union_arm_payload_widen.bin)
+
+static void union_arm_payload_widen_case()
+{
+    namespace vo = vold_union_arm_payload_widen;
+    namespace vn = vnew_union_arm_payload_widen;
+
+    std::vector<uint8_t> oldf( (size_t) vo::LineageFixedMeasure( 1 ) );
+    {
+        vo::Lineage v;
+        vo::LineageReset( v );
+        v.pick.type = vo::PickType::Alpha;
+        v.pick.alpha.x = 21;
+        v.seq = 18;
+        check( vo::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) == (int64_t) oldf.size(),
+               "union_arm_payload_widen: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vn::LineageFixedMeasure( 1 ) );
+    {
+        vn::Lineage v;
+        vn::LineageReset( v );
+        v.pick.type = vn::PickType::Alpha;
+        v.pick.alpha.x = 22;
+        v.pick.alpha.y = 23;
+        v.seq = 19;
+        check( vn::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) == (int64_t) newf.size(),
+               "union_arm_payload_widen: the NEW file saves" );
+    }
+
+    {
+        vn::Lineage back;
+        vn::LineageReset( back );
+        vn::TableReport r;
+        std::vector<vn::TableFixedEntry> plan( 1024 );
+        const int64_t n = vn::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                plan.data(), 1024, NULL, &r );
+        check( n == 1, "union_arm_payload_widen: NEW-READS-OLD — one record" );
+        check( back.pick.type == vn::PickType::Alpha,
+               "union_arm_payload_widen: NEW-READS-OLD — the arm lands" );
+        check( back.pick.alpha.x == 21, "union_arm_payload_widen: NEW-READS-OLD — `x` lands exactly" );
+        char what[256];
+        std::snprintf( what, sizeof( what ),
+                       "union_arm_payload_widen/NEW-READS-OLD: the appended `y` under arm `alpha` takes "
+                       "its declared default 55 — it landed %d", (int) back.pick.alpha.y );
+        check_red( back.pick.alpha.y == 55, "union_arm_payload_widen/NEW-READS-OLD", what );
+        check( back.seq == 18, "union_arm_payload_widen: NEW-READS-OLD — the scalar behind the union lands" );
+        reads_clean( "union_arm_payload_widen", r, 0, 0 );
+    }
+
+    {
+        vo::Lineage back;
+        vo::LineageReset( back );
+        vo::TableReport r;
+        std::vector<vo::TableFixedEntry> plan( 1024 );
+        const int64_t n = vo::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                plan.data(), 1024, NULL, &r );
+        refuses_newer( "union_arm_payload_widen/OLD-REFUSES-NEW", "the field `y` under arm `alpha`", n, r,
+                       VL_OWN_REASON( vo, r ) );
+        check_red( back.seq == 0 && back.pick.type == vo::PickType::None,
+                   "union_arm_payload_widen/OLD-REFUSES-NEW",
+                   "union_arm_payload_widen/OLD-REFUSES-NEW: nothing was decoded" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// flags_append: Caps {Jump,Crouch} -> + Fly
+// (old_flags_append.bin / new_flags_append.bin)
+//
+// THE ROW THAT SAYS THE LAYOUT IS MISSING SOMETHING. A flags field rides as an
+// eight-byte mask and its layout entry carries children = 0 (ir/fixedform.go),
+// so appending a flag moves NO LAYOUT BYTE: the two hashes are equal, the
+// reader takes the identity plan, and no version check has anything to read.
+// The case asserts the LAW anyway — that is what tells whoever lands
+// `layout_newer` that the layout entry owes a flag count first.
+
+static void flags_append_case()
+{
+    check( vold_flags_append::LineageFixedHash == vnew_flags_append::LineageFixedHash,
+           "flags_append: TODAY the two layouts hash the SAME — a flags append moves no layout byte, "
+           "which is why the refusal below cannot fire yet" );
+
+    std::vector<uint8_t> oldf( (size_t) vold_flags_append::LineageFixedMeasure( 1 ) );
+    {
+        vold_flags_append::Lineage v;
+        vold_flags_append::LineageReset( v );
+        v.caps = vold_flags_append::Caps_Jump | vold_flags_append::Caps_Crouch;
+        v.seq = 20;
+        check( vold_flags_append::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "flags_append: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_flags_append::LineageFixedMeasure( 1 ) );
+    {
+        vnew_flags_append::Lineage v;
+        vnew_flags_append::LineageReset( v );
+        v.caps = vnew_flags_append::Caps_Jump | vnew_flags_append::Caps_Fly;
+        v.seq = 21;
+        check( vnew_flags_append::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "flags_append: the NEW file saves" );
+    }
+
+    {
+        vnew_flags_append::Lineage back;
+        vnew_flags_append::LineageReset( back );
+        vnew_flags_append::TableReport r;
+        std::vector<vnew_flags_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_flags_append::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        check( n == 1, "flags_append: NEW-READS-OLD — one record" );
+        check( back.caps == ( vnew_flags_append::Caps_Jump | vnew_flags_append::Caps_Crouch ),
+               "flags_append: NEW-READS-OLD — the mask lands equal, bit for bit" );
+        check( back.seq == 20, "flags_append: NEW-READS-OLD — the scalar behind the mask lands exactly" );
+        reads_clean( "flags_append", r, 0, 0 );
+    }
+
+    {
+        vold_flags_append::Lineage back;
+        vold_flags_append::LineageReset( back );
+        vold_flags_append::TableReport r;
+        std::vector<vold_flags_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_flags_append::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                              plan.data(), 1024, NULL, &r );
+        refuses_newer( "flags_append/OLD-REFUSES-NEW", "the flag `Fly`", n, r,
+                       VL_OWN_REASON( vold_flags_append, r ) );
+        check_red( back.caps == 0 && back.seq == 0, "flags_append/OLD-REFUSES-NEW",
+                   "flags_append/OLD-REFUSES-NEW: nothing was decoded" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// keyed_array_enum_append: [Tier]int32 with Tier gaining Platinum
+// (old_keyed_array_enum_append.bin / new_keyed_array_enum_append.bin)
+
+static void keyed_array_enum_append_case()
+{
+    namespace vo = vold_keyed_array_enum_append;
+    namespace vn = vnew_keyed_array_enum_append;
+
+    std::vector<uint8_t> oldf( (size_t) vo::LineageFixedMeasure( 1 ) );
+    {
+        vo::Lineage v;
+        vo::LineageReset( v );
+        v.slots[vo::Tier::Bronze] = 101;
+        v.slots[vo::Tier::Silver] = 102;
+        v.slots[vo::Tier::Gold] = 103;
+        v.seq = 22;
+        check( vo::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) == (int64_t) oldf.size(),
+               "keyed_array_enum_append: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vn::LineageFixedMeasure( 1 ) );
+    {
+        vn::Lineage v;
+        vn::LineageReset( v );
+        v.slots[vn::Tier::Bronze] = 201;
+        v.slots[vn::Tier::Silver] = 202;
+        v.slots[vn::Tier::Gold] = 203;
+        v.slots[vn::Tier::Platinum] = 204;
+        v.seq = 23;
+        check( vn::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) == (int64_t) newf.size(),
+               "keyed_array_enum_append: the NEW file saves" );
+    }
+
+    {
+        vn::Lineage back;
+        vn::LineageReset( back );
+        vn::TableReport r;
+        std::vector<vn::TableFixedEntry> plan( 1024 );
+        const int64_t n = vn::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                plan.data(), 1024, NULL, &r );
+        check( n == 1, "keyed_array_enum_append: NEW-READS-OLD — one record" );
+        check( back.slots[vn::Tier::Bronze] == 101 && back.slots[vn::Tier::Silver] == 102 &&
+               back.slots[vn::Tier::Gold] == 103,
+               "keyed_array_enum_append: NEW-READS-OLD — the three slots the writer had land exactly" );
+        check( back.slots[vn::Tier::Platinum] == 0,
+               "keyed_array_enum_append: NEW-READS-OLD — the slot the appended key opened takes the "
+               "element's default" );
+        check( back.seq == 22, "keyed_array_enum_append: NEW-READS-OLD — the scalar behind the array lands" );
+        reads_clean( "keyed_array_enum_append", r, 0, 0 );
+    }
+
+    {
+        vo::Lineage back;
+        vo::LineageReset( back );
+        vo::TableReport r;
+        std::vector<vo::TableFixedEntry> plan( 1024 );
+        const int64_t n = vo::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                plan.data(), 1024, NULL, &r );
+        refuses_newer( "keyed_array_enum_append/OLD-REFUSES-NEW",
+                       "the variant `Platinum` of the key enum `Tier`", n, r, VL_OWN_REASON( vo, r ) );
+        check_red( back.slots[vo::Tier::Bronze] == 0 && back.seq == 0,
+                   "keyed_array_enum_append/OLD-REFUSES-NEW",
+                   "keyed_array_enum_append/OLD-REFUSES-NEW: nothing was decoded, no slot touched" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// nested_append: Vec {x,y,z} -> {x,y,z,w}, inside Lineage
+// (old_nested_append.bin / new_nested_append.bin)
+
+static void nested_append_case()
+{
+    std::vector<uint8_t> oldf( (size_t) vold_nested_append::LineageFixedMeasure( 1 ) );
+    {
+        vold_nested_append::Lineage v;
+        vold_nested_append::LineageReset( v );
+        v.v.x = 1; v.v.y = 2; v.v.z = 3; v.seq = 24;
+        check( vold_nested_append::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "nested_append: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_nested_append::LineageFixedMeasure( 1 ) );
+    {
+        vnew_nested_append::Lineage v;
+        vnew_nested_append::LineageReset( v );
+        v.v.x = 4; v.v.y = 5; v.v.z = 6; v.v.w = 7; v.seq = 25;
+        check( vnew_nested_append::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "nested_append: the NEW file saves" );
+    }
+
+    {
+        vnew_nested_append::Lineage back;
+        vnew_nested_append::LineageReset( back );
+        vnew_nested_append::TableReport r;
+        std::vector<vnew_nested_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_nested_append::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                               plan.data(), 1024, NULL, &r );
+        check( n == 1, "nested_append: NEW-READS-OLD — one record" );
+        check( back.v.x == 1 && back.v.y == 2 && back.v.z == 3,
+               "nested_append: NEW-READS-OLD — the nested table's old fields land exactly" );
+        check( back.v.w == 88,
+               "nested_append: NEW-READS-OLD — `Vec.w`, appended inside the nested table, takes its default" );
+        check( back.seq == 24,
+               "nested_append: NEW-READS-OLD — the field AFTER the grown nested table did not slide" );
+        reads_clean( "nested_append", r, 0, 0 );
+    }
+
+    {
+        vold_nested_append::Lineage back;
+        vold_nested_append::LineageReset( back );
+        vold_nested_append::TableReport r;
+        std::vector<vold_nested_append::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_nested_append::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                               plan.data(), 1024, NULL, &r );
+        refuses_newer( "nested_append/OLD-REFUSES-NEW", "the field `Vec.w`", n, r,
+                       VL_OWN_REASON( vold_nested_append, r ) );
+        check_red( back.v.x == 0 && back.v.y == 0 && back.v.z == 0 && back.seq == 0,
+                   "nested_append/OLD-REFUSES-NEW",
+                   "nested_append/OLD-REFUSES-NEW: nothing was decoded, inside the nesting or outside it" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rename_without_was: `a` -> `b was = "a"`
+// (old_rename_without_was.bin / new_rename_without_was.bin)
+//
+// The row with NO refusal in it, and that is its content. Wire identity is the
+// hash of the name and `was` keeps the old name's hash, so the rename moves no
+// layout byte at all: the two layouts are byte-identical, both readers take the
+// identity plan, and the pair reads in both directions. The compile-time half
+// of this row — `b` ALONE, with no `was`, refused as "renamed without was" — is
+// the lock's (internal/lockfile), not the reader's.
+
+static void rename_without_was_case()
+{
+    check( vold_rename_without_was::LineageFixedHash == vnew_rename_without_was::LineageFixedHash,
+           "rename_without_was: a rename THROUGH `was` moves no layout byte — the two hashes are equal, "
+           "so the edit is not a version at all" );
+    check( vold_rename_without_was::LineageFixedLayoutBytes ==
+           vnew_rename_without_was::LineageFixedLayoutBytes &&
+           std::memcmp( vold_rename_without_was::LineageFixedLayout,
+                        vnew_rename_without_was::LineageFixedLayout,
+                        (size_t) vold_rename_without_was::LineageFixedLayoutBytes ) == 0,
+           "rename_without_was: and the layouts are byte-identical, not merely equal by hash" );
+
+    std::vector<uint8_t> oldf( (size_t) vold_rename_without_was::LineageFixedMeasure( 1 ) );
+    {
+        vold_rename_without_was::Lineage v;
+        vold_rename_without_was::LineageReset( v );
+        v.a = 31; v.seq = 26;
+        check( vold_rename_without_was::LineageFixedSave( &v, 1, oldf.data(), (int64_t) oldf.size() ) ==
+               (int64_t) oldf.size(), "rename_without_was: the OLD file saves" );
+    }
+    std::vector<uint8_t> newf( (size_t) vnew_rename_without_was::LineageFixedMeasure( 1 ) );
+    {
+        vnew_rename_without_was::Lineage v;
+        vnew_rename_without_was::LineageReset( v );
+        v.b = 32; v.seq = 27;
+        check( vnew_rename_without_was::LineageFixedSave( &v, 1, newf.data(), (int64_t) newf.size() ) ==
+               (int64_t) newf.size(), "rename_without_was: the NEW file saves" );
+    }
+
+    {
+        vnew_rename_without_was::Lineage back;
+        vnew_rename_without_was::LineageReset( back );
+        vnew_rename_without_was::TableReport r;
+        std::vector<vnew_rename_without_was::TableFixedEntry> plan( 1024 );
+        const int64_t n = vnew_rename_without_was::LineageFixedLoad( &back, 1, oldf.data(), (int64_t) oldf.size(),
+                                                                    plan.data(), 1024, NULL, &r );
+        check( n == 1, "rename_without_was: NEW-READS-OLD — one record" );
+        check( back.b == 31, "rename_without_was: NEW-READS-OLD — `b` reads `a`'s bytes under `was`" );
+        check( back.seq == 26, "rename_without_was: NEW-READS-OLD — the scalar beside it lands exactly" );
+        reads_clean( "rename_without_was", r, 0, 0 );
+    }
+    {
+        vold_rename_without_was::Lineage back;
+        vold_rename_without_was::LineageReset( back );
+        vold_rename_without_was::TableReport r;
+        std::vector<vold_rename_without_was::TableFixedEntry> plan( 1024 );
+        const int64_t n = vold_rename_without_was::LineageFixedLoad( &back, 1, newf.data(), (int64_t) newf.size(),
+                                                                    plan.data(), 1024, NULL, &r );
+        check( n == 1, "rename_without_was: OLD-READS-NEW — a rename through `was` is not newer" );
+        check( back.a == 32, "rename_without_was: OLD-READS-NEW — `a` reads `b`'s bytes" );
+        check( !r.refused && !r.malformed, "rename_without_was: OLD-READS-NEW — no refusal and no damage" );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// THE ONE REGISTRATION CALL. fixedform_main.cpp calls this once and adds the
+// count to its own, so this file owns its cases and its known-red list and the
+// main file owns one line.
+
+int versioning_lists_cases();
+
+int versioning_lists_cases()
+{
+    field_append_case();
+    field_deprecate_case();
+    field_undeprecate_case();
+    enum_append_case();
+    enum_width_case();
+    union_append_case();
+    union_arm_payload_widen_case();
+    flags_append_case();
+    keyed_array_enum_append_case();
+    nested_append_case();
+    rename_without_was_case();
+    failures += known_red_report();
+    if ( failures == 0 ) { std::printf( "versioning lists: the LIST rows' read columns green\n" ); }
+    return failures;
+}


### PR DESCRIPTION
The two READ columns of `docs/FIXED-FORM-VERSIONING-TESTS.md` — **NEW-READS-OLD** and **OLD-REFUSES-NEW** — for the eleven rows that are **LISTS**, on the C++ reference. Red first, by name. No runtime and no emitter touched.

## The rows

| row | NEW-READS-OLD | OLD-REFUSES-NEW | what the red is waiting on |
|---|---|---|---|
| `field_append` | 🟢 green | 🔴 red | `layout_newer` |
| `field_deprecate` | 🔴 red | 🟢 green (a deprecation is not newer: the old reader READS, `b` landing as written) | the layout recording `\| deprecated` |
| `field_undeprecate` | 🟢 green | 🟢 green (reads, both directions) | — |
| `enum_append` | 🟢 green | 🔴 red | `layout_newer` |
| `enum_width` (255 → 256) | 🔴 red (value exact, counter missing) | 🔴 red | `COUNT widened` on a grown ordinal; `layout_newer` |
| `union_append` | 🟢 green | 🔴 red | `layout_newer` |
| `union_arm_payload_widen` | 🔴 red (the appended field lands **1**) | 🔴 red | the prefill reaching inside an arm's payload; `layout_newer` |
| `flags_append` | 🟢 green | 🔴 red (unreachable today) | the layout recording a flags' **bit count**, THEN `layout_newer` |
| `keyed_array_enum_append` | 🟢 green | 🔴 red | `layout_newer` |
| `nested_append` | 🟢 green | 🔴 red | `layout_newer` |
| `rename_without_was` | 🟢 green | 🟢 green (reads: the rename moves no layout byte — the two layouts are byte-identical) | — |

**11 known-reds**, every one printed by name and held from both ends: a listed case that starts PASSING fails the target, so landing a fix means deleting its line from `known_red[]` (the convention is `test/tables/fixedform_properties.cpp`'s). `make tables-fixedform` and `make tables-fixedform-corpus` both run green with the eleven reds named.

## What the tests found, beyond `layout_newer`

Glenn: *"Let the tests guide us in C++ to the correct implementation."* Four of the reds are not about `layout_newer` at all, and three of them say the LAYOUT is missing something before the refusal can be written:

1. **A flags append moves no layout byte.** `ir/fixedform.go` pushes a `flags` field as a plain 8-byte scalar with `children = 0`, so `Caps {Jump,Crouch}` and `Caps {Jump,Crouch,Fly}` hash identically, the reader takes the identity plan, and the bill's *"flags: bits a prefix of the reader's"* row has nothing to read. The layout entry owes a flag count the way an enum's entry carries its variant count.
2. **`| deprecated` moves no layout byte either.** Nothing in `ir/` reads `Field.Deprecated` — it is a lock and reflection marker only — so a reader cannot drop-and-count the slot it was told to stop needing (bill §3, `unknown += 1` per plan).
3. **A grown enum ordinal counts nowhere.** The value lands exactly (width 1 → width 2), but `widened` stays 0 where §5.2 says *"wider in y: widen (COUNT widened)"*. Compare FU1/FU2's `int16 → int32`, which does count.
4. **A field appended inside a union arm's payload lands `1`.** Not its declared default (55), and not zero — a byte from elsewhere in the record. The prefill reaches a table's own appended field (FX2's `added` lands 11) and does not reach one under an arm. The assertion prints the landed value so it cannot drift.

## The schemas' shape

Two schemas per row, `test/tables/VOLD_<row>.schema` and `VNEW_<row>.schema`, differing by exactly that row's definition change and nothing else. **The same table name `Lineage` on both sides** — the two layouts are ONE LINEAGE — with only the package differing (`vold_<row>` / `vnew_<row>`), so both generations compile into one test binary. That is the FX1/FX2 precedent, and it means no row needs `Old<Row>` / `New<Row>` names.

## What is where

- `test/tables/VOLD_*.schema`, `VNEW_*.schema` — 22 schemas, the eleven lineage pairs.
- `test/tables/fixedform_dump.cpp` — one marked block writing `old_<row>.bin` and `new_<row>.bin` (22 files) into `build/fixedform-corpus`, the corpus every other leg reads.
- `test/tables/versioning_lists.cpp` — NEW (450 lines): the eleven `<row>_case()`s, the known-red list, and the refusal helper.
- `test/tables/fixedform_main.cpp` — one marked block: a declaration and `failures += versioning_lists_cases();`.
- `Makefile` — marked blocks only: the 22 schemas in the cpp generate list and the stamp's prerequisites, a `VLISTS_INCLUDES` variable, and the new TU in the plain and ASan `tables-fixedform` binaries.

### On the refusal's name

The runtime carries no `layout_newer` enumerator, so no case can spell it. Each case asserts everything the name is worth and all of it is observable today: the read is refused before any record (`n < 0`), no counter moved and nothing malformed (REFUSE is total), the destination is untouched, and the reason is **not one this build already has** — not a form byte, not one of §1.1's eight broken-layout reasons. The reference exposes no *text* for a reason, so "the refusal names the row's definition" has nowhere to land on this leg; the definition is named in the case's own message instead, which is what a leg with text will assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
