### PR TITLE
the compiler ships the lock's lineage: one read, every backend that takes it

### DIFF
--- a/compiler/fixedlineageship_test.go
+++ b/compiler/fixedlineageship_test.go
@@ -1,0 +1,203 @@
+// THE COMPILER SHIPS THE LOCK'S LINEAGE (docs/FIXED-FORM-ALGORITHM.md §5.2's
+// COMPILE(lock, T), and §5.9 #1: the lineage reaches a backend AS DATA through
+// a second entry point, and the CALLER — this package — makes the lock's three
+// calls).
+//
+// The Java port (#920) found what this test is here to pin: every backend that
+// grew `GenerateLineage` grew it for its own versioning harness, and NOTHING in
+// the tree called it. `schema generate` called the plain `Generate`, so no real
+// build on any leg shipped a lineage of more than one entry, however long the
+// committed lock's lineage was. A port passing its own harness proved its
+// emitter; it proved nothing about the compiler.
+//
+// So the fixture is a REAL LOCK, written the way an operator writes it — `schema
+// lock`, a widening, `schema lock` again — and the assertion is made on the
+// bytes `Compiler.Generate` returns: the OLDER layout's wire hash is in the
+// emitted source, as static data, beside the current one. That is the only
+// statement that distinguishes a backend the driver hands the lineage to from
+// one it does not.
+package compiler
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// fixedLineageShipTargets are the targets whose table backend takes the
+// lineage as data today: `go` and `rust` through `GenerateLineage`, and `cpp`
+// through the lock the driver now opens for it. Every other built-in target's
+// table backend has no second entry point yet (c, cs, dart, elixir, java, js);
+// their `GenerateLineage` lives on the open port branches, and the day one
+// lands its target joins this list and nothing else changes.
+var fixedLineageShipTargets = []string{"cpp", "go", "rust"}
+
+// TestFixedLineageEntryPointIsReachedFromTheDriver: the driver must HAVE the
+// second entry point for those targets. Before #921 no caller in the tree did —
+// every target answered only `Generate`, so the lock's lineage reached no
+// backend from any real build.
+func TestFixedLineageEntryPointIsReachedFromTheDriver(t *testing.T) {
+	c := New()
+	for _, target := range fixedLineageShipTargets {
+		g, ok := c.gens[target]
+		if !ok {
+			t.Fatalf("%s is a built-in target", target)
+		}
+		if _, takes := g.(lineageGenerator); !takes {
+			t.Errorf("%s does not take the lineage from the driver (§5.9 #1: the caller makes lockfile.Open/Lineage/Floor and hands the backend the entries)", target)
+		}
+	}
+}
+
+// fixedLineageShipSchema is the fixture's one file: one fixed table whose body
+// is the fields given. An APPEND is the widening §5.1 permits, so locking,
+// appending and locking again is the shortest path to a lineage of two.
+func fixedLineageShipSchema(fields string) string {
+	return "package lineageship\n\nfixed table Row\n{\n" + fields + "}\n"
+}
+
+// fixedLineageShipHash is the number the file's header and every record carry,
+// computed the way every backend computes it.
+func fixedLineageShipHash(t *testing.T, u *ir.Unit) uint64 {
+	t.Helper()
+	st := u.Tables["Row"]
+	if st == nil {
+		t.Fatal("the fixture declares Row")
+	}
+	return ir.TableFixedLayoutHash(ir.TableFixedLayoutBytes(ir.TableFixedWalkRoot(st)), st)
+}
+
+// TestFixedLineageIsShippedByEveryTargetThatTakesIt is step 1 of #921: a unit
+// with a LOCKED LINEAGE OF TWO, generated through the public driver, and every
+// target whose table backend exports `GenerateLineage` must carry BOTH hashes
+// as static data. A target still on the plain `Generate` carries one, and is
+// named here rather than asserted about, because its backend has no second
+// entry point yet.
+func TestFixedLineageIsShippedByEveryTargetThatTakesIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Lineage.schema")
+	if err := os.WriteFile(path, []byte(fixedLineageShipSchema("    a int32\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	paths, err := GatherPaths([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := New()
+
+	// THE OPERATOR'S THREE COMMANDS: lock, widen, lock.
+	first, err := c.Load(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := fixedLineageShipHash(t, first)
+	if _, _, err := UpdateSchemaLock(first, paths); err != nil {
+		t.Fatalf("the first lock: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(fixedLineageShipSchema("    a int32\n    b int32\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	widened, err := c.Load(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := UpdateSchemaLock(widened, paths); err != nil {
+		t.Fatalf("the second lock: %v", err)
+	}
+	current := fixedLineageShipHash(t, widened)
+	if older == current {
+		t.Fatal("the widening must change the layout hash, or the fixture proves nothing")
+	}
+
+	// THE LOCK IS THE SOURCE, and it holds two entries OLDEST FIRST. This is
+	// the premise every assertion below rests on, so it is checked first.
+	lock, ok, err := lockfile.Open(paths)
+	if err != nil || !ok {
+		t.Fatalf("the fixture's lock: ok=%v err=%v", ok, err)
+	}
+	lin := lockfile.Lineage(lock, "Row")
+	if len(lin) != 2 || lin[0].Wire != older || lin[1].Wire != current {
+		t.Fatalf("the lock holds two entries oldest first: %d entries, %v", len(lin), lin)
+	}
+	if f := lockfile.Floor(lock, "Row"); f != 0 {
+		t.Fatalf("nothing is retired, so the floor is 0: %d", f)
+	}
+
+	u, err := c.Load(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// EVERY TARGET WHOSE TABLE BACKEND TAKES THE LINEAGE. cpp is here too: its
+	// backend reads the lock itself (§5.8 row 1's interim), so it is the
+	// CONTROL — green before this change and after it.
+	for _, target := range fixedLineageShipTargets {
+		files, err := c.Generate(u, target, nil)
+		if err != nil {
+			t.Fatalf("%s: generate: %v", target, err)
+		}
+		var carries []string
+		for name, data := range files {
+			if strings.Contains(string(data), fmt.Sprintf("0x%016x", older)) {
+				carries = append(carries, name)
+			}
+		}
+		if len(carries) == 0 {
+			t.Errorf("%s: the emitted source carries no entry for the OLDER layout 0x%016x — the driver handed the backend no lineage, so a build of this unit reads only its own records (§5.9 #1)", target, older)
+		}
+		found := false
+		for _, data := range files {
+			if strings.Contains(string(data), fmt.Sprintf("0x%016x", current)) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: the emitted source carries no entry for the CURRENT layout 0x%016x", target, current)
+		}
+	}
+}
+
+// TestFixedLineageWithoutALockIsOneEntry is the other half of §5.9 #1: a unit
+// that was never locked PROMISES NOTHING, so the driver hands nothing and every
+// table carries the single entry it can always compute — its own. The shared
+// lock read must not turn an unlocked unit into an error, and it must not move
+// one byte of its output.
+func TestFixedLineageWithoutALockIsOneEntry(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Lineage.schema"), []byte(fixedLineageShipSchema("    a int32\n    b int32\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	paths, err := GatherPaths([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, SchemaLockFileName)); !os.IsNotExist(err) {
+		t.Fatal("the fixture has no lock")
+	}
+	c := New()
+	u, err := c.Load(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	own := fixedLineageShipHash(t, u)
+	for _, target := range fixedLineageShipTargets {
+		files, err := c.Generate(u, target, nil)
+		if err != nil {
+			t.Fatalf("%s: generate: %v", target, err)
+		}
+		found := false
+		for _, data := range files {
+			if strings.Contains(string(data), fmt.Sprintf("0x%016x", own)) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: an unlocked unit still carries its own layout 0x%016x", target, own)
+		}
+	}
+}

--- a/compiler/generate.go
+++ b/compiler/generate.go
@@ -73,7 +73,16 @@ func (c *Compiler) Targets() []string {
 
 // Generate emits target's source for the unit and returns the files, keyed by
 // output file name. It writes nothing — the caller chooses the destination —
-// and it is pure in the unit: generating twice yields the same bytes.
+// and it is deterministic: generating twice yields the same bytes.
+//
+// IT READS ONE FILE: the unit's schema.lock, for the FIXED FORM'S LINEAGE
+// (docs/FIXED-FORM-ALGORITHM.md §5.2). A fixed table reads backward, so a
+// backend that is to emit a reader for the layouts this unit has already shipped
+// must be handed them, and §5.9 #1 puts the three lock calls HERE — in the
+// caller — so the disk is read in one place and no backend opens a file. A unit
+// with no lock hands nothing and every table carries its own layout alone,
+// exactly as before. A lock that will not parse is an error rather than a
+// silently shorter lineage.
 func (c *Compiler) Generate(u *ir.Unit, target string, opts Options) (map[string][]byte, error) {
 	g, ok := c.gens[target]
 	if !ok {
@@ -81,6 +90,13 @@ func (c *Compiler) Generate(u *ir.Unit, target string, opts Options) (map[string
 			return nil, fmt.Errorf("target %q is not implemented — no generators are registered", target)
 		}
 		return nil, fmt.Errorf("target %q is not implemented — %s are the live targets", target, englishList(c.Targets()))
+	}
+	if lg, takes := g.(lineageGenerator); takes {
+		lineage, err := openFixedLineage(u)
+		if err != nil {
+			return nil, err
+		}
+		return lg.GenerateLineage(u, opts, lineage)
 	}
 	return g.Generate(u, opts)
 }

--- a/compiler/lineage.go
+++ b/compiler/lineage.go
@@ -1,0 +1,153 @@
+// THE LINEAGE THE DRIVER HANDS A BACKEND (docs/FIXED-FORM-ALGORITHM.md §5.2's
+// COMPILE(lock, T), and §5.9 #1).
+//
+// A fixed table reads BACKWARD: a file is matched on the eight bytes of its
+// header's hash against a lineage THE BUILD laid down, and nothing parses a
+// stranger's layout on any path. So a backend needs one input it cannot compute
+// — the layouts this unit has ALREADY shipped — and §5.9 #1 says exactly where
+// it comes from: `lockfile.Open`, `lockfile.Lineage` and `lockfile.Floor` are
+// THE CALLER'S THREE CALLS, so the disk is read in ONE place and a backend opens
+// no file. This file is that one place.
+//
+// Until #921 nothing in the tree made the call. Every table backend that grew a
+// `GenerateLineage` grew it for its own versioning harness, `schema generate`
+// called the plain `Generate`, and a build of a unit whose committed lock held
+// five layouts shipped a reader for one of them. The lock was right, the
+// emitters were right, and the compiler dropped the lineage on the floor.
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// A FixedLineage is one unit's locked lineage, read once per generate: per
+// FIXED TABLE the lock's entries OLDEST FIRST — the current layout last — and
+// the floor that entry's retired marks cut at.
+//
+// A unit with NO LOCK has no FixedLineage at all (a nil one): a unit that was
+// never locked promises nothing, so every table carries the single entry it can
+// always compute, its own (§5.9 #2). Every accessor is nil-safe for exactly
+// that reason.
+type FixedLineage struct {
+	// lock is the parsed file itself, for the one backend that still reads it
+	// directly — the C++ reference, whose lineage also comes from the sibling
+	// filename convention §5.8 row 1 holds as an interim. The OPEN is shared
+	// even there; the interpretation is not, yet.
+	lock *lockfile.Unit
+
+	// entries and floor are keyed by the table's DECLARED name, which is what a
+	// backend's emitter holds; the LOCK is keyed by the wire name, and the
+	// translation happens here once.
+	entries map[string][]lockfile.LineageEntry
+	floor   map[string]int
+}
+
+// lineageGenerator is the SECOND ENTRY POINT of §5.9 #1, as the driver sees it:
+// a generator that takes the lock's lineage as data. A target implements it when
+// its table backend exports `GenerateLineage`; a target that does not is called
+// through plain [Generator.Generate] and emits a lineage of one, which is what
+// it did before and still the right answer for a unit with no lock.
+type lineageGenerator interface {
+	GenerateLineage(u *ir.Unit, opts Options, lineage *FixedLineage) (map[string][]byte, error)
+}
+
+// unitSchemaPaths are the unit's *.schema files, which is where the lock lives
+// — beside them, under [SchemaLockFileName].
+func unitSchemaPaths(u *ir.Unit) []string {
+	if u == nil {
+		return nil
+	}
+	var paths []string
+	for _, f := range u.Files {
+		if f != nil && f.Path != "" {
+			paths = append(paths, f.Path)
+		}
+	}
+	return paths
+}
+
+// openFixedLineage makes the caller's three calls of §5.9 #1 for one unit: it
+// locates and parses the lock beside the unit's schema files, and reads the
+// lineage and the floor of every fixed table the unit declares.
+//
+// NO LOCK IS NOT AN ERROR and returns a nil lineage: a unit that has never been
+// locked promises nothing. A lock that will not PARSE is an error, and a loud
+// one — the alternative is shipping a reader for one layout out of five and
+// saying nothing, which is the defect this whole path exists to close.
+func openFixedLineage(u *ir.Unit) (*FixedLineage, error) {
+	paths := unitSchemaPaths(u)
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	lock, ok, err := lockfile.Open(paths)
+	if err != nil {
+		return nil, fmt.Errorf("reading the unit's %s for the fixed form's lineage (docs/FIXED-FORM-ALGORITHM.md §5.2): %w", SchemaLockFileName, err)
+	}
+	if !ok || lock == nil {
+		return nil, nil
+	}
+	l := &FixedLineage{lock: lock, entries: map[string][]lockfile.LineageEntry{}, floor: map[string]int{}}
+	for _, st := range ir.TableFixedRoots(u) {
+		if st == nil {
+			continue
+		}
+		entries := lockfile.Lineage(lock, st.WireName())
+		if len(entries) == 0 {
+			continue
+		}
+		floor := lockfile.Floor(lock, st.WireName())
+		// ONE STATEMENT MADE TWICE, the way the lock's own lines are: the floor
+		// is 1 + the highest retired index, and a backend that derives it from
+		// the entries it was handed must land on the same number the lock's own
+		// accessor reports. A disagreement is a defect here or there, never
+		// something to emit.
+		derived := 0
+		for i, e := range entries {
+			if e.Retired {
+				derived = i + 1
+			}
+		}
+		if derived != floor {
+			return nil, fmt.Errorf("%s: the lock's floor for %s is %d and its retired marks say %d (docs/FIXED-FORM-ALGORITHM.md §5.2)", SchemaLockFileName, st.Name, floor, derived)
+		}
+		l.entries[st.Name] = entries
+		l.floor[st.Name] = floor
+	}
+	return l, nil
+}
+
+// Entries is the lineage of one fixed table, by DECLARED name: the lock's
+// entries OLDEST FIRST, the current layout last. Nil for a table the lock does
+// not carry, and for a unit with no lock.
+func (l *FixedLineage) Entries(table string) []lockfile.LineageEntry {
+	if l == nil {
+		return nil
+	}
+	return l.entries[table]
+}
+
+// Floor is §5.2's one number for one fixed table: 1 + the highest RETIRED index,
+// 0 when none is. Below it a layout this build once served is retired and the
+// answer is `layout_unsupported` — upgrade the client; outside the lineage it is
+// `layout_newer` — ship the reader.
+func (l *FixedLineage) Floor(table string) int {
+	if l == nil {
+		return 0
+	}
+	return l.floor[table]
+}
+
+// Lock is the parsed lock itself, for the C++ reference alone: its lineage is
+// still built from sibling schema files by filename convention (§5.8 row 1's
+// interim, `internal/codegen/cpptable/lineage.go`), so it needs the file and not
+// the entries. Nil for a unit with no lock. The day that interim goes away this
+// accessor goes with it.
+func (l *FixedLineage) Lock() *lockfile.Unit {
+	if l == nil {
+		return nil
+	}
+	return l.lock
+}

--- a/compiler/target_cpp.go
+++ b/compiler/target_cpp.go
@@ -15,7 +15,19 @@ type cppTarget struct{}
 
 func (cppTarget) Names() []string { return []string{"cpp"} }
 
-func (cppTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+// Generate is the case where the caller read no lock: cpptable then opens the
+// unit's lock itself, as it did before #921.
+func (t cppTarget) Generate(u *ir.Unit, opts Options) (map[string][]byte, error) {
+	return t.GenerateLineage(u, opts, nil)
+}
+
+// GenerateLineage takes the lock the DRIVER opened (compiler/lineage.go) rather
+// than opening it a second time. The C++ reference is the one backend that still
+// INTERPRETS the lock itself: its lineage also comes from sibling schema files by
+// filename convention, and its floor from a test-only map, which is §5.8 row 1's
+// interim. So the OPEN is shared here and the interpretation is not, yet — the
+// entries of §5.9 #1 are what it will take the day the convention goes away.
+func (cppTarget) GenerateLineage(u *ir.Unit, _ Options, lineage *FixedLineage) (map[string][]byte, error) {
 	files, err := cpp.Generate(u)
 	if err != nil {
 		return nil, err
@@ -23,7 +35,7 @@ func (cppTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 	// units that declare tables ALSO get <Base>Table.h per file — the
 	// TABLE-wire codecs (docs/SPEC-TABLES.md); a table-free unit's output is
 	// byte-identical to what the packet emitter alone produces
-	tables, err := cpptable.Generate(u)
+	tables, err := cpptable.GenerateLineage(u, lineage.Lock())
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/target_go.go
+++ b/compiler/target_go.go
@@ -15,7 +15,18 @@ type goTarget struct{}
 
 func (goTarget) Names() []string { return []string{"go"} }
 
-func (goTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+// Generate is the NO-LINEAGE case: a unit whose lock the caller did not read,
+// or that has none. Every fixed table then carries the single entry it can
+// always compute — its own (docs/FIXED-FORM-ALGORITHM.md §5.9 #1).
+func (t goTarget) Generate(u *ir.Unit, opts Options) (map[string][]byte, error) {
+	return t.GenerateLineage(u, opts, nil)
+}
+
+// GenerateLineage is the second entry point of §5.9 #1: the driver read the
+// unit's lock once (compiler/lineage.go) and hands the lineage down as DATA, so
+// gotable opens no file and a build ships a reader for every layout the lock
+// records.
+func (goTarget) GenerateLineage(u *ir.Unit, _ Options, lineage *FixedLineage) (map[string][]byte, error) {
 	// Wide text is carried by both packet and table surfaces.
 	if err := refuseWideText(u, "go"); err != nil {
 		return nil, err
@@ -31,7 +42,7 @@ func (goTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 	// TABLE-wire codecs and the reflection descriptors (SPEC-TABLES.md); a
 	// table-free unit's output is byte-identical to what the packet emitter
 	// alone produces
-	tables, err := gotable.Generate(u)
+	tables, err := gotable.GenerateLineage(u, goTableLineage(u, lineage))
 	if err != nil {
 		return nil, err
 	}
@@ -42,6 +53,31 @@ func (goTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 		files[name] = data
 	}
 	return files, nil
+}
+
+// goTableLineage is the lock's lineage in the Go backend's own spelling. Nil in,
+// nil out: a unit with no lock hands nothing.
+func goTableLineage(u *ir.Unit, lineage *FixedLineage) map[string][]gotable.FixedLineageEntry {
+	if lineage == nil {
+		return nil
+	}
+	out := map[string][]gotable.FixedLineageEntry{}
+	for _, st := range ir.TableFixedRoots(u) {
+		entries := lineage.Entries(st.Name)
+		if len(entries) == 0 {
+			continue
+		}
+		for _, e := range entries {
+			out[st.Name] = append(out[st.Name], gotable.FixedLineageEntry{
+				Wire:    e.Wire,
+				Layout:  e.Layout,
+				Record:  e.Record,
+				Retired: e.Retired,
+				Reason:  e.Reason,
+			})
+		}
+	}
+	return out
 }
 
 func init() {

--- a/compiler/target_rust.go
+++ b/compiler/target_rust.go
@@ -15,7 +15,17 @@ type rustTarget struct{}
 
 func (rustTarget) Names() []string { return []string{"rust"} }
 
-func (rustTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+// Generate is the NO-LINEAGE case: a unit whose lock the caller did not read,
+// or that has none, whose every fixed table carries its own layout alone
+// (docs/FIXED-FORM-ALGORITHM.md §5.9 #1).
+func (t rustTarget) Generate(u *ir.Unit, opts Options) (map[string][]byte, error) {
+	return t.GenerateLineage(u, opts, nil)
+}
+
+// GenerateLineage is the second entry point of §5.9 #1: the driver read the
+// unit's lock once (compiler/lineage.go) and hands the lineage down as DATA, so
+// rusttable opens no file and a build ships a reader for every locked layout.
+func (rustTarget) GenerateLineage(u *ir.Unit, _ Options, lineage *FixedLineage) (map[string][]byte, error) {
 	// Packet wide text is carried; table kind 33 remains a named refusal.
 	if err := refuseWideText(u, "rust"); err != nil {
 		return nil, err
@@ -40,7 +50,7 @@ func (rustTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 	// codecs, the reflection descriptors, the text form and the two
 	// accelerators (docs/SPEC-TABLES.md); a table-free unit's output is
 	// byte-identical to what the packet emitter alone produces.
-	tables, err := rusttable.Generate(u)
+	tables, err := rusttable.GenerateLineage(u, rustTableLineage(u, lineage))
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +70,31 @@ func (rustTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
 	}
 	files["lib.rs"] = lib
 	return files, nil
+}
+
+// rustTableLineage is the lock's lineage in the Rust backend's own spelling.
+// Nil in, nil out: a unit with no lock hands nothing.
+func rustTableLineage(u *ir.Unit, lineage *FixedLineage) map[string][]rusttable.FixedLineageEntry {
+	if lineage == nil {
+		return nil
+	}
+	out := map[string][]rusttable.FixedLineageEntry{}
+	for _, st := range ir.TableFixedRoots(u) {
+		entries := lineage.Entries(st.Name)
+		if len(entries) == 0 {
+			continue
+		}
+		for _, e := range entries {
+			out[st.Name] = append(out[st.Name], rusttable.FixedLineageEntry{
+				Wire:    e.Wire,
+				Layout:  e.Layout,
+				Record:  e.Record,
+				Retired: e.Retired,
+				Reason:  e.Reason,
+			})
+		}
+	}
+	return out
 }
 
 func init() {

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -1468,6 +1468,24 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 // tables, and nothing when it does not — a table-free unit's generated tree
 // is byte-identical with or without this package.
 func Generate(u *ir.Unit) (map[string][]byte, error) {
+	return GenerateLineage(u, loadUnitLock(u))
+}
+
+// GenerateLineage is Generate with the unit's LOCK handed in by the caller
+// (docs/FIXED-FORM-ALGORITHM.md §5.9 #1: the lock is opened in ONE place, the
+// driver, and a backend opens no file). A nil lock is a unit that was never
+// locked — or a caller that read none — and the lineage then comes from the
+// sibling-filename convention this backend still carries as §5.8 row 1's
+// interim.
+//
+// IT TAKES THE LOCK AND NOT §5.9 #1'S ENTRIES, and that is the interim showing:
+// this backend's lineage entries also carry the RANGES of an older declaration
+// (collectKnownRanges, read off a peer schema UNIT, not off the lock) and its
+// floor falls back to a test-only map keyed by package. Those two have no
+// spelling in lockfile.LineageEntry, so nothing in the shared path can supply
+// them yet. What moved is the READ; the interpretation moves with the
+// convention.
+func GenerateLineage(u *ir.Unit, lock *lockfile.Unit) (map[string][]byte, error) {
 	if len(u.Tables) == 0 {
 		return map[string][]byte{}, nil
 	}
@@ -1508,7 +1526,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// can name, and the index it takes in the ascending set TableIds's
 	// capacity counts.
 	idOrdinal := wireIdOrdinals(u)
-	lock := loadUnitLock(u)
 	var peers []*ir.Unit
 	if lock == nil {
 		// Fixture siblings (VOLD_/numbered) are TEST-ONLY. A locked unit


### PR DESCRIPTION
#920 found the hole: **nothing in the tree called the entry point §5.9 #1 names.** Every table backend that grew `GenerateLineage` grew it for its own versioning harness, and `compiler/target_*.go` all called the plain `Generate`. So a unit whose committed lock held five layouts generated a reader for ONE of them, on every leg, and no test anywhere said so. The lock was right, the emitters were right, the driver dropped the lineage on the floor.

## Red first

`compiler/fixedlineageship_test.go` builds the fixture the way an operator does — `schema lock`, append a field (§5.1's widening), `schema lock` again — checks the premise against `lockfile.Lineage` (two entries, oldest first, floor 0), then asserts on the bytes `Compiler.Generate` returns: the OLDER layout's wire hash must be in the emitted source beside the current one.

Before the change:

```
--- FAIL: TestFixedLineageEntryPointIsReachedFromTheDriver
    cpp does not take the lineage from the driver (§5.9 #1: the caller makes lockfile.Open/Lineage/Floor …)
    go  does not take the lineage from the driver …
    rust does not take the lineage from the driver …
--- FAIL: TestFixedLineageIsShippedByEveryTargetThatTakesIt
    go:   the emitted source carries no entry for the OLDER layout 0x4842a4b029549be5 — the driver handed
          the backend no lineage, so a build of this unit reads only its own records (§5.9 #1)
    rust: the emitted source carries no entry for the OLDER layout 0x4842a4b029549be5 — …
```

**`cpp` was green on the lineage assertion and red only on the entry point**, because it opens the lock itself — §5.8 row 1's interim. That makes it the control: the one leg that already shipped a real lineage proves the fixture measures what it claims to.

The second test, `TestFixedLineageWithoutALockIsOneEntry`, is the other half of §5.9 #1: an unlocked unit still carries its own layout, and the shared lock read must neither error nor move a byte.

## The one place the lock is read

`compiler/lineage.go` — `lockfile.Open` beside the unit's schema files, then `lockfile.Lineage` and `lockfile.Floor` per fixed table, translating the lock's wire name to the declared name the emitters hold.

- **no lock hands nothing**: a unit that was never locked promises nothing and keeps its lineage of one;
- **a lock that will not PARSE is an error**, because the alternative is exactly this PR's defect — a shorter lineage and no sentence;
- the floor comes from `lockfile.Floor` and is **checked against the entries' own retired marks**, one statement made twice, the way the lock's own lines are.

`lineageGenerator` is §5.9 #1's second entry point as the driver sees it; `Compiler.Generate` calls it where a target has one and plain `Generate` where it does not. `Compiler.Generate`'s doc now says it reads that one file.

## Each target's call, after this PR

| target | table backend call |
|---|---|
| `go` | `gotable.GenerateLineage(u, goTableLineage(u, lineage))` |
| `rust` | `rusttable.GenerateLineage(u, rustTableLineage(u, lineage))` |
| `cpp` | `cpptable.GenerateLineage(u, lineage.Lock())` |
| `c`, `cs`, `dart`, `elixir`, `java`, `js` | `…table.Generate(u)` — **no second entry point on this branch** |

The six on plain `Generate` are not a regression: their backends export no `GenerateLineage` on `fixed-table-form`. #917 (c), #920 (java), #922 (js) and #923 (dart) each grow one on their own branch, and the day one merges its target is three lines — a conversion function and the two-line method — and `fixedLineageShipTargets` in the test gains a name.

## The C++ backend's own lock read (item 3)

**The OPEN moved; the interpretation did not, and here is why not.** `cpptable.Generate` is now `GenerateLineage(u, lock)` and the driver hands it the lock it already opened, so the disk is read once per generate. Its lineage ENTRIES cannot come from `lockfile.LineageEntry` yet, because they carry two facts the lock has no spelling for:

- `collectKnownRanges` reads an older declaration's integer RANGES off a peer schema **unit**, not off the lock — it is what the reference's range-narrowing guards are built from;
- `lineageFloor` falls back to `fixtureFloor`, a test-only map keyed by package, for the `VNEW_floor` fixture that has no lock at all.

Both belong to the sibling-filename convention §5.8 row 1 holds as an interim. Moving them now would mean teaching the shared path the convention, which is the opposite of retiring it. So `FixedLineage.Lock()` exists for exactly one caller and goes away with the convention.

## Gates

- `gofmt -l .` empty.
- `go test ./compiler/ -run 'Lineage|Fixed' ./internal/codegen/...` green.
- `go test ./compiler/ ./internal/lockfile/ ./internal/codegen/cpptable/ ./cmd/...` green (compiler 221s).
- **Regen sweep** — `rm -f bin/schema`, every `generated/**/.stamp` removed and remade: `git status --porcelain generated/` and `git diff --stat generated/` both **empty**. Nothing moved, and the reason is checkable: no unit under `examples/`, `examples128/` or `bench/corpus/` carries a `schema.lock`, so every committed tree's lineage is still the one entry it always was. The committed locks live under `tables/`, `examples-wide/` and `test/table-base64/`, which no committed generated tree is emitted from — the first lock to land beside a generated unit is the first time this sweep will move a file, and it will move it by ADDING older entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)