### PR TITLE
red team: composed widenings, three generations, two legs

### DIFF
--- a/internal/codegen/gotable/fixedredteam_test.go
+++ b/internal/codegen/gotable/fixedredteam_test.go
@@ -1,0 +1,947 @@
+package gotable
+
+// THE RED TEAM AGAINST §5, BY COMPOSITION AND BY HISTORY.
+//
+// docs/FIXED-FORM-VERSIONING-TESTS.md gives one row per definition change and
+// proves each alone. This file attacks what the rows cannot: TWO OR MORE
+// lawful widenings in ONE step, THREE generations at once, a widening on a
+// table reached from two places, and the histories the lock records.
+//
+// The harness is self-contained — no C++ corpus. Stage one generates the OLD
+// unit and WRITES a file with its own `FixedSave`, which is the lawful old
+// file by construction; stage two generates the NEW unit with the older units'
+// locked entries as its lineage and READS that file. A FINDING is a lawful old
+// file refused, read with a wrong value, or read differently from the
+// reference.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redRuntime is the one thing this suite needs from outside the repository:
+// the Go runtime the generated package replaces `serialize.go` with, as a
+// SIBLING checkout — the same path `runVersionProbeRetired` compiles against.
+// A tree without it cannot build a probe at all, so the suite says so and
+// skips, the way the versioning suite skips a missing corpus; under
+// SCHEMA_REQUIRE_CORPUS something promised the build and a skip would report
+// green over a suite that never ran.
+func redRuntime(t *testing.T) {
+	t.Helper()
+	path, err := filepath.Abs("../../../../serialize.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.Getenv("SCHEMA_REQUIRE_CORPUS") != "" {
+			t.Fatalf("SCHEMA_REQUIRE_CORPUS is set and the Go runtime is not a sibling checkout at %s: %v", path, err)
+		}
+		t.Skipf("the Go runtime is not a sibling checkout at %s", path)
+	}
+}
+
+// redWrite generates `schema` alone and runs `body` in its package, which must
+// write the file at the path the body is handed as `out`. It returns the path.
+func redWrite(t *testing.T, dir, name, schema, body string) string {
+	t.Helper()
+	redRuntime(t)
+	out := filepath.Join(dir, name+".bin")
+	src := fmt.Sprintf(`package probe
+
+import ("os"; "testing")
+
+func TestWrite(t *testing.T) {
+	out := %q
+	_ = out
+%s
+}
+`, out, body)
+	o, err := runVersionProbe(t, schema, nil, src)
+	if err != nil {
+		t.Fatalf("the OLD writer did not write its own file: %v\n%s", err, o)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("the OLD writer wrote nothing: %v", err)
+	}
+	return out
+}
+
+// redRead generates `schema` with `older`'s locked entries as its lineage and
+// runs `body` in its package.
+func redRead(t *testing.T, schema string, older []string, body string) {
+	t.Helper()
+	src := fmt.Sprintf(`package probe
+
+import ("encoding/binary"; "os"; "testing")
+
+var _ = binary.LittleEndian
+var _ = os.ReadFile
+
+func TestRead(t *testing.T) {
+%s
+}
+`, body)
+	o, err := runVersionProbe(t, schema, older, src)
+	if err != nil {
+		t.Fatalf("the NEW reader failed its read: %v\n%s", err, o)
+	}
+}
+
+// ---- case 1: THREE lawful widenings in ONE step -----------------------------
+//
+// A field appended AND an enum grown AND an array bound grown, between one
+// locked layout and the next. Every row of the versioning page proves one of
+// these alone; a plan is built by ONE walk over both layouts, so three changes
+// at once is the first thing that can put a destination offset in the wrong
+// place.
+
+const redComposeOld = `package redcompose
+
+enum Tier { bronze, silver }
+
+fixed table Lineage
+{
+    t Tier
+    a [..2]int32
+    x int32 = 0
+}
+`
+
+const redComposeNew = `package redcomposenew
+
+enum Tier { bronze, silver, gold }
+
+fixed table Lineage
+{
+    t Tier
+    a [..4]int32
+    x int32 = 0
+    w int32 = 77
+}
+`
+
+func TestFixedRedTeamComposedWidenings(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "compose", redComposeOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.T = Tiersilver
+	v.A[0], v.A[1] = 5, 6
+	v.ACount = 2
+	v.X = 9
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redComposeNew, []string{redComposeOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("three lawful widenings at once and the new reader refused: n=%%d %%+v", n, r)
+	}
+	if back[0].T != Tiersilver {
+		t.Fatalf("the grown enum lost the old ordinal: %%+v", back[0])
+	}
+	if back[0].ACount != 2 || back[0].A[0] != 5 || back[0].A[1] != 6 {
+		t.Fatalf("the grown array lost the old elements: %%+v", back[0])
+	}
+	if back[0].A[2] != 0 || back[0].A[3] != 0 {
+		t.Fatalf("the grown array's new slots are not their default: %%+v", back[0])
+	}
+	if back[0].X != 9 {
+		t.Fatalf("a field after the grown array moved: %%+v", back[0])
+	}
+	if back[0].W != 77 {
+		t.Fatalf("the appended field is not its declared default: %%+v", back[0])
+	}
+	if r.Widened != 0 || r.Unknown != 0 || r.KindMismatch != 0 || r.Clamped != 0 {
+		t.Fatalf("three appends are not events: %%+v", r)
+	}`, file))
+}
+
+// ---- case 2: a widened table reached from TWO places at once ----------------
+//
+// `Vec` is both a field and an ARRAY ELEMENT of the same root. One widening
+// moves BOTH of the outer's layouts: the field's own bytes and the array's
+// stride. The versioning page's `nested_append` row proves the field; nothing
+// proves the element, whose destination stride is the READER's and whose source
+// stride is the WRITER's.
+
+const redTwoPlacesOld = `package redtwoplaces
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 0
+}
+
+fixed table Lineage
+{
+    v   Vec
+    vs  [..2]Vec
+    seq int32 = 0
+}
+`
+
+const redTwoPlacesNew = `package redtwoplacesnew
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 0
+    z int32 = 99
+}
+
+fixed table Lineage
+{
+    v   Vec
+    vs  [..2]Vec
+    seq int32 = 0
+}
+`
+
+func TestFixedRedTeamWidenedTableInTwoPlaces(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "twoplaces", redTwoPlacesOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.V.X, v.V.Y = 1, 2
+	v.Vs[0].X, v.Vs[0].Y = 3, 4
+	v.Vs[1].X, v.Vs[1].Y = 5, 6
+	v.VsCount = 2
+	v.Seq = 7
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redTwoPlacesNew, []string{redTwoPlacesOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("the widened element's reader refused a lawful old file: n=%%d %%+v", n, r)
+	}
+	g := back[0]
+	if g.V.X != 1 || g.V.Y != 2 || g.V.Z != 99 {
+		t.Fatalf("the FIELD place: %%+v", g.V)
+	}
+	if g.VsCount != 2 {
+		t.Fatalf("the array count: %%+v", g)
+	}
+	if g.Vs[0].X != 3 || g.Vs[0].Y != 4 || g.Vs[0].Z != 99 {
+		t.Fatalf("element 0 under the grown stride: %%+v", g.Vs[0])
+	}
+	if g.Vs[1].X != 5 || g.Vs[1].Y != 6 || g.Vs[1].Z != 99 {
+		t.Fatalf("element 1 under the grown stride: %%+v", g.Vs[1])
+	}
+	if g.Seq != 7 {
+		t.Fatalf("a field after the grown array moved: %%+v", g)
+	}
+	if r.Widened != 0 || r.Unknown != 0 || r.KindMismatch != 0 || r.Clamped != 0 {
+		t.Fatalf("an append is not an event: %%+v", r)
+	}`, file))
+}
+
+// ---- case 3: an appended union arm whose payload is the WIDEST --------------
+//
+// The tag sits AFTER the widest arm, so an arm bigger than every existing one
+// MOVES THE TAG — in the reader's storage and in the lock's layout bytes both.
+// The guard is read at THE WRITER'S tag offset and the `const` lands at the
+// READER'S; the `union_append` row appends an arm that fits, so nothing yet
+// proves the two offsets stay apart.
+
+const redUnionGrowOld = `package reduniongrow
+
+type A { p int32 = 0 }
+type B { q int32 = 0 }
+
+union Pick
+{
+    a A
+    b B
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}
+`
+
+const redUnionGrowNew = `package reduniongrownew
+
+type A { p int32 = 0 }
+type B { q int32 = 0 }
+type C
+{
+    r int64 = 0
+    s int64 = 0
+    u int64 = 0
+}
+
+union Pick
+{
+    a A
+    b B
+    c C
+}
+
+fixed table Lineage
+{
+    pick Pick
+    seq  int32 = 0
+}
+`
+
+func TestFixedRedTeamUnionArmWidensTheSlot(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "uniongrow", redUnionGrowOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.Pick.Type = PickTypeB
+	v.Pick.B.Q = 42
+	v.Seq = 11
+	var none Lineage
+	LineageReset(&none)
+	none.Seq = 12
+	buf := make([]byte, LineageFixedMeasure(2))
+	if LineageFixedSave([]Lineage{v, none}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redUnionGrowNew, []string{redUnionGrowOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 2 || r.Reason != "" || r.Malformed {
+		t.Fatalf("the grown union slot refused a lawful old file: n=%%d %%+v", n, r)
+	}
+	if back[0].Pick.Type != PickTypeB {
+		t.Fatalf("the old tag did not land under the MOVED tag offset: %%+v", back[0].Pick)
+	}
+	if back[0].Pick.B.Q != 42 {
+		t.Fatalf("the old arm's payload: %%+v", back[0].Pick)
+	}
+	if back[0].Seq != 11 {
+		t.Fatalf("the field after the grown union moved: %%+v", back[0])
+	}
+	// The UNGUARDED None stands when no arm matches, at the MOVED tag offset.
+	if back[1].Pick.Type != PickTypeNone || back[1].Seq != 12 {
+		t.Fatalf("the None tag did not land under the moved tag offset: %%+v", back[1])
+	}
+	if r.Widened != 0 || r.Unknown != 0 || r.KindMismatch != 0 || r.Clamped != 0 {
+		t.Fatalf("an arm append is not an event: %%+v", r)
+	}`, file))
+}
+
+// ---- case 4: a `was =` rename COMPOSED with an append -----------------------
+//
+// A rename through `was` alone moves no layout byte, so the pair takes the
+// IDENTITY plan and the compiled plan's id match is never exercised on a
+// renamed field. Compose it with an append and the hash moves: now the plan
+// must match the renamed reader field to the writer's field BY THE OLD NAME.
+
+const redRenameOld = `package redrename
+
+fixed table Lineage
+{
+    a   int32 = 0
+    seq int32 = 0
+}
+`
+
+const redRenameNew = `package redrenamenew
+
+fixed table Lineage
+{
+    b   int32 = 0 | was = "a"
+    seq int32 = 0
+    w   int32 = 77
+}
+`
+
+func TestFixedRedTeamRenameComposedWithAppend(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "rename", redRenameOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.A = 31
+	v.Seq = 32
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redRenameNew, []string{redRenameOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("rename plus append refused a lawful old file: n=%%d %%+v", n, r)
+	}
+	if back[0].B != 31 {
+		t.Fatalf("the renamed field did not match by the OLD name: %%+v", back[0])
+	}
+	if back[0].Seq != 32 || back[0].W != 77 {
+		t.Fatalf("%%+v", back[0])
+	}
+	if r.Unknown != 0 {
+		t.Fatalf("a renamed field is not an unknown field: %%+v", r)
+	}`, file))
+}
+
+// ---- case 5: THREE generations, and the two-step skip ------------------------
+//
+// V1 -> V2 appends `b`, V2 -> V3 appends `c`. V3's plan for V1 is built from
+// V1's locked layout bytes against V3's own — V2 is never in between — so the
+// V1 file must land `a` exactly and BOTH tails at their declared defaults. The
+// destinations are POISONED first: a prefill that does not run shows here.
+
+const redGenV1 = `package redgen1
+
+fixed table Lineage
+{
+    a int32 = 0
+}
+`
+
+const redGenV2 = `package redgen2
+
+fixed table Lineage
+{
+    a int32 = 0
+    b int32 = 22
+}
+`
+
+const redGenV3 = `package redgen3
+
+fixed table Lineage
+{
+    a int32 = 0
+    b int32 = 22
+    c int32 = 33
+}
+`
+
+func TestFixedRedTeamThreeGenerations(t *testing.T) {
+	dir := t.TempDir()
+	v1 := redWrite(t, dir, "gen1", redGenV1, `
+	var v Lineage
+	LineageReset(&v)
+	v.A = 1
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	v2 := redWrite(t, dir, "gen2", redGenV2, `
+	var v Lineage
+	LineageReset(&v)
+	v.A, v.B = 2, 99
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+
+	// Nothing retired: V3 reads V1 (the two-step skip) and V2.
+	redRead(t, redGenV3, []string{redGenV1, redGenV2}, fmt.Sprintf(`
+	poison := func(back []Lineage) {
+		for k := range back {
+			back[k] = Lineage{A: 0x5A5A5A5A, B: 0x5A5A5A5A, C: 0x5A5A5A5A}
+		}
+	}
+	one, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+
+	poison(back)
+	if n := LineageFixedLoad(back, one, plan, &r); n != 1 || r.Reason != "" {
+		t.Fatalf("V3 refused V1, two generations back: n=%%d %%+v", n, r)
+	}
+	if back[0].A != 1 || back[0].B != 22 || back[0].C != 33 {
+		t.Fatalf("the two-step skip did not prefill both tails: %%+v", back[0])
+	}
+
+	poison(back)
+	r = TableReport{}
+	if n := LineageFixedLoad(back, two, plan, &r); n != 1 || r.Reason != "" {
+		t.Fatalf("V3 refused V2: n=%%d %%+v", n, r)
+	}
+	if back[0].A != 2 || back[0].B != 99 || back[0].C != 33 {
+		t.Fatalf("V2's own values plus ONE tail: %%+v", back[0])
+	}`, v1, v2))
+
+	// V1 retired: the floor is 1. V1 is layout_unsupported BY NAME and V2, at
+	// the raised floor, still reads.
+	src := fmt.Sprintf(`package probe
+
+import ("os"; "testing")
+
+func TestFloorRaised(t *testing.T) {
+	one, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 4)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	if n := LineageFixedLoad(back, one, plan, &r); n != -1 || r.Reason != "layout_unsupported" {
+		t.Fatalf("a retired generation owes layout_unsupported: n=%%d %%+v", n, r)
+	}
+	if r.LayoutHash == 0 {
+		t.Fatal("layout_unsupported reports THE FILE'S hash")
+	}
+	if r.Malformed || r.Widened != 0 || r.Unknown != 0 || r.Clamped != 0 {
+		t.Fatalf("REFUSE is total: %%+v", r)
+	}
+	r = TableReport{}
+	if n := LineageFixedLoad(back, two, plan, &r); n != 1 || r.Reason != "" {
+		t.Fatalf("the generation AT the raised floor must still read: n=%%d %%+v", n, r)
+	}
+	if back[0].A != 2 || back[0].B != 99 || back[0].C != 33 {
+		t.Fatalf("%%+v", back[0])
+	}
+}
+`, v1, v2)
+	if out, err := runVersionProbeRetired(t, redGenV3, []string{redGenV1, redGenV2}, 1, src); err != nil {
+		t.Fatalf("the raised floor: %v\n%s", err, out)
+	}
+}
+
+// ---- case 6: ONE nested table, TWO fixed roots, ONE schema file -------------
+//
+// One lock, two lineages. `Vec` widens once and BOTH roots' layouts move; each
+// root owes its OWN plan for its own older entry, and a plan shared by name
+// would land the second root's values at the first root's offsets.
+
+const redTwoRootsOld = `package redtworoots
+
+fixed table Vec
+{
+    x int32 = 0
+}
+
+fixed table Alpha
+{
+    v   Vec
+    seq int32 = 0
+}
+
+fixed table Beta
+{
+    tag int32 = 0
+    v   Vec
+}
+`
+
+const redTwoRootsNew = `package redtworootsnew
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 44
+}
+
+fixed table Alpha
+{
+    v   Vec
+    seq int32 = 0
+}
+
+fixed table Beta
+{
+    tag int32 = 0
+    v   Vec
+}
+`
+
+func TestFixedRedTeamTwoRootsShareANestedTable(t *testing.T) {
+	dir := t.TempDir()
+	files := redWrite(t, dir, "tworoots", redTwoRootsOld, `
+	var a Alpha
+	AlphaReset(&a)
+	a.V.X, a.Seq = 7, 8
+	ab := make([]byte, AlphaFixedMeasure(1))
+	if AlphaFixedSave([]Alpha{a}, ab) < 0 {
+		t.Fatal("save alpha")
+	}
+	if err := os.WriteFile(out, ab, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var b Beta
+	BetaReset(&b)
+	b.Tag, b.V.X = 9, 10
+	bb := make([]byte, BetaFixedMeasure(1))
+	if BetaFixedSave([]Beta{b}, bb) < 0 {
+		t.Fatal("save beta")
+	}
+	if err := os.WriteFile(out+".beta", bb, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redTwoRootsNew, []string{redTwoRootsOld}, fmt.Sprintf(`
+	ab, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bb, err := os.ReadFile(%[1]q + ".beta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	as := make([]Alpha, 2)
+	if n := AlphaFixedLoad(as, ab, plan, &r); n != 1 || r.Reason != "" {
+		t.Fatalf("the first root refused its own old file: n=%%d %%+v", n, r)
+	}
+	if as[0].V.X != 7 || as[0].V.Y != 44 || as[0].Seq != 8 {
+		t.Fatalf("the first root: %%+v", as[0])
+	}
+	r = TableReport{}
+	bs := make([]Beta, 2)
+	if n := BetaFixedLoad(bs, bb, plan, &r); n != 1 || r.Reason != "" {
+		t.Fatalf("the SECOND root refused its own old file: n=%%d %%+v", n, r)
+	}
+	if bs[0].Tag != 9 || bs[0].V.X != 10 || bs[0].V.Y != 44 {
+		t.Fatalf("the second root: %%+v", bs[0])
+	}`, files))
+}
+
+// ---- case 7: a keyed array's KEY grows and its ELEMENT widens, at once ------
+//
+// `[Tier]Qty` sizes itself from the enum, so appending a variant GROWS THE SLOT
+// RUN, and widening `Qty`'s field grows the STRIDE. Both at once: the old
+// file's three slots must land under the new stride and the fourth slot must be
+// the element's own default.
+
+const redKeyedOld = `package redkeyed
+
+enum Tier { bronze, silver, gold }
+
+fixed table Qty
+{
+    n int16 = 7
+}
+
+fixed table Lineage
+{
+    slots [Tier]Qty
+    seq   int32 = 0
+}
+`
+
+const redKeyedNew = `package redkeyednew
+
+enum Tier { bronze, silver, gold, platinum }
+
+fixed table Qty
+{
+    n int32 = 7
+}
+
+fixed table Lineage
+{
+    slots [Tier]Qty
+    seq   int32 = 0
+}
+`
+
+func TestFixedRedTeamKeyedKeyGrowsAndElementWidens(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "keyed", redKeyedOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.Slots[0].N = 11
+	v.Slots[1].N = 22
+	v.Slots[2].N = 33
+	v.Seq = 44
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redKeyedNew, []string{redKeyedOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 2)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("the grown keyed array refused a lawful old file: n=%%d %%+v", n, r)
+	}
+	g := back[0]
+	if g.Slots[0].N != 11 || g.Slots[1].N != 22 || g.Slots[2].N != 33 {
+		t.Fatalf("the old slots did not land under the grown stride: %%+v", g.Slots)
+	}
+	if g.Slots[3].N != 7 {
+		t.Fatalf("the APPENDED slot is not the element's declared default: %%+v", g.Slots)
+	}
+	if g.Seq != 44 {
+		t.Fatalf("the field after the grown slot run moved: %%+v", g)
+	}
+	if r.Widened != 3 {
+		t.Fatalf("three widened elements, not %%d: %%+v", r.Widened, r)
+	}
+	if r.Unknown != 0 || r.KindMismatch != 0 || r.Clamped != 0 {
+		t.Fatalf("%%+v", r)
+	}`, file))
+}
+
+// ---- case 8: `T` becomes `?T` AND the payload gains a field ------------------
+//
+// The optional wrapper lands a CONSTANT `1` at the present byte and then
+// recurses into the payload (bill §12.8). Composed with an append inside the
+// payload, the recursion carries the wrapper's guard AND the payload's own
+// prefill: `optional_add` alone never has a tail to prefill.
+
+const redOptOld = `package redopt
+
+fixed table Vec
+{
+    x int32 = 0
+}
+
+fixed table Lineage
+{
+    v   Vec
+    seq int32 = 0
+}
+`
+
+const redOptNew = `package redoptnew
+
+fixed table Vec
+{
+    x int32 = 0
+    y int32 = 55
+}
+
+fixed table Lineage
+{
+    v   ?Vec
+    seq int32 = 0
+}
+`
+
+func TestFixedRedTeamOptionalAddedAndPayloadAppended(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "opt", redOptOld, `
+	var v Lineage
+	LineageReset(&v)
+	v.V.X = 13
+	v.Seq = 14
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redOptNew, []string{redOptOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 2)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("T into ?T with an appended payload field refused: n=%%d %%+v", n, r)
+	}
+	if !back[0].VPresent {
+		t.Fatalf("T into ?T lands present: %%+v", back[0])
+	}
+	if back[0].V.X != 13 {
+		t.Fatalf("the payload's old value: %%+v", back[0].V)
+	}
+	if back[0].V.Y != 55 {
+		t.Fatalf("the payload's APPENDED field is not its declared default: %%+v", back[0].V)
+	}
+	if back[0].Seq != 14 {
+		t.Fatalf("the field after the wrapper moved: %%+v", back[0])
+	}`, file))
+}
+
+// ---- case 9: a string's capacity grows, a field FOLLOWS it, and one is
+// appended ---------------------------------------------------------------------
+//
+// The text op writes the length at `dst` and the WHOLE SPAN at `aux`, and the
+// span it copies is the WRITER's. Grow the capacity, keep a field after the
+// string, and append one: the reader's slack past the writer's span must stay
+// the prefill's and the following field must not move.
+
+const redTextOld = `package redtext
+
+fixed table Lineage
+{
+    s   string(8)
+    seq int32 = 0
+}
+`
+
+const redTextNew = `package redtextnew
+
+fixed table Lineage
+{
+    s   string(16)
+    seq int32 = 0
+    w   int32 = 77
+}
+`
+
+func TestFixedRedTeamStringGrowsWithAFollowingField(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "text", redTextOld, `
+	var v Lineage
+	LineageReset(&v)
+	copy(v.S[:], "abcd")
+	v.SLength = 4
+	v.Seq = 21
+	buf := make([]byte, LineageFixedMeasure(1))
+	if LineageFixedSave([]Lineage{v}, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redTextNew, []string{redTextOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 2)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 1 || r.Reason != "" || r.Malformed {
+		t.Fatalf("a grown string with a field behind it refused: n=%%d %%+v", n, r)
+	}
+	if back[0].SLength != 4 || string(back[0].S[:4]) != "abcd" {
+		t.Fatalf("the old text: %%+v", back[0])
+	}
+	for i := 4; i < len(back[0].S); i++ {
+		if back[0].S[i] != 0 {
+			t.Fatalf("the grown capacity's slack is not zero at %%d: %%+v", i, back[0])
+		}
+	}
+	if back[0].Seq != 21 {
+		t.Fatalf("the field after the grown string moved: %%+v", back[0])
+	}
+	if back[0].W != 77 {
+		t.Fatalf("the appended field is not its default: %%+v", back[0])
+	}
+	if r.Clamped != 0 {
+		t.Fatalf("a grown capacity clamps nothing: %%+v", r)
+	}`, file))
+}
+
+// ---- case 10: the ONLY field of a table widens ------------------------------
+//
+// No neighbour, and the record body size changes by the widening alone. The
+// plan's single entry is the whole record.
+
+const redOnlyOld = `package redonly
+
+fixed table Lineage
+{
+    a int16 = 0
+}
+`
+
+const redOnlyNew = `package redonlynew
+
+fixed table Lineage
+{
+    a int32 = 0
+}
+`
+
+func TestFixedRedTeamOnlyFieldWidens(t *testing.T) {
+	dir := t.TempDir()
+	file := redWrite(t, dir, "only", redOnlyOld, `
+	vals := []Lineage{{A: -1}, {A: -32768}, {A: 32767}}
+	buf := make([]byte, LineageFixedMeasure(int64(len(vals))))
+	if LineageFixedSave(vals, buf) < 0 {
+		t.Fatal("save")
+	}
+	if err := os.WriteFile(out, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}`)
+	redRead(t, redOnlyNew, []string{redOnlyOld}, fmt.Sprintf(`
+	data, err := os.ReadFile(%q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := make([]Lineage, 8)
+	plan := make([]TableFixedEntry, 4096)
+	var r TableReport
+	n := LineageFixedLoad(back, data, plan, &r)
+	if n != 3 || r.Reason != "" || r.Malformed {
+		t.Fatalf("a table whose only field widened refused: n=%%d %%+v", n, r)
+	}
+	want := []int32{-1, -32768, 32767}
+	for k := range want {
+		if back[k].A != want[k] {
+			t.Fatalf("record %%d sign-extended wrong: %%+v", k, back[k])
+		}
+	}
+	if r.Widened != 3 {
+		t.Fatalf("one widen per record: %%+v", r)
+	}`, file))
+}

--- a/internal/lockfile/lineagecompose_test.go
+++ b/internal/lockfile/lineagecompose_test.go
@@ -1,0 +1,143 @@
+// THE RED TEAM AGAINST THE LOCK'S LINEAGE, BY COMPOSITION.
+//
+// lineage_test.go proves ONE widening at a time. This file proves what a
+// release actually looks like: SEVERAL lawful widenings between one lock and
+// the next, and three generations of them in a row. The lineage is one entry
+// per LAYOUT, not one per change, and an older entry's LINE must come out of a
+// re-lock byte for byte — a rewritten line is a rewritten history, and no
+// command can recover the layout bytes of a record nobody declares any more
+// (docs/FIXED-FORM-ALGORITHM.md §5.2).
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+)
+
+// lineageLines is the lock's lineage text for one table, the lines a hand could
+// edit and the parse holds to its own recomputation.
+func lineageLines(t *testing.T, path, table string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	in := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "fixed table "):
+			in = strings.Fields(trimmed)[2] == table
+		case in && strings.HasPrefix(trimmed, "lineage "):
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+const composeBefore = `enum Tier
+{
+    bronze
+    silver
+}
+`
+
+const composeAfter = `enum Tier
+{
+    bronze
+    silver
+    gold
+}
+`
+
+// TestLockLineageSeveralWideningsInOneStepAddOneEntry: a release that appends a
+// field AND grows an enum AND grows an array bound is ONE new layout, so it
+// earns ONE lineage entry — and the entry that was there comes back verbatim.
+func TestLockLineageSeveralWideningsInOneStepAddOneEntry(t *testing.T) {
+	dir, paths := fixture(t, rowWith(composeBefore, "    t Tier\n    a [..2]int32\n    x int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, lockfile.FileName)
+	first := lineageLines(t, path, "Row")
+	if len(first) != 1 {
+		t.Fatalf("the first lock holds one lineage line, got %d", len(first))
+	}
+
+	// THREE lawful widenings, in one step.
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"),
+		[]byte(rowWith(composeAfter, "    t Tier\n    a [..4]int32\n    x int32\n    w int32 = 77")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || !rewrote {
+		t.Fatalf("`schema lock` takes three widenings at once: rewrote=%v err=%v", rewrote, err)
+	}
+
+	second := lineageLines(t, path, "Row")
+	if len(second) != 2 {
+		t.Fatalf("several widenings in one step are ONE layout: want 2 lineage lines, got %d:\n%s",
+			len(second), strings.Join(second, "\n"))
+	}
+	if second[0] != first[0] {
+		t.Errorf("the older entry's line was REWRITTEN:\n  before %s\n  after  %s", first[0], second[0])
+	}
+	if second[1] == first[0] {
+		t.Error("the new entry is the same line as the old one; the fixture proves nothing")
+	}
+	// The lock must read back: the per-line recomputation and the set's roll-up
+	// both hold after a composed step.
+	if got := lineageOf(t, path, "Row"); len(got) != 2 || got[0].Retired {
+		t.Fatalf("the committed lock does not parse back into two live entries: %d", len(got))
+	}
+
+	// A third generation: another composed step. The first two lines stay.
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"),
+		[]byte(rowWith(composeAfter, "    t Tier\n    a [..8]int32\n    x int64\n    w int32 = 77\n    v int32 = 88")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	third := lineageLines(t, path, "Row")
+	if len(third) != 3 {
+		t.Fatalf("a third generation is a third line, got %d", len(third))
+	}
+	if third[0] != first[0] || third[1] != second[1] {
+		t.Errorf("the lineage only grows, and never rewrites:\n  %s\n  %s", strings.Join(second, "\n  "), strings.Join(third, "\n  "))
+	}
+}
+
+// TestLockDeprecatedThenSameNameAppendRefused: a deprecated field keeps its
+// slot and its name forever (bill §12.3), so a later release that APPENDS a
+// field of the same name is two fields with one id — the plan would have two
+// entries claiming one source — and it must not compile.
+func TestLockDeprecatedThenSameNameAppendRefused(t *testing.T) {
+	dir, paths := fixture(t, rowTable("    a int32\n    b int32 | deprecated\n    c int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"),
+		[]byte(rowTable("    a int32\n    b int32 | deprecated\n    c int32\n    b int32")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The re-declaration is refused BEFORE the lock is consulted: a duplicate
+	// field name is not a versioning question.
+	if _, err := compiler.New().Load(paths); err == nil {
+		t.Fatal("a field whose name a deprecated field already holds must not compile")
+	}
+}
+
+// TestLockDeprecatedThenOtherNameAppendAllowed is the control: the same shape
+// with a DIFFERENT name is an ordinary append over a deprecated slot.
+func TestLockDeprecatedThenOtherNameAppendAllowed(t *testing.T) {
+	rowAllows(t,
+		rowTable("    a int32\n    b int32 | deprecated\n    c int32"),
+		rowTable("    a int32\n    b int32 | deprecated\n    c int32\n    d int32"),
+		"Row")
+}

--- a/internal/lockfile/lineagecompose_test.go
+++ b/internal/lockfile/lineagecompose_test.go
@@ -29,7 +29,7 @@ func lineageLines(t *testing.T, path, table string) []string {
 	}
 	var out []string
 	in := false
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		trimmed := strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(trimmed, "fixed table "):


### PR DESCRIPTION
Glenn's ask: "red team against the compiler in fixed table versioning … find undefined behavior in the fixed table, or where a new version can't read the old schema version."

My angle was THE NEW READER CANNOT READ A LAWFUL OLD FILE, attacked by COMPOSITION (several lawful widenings in one step) and by HISTORY (three generations, a raised floor, a re-lock). `docs/FIXED-FORM-VERSIONING-TESTS.md` proves every row ALONE; none of these cases is one row.

**No finding.** Twelve cases, all held — the reader read every lawful old file, every value landed exactly, every tail landed its declared default, and every counter was what §5.2 says. They are kept as tests because the next change to PLAN is what they are for.

## The cases, and what each one could have broken

`internal/codegen/gotable/fixedredteam_test.go` — the Go leg, generated code and runtime:

1. `TestFixedRedTeamComposedWidenings` — a field appended AND an enum grown AND an array bound grown between one locked layout and the next. One walk over two layouts, three changes at once: the first thing that can put a destination offset in the wrong place.
2. `TestFixedRedTeamWidenedTableInTwoPlaces` — `Vec` is a field AND an array element of one root. One widening moves the field's bytes and the array's STRIDE; `nested_append` proves the field, nothing proved the element.
3. `TestFixedRedTeamUnionArmWidensTheSlot` — an appended arm LARGER than every existing one, so the tag MOVES in both the writer's layout and the reader's storage. The guard is read at the writer's tag offset and the `const` lands at the reader's; `union_append` appends an arm that fits. Includes a record whose tag is `None`, so the unguarded `const 0` is proved at the moved offset too.
4. `TestFixedRedTeamRenameComposedWithAppend` — a `was =` rename alone moves no layout byte, so the pair takes the IDENTITY plan and the compiled plan's id match is NEVER exercised on a renamed field. Composed with an append the hash moves, and the renamed reader field must match the writer's field by the OLD name.
5. `TestFixedRedTeamThreeGenerations` — V1→V2 appends `b`, V2→V3 appends `c`. V3's plan for V1 is built against V1's locked bytes with V2 never in between, so the two-step skip must prefill BOTH tails. Destinations poisoned `0x5A5A5A5A` first. Then V1 retired: `layout_unsupported` by name with the file's hash, no counter moved, and V2 at the raised floor still reads.
6. `TestFixedRedTeamTwoRootsShareANestedTable` — one schema file, one lock, TWO lineages: `Alpha` and `Beta` both carry `Vec`, which widens once. Each root owes its OWN plan; a plan shared by name would land the second root's values at the first root's offsets.
7. `TestFixedRedTeamKeyedKeyGrowsAndElementWidens` — `[Tier]Qty` with the enum gaining a variant AND `Qty`'s field widening `int16`→`int32`: the slot run grows and the stride grows together. The fourth slot is the element's own default, and `widened == 3` exactly, which pins the per-ENTRY counting rule.
8. `TestFixedRedTeamOptionalAddedAndPayloadAppended` — `T` into `?T` (bill §12.8) with a field appended INSIDE the payload: the wrapper's constant `present` plus the payload's own prefill. `optional_add` alone has no tail to prefill.
9. `TestFixedRedTeamStringGrowsWithAFollowingField` — a capacity grown, a field BEHIND the string, and one appended: the text op's length-at-`dst` / span-at-`aux` lanes with a moved neighbour, and the grown slack asserted zero.
10. `TestFixedRedTeamOnlyFieldWidens` — the only field of a table widens: no neighbour, and the record body size changes by the widening alone. Sign extension pinned on `-1`, `MIN`, `MAX`.

`internal/lockfile/lineagecompose_test.go` — the lock:

11. `TestLockLineageSeveralWideningsInOneStepAddOneEntry` — three lawful widenings in one step are ONE layout, so ONE lineage line; the older line comes back BYTE FOR BYTE, and a third composed generation keeps both. A rewritten line is a rewritten history and no command can recover the layout bytes of a record nobody declares any more (§5.2).
12. `TestLockDeprecatedThenSameNameAppendRefused` / `…OtherNameAppendAllowed` — a deprecated field keeps its slot and its NAME forever (bill §12.3), so a later append of the same name would be two fields with one id and two plan entries claiming one source. It does not compile, and the control with a different name is an ordinary append over a deprecated slot.

## The harness

Self-contained, no C++ corpus. Stage one generates the OLD unit and WRITES the file with its own `FixedSave` — lawful by construction; stage two generates the NEW unit with the older units' locked entries as its lineage and READS it. So these run anywhere the Go runtime sibling checkout is, and skip with a named reason where it is not (a failure under `SCHEMA_REQUIRE_CORPUS`, the existing suite's rule).

## What I did NOT reach, and it is the open work

- **The C++ reference leg.** Each case above is the Go leg only. The two-leg disagreement test — the same lock, two independent ports, one of them wrong — needs `VOLD_`/`VNEW_` fixture pairs in `test/tables` and corpus rows, which is a bigger change than the deadline held. Ten cases × two legs is the follow-up card.
- **A lock produced on one platform and compiled on another** (the brief's case 11): the layout bytes are wire and the plan's `dst` offsets are the reader's own `offsetof`, so the cross-ABI agreement is a real question and untested here.

## Gates

`go test ./internal/lockfile/ ./compiler/ ./internal/codegen/gotable/ -run 'Lock|Lineage|Fixed|Versioning'` green. `gofmt -l .` empty. No C++ fixtures added, so `make tables-fixedform` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
