### PR TITLE
bench standard: the plan-read arm, so a lineage read is on the clock

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -666,6 +666,261 @@ form and the cook. Those stay C++/C#, measured in the game on real render
 data, under `make tables-block-gate2` (docs/SPEC-TABLES.md §12.1) and the
 cook's open-cost gate (§7.5). No per-language block or cook bench is owed.
 
+### §1.10 The lineage corpus and the PLAN-READ arm
+
+**The belief this arm exists to measure.** Glenn's gate on the bitpacked message
+form is that the fixed table be 100% and PERFORMANT across nine languages first,
+and the performance half of that gate rests on two claims nobody has measured:
+
+1. **the identity lane is free** — the reader's own wire hash selects the
+   identity entry (docs/FIXED-FORM-ALGORITHM.md §5.3 step 8: the fills are
+   EMPTY, `record_bytes` is `8 + C(root)`, and no plan compiler runs), so a
+   fixed-form read of a CURRENT file costs nothing over the form-3 read the
+   board already publishes; and
+2. **a lineage read is within a small constant of it** — a read of an OLDER
+   layout selects a lineage entry, PREFILLS the destination with that entry's
+   fills (§4.3) and scatters through the COMPILED plan (§4.4, §4.5), and that
+   is the whole price of reading backward.
+
+**Nothing under `bench/` can measure the second claim today, and this is the
+honest inventory.** `bench/tools/ledger.go:216` admits only
+`bench_mixed` / family `gen` rows, so a fixed-form row cannot enter the
+across-time series at all. `test/bench/fixedform_measure.cpp`'s nearest arm, A3
+("the SHIPPED loop over a RUNTIME copy of the same plan"), reads the SAME
+layout through a runtime plan copy — it prices the plan's indirection, not a
+widening, and an identity plan has no fills to prefill and no scatter to do. No
+producer in the estate emits an older-layout record into a bench corpus. And no
+read arm in any of the `bench/tables/<lang>/` runners lets `LOAD` select a
+non-identity entry: every one of them loads `bench_fixed.bin`, whose hash is the
+reader's own. **A3 is not arm 2 wearing a different name, and this section is
+not a rename of A3.**
+
+**The arm is READ-ONLY, and that is structural, not an omission.** A fixed table
+writes its own layout and no other (§3.1 there), so there is no "write the old
+layout" to time and no round trip to close. The arm therefore reports the `read`
+path, **measured**, which is the one place in this standard where a measured
+`read` row is correct: §2.9's "`read` is DERIVED" binds the gen family's
+`bench_mixed` rows, where a round trip exists to derive it from. Here there is
+no round trip, so a derived number would have nothing to be derived from.
+
+#### The producer
+
+**One older-layout file per paired unit, written by the C++ dump, from a named
+VOLD schema.** The byte authority for this form is the C++ reference
+(`test/tables/fixedform_dump.cpp`, the cross-language byte oracle), so the
+reference writes these bytes too and every leg reads the same ones.
+
+- **The schema** is `bench/corpus/VOLD_bench_lineage.schema`: `BenchMixed` ONE
+  GENERATION BACK, declaring the same table name so the two layouts are one
+  lineage, in its own package so both generations compile into one binary (the
+  FX1/FX2 and `VOLD_*`/`VNEW_*` precedent). The NEW side of the pair is not a
+  new file: it is `bench/corpus/Bench.schema` itself, unchanged, because the
+  READER of this arm must be the leg's ordinary generated `BenchMixed` codec
+  and nothing built for the bench.
+- **Its widening touches every kind class a lineage read can carry**, so the
+  number is not one cheap op repeated:
+
+  | class | OLD (`VOLD_bench_lineage`) | NEW (`Bench.schema`, today) | what the plan does |
+  |---|---|---|---|
+  | appended field | body ends at `extra` | `idle_ticks int32 \| 0..15` | a FILL; the field is never on the wire |
+  | widened array bound | `stats [..64]MixedStat` | `stats [..80]MixedStat` | count and 64 elements land; slots 64..79 take the ELEMENT default — the prefill's largest span |
+  | widened text | `player_name string(8)` | `player_name string(15)` | length and used bytes exact, the slack zeroed |
+  | new union arm | `MixedEvent { hit, chat }` | `{ hit, chat, pickup }` | the pinned arm is `hit`, so the read lands through a plan ARM; the tag width is equal both sides |
+  | enum append | `MixedWeapon`, 12 variants | 15 variants | the bounds pass guards against the WRITER's variant count, carried by the plan |
+  | integer widen | `MixedStat.delta int16` | `delta int32` | **80 widen entries per record**: §5.9 #33 forbids folding a run across a widening, so this is the only arm that puts ARITHMETIC rather than a copy on the clock, and a plan-read number without it measures the cheap half |
+
+  **What this corpus does NOT carry, named rather than faked:** an enum ORDINAL
+  WIDTH widen needs 255 → 256 variants, which would destroy the shape §1.9's
+  mirror rule exists to protect. It stays in the versioning corpus's
+  `enum_width` row (docs/FIXED-FORM-VERSIONING-TESTS.md) and is not smuggled in
+  here. `wstring` and `bytes` capacity growth is the SAME plan op as
+  `string(N)` growth, so the text class is carried once.
+- **The files** are `bench/paired/corpus/bench_lineage.bin` and
+  `bench_lineage.layout`, beside `bench_fixed.bin` / `bench_fixed.layout` and
+  named the same way. **There is no length index and there must not be one:**
+  a form-3 file's records are constant-size by construction (§5.3 step 9's
+  `rest mod record_bytes`), which is exactly what the form-1 paired corpus
+  needed its 64-entry index for. The OLD record size differs from the reader's
+  and is the LOCK's, never the file's (§5.3 step 8, §5.9 #34).
+- **The values are the paired unit's own.** The 64 records are the SAME 64
+  logical records, decoded once from the canonical packet corpus, exactly as
+  `test/bench/paired_main.cpp` derives the form-1 corpus. There is no second
+  field list and no independent value generator; the three fields the OLD
+  schema cannot hold (`idle_ticks`, `stats[64..79]`, `player_name` past 8
+  bytes) are the three the reader is supposed to fill, and the dump writes a
+  manifest line for the file like every other corpus row (§5.9 #32) so a leg
+  asserts the manifest and never reads the dump.
+- **The lock is what makes the reader's layout the newer one.** The paired unit
+  gains `bench/corpus/schema.lock` carrying BenchMixed's lineage with the VOLD
+  layout at index 0, the identity at index 1, and `floor = 0`. Without that
+  entry every leg answers `layout_newer` and the arm measures a refusal; with
+  it, `LOAD` takes step 5's first matching index and step 8's plan. **The lock
+  is committed corpus**: it hashes into `corpus_id` with the bytes, because a
+  lock edit silently changes which plan ran.
+
+#### The read arm, per leg
+
+Every `bench/tables/<lang>/` runner gains ONE new mode, and in it TWO timed
+paths over the SAME 64 records at the SAME uniform iteration count per wire
+that §2.1 fixes for the identity row, in the SAME sitting, interleaved by
+§2.4:
+
+| row | what `LOAD` selects | path | statistic |
+|---|---|---|---|
+| `bench_fixed` | the identity entry | `write`, `round_trip` | **UNCHANGED**; no existing board moves |
+| `bench_fixed_read` | the identity entry, read alone | `read` | measured |
+| `bench_plan_read` | the OLDER entry, by its hash | `read` | measured |
+
+**`bench_fixed_read` is not a convenience row; §2.9 forces it into existence.**
+The plan/identity ratio needs an identity read on the clock, and
+`bench_fixed`'s read is DERIVED and printed to stderr precisely so it can never
+be divided. Deriving the ratio's denominator would be the exact failure §2.9
+legislated against.
+
+Everything §1.5, §1.6, §1.9 and §2 says applies unchanged: the golden gate
+before any clock, 1 discarded warmup plus 7 runs, best with median beside it,
+the escape barriers, the 200 ms floor, the control legs. Two clauses are
+restated because the arm is new:
+
+- **The gate before the clock is the versioning law's own.** A leg may not
+  start this clock until its `bench_plan_read` mode has proved, on all 64
+  records, that every OLD value landed exactly, that the reader's appended tail
+  holds its declared DEFAULT, and that the counters are what
+  docs/FIXED-FORM-ALGORITHM.md §5.4 says for these six classes — 80 `widened`
+  per record among them. A plan read that decoded wrongly does not get to be
+  fast.
+- **The prefill and the scatter are ON the clock, and the LOAD is the whole
+  timed operation.** PREFILL, RUN, BOUNDS (§4.3–§4.6) are the work being
+  priced; a runner that hoists the prefill out of the loop, or reuses a
+  destination it filled on a previous iteration, has measured the identity lane
+  twice. The destination is reused across iterations — that is the shipped
+  call — but every iteration pays its own prefill.
+
+#### `corpus_id`: the plan rows carry their own, by construction
+
+The plan mode loads `bench_lineage.bin`, `bench_lineage.layout` and the lock in
+ADDITION to the identity goldens, so its `corpus_id` differs from the ordinary
+table pass's by §1.6's definition, with no new rule needed. That is the whole
+protection asked of it, in both directions:
+
+- `bench_plan_read` and `bench_fixed_read` come out of ONE invocation and so
+  SHARE an id — the ratio's two halves are divisible, which is the point; and
+- neither can ever be divided against a `bench_fixed` row from the ordinary
+  pass, whose id is different. **A plan row is never divided against an
+  identity row it was not measured beside.**
+
+Rows ride the existing §5.1 columns with no schema change: family `table`,
+`path = read`, and column 2 carrying two new values. **§5.3 rule 2
+(`bytes_per_op`) refuses the plan/identity ratio, and it is RIGHT to** — the
+OLD record is a different length by construction. Only the paired driver may
+print it, the same exception §1.9 already grants it for the table-versus-packet
+ratio, and the caption MUST name both record sizes so nobody reads a
+bytes-per-record difference as a rate difference.
+
+#### What the ledger must accept
+
+> `bench/tools/ledger.go`'s row filter (`ledger.go:216`) must admit
+> `(family table, bench_fixed_read | bench_plan_read, path read)` as series of
+> their OWN, keyed by row name, never folded into the `gen` / `bench_mixed`
+> curve the C/C++ pair lock is defined over.
+
+That is one line of filter and one line of key. **The `--check` teeth stay
+OFF these rows until the bound below is ratified**: `lockedLegs` gates the
+`bench_mixed` / `gen` / `round_trip` statistic and nothing else
+(`ledger.go:44`), and extending a gate to a new statistic is a ruling, not a
+filter change — the same reason the bitpacker rows sit outside the pair lock.
+
+#### The two ratios, and their bounds
+
+| ratio | denominator | bound | status |
+|---|---|---|---|
+| **identity / hand-written straight-line** | `test/bench/fixedform_measure.cpp` arm B, one constant-offset load per leaf, hand-written so the emitter does not grade its own homework | **≤ 1.5x** | RATIFIED, docs/SPEC-TABLES.md §3.4 — the price the one-reader-path ruling was bought with |
+| **plan / identity** | `bench_fixed_read` from the same invocation | **≤ 2.0x** | **PROPOSED** (below) |
+
+**Why 2.0x for plan / identity.** The identity lane is ONE pass over the
+record: empty fills, coalesced runs, a copy. A lineage read adds exactly one
+structural thing — the PREFILL, a second pass over the SAME destination bytes
+before the runs land (§4.3) — plus a run loop that is more fragmented, because
+a widening forbids the fold (§5.9 #33) and each widened element becomes its own
+entry. Fragmentation adds loop and dispatch overhead but touches **no new
+bytes**; the prefill is the only new traffic, and it is bounded by the
+destination's size, which is the identity read's own working set. So **two
+passes where identity pays one is the structural ceiling**, and 2.0x is the
+smallest constant the prefill alone cannot break. A leg above it is not paying
+for tolerance: it is re-reading the record, or dispatching per field where the
+plan should have coalesced, and the number is a coalescing defect to fix rather
+than a cost to accept. The bound is **per leg**, not an average — Glenn's gate
+is nine languages performant, and an average hides the one that is not.
+
+`1.5 x 2.0 = 3.0x` is therefore the worst a backward read may cost against
+hand-written straight-line code, stated once so nobody has to multiply it
+themselves.
+
+#### The per-leg reporting shape
+
+Nine legs, three numbers each, one line per leg, on the paired driver's board
+beside `NINE.md`:
+
+```
+# fixed form: the identity lane and the plan lane
+# host / arch / rev / lane / rounds / corpus_id(identity) / corpus_id(plan)
+# C++ anchor: identity 000.0 ns/record / straight-line 000.0 = 0.00x  (bound 1.5x, SPEC-TABLES §3.4)
+
+leg      identity read    plan read    plan/identity
+         ns/record        ns/record    x (bound 2.0)
+cpp          00.0            00.0          0.00
+c            00.0            00.0          0.00
+go           00.0            00.0          0.00
+rust         00.0            00.0          0.00
+cs           00.0            00.0          0.00
+java         00.0            00.0          0.00
+js           00.0            00.0          0.00
+dart           —               —             —     no runner on this tree
+elixir       00.0            00.0          0.00
+```
+
+Three rules about that page, each paying for a failure this standard already
+names:
+
+- **The ratio column is the verdict and it is per leg.** A leg over 2.0x prints
+  its number and is marked, never dropped and never averaged away.
+- **A leg with no runner is NAMED with its reason**, in §1.9's and
+  `nine.sh`'s own vocabulary — "no runner on this tree", "no leg in this driver
+  yet", "runner present, but its rows do not belong to this sitting" are
+  different facts about the merge, and none is ever estimated. Eight table
+  runners exist under `bench/tables/` today; Dart's fixed-form leg has landed
+  and its bench runner has not, so the ninth line is a named refusal until it
+  does.
+- **The first ratio is C++'s alone and the board says so.** Arm B is
+  hand-written, and nine hand-maintained layouts would be nine chances for the
+  comparand to be wrong in a leg-specific way. The form's rule is one reference
+  for bytes (and one for the straight-line comparand); no leg owes a
+  hand-written arm, and the C++ anchor line is where that ratio lives.
+
+#### The work list — one file, one line, one child each
+
+1. `bench/corpus/VOLD_bench_lineage.schema` — NEW: `BenchMixed` one generation back, the six narrowings of the table above, same table name, own package.
+2. `bench/corpus/schema.lock` — NEW: the paired unit's lock, VOLD layout at lineage index 0, identity at 1, `floor = 0`.
+3. `Makefile`, `tables_generate` — generate the VOLD leg beside the `VOLD_*`/`VNEW_*` rows so both generations compile into one binary.
+4. `test/tables/fixedform_dump.cpp` — write `bench_lineage.bin` + `.layout` from the 64 packet-decoded records, and its `manifest.txt` line through `MS`/`MSI`/`MSTR` like every other row (§5.9 #32).
+5. `Makefile`, `bench-paired-corpus` — re-pin the two lineage files into `bench/paired/corpus/`; ordinary builds only verify them.
+6. `bench/paired/corpus/bench_lineage.bin`, `bench_lineage.layout` — NEW: the committed bytes.
+7. `test/tables/versioning_numbers.cpp` — the reference's NEW-READS-OLD case for this row, counters included (80 `widened` per record), RED before the arm is timed.
+8. `bench/tables/cpp/table_main.cpp` — the `--plan-read` mode: the pre-clock gate, then the two timed `read` paths.
+9. `bench/tables/c/table_main.c` — the same mode, held to the C/C++ twin gate's text.
+10. `bench/tables/go/table_main.go` — the same mode.
+11. `bench/tables/rust/src/main.rs` — the same mode.
+12. `bench/tables/cs/src/Program.cs` — the same mode.
+13. `bench/tables/java/TableMain.java` — the same mode, one timed loop method per path (the JVM discipline, #156 item 5).
+14. `bench/tables/js/table_main.mjs` — the same mode, `codec` column unchanged.
+15. `bench/tables/elixir/runner.exs` — the same mode, and its input manifest gains the two files.
+16. `bench/tables/run.sh` — pass the mode through; a leg that does not answer it is named, not dropped.
+17. `bench/tools/ledger.go` — admit `(table, bench_fixed_read|bench_plan_read, read)` as rows of their own; `lockedLegs` untouched.
+18. `bench/paired/main.go` — `-mode plan-read`: one invocation, the two rows, the distinct `corpus_id`, the `bytes_per_op` caption §5.3 rule 2 requires.
+19. `bench/paired/nine.sh` — the board above, three numbers per leg, the C++ anchor line, named refusals for absent legs.
+20. `docs/SPEC-TABLES.md` §3.4 — record the plan/identity bound once it is ratified; until then this section carries it as PROPOSED and nothing gates on it.
+
+
 ---
 
 ## §2 Methodology

--- a/bench/paired/README.md
+++ b/bench/paired/README.md
@@ -317,3 +317,125 @@ staggered buffer padding never counts as serialized bytes.
 only verify it. The historical `BenchTable.schema`, table corpus and results
 remain intact. They were representative counterparts with different logical
 types and values, so their historical ratios cannot supply this second column.
+
+## The plan-read arm
+
+`-mode plan-read` is the arm that puts a BACKWARD read on the clock.
+BENCH-STANDARD.md §1.10 is its normative text; this is the operating manual.
+
+```sh
+go run ./bench/paired -mode build -langs cpp   generate both generations, build, gate
+go run ./bench/paired -mode gate  -langs cpp   the no-clock gate alone
+go run ./bench/paired -mode plan-read -langs cpp,c,go,cs -fast-rounds 3 -noise-note "..."
+```
+
+**What it measures and why it is not already measured.** A fixed-form read of a
+CURRENT file takes the identity lane: the reader's own wire hash selects the
+identity entry, whose fills are EMPTY and whose record size is `8 + C(root)`
+(docs/FIXED-FORM-ALGORITHM.md §5.3 step 8), and no plan compiler runs. A read of
+an OLDER file selects a LINEAGE entry, prefills the destination with that
+entry's fills (§4.3) and scatters through the compiled plan (§4.4, §4.5). Those
+are two different amounts of work and the estate has a number for neither.
+`test/bench/fixedform_measure.cpp` arm A3 is the nearest thing and it is not
+this: it reads the SAME layout through a runtime copy of the identity plan, so
+it prices the plan's indirection with nothing to prefill and nothing to scatter.
+
+**The arm is read-only.** A fixed table writes its own layout and no other, so
+there is no old-layout write to time and no round trip to close. The rows are
+`read`, **measured** — BENCH-STANDARD §2.9's "`read` is DERIVED" binds the gen
+family's `bench_mixed` rows, where a round trip exists to derive it from.
+
+**The corpus.** `bench/paired/corpus/bench_lineage.bin` and
+`bench_lineage.layout`, written by the C++ dump
+(`test/tables/fixedform_dump.cpp`, the form's byte oracle) from
+`bench/corpus/VOLD_bench_lineage.schema` — `BenchMixed` one generation back,
+whose widening touches an appended field, a widened array bound, a widened
+text, a new union arm, an appended enum variant and an integer widen inside the
+80-element `stats` array. That last one is the row that matters most: §5.9 #33
+forbids folding a run across a widening, so it is 80 widen entries per record
+and the only arm putting arithmetic rather than a copy on the clock.
+**There is no length index and there must not be one** — a form-3 file's records
+are constant-size by construction, which is exactly what the form-1 paired
+corpus needed its 64-entry index for. The 64 records are the SAME 64 logical
+records, decoded once from the canonical packet corpus: no second field list,
+no independent value generator.
+
+**The lock is what makes the reader's layout the newer one.**
+`bench/corpus/schema.lock` carries BenchMixed's lineage with the VOLD layout at
+index 0, the identity at index 1 and `floor = 0`. Without that entry every leg
+answers `layout_newer` and the arm times a refusal. The lock is committed
+corpus and hashes into `corpus_id` with the bytes, because a lock edit silently
+changes which plan ran.
+
+**The rows.** `bench_fixed` is untouched — `write` + `round_trip`, read derived
+— so no published board moves. The arm adds two:
+
+| row | `LOAD` selects | path |
+|---|---|---|
+| `bench_fixed_read` | the identity entry, read alone | `read` |
+| `bench_plan_read` | the OLDER entry, by its hash | `read` |
+
+`bench_fixed_read` exists because §2.9 forces it: the ratio's denominator has to
+be a measured identity read, and `bench_fixed`'s read is derived to stderr
+precisely so it can never be divided.
+
+Both rows come out of ONE invocation, at the same uniform iteration count per
+wire as the identity row, over the same 64 records, in the same sitting,
+interleaved. That invocation loads the two lineage files and the lock in
+ADDITION to the identity goldens, so its `corpus_id` differs from the ordinary
+table pass's by §1.6's own definition: the ratio's two halves share an id and
+are divisible, and neither can ever be divided against a `bench_fixed` row it
+was not measured beside. **§5.3 rule 2 refuses the plan/identity ratio on
+`bytes_per_op` and is right to** — the old record is a different length by
+construction — so this driver is the only tool that prints it, the same
+exception it already holds for table-versus-packet, and its caption names both
+record sizes.
+
+**The gate before the clock is the versioning law's.** No leg starts this clock
+until its plan-read mode has proved, on all 64 records, that every old value
+landed exactly, that the reader's appended tail holds its declared default, and
+that the counters are what §5.4 says for these six classes. A plan read that
+decoded wrongly does not get to be fast. The prefill, the run and the bounds
+pass are all INSIDE the timed operation: the destination is reused across
+iterations, as the shipped call reuses it, but every iteration pays its own
+prefill. A runner that hoists the prefill out of the loop has measured the
+identity lane twice.
+
+**The board: nine legs, three numbers each.**
+
+```
+# fixed form: the identity lane and the plan lane
+# host / arch / rev / lane / rounds / corpus_id(identity) / corpus_id(plan)
+# C++ anchor: identity 000.0 ns/record / straight-line 000.0 = 0.00x  (bound 1.5x)
+
+leg      identity read    plan read    plan/identity
+         ns/record        ns/record    x (bound 2.0)
+```
+
+Two bounds. **identity / hand-written straight-line ≤ 1.5x** is ratified
+(docs/SPEC-TABLES.md §3.4) and is C++'s alone — arm B of
+`fixedform_measure.cpp` is hand-written, and nine hand-maintained layouts would
+be nine chances for the comparand to be wrong in a leg-specific way, so the
+anchor line is where that ratio lives and no leg owes a hand-written arm.
+**plan / identity ≤ 2.0x is PROPOSED**: the identity lane is one pass over the
+record, a lineage read adds exactly one structural thing — the prefill, a second
+pass over the same destination bytes — and fragmenting the runs costs loop
+overhead but touches no new bytes, so two passes where identity pays one is the
+structural ceiling. A leg above it is re-reading the record or dispatching per
+field where the plan should have coalesced: a coalescing defect to fix, not a
+cost of tolerance. The bound is per leg, never an average, because the gate is
+nine languages performant and an average hides the one that is not.
+
+A leg with no runner is NAMED with its reason in `nine.sh`'s own vocabulary and
+never estimated. Eight table runners exist under `bench/tables/` today; Dart's
+fixed-form leg has landed and its bench runner has not, so the ninth line is a
+named refusal until it does.
+
+This mode publishes nothing and seals nothing until a confirmation pass carries
+it: like fast mode it is the diagnostic, and the certified sitting is still
+`-mode run` inside the quiet window. `bench/tools/ledger.go` must admit
+`(family table, bench_fixed_read | bench_plan_read, path read)` as series of
+their own, keyed by row name and never folded into the `gen` / `bench_mixed`
+curve the C/C++ pair lock is defined over; the `--check` teeth stay off these
+rows until the plan/identity bound is ratified, because extending a gate to a
+new statistic is a ruling and not a filter change.


### PR DESCRIPTION
DOC + design change. **No runner code.** `bench/BENCH-STANDARD.md` gains `§1.10 The lineage corpus and the PLAN-READ arm`; `bench/paired/README.md` gains its operating manual.

## Why

Glenn's gate: the bitpacked message form starts only after the fixed table is 100% and PERFORMANT across nine languages. The performance half of that gate rests on two beliefs nobody has measured:

1. **the identity lane is free** — the reader's own wire hash selects the identity entry (`docs/FIXED-FORM-ALGORITHM.md` §5.3 step 8: fills EMPTY, `record_bytes = 8 + C(root)`, no plan compiler runs), so a read of a CURRENT file costs nothing over the form-3 read already on the board; and
2. **a lineage read is within a small constant of it** — an OLDER layout selects a lineage entry, PREFILLS the destination (§4.3) and scatters through the compiled plan (§4.4, §4.5).

## Nothing under `bench/` can measure the second today

- `bench/tools/ledger.go:216` admits only `bench_mixed` / family `gen` rows, so no fixed-form row can enter the across-time series at all.
- `test/bench/fixedform_measure.cpp`'s nearest arm, **A3**, reads the **same** layout through a runtime copy of the identity plan — it prices the plan's indirection, with nothing to prefill and nothing to scatter. **This arm is not a rename of A3.**
- No producer emits an older-layout record into a bench corpus.
- No read arm in any `bench/tables/<lang>/` runner lets `LOAD` select a non-identity entry.

## What the two sections specify

- **The producer** — `bench/corpus/VOLD_bench_lineage.schema`: `BenchMixed` one generation back, same table name, own package; the NEW side is `Bench.schema` itself, unchanged, because the reader must be the leg's ordinary generated codec. Its widening touches every kind class a lineage read can carry: an appended field (`idle_ticks`), a widened array bound (`stats [..64] -> [..80]`), a widened text (`player_name string(8) -> string(15)`), a new union arm (`MixedEvent` gains `pickup`), an appended enum variant (`MixedWeapon` 12 -> 15), and an integer widen — `MixedStat.delta int16 -> int32` — which is **80 widen entries per record** because §5.9 #33 forbids folding a run across a widening, and is the only arm putting arithmetic rather than a copy on the clock. An enum ORDINAL-WIDTH widen needs 255 -> 256 variants and would destroy §1.9's mirror rule, so it is **named as not carried** and stays in the versioning corpus's `enum_width` row rather than being faked.
- **The files** — `bench/paired/corpus/bench_lineage.bin` + `.layout`, written by the C++ dump (the form's byte oracle), from the same 64 packet-decoded records. **No length index, and there must not be one**: form-3 records are constant-size by construction, which is exactly what the form-1 paired corpus needed its index for.
- **The lock** — `bench/corpus/schema.lock`, VOLD at lineage index 0, identity at 1, `floor = 0`. Without it every leg answers `layout_newer` and the arm times a refusal. Committed corpus, hashed into `corpus_id`.
- **The read arm, read-only and measured.** A fixed table writes its own layout and no other, so there is no old-layout write and no round trip. §2.9's "`read` is DERIVED" binds the gen family's `bench_mixed` rows, where a round trip exists to derive it from.
- **The rows** — `bench_fixed` untouched (`write` + `round_trip`, read derived), so no published board moves. Added: `bench_fixed_read` (identity, measured) and `bench_plan_read` (the older entry). `bench_fixed_read` is **forced into existence by §2.9**: the ratio's denominator must be measured, and `bench_fixed`'s read is derived to stderr precisely so it can never be divided.
- **`corpus_id`** — the plan invocation loads the lineage files and the lock in ADDITION, so its id differs by §1.6's own definition, with no new rule: the ratio's halves share an id and are divisible, and neither can be divided against a `bench_fixed` row it was not measured beside. §5.3 rule 2 refuses the ratio on `bytes_per_op` and is **right to** — the old record is a different length — so the paired driver is the only tool that prints it, under the exception §1.9 already grants it, captioning both record sizes.
- **The ledger** — one line: admit `(family table, bench_fixed_read | bench_plan_read, path read)` as series of their own, keyed by row name, never folded into the `gen` curve the C/C++ pair lock is defined over. `--check` teeth stay OFF until the bound is ratified, because extending a gate to a new statistic is a ruling, not a filter change.
- **The two ratios** — identity / hand-written straight-line **<= 1.5x**, RATIFIED (`docs/SPEC-TABLES.md` §3.4), and C++'s alone: arm B is hand-written and nine hand-maintained layouts would be nine chances for the comparand to be wrong leg-specifically. plan / identity **<= 2.0x, PROPOSED**.
- **The board** — nine legs, three numbers each (identity ns/record, plan ns/record, plan/identity), the C++ anchor line carrying the first ratio, named refusals for absent legs. Eight table runners exist today; Dart's fixed-form leg has landed and its bench runner has not, so the ninth line is a named refusal until it does.
- **A twenty-item work list**, file and one line each, so children take them one at a time.

## The proposed bound, and why 2.0x

The identity lane is ONE pass over the record: empty fills, coalesced runs, a copy. A lineage read adds exactly one structural thing — the **prefill**, a second pass over the SAME destination bytes before the runs land — plus a more fragmented run loop, because a widening forbids the fold (§5.9 #33). Fragmentation costs loop and dispatch overhead but touches **no new bytes**; the prefill is the only new traffic and it is bounded by the destination's size, which is the identity read's own working set. **Two passes where identity pays one is the structural ceiling**, so 2.0x is the smallest constant the prefill alone cannot break. A leg above it is not paying for tolerance — it is re-reading the record, or dispatching per field where the plan should have coalesced, and the number is a coalescing defect to fix. The bound is **per leg, never an average**: the gate is nine languages performant and an average hides the one that is not. `1.5 x 2.0 = 3.0x` is the worst a backward read may cost against hand-written straight-line code, stated once.

Ratification is Glenn's; the section carries it as PROPOSED and nothing gates on it until `docs/SPEC-TABLES.md` §3.4 records it.

## Gates

Docs only. `ci.yml` runs no markdown or docs lint (its `lint` job is golangci-lint over Go), and nothing gates on `BENCH-STANDARD.md`. No runner, tool, schema or corpus byte changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)