### PR TITLE
tip green again: the new versioning fixtures compile, and the lock's lint

### DIFF
--- a/generated/bench/paired/cpp/BenchTable.h
+++ b/generated/bench/paired/cpp/BenchTable.h
@@ -8657,7 +8657,7 @@ inline bool BenchMixedSaveMessageBody( TableBitWriter & w, const BenchMixed & va
     if ( value.server_time != 0 )
     {
         w.put( 9, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.server_time ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 24 ); }
+        w.put( (uint64_t) ( value.server_time ), 24 );
     }
     if ( value.entities_count < 0 || value.entities_count > 8 ) { return false; } // storage invariant
     if ( value.entities_count > 0 )
@@ -8772,7 +8772,7 @@ inline bool BenchMixedSaveMessageBody( TableBitWriter & w, const BenchMixed & va
     if ( value.ping != 0 )
     {
         w.put( 23, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.ping ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 16 ); }
+        w.put( (uint64_t) ( value.ping ), 16 );
     }
     if ( value.crc_hint != 0 )
     {

--- a/internal/codegen/cpptable/fixedform.go
+++ b/internal/codegen/cpptable/fixedform.go
@@ -853,7 +853,7 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 			// above the extent, so the comparison is always false and the
 			// emitter drops it rather than hand a warning-as-error build a
 			// tautology. No semantics move — the elided check never clamped.
-			if ordinalFillsStorage(int64(r.Max), r.StorageBits) {
+			if ordinalFillsStorage(r.Max, r.StorageBits) {
 				return
 			}
 			g.pf("%sif ( (uint64_t) %s > %du ) { %s = %s::None; clamped++; }\n",

--- a/internal/codegen/cpptable/fixedform.go
+++ b/internal/codegen/cpptable/fixedform.go
@@ -795,6 +795,18 @@ func (g *tableGen) emitFixedTextContent(f *ir.Field, val, ind string) {
 	g.pf("%s    damaged++;\n%s}\n", ind, ind)
 }
 
+// ordinalFillsStorage reports whether an ordinal's extent is the LARGEST value
+// its storage width holds — 255 in a byte, 65535 in two. The read-side clamp
+// for such an ordinal is `> extent`, a comparison the tag's own type can never
+// satisfy, so the emitter drops it: the same "this check cannot fire" test
+// tableClampEnds applies to a ranged scalar's end sitting on its width's limit.
+func ordinalFillsStorage(max int64, storageBits int) bool {
+	if storageBits <= 0 || storageBits >= 64 {
+		return false
+	}
+	return uint64(max) >= uint64(1)<<uint(storageBits)-1
+}
+
 func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 	ind := strings.Repeat(" ", indent)
 	if f.Type.Kind == ir.TNamed {
@@ -810,8 +822,10 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 			// is a raw copy out of a stranger's bytes, and this is what holds
 			// it. It lands None — the same nothing an unset union holds — and
 			// counts.
-			g.pf("%sif ( (uint32_t) %s.type > %du ) { %s.type = %sType::None; clamped++; }\n",
-				ind, expr, r.Max, expr, f.Type.Name)
+			if !ordinalFillsStorage(r.Max, ir.StorageBitsFor(r.Max)) {
+				g.pf("%sif ( (uint32_t) %s.type > %du ) { %s.type = %sType::None; clamped++; }\n",
+					ind, expr, r.Max, expr, f.Type.Name)
+			}
 			if !ir.TableFixedClampNeededUnionArm(r) {
 				return
 			}
@@ -832,6 +846,16 @@ func (g *tableGen) emitFixedClampElement(f *ir.Field, expr string, indent int) {
 			// all. It lands None and counts. A value INSIDE an `| max = K`
 			// widening is the other case and is left alone: that is a name a
 			// later generation has, not a bound this one broke.
+			//
+			// An enum whose extent FILLS its storage (255 variants in a byte)
+			// is the "this check cannot fire" case tableClampEnds already
+			// applies to a ranged scalar: the tag's own type holds no value
+			// above the extent, so the comparison is always false and the
+			// emitter drops it rather than hand a warning-as-error build a
+			// tautology. No semantics move — the elided check never clamped.
+			if ordinalFillsStorage(int64(r.Max), r.StorageBits) {
+				return
+			}
 			g.pf("%sif ( (uint64_t) %s > %du ) { %s = %s::None; clamped++; }\n",
 				ind, expr, r.Max, expr, f.Type.Name)
 			return

--- a/internal/codegen/cpptable/messagecodec.go
+++ b/internal/codegen/cpptable/messagecodec.go
@@ -530,11 +530,20 @@ func (g *tableGen) emitMessageScalar(f *ir.Field, kind uint8, shape ir.TableMess
 		}
 		g.pf("%sw.put( (uint64_t) table_float_to_bits( %s ), 32 );\n", ind, expr)
 	default:
-		if ir.TableKindWide(int(kind)) {
+		if tableKindWidth(int(kind)) == 16 {
 			// A 128-BIT KIND at the width its shape states: the base subtracted
 			// at 128 bits, the low half first and the high half where the
 			// width reaches it, which is ONE arithmetic for measure, save and
-			// read (§3.3)
+			// read (§3.3).
+			//
+			// THE GATE IS THE STORAGE WIDTH, not ir.TableKindWide: the wide
+			// vocabulary is kinds 18–29, which is the 128-bit integers AND the
+			// whole fixed-point family, and `fixed(12, 4)` rides in sixteen
+			// bits. Its raw value and its base both fit a uint64_t, so it takes
+			// the plain path below — the same gate the read side gates on
+			// (messageload.go's `bytesWide == 16`), and the one that keeps a
+			// Table.h of narrow fixed fields free of serialize.h, which only a
+			// unit whose closure declares a 128-bit field includes.
 			base := "serialize::uint128_t( 0 )"
 			if shape.Packing == ir.TableMessageRanged && shape.Base != nil && shape.Base.Sign() != 0 {
 				base = tableWideLit(shape.Base, false)

--- a/internal/lockfile/lineage.go
+++ b/internal/lockfile/lineage.go
@@ -35,6 +35,7 @@ package lockfile
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -380,7 +381,8 @@ func mergeLineage(locked, live *Unit) {
 			lv.Lineage = history
 			continue
 		}
-		lv.Lineage = append(history, cur)
+		history = append(history, cur)
+		lv.Lineage = history
 	}
 }
 
@@ -458,8 +460,8 @@ func diffLineage(lk, lv *Table, policy Policy) error {
 type lineageDrift struct{ error }
 
 func isLineageDrift(err error) bool {
-	_, ok := err.(lineageDrift)
-	return ok
+	var drift lineageDrift
+	return errors.As(err, &drift)
 }
 
 // retiredText is the tail a retired lineage entry or a retired table carries:

--- a/internal/lockfile/lineage_test.go
+++ b/internal/lockfile/lineage_test.go
@@ -175,7 +175,7 @@ func TestLockV6SalvagesIntoV7WithOneEntry(t *testing.T) {
 	// the v6 file this lock would have been one rendering version ago: the
 	// same lines, without the lineage the version added
 	var v6 []string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
 			continue
 		}
@@ -288,7 +288,7 @@ func TestLockLineageWarnsPastTheAdvisoryBound(t *testing.T) {
 // lineage entry retired (a permitted non-append edit, recorded with a reason);
 // COMPILE emits the retired hashes beside the supported ones so LOAD can say
 // `layout_unsupported` rather than `layout_newer`; a retired entry stays in the
-// lineage forever."
+// lineage forever".
 func TestLockRetireEntry(t *testing.T) {
 	dir, paths := fixture(t, rowTable("    a int32"))
 	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
@@ -343,7 +343,7 @@ func TestLockRetireEntry(t *testing.T) {
 // never removed, until nothing live speaks it. `schema lock --retire Table`
 // marks the whole table retired; its lineage stays; the schema may then drop
 // the declaration, and §5.1's 'fixed removed' refusal applies only to an
-// UNRETIRED table."
+// UNRETIRED table".
 func TestLockRetireTableThenRemoveTheDeclaration(t *testing.T) {
 	const two = "package lockrows\n\nfixed table Row\n{\n    a int32\n}\n\nfixed table Keep\n{\n    k int32\n}\n"
 	dir, paths := fixture(t, two)
@@ -421,7 +421,7 @@ func TestLineageAccessorIsWhatCompileReads(t *testing.T) {
 	dir, paths := fixture(t, rowTable("    a int32"))
 	var hashes []uint64
 	fields := "    a int32"
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
 			t.Fatal(err)
 		}
@@ -518,7 +518,7 @@ func TestLineageSetIsBoundByTheRollup(t *testing.T) {
 	}
 	var kept []string
 	dropped := false
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		if !dropped && strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
 			dropped = true
 			continue

--- a/internal/lockfile/lockclosure_test.go
+++ b/internal/lockfile/lockclosure_test.go
@@ -811,7 +811,7 @@ func TestALockFromTheRenderingJustBeforeThisOneSalvages(t *testing.T) {
 	// the same file one rendering back: its body without the lineage this
 	// rendering added
 	var body []string
-	for _, line := range strings.Split(string(current[len(head):]), "\n") {
+	for line := range strings.SplitSeq(string(current[len(head):]), "\n") {
 		if !strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
 			body = append(body, line)
 		}

--- a/internal/lockfile/monotone.go
+++ b/internal/lockfile/monotone.go
@@ -18,6 +18,7 @@ package lockfile
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 )
 
@@ -242,12 +243,7 @@ func idRule(lk, lv *Table, want, got Entry) string {
 
 // hasValue reports whether a list carries this value anywhere.
 func (v *ValueList) hasValue(s string) bool {
-	for _, got := range v.Values {
-		if got == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(v.Values, s)
 }
 
 // moveWord is the word a reorder takes per declaration: a flags mask's bits

--- a/testdata/golden/tables/scalars/ScalarsTable.h
+++ b/testdata/golden/tables/scalars/ScalarsTable.h
@@ -4960,17 +4960,17 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
     if ( value.tilt != 0 )
     {
         w.put( 4, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.tilt ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744073709551488ull ) ); w.put( uint64_t( raw_v ), 8 ); }
+        w.put( (uint64_t) ( value.tilt ) - 18446744073709551488ull, 8 );
     }
     if ( value.angle != 0 )
     {
         w.put( 5, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.angle ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744073697755136ull ) ); w.put( uint64_t( raw_v ), 25 ); }
+        w.put( (uint64_t) ( value.angle ) - 18446744073697755136ull, 25 );
     }
     if ( value.position != 0 )
     {
         w.put( 6, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.position ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744071743471616ull ) ); w.put( uint64_t( raw_v ), 32 ); }
+        w.put( (uint64_t) ( value.position ) - 18446744071743471616ull, 32 );
     }
     if ( value.reach != 0 )
     {
@@ -4980,22 +4980,22 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
     if ( value.ticks != 0 )
     {
         w.put( 8, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.ticks ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 20 ); }
+        w.put( (uint64_t) ( value.ticks ), 20 );
     }
     if ( value.ratio != 0 )
     {
         w.put( 9, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.ratio ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 8 ); }
+        w.put( (uint64_t) ( value.ratio ), 8 );
     }
     if ( value.speed != 0 )
     {
         w.put( 10, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.speed ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 26 ); }
+        w.put( (uint64_t) ( value.speed ), 26 );
     }
     if ( value.span != 0 )
     {
         w.put( 11, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.span ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 64 ); }
+        w.put( (uint64_t) ( value.span ), 64 );
     }
     if ( value.mass != 0 )
     {
@@ -5005,7 +5005,7 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
     if ( value.frames != 0 )
     {
         w.put( 13, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.frames ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 32 ); }
+        w.put( (uint64_t) ( value.frames ), 32 );
     }
     if ( value.flux != 0 )
     {
@@ -5025,7 +5025,7 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
     if ( value.scale != 65536 )
     {
         w.put( 17, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.scale ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744073709027328ull ) ); w.put( uint64_t( raw_v ), 21 ); }
+        w.put( (uint64_t) ( value.scale ) - 18446744073709027328ull, 21 );
     }
     {
         bool rides_samples = false;
@@ -5035,7 +5035,7 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
             w.put( 18, kTableMessageRefBitsHere );
             for ( int32_t i = 0; i < 3; i++ )
             {
-                { serialize::uint128_t raw_v_2 = serialize::uint128_t( value.samples[i] ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744073709027328ull ) ); w.put( uint64_t( raw_v_2 ), 21 ); }
+                w.put( (uint64_t) ( value.samples[i] ) - 18446744073709027328ull, 21 );
             }
         }
     }
@@ -5046,7 +5046,7 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
         w.put( (uint64_t) ( value.weights_count ) - 0, 3 );
         for ( int32_t i = 0; i < value.weights_count; i++ )
         {
-            { serialize::uint128_t raw_v_2 = serialize::uint128_t( value.weights[i] ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v_2 ), 15 ); }
+            w.put( (uint64_t) ( value.weights[i] ), 15 );
         }
     }
     {
@@ -5071,7 +5071,7 @@ inline bool SimStateSaveMessageBody( TableBitWriter & w, const SimState & value 
                 uint64_t key_slot = 0;
                 if ( !TableEnumSlot( (Axis) ( i + 1 ), key_slot ) ) { return false; }
                 w.put( key_slot, kTableMessageRefBitsHere ); // the slot's VARIANT reference, not its position
-                { serialize::uint128_t raw_v_2 = serialize::uint128_t( value.axes.slots[i] ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446743644212822016ull ) ); w.put( uint64_t( raw_v_2 ), 40 ); }
+                w.put( (uint64_t) ( value.axes.slots[i] ) - 18446743644212822016ull, 40 );
             }
         }
     }
@@ -6093,17 +6093,17 @@ inline bool PoseSaveMessageBody( TableBitWriter & w, const Pose & value )
     if ( value.x != 32768ll )
     {
         w.put( 1, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.x ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744071743471616ull ) ); w.put( uint64_t( raw_v ), 32 ); }
+        w.put( (uint64_t) ( value.x ) - 18446744071743471616ull, 32 );
     }
     if ( value.y != 0 )
     {
         w.put( 2, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.y ) - ( ( serialize::uint128_t( 18446744073709551615ull ) << 64 ) | serialize::uint128_t( 18446744071743471616ull ) ); w.put( uint64_t( raw_v ), 32 ); }
+        w.put( (uint64_t) ( value.y ) - 18446744071743471616ull, 32 );
     }
     if ( value.heading != 0 )
     {
         w.put( 3, kTableMessageRefBitsHere );
-        { serialize::uint128_t raw_v = serialize::uint128_t( value.heading ) - serialize::uint128_t( 0 ); w.put( uint64_t( raw_v ), 25 ); }
+        w.put( (uint64_t) ( value.heading ), 25 );
     }
     w.put( 0, kTableMessageRefBitsHere ); // the ZERO REFERENCE that ends the body
     return !w.overflow;


### PR DESCRIPTION
The branch tip (3f131e76) was fully green at #905 and went red on nine jobs. Eight of them share ONE cause, and it is two emitter defects the C++ versioning fixtures were the first schemas in the corpus to reach.

## `pins`, `big-endian`, `negative controls (base-keyed)`, `(base-shared-node)`, `(dart)`, `(elixir)`, `(java)`, `(js)`

**Cause — generated C++ that does not compile. Left by #906 and #907** (the versioning fixture schemas under `test/tables/`), which the tables generate list picks up into `build/tables-generated/vnum` and `build/tables-generated/vold_enum_width`, and every one of these jobs builds a binary over that tree (`schema_test_tables`, `schema_test_tables_be`, `schema_test_fixedform_dump`, the first-slot and no-identity control trees). Two defects:

1. `'serialize' has not been declared` (`VOLD/VNEW_fixed_I_growTable.h`, #907's numbers rows). `emitMessageScalar` took the 128-bit write path for every kind `ir.TableKindWide` answers true for — kinds 18–29, which is the 128-bit integers **and the whole fixed-point family** — and emitted `serialize::uint128_t` for a `fixed(12, 4)` that rides in sixteen bits. A `Table.h` includes `serialize.h` only where its closure declares a 128-**bit** field (`unitHas128`), so the header would not compile in any TU. **Fix:** the gate is the storage width, `tableKindWidth(kind) == 16` — which is what the read side has always gated on (`messageload.go`'s `bytesWide == 16`). The narrow kinds take the plain path; same width, same base subtracted, same bytes.

2. `comparison is always false due to limited range of data type [-Werror=type-limits]` (`VOLD_enum_widthTable.h`, #906's `enum_width` row: 255 variants, a one-byte ordinal). The read-side clamp asked `(uint64_t) value.tier > 255u` of a `uint8_t` tag. **Fix:** the emitter drops an ordinal check the tag's own type cannot satisfy — the same "this check cannot fire" test `tableClampEnds` already applies to a ranged scalar sitting on its width's limit. The elided check never clamped, so nothing moves. The union tag's identical check is gated the same way.

`pins` additionally needed its golden: `make conformance-pin update-goldens` rewrote `testdata/golden/tables/scalars/ScalarsTable.h`, where six narrow `fixed` fields move onto the plain write path. No conformance pin under `testdata/` moved.

## `lint`

**Cause — four golangci-lint findings in the lock's lineage code. Left by #909.** `errorlint` (a type assertion on an error that misses a wrapped one → `errors.As`), `gocritic appendAssign` (`append` to one slice, assigned to another), `godot` twice (a doc comment ending on a closing quote). Fixed as each check names it.

And the **five `modernize` names behind them**, also #909's: the lint job runs `modernize` after `golangci-lint`, so no run had reached them, and they would have turned the job red a second time. `range 3`, `slices.Contains`, and three `strings.SplitSeq`.

## Verified locally, as each workflow runs it

- `make -j8 conformance-pin update-goldens` → exit 0, then `git diff --exit-code -- testdata/` clean with the golden above committed (the `pins` job, whole)
- `make -j8 build/schema_test_tables build/schema_test_fixedform_dump` → compiles; `./build/schema_test_tables` → `tables test passed` (the compile step every red job died at; the s390x cross-compile itself is not reproducible on this bench)
- `gofmt -l .` empty, `go mod tidy -diff` clean, `go test ./internal/ci/`, `golangci-lint run ./...` → **0 issues**, `modernize ./...` → silent (the `lint` job, whole)
- `go test ./...` green (it rides `update-goldens`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)