### PR TITLE
lock: fixed(I,F)'s I only widens

### DIFF
--- a/docs/FIXED-FORM-VERSIONING-TESTS.md
+++ b/docs/FIXED-FORM-VERSIONING-TESTS.md
@@ -50,7 +50,8 @@ Naming: `V_<row>`; the Go test is `TestLock<Row>Refuses` / `TestLock<Row>Allows`
 | `range_widen` | `int32 \| 0..100` | `\| 0..200`; unranged | `\| 0..50`: "range narrowed"; `\| 10..100`: "range narrowed" | 100 lands, `clamped` == 0 | the range |
 | `range_added` | `int32` | — | `int32 \| 0..100`: "range added where none was" | — | — |
 | `bits_grow` | `bits(8)` | `bits(12)` | `bits(4)`: "narrowed" | exact | the width |
-| `fixed_I_grow` | `fixed(8,4)` | `fixed(16,4)` | `fixed(8,8)`: "F changed"; `fixed(4,4)`: "I narrowed" | the raw scaled value exact | the width |
+| `fixed_I_grow` | `fixed(8,4)` | `fixed(16,4)` | `fixed(8,8)`: "F changed"; `fixed(4,4)`: "I narrowed (8 -> 4)"; `fixed(12,4)` from `fixed(8,8)`: "F changed" (I + F EQUALS a storage width per SPEC §4.6, so with F held a narrowed I IS a narrowed kind, and the only same-storage move is I against F) | the raw scaled value exact | the width |
+| `fixed_I_grow_element` | `[4]fixed(12,4)` | `[4]fixed(28,4)` | `[4]fixed(12,4)` from `[4]fixed(28,4)`: "element I narrowed (28 -> 12)" | as the scalar row, per slot | the element width |
 | `optional_add` | `T` | `?T` | `T` from `?T`: "optional removed" | present == 1, value exact | the present byte |
 | `nested_append` | `Root { v Vec }`, `Vec {x,y,z}` | `Vec {x,y,z,w}` | `Vec {x,y}`: "field removed" (in the nested type, named as `Root: Vec.z`) | as `field_append`, inside Root | the field Vec.w |
 | `default_change` | `a int32 = 1` | — | `a int32 = 2`: "default changed" | — | — |

--- a/internal/lockfile/lockrows_test.go
+++ b/internal/lockfile/lockrows_test.go
@@ -556,11 +556,39 @@ func TestLockFixedIGrowRefuses(t *testing.T) {
 		rowRefuses(t, before, rowTable("    pos fixed(4, 4) | min = -8, max = 7"),
 			"fixed table Row", "field pos", "I narrowed (12 -> 4)")
 	})
+	// I AND F INSIDE ONE STORAGE WIDTH, which is the half the row's line did
+	// not spell: SPEC §4.6 makes I + F EQUAL a storage width, so with F held a
+	// narrowed I IS a narrowed kind (the subtest above), and the only
+	// same-storage move left is I against F — a moved SCALE, which takes the F
+	// sentence. The two subtests together are the whole of `I(a) <= I(b) and
+	// F(a) == F(b)` (docs/FIXED-FORM-ALGORITHM.md §5.1) at the lock.
+	t.Run("I narrowed against F, same storage", func(t *testing.T) {
+		rowRefuses(t, rowTable("    pos fixed(28, 4) | min = -8, max = 7"),
+			rowTable("    pos fixed(24, 8) | min = -8, max = 7"),
+			"fixed table Row", "field pos", "F changed (4 -> 8)")
+	})
+	// AN ARRAY'S ELEMENT, one level in, and the one place the refusal did not
+	// hold this file's own law ("BOTH VALUES in the sentence"): it named the
+	// element's kind twice, "element I narrowed (fixed -> fixed)", where the
+	// lock has the element's I recorded all along.
+	t.Run("element I narrowed", func(t *testing.T) {
+		rowRefuses(t, rowTable("    pos [4]fixed(28, 4) | min = -8, max = 7"),
+			rowTable("    pos [4]fixed(12, 4) | min = -8, max = 7"),
+			"fixed table Row", "field pos", "element I narrowed (28 -> 12)")
+	})
 }
 
 func TestLockFixedIGrowAllows(t *testing.T) {
 	rowAllows(t, rowTable("    pos fixed(12, 4) | min = -8, max = 7"),
 		rowTable("    pos fixed(28, 4) | min = -8, max = 7"), "Row")
+}
+
+// THE POSITIVE HALF OF THE ELEMENT ROW: an element's I widens with F held, so
+// the raw scaled value every older writer packed is the same number in a wider
+// slot, and `schema lock` takes it.
+func TestLockFixedIGrowElementAllows(t *testing.T) {
+	rowAllows(t, rowTable("    pos [4]fixed(12, 4) | min = -8, max = 7"),
+		rowTable("    pos [4]fixed(28, 4) | min = -8, max = 7"), "Row")
 }
 
 // ---- optional_add ----

--- a/internal/lockfile/monotone.go
+++ b/internal/lockfile/monotone.go
@@ -124,6 +124,17 @@ func shapeWord(shape string) string {
 
 // kindRule classifies a kind change on the scalar ladders: widen reports true,
 // and everything else comes back as the rule phrase that names it.
+//
+// WHY `fixed`'s I NEEDS NO COMPARISON OF ITS OWN, although the lock records it
+// (`ibits=`) and docs/FIXED-FORM-ALGORITHM.md §5.1 states the law as
+// "I(a) <= I(b) and F(a) == F(b)": SPEC §4.6 makes I + F EQUAL a storage width
+// (internal/check/check.go), so the kind pins I + F, and a declaration that
+// holds F and narrows I has narrowed the KIND — which is the branch below,
+// naming I in the sentence. A declaration that narrows I inside one storage
+// width has widened F, which is a moved SCALE and takes [rangeRule]'s "F
+// changed". There is no third move, and a hand-edited `ibits=` does not reach
+// here: the layout hash the lock records covers the entry line, `ibits=` with
+// it. Checked against both docs 2026-09-11.
 func kindRule(want, got Entry) (rule string, widened bool) {
 	wf, wb := ladder(want.Kind)
 	gf, gb := ladder(got.Kind)
@@ -154,7 +165,7 @@ func elemRule(want, got Entry) (rule string, widened bool) {
 	case wf != ladderNone && wf == gf && gb > wb:
 		return "", true
 	case wf != ladderNone && wf == gf && (wf == ladderFixed || wf == ladderUFixed):
-		return fmt.Sprintf("element I narrowed (%s -> %s)", kindName(want.ElemKind), kindName(got.ElemKind)), false
+		return fmt.Sprintf("element I narrowed (%d -> %d)", want.IBits, got.IBits), false
 	case wf != ladderNone && wf == gf:
 		return fmt.Sprintf("element narrowed (%s -> %s)", kindName(want.ElemKind), kindName(got.ElemKind)), false
 	default:


### PR DESCRIPTION
A spec-against-spec read found what looked like a lock hole and it turned out to
be two things: a question the code answers without saying so, and one real gap
one level in.

**The question.** The lock records `fixed(I,F)`'s I (`ibits=`, lockfile.go ~885,
parsed ~1225), `docs/FIXED-FORM-BILL-READS-BACKWARD.md` §12.1 records it in
order to compare it, `docs/FIXED-FORM-ALGORITHM.md` §5.1 states the law as
`I(a) <= I(b) and F(a) == F(b)` — and `monotone()` has no IBits branch. The
reported hole was `fixed(24,4)` -> `fixed(20,4)`: same 32-bit storage, same F,
accepted.

**It is not reachable.** `fixed(24,4)` does not compile: SPEC §4.6
(`internal/check/check.go:1460`) makes `I + F` **EQUAL** a storage width — 8,
16, 32, 64 or 128 — so the kind pins `I + F`. A declaration that holds F and
narrows I has narrowed the KIND, which `kindRule` already refuses as
`I narrowed (12 -> 4)` with both values; the only same-storage move left is I
against F (`fixed(28,4)` -> `fixed(24,8)`), which is a moved SCALE and takes
`rangeRule`'s `F changed (4 -> 8)`. There is no third move. A hand-edited
`ibits=` does not reach `monotone` either: the layout hash the lock records
covers the entry line, `ibits=` with it, so the edit is refused before the law
runs. An IBits branch would be code no row can turn red, so the reasoning is a
paragraph above `kindRule` instead — named, dated, and pointing at both docs.

**The real gap: the ELEMENT.** `elemRule` refused an array element's I
narrowing with `element I narrowed (fixed -> fixed)` — the element's kind
printed twice, where this file's own law is the table, the definition, the rule
and **BOTH VALUES** in the sentence, and the lock has had the element's I
recorded all along. It now reads `element I narrowed (28 -> 12)`.

**The rows** (`internal/lockfile/lockrows_test.go`, `fixed_I_grow`):

| row | before -> after | verdict |
| --- | --- | --- |
| `I narrowed against F, same storage` | `fixed(28,4)` -> `fixed(24,8)` | refuses `F changed (4 -> 8)` — green on the tip, it pins the half §5.1's line did not spell |
| `element I narrowed` | `[4]fixed(28,4)` -> `[4]fixed(12,4)` | **RED on the tip** (`element I narrowed (fixed -> fixed)`), green here |
| `TestLockFixedIGrowElementAllows` | `[4]fixed(12,4)` -> `[4]fixed(28,4)` | allows, and the layout hash moves — the positive half of the element rule |

F had no hole: `fbits` is not a token, F is `frac=` and is compared through
`sameRange` -> `rangeRule`, which is the `F changed` row above.

**Doc.** `docs/FIXED-FORM-VERSIONING-TESTS.md`'s `fixed_I_grow` row now carries
the refusal text the code writes (`I narrowed (8 -> 4)`), the same-storage fact
and why, and a `fixed_I_grow_element` row for the element half.

Gates: `go test ./internal/lockfile/` green, `go test ./compiler/ -run
'Lock|Lineage|Fixed'` green, `gofmt -l .` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)