### PR TITLE
the lineage the driver hands a backend carries the WHOLE record size

### DIFF
--- a/compiler/fixedlineageship_test.go
+++ b/compiler/fixedlineageship_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -78,7 +80,14 @@ func fixedLineageShipHash(t *testing.T, u *ir.Unit) uint64 {
 // as static data. A target still on the plain `Generate` carries one, and is
 // named here rather than asserted about, because its backend has no second
 // entry point yet.
-func TestFixedLineageIsShippedByEveryTargetThatTakesIt(t *testing.T) {
+// fixedLineageShipLockedUnit is THE OPERATOR'S THREE COMMANDS as a fixture —
+// `schema lock`, a widening, `schema lock` again — so the committed lock holds a
+// lineage of TWO: the older layout first, the declaration's own last. It returns
+// the driver, the unit loaded from the locked tree, the two wire hashes and the
+// LOCK'S OWN ENTRIES, and it checks the premise every assertion rests on before
+// handing them back.
+func fixedLineageShipLockedUnit(t *testing.T) (*Compiler, *ir.Unit, uint64, uint64, []lockfile.LineageEntry) {
+	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Lineage.schema")
 	if err := os.WriteFile(path, []byte(fixedLineageShipSchema("    a int32\n")), 0o600); err != nil {
@@ -132,6 +141,17 @@ func TestFixedLineageIsShippedByEveryTargetThatTakesIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return c, u, older, current, lin
+}
+
+// TestFixedLineageIsShippedByEveryTargetThatTakesIt is step 1 of #921: a unit
+// with a LOCKED LINEAGE OF TWO, generated through the public driver, and every
+// target whose table backend exports `GenerateLineage` must carry BOTH hashes
+// as static data. A target still on the plain `Generate` carries one, and is
+// named here rather than asserted about, because its backend has no second
+// entry point yet.
+func TestFixedLineageIsShippedByEveryTargetThatTakesIt(t *testing.T) {
+	c, u, older, current, _ := fixedLineageShipLockedUnit(t)
 
 	// EVERY TARGET WHOSE TABLE BACKEND TAKES THE LINEAGE. cpp is here too: its
 	// backend reads the lock itself (§5.8 row 1's interim), so it is the
@@ -158,6 +178,84 @@ func TestFixedLineageIsShippedByEveryTargetThatTakesIt(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("%s: the emitted source carries no entry for the CURRENT layout 0x%016x", target, current)
+		}
+	}
+}
+
+// fixedLineageShipKnownRecord is, PER LEG, the known-layout line the leg writes
+// for ONE lineage entry, with the record size as its one capture. Each leg
+// spells the static data in its own language and nothing shared can be grepped
+// for, so the shapes are written out here — the `cpp` one is the REFERENCE's,
+// against which the other three are read.
+var fixedLineageShipKnownRecord = map[string]func(hash uint64) *regexp.Regexp{
+	// internal/codegen/gotable/fixedform.go: Hash, an optional RETIRED note,
+	// then Record.
+	"go": func(h uint64) *regexp.Regexp {
+		return regexp.MustCompile(fmt.Sprintf(`Hash:\s+0x%016x,\n(?:\s*//[^\n]*\n)?\s*Record:\s*(\d+),`, h))
+	},
+	// internal/codegen/ctable/fixedform.go: one brace-initialized row, the
+	// layout's length taken by sizeof, the record size last.
+	"c": func(h uint64) *regexp.Regexp {
+		return regexp.MustCompile(fmt.Sprintf(`\{ 0x%016xull, \w+, \(int64_t\) sizeof\( \w+ \), (\d+) \}`, h))
+	},
+	// internal/codegen/cpptable/fixedform.go: hash, layout, layout_bytes,
+	// record_bytes — §5.9 #19's four members in order.
+	"cpp": func(h uint64) *regexp.Regexp {
+		return regexp.MustCompile(fmt.Sprintf(`\{ 0x%016xull, \w+, \d+, (\d+) \}`, h))
+	},
+	// internal/codegen/rusttable/fixedform.go: a struct literal, one field per
+	// line, record after layout.
+	"rust": func(h uint64) *regexp.Regexp {
+		return regexp.MustCompile(fmt.Sprintf(`hash: 0x%016x,\n\s*layout: [^\n]*\n\s*record: (\d+),`, h))
+	},
+}
+
+// TestFixedLineageRecordSizeIsTheWholeRecord is what the Java wiring found
+// (#920): §5.2's `record_bytes` is THE WHOLE RECORD — `8 + C(root)`, the
+// record's own eight hash bytes and then the body — and the LOCK records the
+// BODY (internal/lockfile/lineage.go, `LineageEntry.Record`,
+// `ir.TableFixedTypeBytes`). Every leg's own entry for its own layout is
+// `8 + body` already, so a driver that passed the lock's number through
+// unchanged shipped a LOCKED unit's older entries EIGHT BYTES SHORT — and step
+// 9 divides the tail behind the layout by that number, so every record of a
+// file written by the older peer is misread or the read is refused as ragged.
+//
+// It is invisible in every harness fixture because none of them carries a lock,
+// and invisible for the CURRENT layout because the leg's own entry wins for it.
+// So the assertion is on the OLDER entry of a REAL LOCK, read back out of the
+// emitted source by the shape each leg writes it in.
+func TestFixedLineageRecordSizeIsTheWholeRecord(t *testing.T) {
+	c, u, older, _, lin := fixedLineageShipLockedUnit(t)
+	body := lin[0].Record
+	if body <= 0 {
+		t.Fatalf("the lock records the older layout's body size: %d", body)
+	}
+	want := 8 + body
+	for _, target := range fixedLineageShipTargets {
+		files, err := c.Generate(u, target, nil)
+		if err != nil {
+			t.Fatalf("%s: generate: %v", target, err)
+		}
+		shape, ok := fixedLineageShipKnownRecord[target]
+		if !ok {
+			t.Fatalf("%s: every target that takes the lineage has a known-layout shape here", target)
+		}
+		re := shape(older)
+		matches := 0
+		for name, data := range files {
+			for _, m := range re.FindAllStringSubmatch(string(data), -1) {
+				matches++
+				got, err := strconv.ParseInt(m[1], 10, 64)
+				if err != nil {
+					t.Fatalf("%s: %s: the record size is a number: %q", target, name, m[1])
+				}
+				if got != want {
+					t.Errorf("%s: %s: the OLDER layout 0x%016x is emitted with record_bytes %d, and §5.2's record_bytes is THE WHOLE RECORD — 8 + the lock's body size %d = %d. The lock records the BODY and the driver must add the eight hash bytes once, for every leg (docs/FIXED-FORM-ALGORITHM.md §5.2, compiler/lineage.go)", target, name, older, got, body, want)
+				}
+			}
+		}
+		if matches == 0 {
+			t.Errorf("%s: no known-layout line for the OLDER layout 0x%016x was found in the emitted source — the lineage did not ship, or this leg's line has changed shape and the grep in fixedLineageShipKnownRecord has to change with it", target, older)
 		}
 	}
 }

--- a/compiler/lineage.go
+++ b/compiler/lineage.go
@@ -41,9 +41,24 @@ type FixedLineage struct {
 	// entries and floor are keyed by the table's DECLARED name, which is what a
 	// backend's emitter holds; the LOCK is keyed by the wire name, and the
 	// translation happens here once.
+	//
+	// AN ENTRY'S `Record` IS §5.2's `record_bytes`: THE WHOLE RECORD, `8 +
+	// C(root)` — the record's own eight hash bytes and then the body — which is
+	// NOT the number the lock carries. The lock records the BODY
+	// (internal/lockfile/lineage.go's `LineageEntry.Record`,
+	// `ir.TableFixedTypeBytes`) and [openFixedLineage] adds the eight once, so
+	// the value every backend is handed is already the one its static data
+	// needs. A backend adds nothing.
 	entries map[string][]lockfile.LineageEntry
 	floor   map[string]int
 }
+
+// fixedRecordHashBytes is the eight bytes of a record's OWN layout hash, the
+// ones that stand in front of every record's body (docs/FIXED-FORM-ALGORITHM.md
+// §5.2: "record_bytes is 8 + C(root)", and §5.3 step 9 divides the tail behind
+// the layout by that whole number). Every table backend spells its own entry as
+// `8 + body`; this is the same eight, for the entries that come off the lock.
+const fixedRecordHashBytes = int64(8)
 
 // lineageGenerator is the SECOND ENTRY POINT of §5.9 #1, as the driver sees it:
 // a generator that takes the lock's lineage as data. A target implements it when
@@ -113,7 +128,27 @@ func openFixedLineage(u *ir.Unit) (*FixedLineage, error) {
 		if derived != floor {
 			return nil, fmt.Errorf("%s: the lock's floor for %s is %d and its retired marks say %d (docs/FIXED-FORM-ALGORITHM.md §5.2)", SchemaLockFileName, st.Name, floor, derived)
 		}
-		l.entries[st.Name] = entries
+		// §5.2's `record_bytes` IS THE WHOLE RECORD and the lock records the
+		// BODY, so the eight hash bytes are added HERE, ONCE, for every backend
+		// the driver hands entries to. The Java wiring (#920) found the other
+		// way round: each leg's entry for its OWN layout is `8 + body` already
+		// (gotable, ctable, rusttable all spell it that way), so passing the
+		// lock's number through shipped a LOCKED unit's OLDER entries eight
+		// bytes short — and step 9 divides the file's tail by that number, so
+		// every record an older peer wrote is misread or refused as ragged. It
+		// was invisible only because no harness fixture carries a lock and the
+		// leg's own entry wins for the current layout.
+		//
+		// THE SLICE IS COPIED BEFORE THE NUMBER MOVES: `lockfile.Lineage` hands
+		// back the parsed file's own entries, and the C++ reference reads that
+		// same parsed lock through [FixedLineage.Lock] — where the conversion
+		// is its own (`internal/codegen/cpptable/lineage.go`, `8+e.Record`).
+		whole := make([]lockfile.LineageEntry, len(entries))
+		copy(whole, entries)
+		for i := range whole {
+			whole[i].Record += fixedRecordHashBytes
+		}
+		l.entries[st.Name] = whole
 		l.floor[st.Name] = floor
 	}
 	return l, nil
@@ -122,6 +157,10 @@ func openFixedLineage(u *ir.Unit) (*FixedLineage, error) {
 // Entries is the lineage of one fixed table, by DECLARED name: the lock's
 // entries OLDEST FIRST, the current layout last. Nil for a table the lock does
 // not carry, and for a unit with no lock.
+//
+// Each entry's `Record` is §5.2's `record_bytes` — THE WHOLE RECORD, eight hash
+// bytes plus the body — and not the body size the lock's line carries. A
+// backend writes it into its static data as it stands and adds nothing to it.
 func (l *FixedLineage) Entries(table string) []lockfile.LineageEntry {
 	if l == nil {
 		return nil


### PR DESCRIPTION
## The bug the Java wiring found (#920)

`docs/FIXED-FORM-ALGORITHM.md` §5.2's static data carries `record_bytes` = **the whole record**, `8 + C(root)` — the record's own eight hash bytes and then the body. The **lock records the BODY** (`internal/lockfile/lineage.go`, `LineageEntry.Record`, `ir.TableFixedTypeBytes`).

Every table backend spells its entry for its OWN layout as `8 + body` (`gotable`, `ctable`, `rusttable` all say it that way), and the C++ reference converts the lock's number at `internal/codegen/cpptable/lineage.go:257` (`8+e.Record`). But `compiler/lineage.go` handed a backend the lock's number unchanged, and `goTableLineage` (#925), `cTableLineage` (#917) and `rustTableLineage` copied it through — so a **LOCKED** unit's Go, C and Rust builds emitted `record_bytes` **eight bytes short for every entry but the current one**. §5.3 step 9 divides the tail behind the layout by that number, so every record an older peer wrote is misread, or the read is refused as ragged.

It is invisible today only because no harness fixture carries a lock, and because the leg's own entry wins for the current layout. No tracked generated tree moves: `generated/**` comes from `examples/`, `examples128/` and `bench/corpus/`, and none of those carries a lock.

## The fix is ONE place

`openFixedLineage` adds the eight once, on a **copy** of the lock's entries — `lockfile.Lineage` hands back the parsed file's own slice, and the C++ reference reads that same parsed lock through `FixedLineage.Lock()`, where the conversion is its own. So:

- `FixedLineage`'s entries now carry §5.2's `record_bytes`, documented on the field and on `Entries`;
- no target helper adds anything (none did in this tree);
- `cpptable`'s path is **unchanged** — it is the control.

## Coordination: the Java helper's pending +8

`javaTableLineage` on `rowan/java-reads-backward` adds the 8 itself. That branch is **not touched here**. Now that the compiler's value is already whole, **the Java helper must drop its `+8` when it merges**, or the Java leg ships sixteen over.

## Red then green

`TestFixedLineageRecordSizeIsTheWholeRecord` in `compiler/fixedlineageship_test.go`: a real lock — `schema lock`, a widening, `schema lock` again — generated through the public driver, and the OLDER entry's emitted record size read back out of each leg's own known-layout line by a leg-specific grep (the four shapes are written out in `fixedLineageShipKnownRecord`).

| target | before | after |
| --- | --- | --- |
| `c` | RED — `record_bytes 4`, want `12` | green |
| `go` | RED — `record_bytes 4`, want `12` | green |
| `rust` | RED — `record_bytes 4`, want `12` | green |
| `cpp` | green (control) | green |

The fixture of `TestFixedLineageIsShippedByEveryTargetThatTakesIt` is factored out into `fixedLineageShipLockedUnit` and shared; its assertions are unchanged.

## Gates

- `go test -run 'Lineage|Fixed' ./compiler/ ./internal/codegen/gotable/ ./internal/codegen/ctable/` — ok (4.8s)
- full `./internal/codegen/gotable/ ./internal/codegen/ctable/ ./internal/lockfile/` — ok (79s / 4.4s / 1.4s)
- `./internal/codegen/rusttable/ ./internal/codegen/cpptable/` (`-run 'Lineage|Fixed'`) — ok (18.4s / 0.4s)
- `make tables-go-fixed-form` — OK, the whole 80915-byte file matches the C++ reference byte for byte (3.6s)
- `make tables-go-versioning` — ok (21.1s)
- `make tables-c-versioning` — ok (12.7s)
- `gofmt -l .` — empty; regen sweep moved nothing (`git status` clean after the gates rebuilt `bin/schema`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)