### PR TITLE
js: a table past the ceiling has no lineage to parse

### DIFF
--- a/internal/codegen/jstable/fixedform_test.go
+++ b/internal/codegen/jstable/fixedform_test.go
@@ -600,3 +600,99 @@ func TestFixedRootsAndRefusalAgree(t *testing.T) {
 		}
 	}
 }
+
+// A TABLE PAST §3.4's CEILING HAS NO FORM, SO IT HAS NO LINEAGE TO PARSE
+// (docs/SPEC-TABLES.md §3.4, docs/FIXED-FORM-ALGORITHM.md §5.9 #8).
+//
+// `tables/examples` holds `WideBlob`, a `fixed table` whose body is 280012
+// bytes. The compiler already says what that means — THE FIXED FORM IS NOT
+// EMITTED FOR IT, because no conforming reader decodes a record that size — and
+// the lock still carries a lineage entry for it, because the lock records every
+// fixed table's layout and the lock is one file five legs read.
+//
+// Those two facts met in this leg and the build died: `fixedRefusal` did not
+// name the ceiling, so the table was a ROOT here and nowhere else, and
+// `refuseFixedLineage` then held the lock's entry to the FORM's rules — where
+// the root's size is past the 65536 the reader caps a record at, so the layout
+// "does not parse" and §5.9 #8 failed the build over a lock that is correct.
+// The rule the other legs keep is the one this test states: a table with no form
+// has no layout of this form's shape, so there is nothing of it to parse, and
+// the only thing the module owes it is the line saying the form is not there.
+func TestJSFixedNoFormMeansNoLineageToParse(t *testing.T) {
+	const src = `package probe
+fixed table Small
+{
+    keep uint32 = 0
+}
+fixed table Huge
+{
+    payload bytes(70000)
+}
+`
+	u := jsUnitOf(t, src)
+
+	// THE CEILING IS A REFUSAL HERE, the way it is in every other leg: the table
+	// is not a root, and the module says so by name.
+	roots := jsFixedUnitRoots(u)
+	if len(roots) != 1 || roots[0].Name != "Small" {
+		var got []string
+		for _, st := range roots {
+			got = append(got, st.Name)
+		}
+		t.Fatalf("a table past the 65536-byte ceiling is NOT a fixed-form root, got roots %v", got)
+	}
+	huge := findTable(t, u, "Huge")
+	if n := fixedTypeBytes(huge); n <= ir.TableFixedRecordMaxBytes {
+		t.Fatalf("the fixture's body is %d bytes, which is not past the %d-byte ceiling", n, ir.TableFixedRecordMaxBytes)
+	}
+	if fixedRefusal(huge) == "" {
+		t.Error("a table past §3.4's ceiling is refused BY NAME, so the module can say which table and why")
+	}
+
+	// THE LOCK'S ENTRY FOR IT IS HANDED IN, exactly as `lockfile.Lineage` hands
+	// the one `tables/examples/schema.lock` holds for `WideBlob`: the layout the
+	// walk computes over the whole body, and the record size that body accounts
+	// for. GENERATE MUST NOT REFUSE IT — it is not an entry of this form.
+	w := fixedWalkRoot(huge)
+	layout := fixedLayoutBytes(w.entries)
+	overCeiling := FixedLineageEntry{
+		Wire:   ir.TableFixedLayoutHash(layout, huge),
+		Layout: layout,
+		Record: fixedHashBytes + fixedTypeBytes(huge),
+	}
+	own, ok := FixedLineageOf(u, "Small")
+	if !ok {
+		t.Fatal("no lineage entry for Small")
+	}
+	files, err := GenerateLineage(u, map[string][]FixedLineageEntry{
+		"Small": {own},
+		"Huge":  {overCeiling},
+	})
+	if err != nil {
+		t.Fatalf("a lineage entry for a table with NO FORM must not fail the build: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("the unit has a fixed root, so a module is written")
+	}
+
+	// AND NOTHING OF IT IS EMITTED: no known layout, no plan, no body size. The
+	// line naming the refusal is the whole of what `Huge` gets.
+	base64Layout := fixedLayoutBase64(layout)
+	sawRefusalLine := false
+	for name, body := range files {
+		src := string(body)
+		for _, bad := range []string{
+			"HugeFixedBodyBytes", "HugeFixedRecordBytes", "HugeFixedLayout",
+			"HugeFixedKnownLayout", "HugeFixedWriteBody", "HugeFixedDecode",
+			base64Layout,
+		} {
+			if strings.Contains(src, bad) {
+				t.Errorf("%s names %q — a table with no fixed form has no fixed surface and no known layout", name, bad)
+			}
+		}
+		sawRefusalLine = sawRefusalLine || strings.Contains(src, "table Huge has NO FIXED FORM in JavaScript")
+	}
+	if !sawRefusalLine {
+		t.Error("NAMED, NEVER SILENT: a generated module says which table has no fixed form and why")
+	}
+}

--- a/internal/codegen/jstable/fixedjs.go
+++ b/internal/codegen/jstable/fixedjs.go
@@ -57,6 +57,19 @@ func fixedRefusal(st *ir.Struct) string {
 	// `table`. So the only class that can ever hold a present flag is the one
 	// THIS FILE emits (emitTableClass), and there was never another emitter's
 	// storage to invent.
+	//
+	// §3.4's 65536-BYTE CEILING IS A REFUSAL OF THE FORM, and it belongs here
+	// rather than in the roots loop, because the refusal IS the filter
+	// (fixedRoots): a ceiling the filter knew and this function did not would be
+	// a module that carries a 280020-byte record and says nothing about it. The
+	// compiler already warns, naming the table and the size — *"THE FIXED FORM
+	// IS NOT EMITTED FOR IT, because no conforming reader decodes a record that
+	// size"* (ir.TableFixedRecordBounds) — and the class is untouched: the table
+	// keeps form 1, its by-value storage, its cook and its block form. So this
+	// is not a refusal of the TABLE and never of the unit.
+	if fixedTypeBytes(st) > ir.TableFixedRecordMaxBytes {
+		return "its record body is past §3.4's 65536-byte ceiling, so no conforming reader would decode a record that size — it keeps form 1 (docs/SPEC-TABLES.md §3.4)"
+	}
 	return ""
 }
 

--- a/internal/codegen/jstable/fixedlineage.go
+++ b/internal/codegen/jstable/fixedlineage.go
@@ -138,9 +138,27 @@ func jsFixedUnitRoots(u *ir.Unit) []*ir.Struct {
 // EXACTLY the entries. A generator check looser than the reader's would pass an
 // entry the reader then refuses at run time, which is the hole this closes; a
 // check stricter than it would fail a build over a layout that reads fine.
-func refuseFixedLineage(lineage map[string][]FixedLineageEntry) error {
+// AND IT IS THE EMITTED ROOTS' LINEAGE AND NOBODY ELSE'S. The lock is ONE file
+// five legs read, and it records a layout for EVERY fixed table — including one
+// this form is not emitted for: a body past §3.4's 65536-byte ceiling keeps form
+// 1 and carries no form-3 layout at all (ir.TableFixedRecordBounds warns by
+// name). Holding such an entry to this form's rules is reading the lock wrong in
+// the loudest possible way: the root's size is past the 65536 the READER caps a
+// record at, so the bytes "do not parse", and #8 then fails the build over a
+// lock that is correct — which is exactly how `tables/examples`' `WideBlob`
+// (280012 bytes) went red here and green in every other leg. A table with no
+// form has no entry OF THIS FORM to check, so the lineage this walks is
+// `fixedRoots`' and the rest of the map is not this form's business.
+func refuseFixedLineage(u *ir.Unit, lineage map[string][]FixedLineageEntry) error {
+	emitted := make(map[string]bool, len(lineage))
+	for _, st := range jsFixedUnitRoots(u) {
+		emitted[st.Name] = true
+	}
 	names := make([]string, 0, len(lineage))
 	for name := range lineage {
+		if !emitted[name] {
+			continue
+		}
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/internal/codegen/jstable/jstable.go
+++ b/internal/codegen/jstable/jstable.go
@@ -216,7 +216,7 @@ func GenerateLineage(u *ir.Unit, lineage map[string][]FixedLineageEntry) (map[st
 	// emitted (§5.9 #8, #26): a layout that does not parse, or a record size
 	// that is not what the entry's own layout accounts for, is never a wire
 	// event and never a refusal at the first file that matches its hash.
-	if err := refuseFixedLineage(lineage); err != nil {
+	if err := refuseFixedLineage(u, lineage); err != nil {
 		return nil, err
 	}
 	// THE WIDE KINDS (docs/SPEC-TABLES.md §15) ARE A REFUSAL OF THE


### PR DESCRIPTION
CI's `conformance (js)` was RED on the tip of `fixed-table-form` (39c7297e, PR #922) at **build the harness and the js driver**:

```
schema: fixed table WideBlob: the lineage entry 0x8202b907d4ac81c4 is not a parseable layout — it is a bug in the LOCK and never a wire event, so the build fails here (docs/FIXED-FORM-ALGORITHM.md §5.2, §5.9 #8)
make: *** [make/js.mk:83: build/tables-generated-js/.stamp] Error 1
```

## The cause

`tables/examples`' `WideBlob` is a `fixed table` whose record body is **280012 bytes**, past §3.4's 65536-byte ceiling. The compiler already says what that means, by name and always on: *THE FIXED FORM IS NOT EMITTED FOR IT, because no conforming reader decodes a record that size* — it keeps form 1, and `fixed` still buys it the CLASS. The lock records a layout and a lineage entry for **every** fixed table, `WideBlob` included, because the lock is one file five legs read.

Two halves of one rule were missing here:

1. **`fixedRefusal` (internal/codegen/jstable/fixedjs.go) never named the ceiling.** In this leg the refusal IS the roots filter (`fixedRoots`), so `WideBlob` was a fixed-form ROOT where it is a root in no other leg — and the emitter wrote its whole surface: `WideBlobFixedBodyBytes = 280012`, `WideBlobFixedRecordBytes = 280020`, the write body, the decode. `darttable` has carried this clause all along.
2. **`refuseFixedLineage` (internal/codegen/jstable/fixedlineage.go) walked EVERY name in the handed lineage map**, so it held the lock's `WideBlob` entry to the FORM's four parse rules — where rule 2 caps a root's size at the 65536 a reader caps a record at. The bytes "do not parse", and §5.9 #8 then failed the build over a lock that is **correct**, reporting a lock bug on bytes that are not this form's at all. `gotable`, `cpptable`, `ctable` and `rusttable` never see such an entry: they only ever index `lineage[st.Name]` for a root they emit.

## The fix

The ceiling joins `fixedRefusal`, where the filter can see it, and the lineage check walks the **emitted roots** — a table with no form has no layout of this form's shape, so there is nothing of it to parse. §5.9 #8 keeps its full teeth on every entry of a table that HAS a form: the fourteen lock-bug rows of `TestJSFixedLineageLockBugFailsTheBuild` are untouched and still red-on-bad.

## The test

`TestJSFixedNoFormMeansNoLineageToParse` in `internal/codegen/jstable/fixedform_test.go`, a `WideBlob` in miniature (`fixed table Huge { payload bytes(70000) }` beside a lawful `Small`), red before the fix and green after. It states all three facts: the table is not a fixed-form root and is refused BY NAME; `GenerateLineage` handed the lock's entry for it does **not** fail; and nothing of it is emitted — no body size, no known layout, not the entry's base64 layout bytes — while the module still carries the line saying which table has no fixed form and why.

## Gates

| gate | result |
| --- | --- |
| `make build/tables-generated-js/.stamp` (all roots) | green, 4.0s |
| `make tables-js-versioning` | green, 3.3s |
| `make tables-js-fixed-form` | green, 1.5s |
| `go test ./internal/codegen/jstable/` | green, 0.3s |
| `gofmt -l .` | empty |

`go test ./compiler/` on this bench fails only where a test needs the sibling `../serialize`, `../serialize.c`, `../serialize.cs` and `../serialize.rs` checkouts, which this clone's parent does not have; every such failure is `real serialize runtime required: stat …/serialize.h: no such file or directory` and none is in a fixed-form or lineage test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)