### PR TITLE
go fixed form: the known-layout struct is TableFixedKnownLayout

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -2551,10 +2551,10 @@ func tableFixedHoles(plan []TableFixedEntry, count int32, dstSize uint32) []tabl
 // (ship the reader); a hash it holds below the floor is layout_unsupported
 // (upgrade the client). Those are the operator's two distinct answers.
 
-// TableFixedKnown is one locked layout: the wire hash a file is matched on, the
-// layout bytes verbatim, and the RECORD SIZE taken from the lock and never from
-// the file.
-type TableFixedKnown struct {
+// TableFixedKnownLayout is one locked layout: the wire hash a file is matched
+// on, the layout bytes verbatim, and the RECORD SIZE taken from the lock and
+// never from the file.
+type TableFixedKnownLayout struct {
 	Hash   uint64
 	Layout []byte
 	Record int64
@@ -2571,7 +2571,7 @@ type tableFixedLineagePlan struct {
 	Why          string
 }
 
-func tableFixedSelect(known []TableFixedKnown, hash uint64) int32 {
+func tableFixedSelect(known []TableFixedKnownLayout, hash uint64) int32 {
 	for i := range known {
 		if known[i].Hash == hash {
 			return int32(i)
@@ -2591,7 +2591,7 @@ func tableFixedRefuseHash(report *TableReport, reason string, hash uint64) int64
 // layout bytes, at package initialization — nothing compiles on the load path,
 // and there is no cache to miss (§5.2, §5.8 row 3). The identity entry keeps a
 // nil plan: the baked one answers it.
-func tableFixedLineagePlans(known []TableFixedKnown, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
+func tableFixedLineagePlans(known []TableFixedKnownLayout, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
 	out := make([]tableFixedLineagePlan, len(known))
 	for i := range known {
 		if known[i].Hash == own {

--- a/generated/bench/paired/go/FixedTableTable.go
+++ b/generated/bench/paired/go/FixedTableTable.go
@@ -1273,7 +1273,7 @@ var FixedTableFixedDst = []TableFixedDst{
 
 var FixedTableFixedPlan = tableFixedBuildPlan(FixedTableFixedLeaves, 310)
 
-var FixedTableFixedKnown = []TableFixedKnown{
+var FixedTableFixedKnown = []TableFixedKnownLayout{
 	{
 		Hash:   0x6237c1dc195f9ec9,
 		Record: 1244,

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -2615,10 +2615,10 @@ func tableFixedHoles(plan []TableFixedEntry, count int32, dstSize uint32) []tabl
 // (ship the reader); a hash it holds below the floor is layout_unsupported
 // (upgrade the client). Those are the operator's two distinct answers.
 
-// TableFixedKnown is one locked layout: the wire hash a file is matched on, the
-// layout bytes verbatim, and the RECORD SIZE taken from the lock and never from
-// the file.
-type TableFixedKnown struct {
+// TableFixedKnownLayout is one locked layout: the wire hash a file is matched
+// on, the layout bytes verbatim, and the RECORD SIZE taken from the lock and
+// never from the file.
+type TableFixedKnownLayout struct {
 	Hash   uint64
 	Layout []byte
 	Record int64
@@ -2635,7 +2635,7 @@ type tableFixedLineagePlan struct {
 	Why          string
 }
 
-func tableFixedSelect(known []TableFixedKnown, hash uint64) int32 {
+func tableFixedSelect(known []TableFixedKnownLayout, hash uint64) int32 {
 	for i := range known {
 		if known[i].Hash == hash {
 			return int32(i)
@@ -2655,7 +2655,7 @@ func tableFixedRefuseHash(report *TableReport, reason string, hash uint64) int64
 // layout bytes, at package initialization — nothing compiles on the load path,
 // and there is no cache to miss (§5.2, §5.8 row 3). The identity entry keeps a
 // nil plan: the baked one answers it.
-func tableFixedLineagePlans(known []TableFixedKnown, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
+func tableFixedLineagePlans(known []TableFixedKnownLayout, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
 	out := make([]tableFixedLineagePlan, len(known))
 	for i := range known {
 		if known[i].Hash == own {
@@ -10635,7 +10635,7 @@ var TableEntityFixedDst = []TableFixedDst{
 
 var TableEntityFixedPlan = tableFixedBuildPlan(TableEntityFixedLeaves, 14)
 
-var TableEntityFixedKnown = []TableFixedKnown{
+var TableEntityFixedKnown = []TableFixedKnownLayout{
 	{
 		Hash:   0x45d64db53ce7ac1f,
 		Record: 59,
@@ -10841,7 +10841,7 @@ var TableStatFixedDst = []TableFixedDst{
 
 var TableStatFixedPlan = tableFixedBuildPlan(TableStatFixedLeaves, 2)
 
-var TableStatFixedKnown = []TableFixedKnown{
+var TableStatFixedKnown = []TableFixedKnownLayout{
 	{
 		Hash:   0x1cdc2a66a7601422,
 		Record: 16,
@@ -11166,7 +11166,7 @@ var TableMixedFixedDst = []TableFixedDst{
 
 var TableMixedFixedPlan = tableFixedBuildPlan(TableMixedFixedLeaves, 311)
 
-var TableMixedFixedKnown = []TableFixedKnown{
+var TableMixedFixedKnown = []TableFixedKnownLayout{
 	{
 		Hash:   0x66b51fa9ec65d701,
 		Record: 1232,

--- a/internal/codegen/gotable/fixedform.go
+++ b/internal/codegen/gotable/fixedform.go
@@ -686,7 +686,7 @@ func (g *tableGen) emitFixedRoot(st *ir.Struct) {
 	// these entries, and the layout it carries is COMPARED with the bytes the
 	// lock recorded, never walked. The floor is 1 + the highest retired index.
 	entries, floor := g.fixedLineage(st, FixedLineageEntry{Wire: hash, Layout: layout, Record: 8 + body})
-	g.pf("var %sFixedKnown = []TableFixedKnown{\n", st.Name)
+	g.pf("var %sFixedKnown = []TableFixedKnownLayout{\n", st.Name)
 	for _, e := range entries {
 		g.pf("\t{\n\t\tHash:   0x%016x,\n", e.Wire)
 		if e.Retired {

--- a/internal/codegen/gotable/fixedruntime.go
+++ b/internal/codegen/gotable/fixedruntime.go
@@ -1011,10 +1011,10 @@ func tableFixedHoles(plan []TableFixedEntry, count int32, dstSize uint32) []tabl
 // (ship the reader); a hash it holds below the floor is layout_unsupported
 // (upgrade the client). Those are the operator's two distinct answers.
 
-// TableFixedKnown is one locked layout: the wire hash a file is matched on, the
-// layout bytes verbatim, and the RECORD SIZE taken from the lock and never from
-// the file.
-type TableFixedKnown struct {
+// TableFixedKnownLayout is one locked layout: the wire hash a file is matched
+// on, the layout bytes verbatim, and the RECORD SIZE taken from the lock and
+// never from the file.
+type TableFixedKnownLayout struct {
 	Hash   uint64
 	Layout []byte
 	Record int64
@@ -1031,7 +1031,7 @@ type tableFixedLineagePlan struct {
 	Why          string
 }
 
-func tableFixedSelect(known []TableFixedKnown, hash uint64) int32 {
+func tableFixedSelect(known []TableFixedKnownLayout, hash uint64) int32 {
 	for i := range known {
 		if known[i].Hash == hash {
 			return int32(i)
@@ -1051,7 +1051,7 @@ func tableFixedRefuseHash(report *TableReport, reason string, hash uint64) int64
 // layout bytes, at package initialization — nothing compiles on the load path,
 // and there is no cache to miss (§5.2, §5.8 row 3). The identity entry keeps a
 // nil plan: the baked one answers it.
-func tableFixedLineagePlans(known []TableFixedKnown, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
+func tableFixedLineagePlans(known []TableFixedKnownLayout, myLayout []byte, dst []TableFixedDst, own uint64) []tableFixedLineagePlan {
 	out := make([]tableFixedLineagePlan, len(known))
 	for i := range known {
 		if known[i].Hash == own {

--- a/internal/tablenames/go.go
+++ b/internal/tablenames/go.go
@@ -423,7 +423,7 @@ func init() {
 		Name{Name: "tableFixedLeafSize", What: "the fixed form: whether a kind is a leaf, and whether its stored width is admitted"},
 		Name{Name: "tableFixedCheck", What: "the fixed form: the read-side layout check's state and its refusal reason"},
 		Name{Name: "tableFixedCheckEntry", What: "the fixed form: the read-side layout check, one subtree per call"},
-		Name{Name: "TableFixedKnown", What: "the fixed form: one known layout of a lineage entry, its hash, its bytes and its record size (§5.2)"},
+		Name{Name: "TableFixedKnownLayout", What: "the fixed form: one known layout of a lineage entry, its hash, its bytes and its record size (§5.2)"},
 		Name{Name: "tableFixedLineagePlan", What: "the fixed form: one precompiled plan per lineage entry (§5.2)"},
 		Name{Name: "tableFixedLineagePlans", What: "the fixed form: the plans for every supported lineage entry, built once from the lock's bytes (§5.2)"},
 		Name{Name: "tableFixedRefuseHash", What: "the fixed form: a refusal that carries the file's hash and nothing else (§5.3)"},

--- a/internal/tablenames/rust.go
+++ b/internal/tablenames/rust.go
@@ -26,6 +26,7 @@ func init() {
 		Name{Name: "TableFixedNoGuard", What: "the guard offset a plan entry that belongs to no union arm carries", RustConst: true},
 		Name{Name: "TableFixedOp", What: "the fixed form's plan ops — the whole set"},
 		Name{Name: "TableFixedEntry", What: "one plan entry: src, dst, size and the op that moves them"},
+		Name{Name: "TableFixedKnown", What: "one known layout of a lineage entry: its hash, its bytes and its record size — the Rust leg's spelling of the page's TableFixedKnownLayout"},
 		Name{Name: "TableFixedReason", What: "the fixed form's refusals, each one BY NAME"},
 		Name{Name: "TableFixedReport", What: "the fixed form's read report — §4's ledger and this form's refusals"},
 		Name{Name: "TableFixedBlock", What: "a parsed vocabulary block: the bytes and the entry count"},


### PR DESCRIPTION
The Go leg named its static known-layout struct `TableFixedKnown` where docs/FIXED-FORM-ALGORITHM.md §5.9 #19, the C++ reference and the C# leg all spell it `TableFixedKnownLayout`, so the type, its registration in internal/tablenames/go.go and the committed Go trees now carry the page's name (the per-table array `<T>FixedKnown` is unchanged — it is identical on every leg). internal/tablenames/rust.go picks up its own `TableFixedKnown` registration, which had been riding on the Go entry until this move left the Rust claim scan with an unregistered name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)