### PR TITLE
red team: the lock allows, the read breaks

### DIFF
--- a/internal/lockfile/diff.go
+++ b/internal/lockfile/diff.go
@@ -105,6 +105,17 @@ func Diff(locked, live *Unit, policy Policy) []error {
 			}
 			continue
 		}
+		// THE FORM'S CEILING, BEFORE THE LAW AND UNDER BOTH READINGS
+		// (lineage.go). It goes first because a record past the ceiling is a
+		// table whose WIRE has changed, which no refusal below it would name:
+		// every monotone fact widened legally, so [Current] would report the
+		// widening as an ordinary stale lock and `schema lock` would write it.
+		if lk.Decl == DeclFixedTable {
+			if err := diffCeiling(lk, lv); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
 		if err := diffTable(lk, lv, policy); err != nil {
 			errs = append(errs, err)
 			continue

--- a/internal/lockfile/lineage.go
+++ b/internal/lockfile/lineage.go
@@ -456,6 +456,39 @@ func diffLineage(lk, lv *Table, policy Policy) error {
 		fmt.Sprintf("not the lineage's last entry (0x%016x): the declaration has a layout the record does not end with", last.Wire))}
 }
 
+// diffCeiling is THE FORM'S CEILING AS A MONOTONE FACT (docs/SPEC-TABLES.md
+// §3.4, docs/FIXED-FORM-BILL-READS-BACKWARD.md §2's `fixed` keyword row).
+//
+// Every size fact in this file only grows, and one of them has a number past
+// which growing STOPS BEING A VERSION: a record body past
+// [ir.TableFixedRecordMaxBytes] does not carry the fixed form at all
+// (ir.TableFixedFormRoots drops it), so the table keeps form 1, which it never
+// lost. That is the right answer for a table that was ALWAYS that large — §12.1's
+// render frame, §2.8's `WideBlob`, neither ever a form-3 table — and it is the
+// wrong answer for a table a fleet already reads: a bound grown across the
+// ceiling is every monotone fact widening legally while the WIRE changes
+// underneath, which the bill calls a form change and not a version ("a different
+// form, not a version"). The lock allowed it and the lineage kept appending: the
+// old readers hold a form-3 layout nothing writes any more, and what reaches
+// them is not `layout_newer` — a refusal that says "ship the reader" — but a
+// form byte their plan never had a branch for.
+//
+// So the ceiling is checked the way every other bound in this file is checked,
+// against WHAT SHIPPED: a table whose last shipped record was inside the ceiling
+// may not cross it. A table already past it crosses nothing and says nothing —
+// it never had the form this refusal protects.
+func diffCeiling(lk, lv *Table) error {
+	if len(lk.Lineage) == 0 || len(lv.Lineage) != 1 {
+		return nil
+	}
+	last, cur := lk.Lineage[len(lk.Lineage)-1], lv.Lineage[0]
+	if last.Record > ir.TableFixedRecordMaxBytes || cur.Record <= ir.TableFixedRecordMaxBytes {
+		return nil
+	}
+	return fmt.Errorf("fixed table %s: its record was %d bytes in the lock and is %d in the declaration: record past the form's %d-byte ceiling (%d -> %d) — past the ceiling a fixed table DOES NOT CARRY THE FIXED FORM (docs/SPEC-TABLES.md §3.4): it keeps form 1, so this is not a widening every reader can hold but a CHANGE OF FORM, and the readers compiled from this lineage would meet a form byte no plan of theirs has a branch for (docs/FIXED-FORM-BILL-READS-BACKWARD.md §2, docs/SPEC-TABLES.md §2.10); shrink the bounds it declares back inside the ceiling, or start a new table under a new name",
+		lk.Name, last.Record, cur.Record, ir.TableFixedRecordMaxBytes, last.Record, cur.Record)
+}
+
 // lineageDrift marks the one lineage finding that is a CONSEQUENCE rather than a
 // fault of the record: the declaration's layout is not the lineage's last entry,
 // which is what a moved field or a moved nested type looks like from here. [Diff]

--- a/internal/lockfile/lockredteam_test.go
+++ b/internal/lockfile/lockredteam_test.go
@@ -1,0 +1,109 @@
+// THE LOCK, RED TEAMED: two pairs the law allowed and the read could not hold
+// (the red-team pass of 2026-09-11, against docs/FIXED-FORM-BILL-READS-BACKWARD.md
+// §2 and §6 and docs/FIXED-FORM-VERSIONING-TESTS.md).
+//
+// Both are the same mistake in two places: a fact the lock compares ENTRY BY
+// ENTRY, when the fact belongs to something the entry only points at.
+//
+//   - an array's ELEMENT WIDTH belongs to the element's own block, so an
+//     appended field in `Vec` was read as a change to every `[4]Vec` — the lock
+//     REFUSED a widening the bill allows, in a sentence that named no change
+//     ("element kind changed (table -> table)"), and a widening the lock refuses
+//     is a table that cannot be versioned at all;
+//   - a record's SIZE belongs to the FORM, and past §3.4's 65536 the fixed form
+//     is not carried. Every monotone fact widened legally while the wire changed
+//     underneath, so the lock ALLOWED a bound grown across the ceiling and the
+//     lineage gained an entry for a layout nothing writes.
+//
+// The idiom is lockrows_test.go's, and the shapes are its shapes.
+package lockfile_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---- the element of an array is a named type: its width is its own block's ----
+
+// TestLockArrayOfNestedAppendAllows guards the bill's `nested_append` row ONE
+// LEVEL IN: the law for a type a fixed record reaches by value is that type's
+// own law, recursively, and an ARRAY of it is reached by value just as surely as
+// a single field is. So `Vec` gaining a field is an append in Vec's block and
+// nothing at all in `[4]Vec`'s entry, whose width moved because the element's
+// did.
+func TestLockArrayOfNestedAppendAllows(t *testing.T) {
+	for _, shape := range []string{"[4]Vec", "[..4]Vec"} {
+		t.Run(shape, func(t *testing.T) {
+			rowAllows(t,
+				rowWith(vecType("    x int32\n    y int32"), "    v "+shape),
+				rowWith(vecType("    x int32\n    y int32\n    z int32"), "    v "+shape),
+				"Vec")
+		})
+	}
+}
+
+// TestLockArrayOfNestedRemoveRefuses is the other half, and it is why the half
+// above is safe: a NARROWING of the element is refused where the element's own
+// law lives, naming the type and the field, not the array that holds it.
+func TestLockArrayOfNestedRemoveRefuses(t *testing.T) {
+	rowRefuses(t,
+		rowWith(vecType("    x int32\n    y int32"), "    v [4]Vec"),
+		rowWith(vecType("    x int32"), "    v [4]Vec"),
+		"type Vec", "field y", "field removed")
+}
+
+// TestLockArrayOfScalarNarrowStillRefuses holds the fix to its own scope: an
+// array whose element is a SCALAR has no block of its own to be refused in, so
+// the element ladder is still the law there (`array_elem_widen`).
+func TestLockArrayOfScalarNarrowStillRefuses(t *testing.T) {
+	rowRefuses(t, rowTable("    a [..4]int32"), rowTable("    a [..4]int16"),
+		"fixed table Row", "field a", "element narrowed")
+}
+
+// ---- the record's size is the FORM's, and the form has a ceiling ----
+
+// TestLockRecordPastCeilingRefuses guards §3.4's 65536 AS A MONOTONE FACT. Past
+// it a fixed table does not carry the fixed form — it keeps form 1 — so a bound
+// or a capacity grown across the ceiling is not a widening every reader can hold
+// but a CHANGE OF FORM, which the bill spells out is "a different form, not a
+// version". Every fact the lock compares widened legally, so without this
+// refusal `schema lock` wrote the crossing down and the readers compiled from
+// the lineage were left holding a layout nothing writes.
+func TestLockRecordPastCeilingRefuses(t *testing.T) {
+	t.Run("a bound grown across it", func(t *testing.T) {
+		rowRefuses(t, rowTable("    a [4]int32"), rowTable("    a [20000]int32"),
+			"fixed table Row", "record past the form's 65536-byte ceiling (16 -> 80000)")
+	})
+	t.Run("a capacity grown across it", func(t *testing.T) {
+		rowRefuses(t, rowTable("    a string(8)"), rowTable("    a string(70000)"),
+			"fixed table Row", "record past the form's 65536-byte ceiling (12 -> 70004)")
+	})
+}
+
+// TestLockRecordAlreadyPastCeilingAllows is the asymmetry the ceiling needs: a
+// table that was ALWAYS past it never carried the fixed form, so it crosses
+// nothing and the lock says nothing — §12.1's render frame and §2.8's `WideBlob`
+// are declared `fixed table` for the CLASS and were never form-3 tables.
+func TestLockRecordAlreadyPastCeilingAllows(t *testing.T) {
+	rowAllows(t, rowTable("    a [20000]int32"), rowTable("    a [30000]int32"), "Row")
+}
+
+// TestLockRecordInsideCeilingAllows keeps the refusal off the ordinary grow: a
+// bound that grows and stays inside the ceiling is the `array_fixed_grow` row
+// and nothing else.
+func TestLockRecordInsideCeilingAllows(t *testing.T) {
+	rowAllows(t, rowTable("    a [4]int32"), rowTable("    a [8]int32"), "Row")
+}
+
+// TestLockCeilingRefusalIsAlsoScrewedDownInLock is the LOCK-REFUSES column's
+// other half for this row: `schema lock` itself must not write the crossing, or
+// the one command that moves the file would be the one that breaks the law.
+func TestLockCeilingRefusesUnderSchemaLock(t *testing.T) {
+	errs := lockThen(t, rowTable("    a [4]int32"), rowTable("    a [20000]int32"))
+	if len(errs) != 1 {
+		t.Fatalf("want one refusal, got %d: %v", len(errs), errs)
+	}
+	if strings.Contains(errs[0].Error(), "write it with `schema lock`") {
+		t.Fatalf("the ceiling is a refusal, never a stale lock: %v", errs[0])
+	}
+}

--- a/internal/lockfile/monotone.go
+++ b/internal/lockfile/monotone.go
@@ -162,6 +162,13 @@ func elemRule(want, got Entry) (rule string, widened bool) {
 	}
 }
 
+// namedElement reports whether an entry's ELEMENT is a named type whose own
+// block in the lock is where its changes are reported — the element's side of
+// the `HeldName` rule the field's own Width already follows.
+func namedElement(want, got Entry) bool {
+	return want.ElemKind == got.ElemKind && want.HeldName != "" && want.ElemWidth != got.ElemWidth
+}
+
 // rangeRule classifies a move of a field's declared bounds or its scale. A
 // range OUTWARD is a widening: every value an older writer could hold is still
 // inside. A range INWARD, a range added where none was, and a moved scale are
@@ -321,7 +328,27 @@ func monotone(where string, want, got Entry) (widened bool, what string, err err
 		return false, "", fmt.Errorf("%s, held %s in the lock and %s in the declaration: held type changed (%s -> %s) — a field already in the lock keeps the type it holds: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",
 			where, heldName(want.HeldName), heldName(got.HeldName), heldName(want.HeldName), heldName(got.HeldName))
 	}
-	if want.ElemKind != got.ElemKind || want.ElemWidth != got.ElemWidth {
+	if namedElement(want, got) {
+		// THE ELEMENT IS A NAMED TYPE — a nested record, an enum, a flags mask,
+		// a union — and then its WIDTH IS NOT THIS ENTRY'S FACT. It is the width
+		// of that type's OWN locked block, and the bill's law for it is that
+		// block's law, recursively: "a nested table or type by value | the
+		// table's own law, recursively: fields added at the end" (§2). An
+		// appended field in `Vec` widens every `[4]Vec` in the unit, and the
+		// removal that would shrink one is refused in Vec's block, by the type
+		// and the field, exactly as `nested_append` already proves for a field
+		// that holds ONE Vec. Both directions are therefore silent HERE, and the
+		// grown one is this entry widened — the same sentence the field's own
+		// Width already takes from `HeldName`, one level in.
+		//
+		// Without this the append read as "element kind changed (table ->
+		// table)": a refusal of a widening the bill allows, naming no change at
+		// all, and a widening the lock refuses is a table that cannot be
+		// versioned.
+		if got.ElemWidth > want.ElemWidth {
+			widened = true
+		}
+	} else if want.ElemKind != got.ElemKind || want.ElemWidth != got.ElemWidth {
 		rule, ok := elemRule(want, got)
 		if !ok {
 			return false, "", fmt.Errorf("%s, holds %s elements in the lock and %s elements in the declaration: %s — a field already in the lock keeps its element type: every record already written holds the old one, and nothing on the wire says which (docs/SPEC-TABLES.md §2.10); deprecate this field and append a new one",


### PR DESCRIPTION
Red team against the compiler in fixed table versioning, Glenn's ask: pairs where the schema compiles, the lock allows the change, and the NEW fixed table cannot read the OLD one exactly — or cannot be committed at all. The angle was THE LOCK: the gap between the bill's words (`docs/FIXED-FORM-BILL-READS-BACKWARD.md` §2, §6) and the tokens `internal/lockfile/monotone.go` compares.

Two findings, both fixed, both kept as minimal unit tests in `internal/lockfile/lockredteam_test.go`. They are the same mistake in two places: a fact compared ENTRY BY ENTRY that belongs to something the entry only points at.

## 1. An array of a nested type could not be widened at all — FIXED

| | |
|---|---|
| OLD | `type Vec { x int32  y int32 }` + `fixed table Row { v [4]Vec }` |
| NEW | `Vec` gains `z int32`, `Row` untouched |
| the lock said | REFUSED: `fixed table Row: entry 1, field v, holds table elements in the lock and table elements in the declaration: element kind changed (table -> table)` |
| the law says | ALLOWED — the bill's `nested_append` row, one level in: "a nested table or type by value \| the table's own law, recursively: fields added at the end" |
| severity | the lock cannot be written for the new version, so the table cannot be versioned at all; the refusal names no change |
| also hit | `[..4]Vec`, `[4]Inner` where Inner is a `fixed table`, and a bound grown in the same step |

Cause: `elemRule` ran the scalar ladder over an element of kind 13/15/7/9, which is on no ladder, so any change in `elem=13/8 -> elem=13/12` fell through to "element kind changed". The element's WIDTH is the element's own block's fact — exactly as a field's own `Width` already defers to `HeldName` — and the narrowing that would shrink it is refused in `Vec`'s block, by the type and the field. Fix: `namedElement` in `monotone.go`; both directions silent at the array entry, the grown one widening it.

Tests: `TestLockArrayOfNestedAppendAllows` (both shapes), `TestLockArrayOfNestedRemoveRefuses` (the narrowing still refused, in Vec's block), `TestLockArrayOfScalarNarrowStillRefuses` (the fix held to its scope).

## 2. A bound grown across the 65536-byte ceiling was allowed — FIXED

| | |
|---|---|
| OLD | `fixed table Row { a [4]int32 }` (record 16) |
| NEW | `fixed table Row { a [20000]int32 }` (record 80000) |
| the lock said | ALLOWED: the bound widened, `schema lock` wrote it, the lineage gained an entry |
| what breaks | past §3.4's ceiling a fixed table DOES NOT CARRY THE FIXED FORM (`ir.TableFixedFormRoots` drops it): it keeps form 1. Every monotone fact widened legally while the WIRE changed underneath. The readers compiled from this lineage hold a form-3 layout nothing writes any more, and what reaches them is not `layout_newer` ("ship the reader") but a form byte no plan of theirs has a branch for — the bill's "a different form, not a version" |
| also hit | `string(8) -> string(70000)`, i.e. any capacity or bound that crosses it |

Fix: `diffCeiling` in `lineage.go`, called from `Diff` before the law and under BOTH readings, so `schema lock` refuses to write the crossing too. It is checked the way every other bound in the lock is checked, against WHAT SHIPPED: a table whose last shipped record was inside the ceiling may not cross it. A table ALREADY past it crosses nothing and says nothing — §12.1's render frame and §2.8's `WideBlob` are declared `fixed table` for the class and were never form-3 tables.

Tests: `TestLockRecordPastCeilingRefuses` (a bound and a capacity), `TestLockRecordAlreadyPastCeilingAllows`, `TestLockRecordInsideCeilingAllows`, `TestLockCeilingRefusesUnderSchemaLock`.

## The candidates that held

- a compressed float's range widened (`0..100 -> 0..200`, same resolution): the layout bytes do not move — a compressed float rides as the float in a fixed record — only the §13 digest does. Correct.
- a compressed float's range REMOVED: refused, "resolution changed". Correct.
- an integer range removed, and widened: layout bytes identical. Correct.
- a keyed array whose key enum gained a variant: bound 2 -> 3, the enum's block appends. Allowed, correct.
- an array of an enum that gained a variant: allowed, correct.
- a single nested fixed table appended to: allowed, correct (the case that already had a test).
- `bits(6) -> bits(12)` across the uint8/uint16 storage width: allowed, the kind widens on the ladder. Correct.
- a deprecation and a widening in the same step (`a int32` -> `a int64 | deprecated`): allowed; undeprecating still refused.
- an optional added to a field holding a nested type: allowed.
- a constant grown behind two uses at once (`[..N]` and `string(N)`): allowed, both widen.
- `fixed(12,4) -> fixed(28,4)`: allowed; F moved and I narrowed still refused.
- a union arm appended while its payload type grew in the same step: allowed; the payload comparison strips the hash, so it does not read the payload's own append as "arm payload changed".

## Gates

- `go test ./internal/lockfile/ ./compiler/ -run 'Lock|Monotone|Lineage|Fixed'` green
- `go test ./internal/lockfile/` green (the whole package)
- `gofmt -l .` empty

## Open, not chased in the window

- the C++ reference read (NEW-READS-OLD) for the array-of-nested pair: no fixture written, so finding 1's read side is argued from the bill rather than measured. A `VOLD_/VNEW_nested_append_in_array` pair belongs beside `VOLD_array_fixed_grow`.
- a compressed float whose MIN moves outward (`0..100 -> -100..100`): the lock allows it and the stored value's meaning depends on the writer's min, so the plan must read min from the OLD lineage entry's digest. Worth one reference case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)