### PR TITLE
fixed form: the dead helpers go, the retained ones say why

### DIFF
--- a/generated/bench/paired/go/BenchTable.go
+++ b/generated/bench/paired/go/BenchTable.go
@@ -1737,15 +1737,6 @@ func tableFixedPut128(b []byte, lo, hi uint64) { tableFixedPut64(b, lo); tableFi
 func tableFixedGet32(b []byte) uint32          { return binary.LittleEndian.Uint32(b) }
 func tableFixedGet64(b []byte) uint64          { return binary.LittleEndian.Uint64(b) }
 
-func tableFixedHashOf(layout []byte) uint64 {
-	h := uint64(0xcbf29ce484222325)
-	for _, c := range layout {
-		h ^= uint64(c)
-		h *= 0x100000001b3
-	}
-	return h
-}
-
 func tableFixedCopyRun(d, s []byte, n uint32) {
 	if n == 0 {
 		return

--- a/generated/bench/paired/js/BenchTable.js
+++ b/generated/bench/paired/js/BenchTable.js
@@ -101,7 +101,6 @@ const TableFixedOpWidenF = 6;  // f32 into f64, SPEC-TABLES §4's float rung
 // the flavours an TableFixedOpText entry lands its units under
 const TableFixedTextUtf8 = 1;
 const TableFixedTextWide = 2;
-const TableFixedTextBytes = 3;
 
 const TableFixedNoGuard = -1;
 
@@ -236,6 +235,11 @@ export class TableFixedPlan {
 
 // A CACHE BY HASH: "the cost of the compile is paid once per peer rather than
 // once per record". The caller owns this too.
+//
+// THE CACHE IS RETAINED AND IGNORED (§5.9 #16): every older plan is static now
+// and built from the lock's bytes, so this has nothing left to hold — it stays
+// because §5.6 RETIRES MECHANISMS, NOT API, and every caller in test/js-tables
+// and the paired bench still names it.
 export class TableFixedPlanCache {
   constructor() {
     this.plans = new Map();

--- a/generated/bench/tables/go/BenchTableTable.go
+++ b/generated/bench/tables/go/BenchTableTable.go
@@ -1801,15 +1801,6 @@ func tableFixedPut128(b []byte, lo, hi uint64) { tableFixedPut64(b, lo); tableFi
 func tableFixedGet32(b []byte) uint32          { return binary.LittleEndian.Uint32(b) }
 func tableFixedGet64(b []byte) uint64          { return binary.LittleEndian.Uint64(b) }
 
-func tableFixedHashOf(layout []byte) uint64 {
-	h := uint64(0xcbf29ce484222325)
-	for _, c := range layout {
-		h ^= uint64(c)
-		h *= 0x100000001b3
-	}
-	return h
-}
-
 func tableFixedCopyRun(d, s []byte, n uint32) {
 	if n == 0 {
 		return

--- a/internal/codegen/elixirtable/elixirtable.go
+++ b/internal/codegen/elixirtable/elixirtable.go
@@ -57,10 +57,10 @@ func GenerateLineage(u *ir.Unit, lineage map[string][]FixedLineageEntry) (map[st
 	//
 	// THE FIXED FORM HAS LANDED HERE, so `fixedForm` is now this backend's OWN
 	// answer rather than the `false` every leg passed while none of them
-	// carried a form-3 codec. It is not ir.TableFixedAnyEmitted: that is the
-	// answer a port whose coverage is the reference's passes, and this leg
-	// narrows further (fixedSupported), so the answer is the roots this leg
-	// actually lays out. A unit whose wide kinds cost it the accelerators and
+	// carried a form-3 codec. The answer is THIS LEG'S OWN ROOTS (fixedRoots,
+	// which narrows on fixedSupported), because coverage is a port's own state
+	// and every leg answers from its own roots for that reason.
+	// A unit whose wide kinds cost it the accelerators and
 	// that has no fixed form to put in their place still has nothing to emit
 	// and is still refused WHOLE and by name.
 	scope := ir.WideTableKinds(u, "Elixir", len(fixedRoots(u)) > 0)

--- a/internal/codegen/gotable/fixedruntime.go
+++ b/internal/codegen/gotable/fixedruntime.go
@@ -197,15 +197,6 @@ func tableFixedPut128(b []byte, lo, hi uint64) { tableFixedPut64(b, lo); tableFi
 func tableFixedGet32(b []byte) uint32 { return binary.LittleEndian.Uint32(b) }
 func tableFixedGet64(b []byte) uint64 { return binary.LittleEndian.Uint64(b) }
 
-func tableFixedHashOf(layout []byte) uint64 {
-	h := uint64(0xcbf29ce484222325)
-	for _, c := range layout {
-		h ^= uint64(c)
-		h *= 0x100000001b3
-	}
-	return h
-}
-
 func tableFixedCopyRun(d, s []byte, n uint32) {
 	if n == 0 {
 		return

--- a/internal/codegen/jstable/fixedform_test.go
+++ b/internal/codegen/jstable/fixedform_test.go
@@ -696,3 +696,39 @@ fixed table Huge
 		t.Error("NAMED, NEVER SILENT: a generated module says which table has no fixed form and why")
 	}
 }
+
+// THE SCOPE ANSWER IS THIS LEG'S OWN ROOTS (jstable.go's §15 note). The answer
+// was a hard-coded `true` while ir carried a helper that answered it for a port
+// whose coverage was the reference's; this leg's coverage is its own, so a unit
+// it lays NO fixed table out for must answer false — otherwise §15's whole-unit
+// refusal is withheld from a unit that has nothing left to emit.
+func TestFixedUnitRootsFalseWithoutAFixedTable(t *testing.T) {
+	refused := unitFrom(t, `package probe
+
+type Item
+{
+    n int32
+}
+
+table Bag
+{
+    entries map[uint32]Item
+    after   int32
+}
+`)
+	if roots := jsFixedUnitRoots(refused); len(roots) != 0 {
+		t.Fatalf("a unit whose only table the form refuses has %d fixed roots, want 0", len(roots))
+	}
+
+	// The positive control, so the test cannot pass by answering false always.
+	plain := unitFrom(t, `package probe
+
+table Bag
+{
+    n int32
+}
+`)
+	if roots := jsFixedUnitRoots(plain); len(roots) == 0 {
+		t.Fatal("a unit of one plain scalar table has no fixed roots, want one")
+	}
+}

--- a/internal/codegen/jstable/fixedruntime.go
+++ b/internal/codegen/jstable/fixedruntime.go
@@ -93,7 +93,6 @@ const TableFixedOpWidenF = 6;  // f32 into f64, SPEC-TABLES §4's float rung
 // the flavours an TableFixedOpText entry lands its units under
 const TableFixedTextUtf8 = 1;
 const TableFixedTextWide = 2;
-const TableFixedTextBytes = 3;
 
 const TableFixedNoGuard = -1;
 
@@ -228,6 +227,11 @@ export class TableFixedPlan {
 
 // A CACHE BY HASH: "the cost of the compile is paid once per peer rather than
 // once per record". The caller owns this too.
+//
+// THE CACHE IS RETAINED AND IGNORED (§5.9 #16): every older plan is static now
+// and built from the lock's bytes, so this has nothing left to hold — it stays
+// because §5.6 RETIRES MECHANISMS, NOT API, and every caller in test/js-tables
+// and the paired bench still names it.
 export class TableFixedPlanCache {
   constructor() {
     this.plans = new Map();

--- a/internal/codegen/jstable/jstable.go
+++ b/internal/codegen/jstable/jstable.go
@@ -201,11 +201,16 @@ func GenerateLineage(u *ir.Unit, lineage map[string][]FixedLineageEntry) (map[st
 	// §15's WIDE-KIND REFUSAL IS THE FORM-1 ACCELERATORS' AND NOT THE WIRE'S
 	// (ir.WideTableKinds). The rule lives in ir because a rule five ports each
 	// spell for themselves is five rules — and the day this backend gained
-	// §3.4's fixed form is the day its answer became `true`: the block form and
-	// the cooked form stand down alone, and the unit is NOT refused whole,
-	// because there is a wire left to emit. The refusal still names every wide
-	// field, and it is stated by name in every module this unit gets.
-	scope := ir.WideTableKinds(u, "JavaScript", true)
+	// §3.4's fixed form is the day the block form and the cooked form stood down
+	// alone, with the unit NOT refused whole because there is a wire left to
+	// emit. The refusal still names every wide field, and it is stated by name in
+	// every module this unit gets.
+	//
+	// THE ANSWER IS THIS LEG'S OWN ROOTS, the way java and elixir answer it
+	// (len(jsFixedUnitRoots) > 0), and not a hard-coded `true`: a unit this leg lays no
+	// fixed table out for has no wire left to put in the accelerators' place, and
+	// `true` would have told ir otherwise and let the unit through unrefused.
+	scope := ir.WideTableKinds(u, "JavaScript", len(jsFixedUnitRoots(u)) > 0)
 	if scope.Unit {
 		return nil, scope.Refusal
 	}

--- a/internal/tablenames/go.go
+++ b/internal/tablenames/go.go
@@ -395,7 +395,6 @@ func init() {
 		Name{Name: "tableFixedPut128", What: "the fixed form (form 3)"},
 		Name{Name: "tableFixedGet32", What: "the fixed form (form 3)"},
 		Name{Name: "tableFixedGet64", What: "the fixed form (form 3)"},
-		Name{Name: "tableFixedHashOf", What: "the fixed form (form 3)"},
 		Name{Name: "tableFixedCopyRun", What: "the fixed form (form 3)"},
 		Name{Name: "tableFixedRun", What: "the fixed form (form 3)"},
 		Name{Name: "tableFixedLayoutEntry", What: "the fixed form (form 3)"},

--- a/internal/tablenames/js.go
+++ b/internal/tablenames/js.go
@@ -92,7 +92,6 @@ func init() {
 		Name{Name: "TableFixedOpWidenF", What: "the plan op that widens an f32 into an f64, §4's float rung"},
 		Name{Name: "TableFixedTextUtf8", What: "a text entry's utf-8 flavour"},
 		Name{Name: "TableFixedTextWide", What: "a text entry's wide flavour, whose units are two bytes"},
-		Name{Name: "TableFixedTextBytes", What: "a text entry's raw-bytes flavour, which terminates nothing"},
 
 		// the plan's storage, the cache that pays a compile once per peer, and
 		// §4's ledger with this form's refusals beside it

--- a/internal/tablenames/tablenames.go
+++ b/internal/tablenames/tablenames.go
@@ -103,13 +103,6 @@ type Name struct {
 	RustConst bool
 }
 
-// All returns the whole registry, sorted by name.
-func All() []Name {
-	out := append([]Name(nil), registry...)
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out
-}
-
 // Claimed is every UNIT-LEVEL registered name, sorted — what the checker
 // claims when a unit declares a table, whatever target it is generating for.
 // Scoped spellings are not claimed: they cannot collide with a declaration.

--- a/internal/tablepack/pack.go
+++ b/internal/tablepack/pack.go
@@ -69,17 +69,6 @@ func Pack(m *tabletext.Model, root, dir string) ([]byte, []string, tabletext.Rep
 	return bytes, p.skipped, *p.report, nil
 }
 
-// PackMessage is Pack over the MESSAGE FORM (docs/SPEC-TABLES.md §3.3): the
-// same tree, the same instance and the same walk, and a BATCH OF ONE comes out
-// the form byte, the count, and one bitpacked body, whose ids live in the
-// announced table rather than in a trailer of this wire's.
-//
-// The tree is unchanged, which is the text form's own claim: a message's text
-// is its variable form's text, byte for byte.
-func PackMessage(m *tabletext.Model, root, dir string) ([]byte, []string, tabletext.Report, error) {
-	return PackMessages(m, []MessageTree{{Root: root, Dir: dir}})
-}
-
 // MessageTree is one message of a batch: the root it is and the tree that
 // holds it.
 type MessageTree struct {

--- a/internal/tablepack/unpack.go
+++ b/internal/tablepack/unpack.go
@@ -81,12 +81,6 @@ func ReadReport(m *tabletext.Model, root string, wire []byte) (tabletext.Report,
 	return report, nil
 }
 
-// UnpackMessage is Unpack over the MESSAGE FORM (docs/SPEC-TABLES.md §3.3),
-// resolving every reference against the announced table: the BATCH OF ONE.
-func UnpackMessage(m *tabletext.Model, root string, announcement, message []byte, dir string, oneFile bool) (tabletext.Report, error) {
-	return UnpackMessages(m, []MessageTree{{Root: root, Dir: dir}}, announcement, message, oneFile)
-}
-
 // UnpackMessages reads a BATCH against the announcement that carried it. The
 // announcement is an ordinary form 1 file and is read first, tolerantly, with
 // its two strict checks; a refused announcement sets no table, so the batch is

--- a/internal/tabletext/maps.go
+++ b/internal/tabletext/maps.go
@@ -60,10 +60,6 @@ func MapKeyOrder(f *ir.Field, a, b MapKey) int {
 	return 0
 }
 
-// MapEntryStruct is the generated entry table a map field's entries are
-// instances of.
-func MapEntryStruct(f *ir.Field) *ir.Struct { return f.MapEntry }
-
 // NewMapEntry is one entry at its declared defaults, key included.
 func (m *Model) NewMapEntry(f *ir.Field) *Instance { return m.New(f.MapEntry) }
 

--- a/internal/tabletext/value.go
+++ b/internal/tabletext/value.go
@@ -486,12 +486,6 @@ func StructOf(f *ir.Field) *ir.Struct {
 	return st
 }
 
-// IsArrayShaped reports whether the field's payload is a wire ARRAY — a
-// declared array, or `bytes(N)`, which rides as an array of u8 (§2.5).
-func IsArrayShaped(f *ir.Field) bool {
-	return f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes
-}
-
 // ---- guards ----
 
 // GuardTerm is one conjunct of a guarded field's branch condition: a bool

--- a/internal/tablewire/message.go
+++ b/internal/tablewire/message.go
@@ -400,13 +400,3 @@ func Refused(err error) bool {
 	_, message := errors.AsType[*MessageRefusal](err)
 	return message
 }
-
-// Trailer splits a FILE wire into its root body and its id table
-// (docs/SPEC-TABLES.md §3): the form byte, the body, and the trailer the
-// reader finds from the END. ok is false where the trailer cannot be read
-// whole, which is malformed on every path that reads one.
-//
-// It is the variable form's half of what [Resolve] needs, and the message form's
-// half is the connection's table, which is why the two forms can be compared
-// under RESOLUTION at all (§3.3).
-func Trailer(data []byte) (body []byte, ids []uint64, ok bool) { return trailer(data) }

--- a/ir/blocklayout.go
+++ b/ir/blocklayout.go
@@ -155,16 +155,6 @@ func (b *BlockUnit) Block(name string) *BlockLayout {
 // IsBlock reports whether a name is a marked block-form table.
 func (b *BlockUnit) IsBlock(name string) bool { return b.Block(name) != nil }
 
-// InClosure reports whether a name is a record the block form touches — a
-// marked table, or anything one of its out-of-line arrays reaches by value.
-func (b *BlockUnit) InClosure(name string) bool {
-	if b == nil {
-		return false
-	}
-	_, ok := b.Members[name]
-	return ok
-}
-
 // SkippedReason is why one table has no block form, or "" when it has one.
 func (b *BlockUnit) SkippedReason(name string) string {
 	if b == nil {

--- a/ir/doctags.go
+++ b/ir/doctags.go
@@ -39,13 +39,6 @@ func DocComment(doc, indent, marker string) string {
 // written. C, C++, C#, Go, Java, JavaScript and Rust all read it.
 func QuoteDoc(doc string) string { return strconv.Quote(doc) }
 
-// QuoteDocDart renders a doc comment as a single-quoted Dart string literal:
-// a backslash, a quote, the interpolation sigil and a newline are escaped.
-func QuoteDocDart(doc string) string {
-	r := strings.NewReplacer(`\`, `\\`, `'`, `\'`, `$`, `\$`, "\n", `\n`, "\r", `\r`, "\t", `\t`)
-	return "'" + r.Replace(doc) + "'"
-}
-
 // QuoteDocElixir renders a doc comment as a double-quoted Elixir string
 // literal: a backslash, a quote, the interpolation opener and a newline are
 // escaped.

--- a/ir/fixedform.go
+++ b/ir/fixedform.go
@@ -1180,18 +1180,6 @@ func TableFixedEmitted(u *Unit, st *Struct) bool {
 	return TableFixedLeafCount(u, st) <= TableFixedLeafCap
 }
 
-// TableFixedAnyEmitted answers whether the unit has ANY table this form is
-// emitted for — the question [WideTableKinds] asks a backend, answered for a
-// port whose form-3 coverage is the reference's.
-func TableFixedAnyEmitted(u *Unit) bool {
-	for _, st := range TableFixedRoots(u) {
-		if TableFixedEmitted(u, st) {
-			return true
-		}
-	}
-	return false
-}
-
 // TableFixedHasWriteBound answers whether any fixed table of the unit has a
 // number the WRITE side bounds: a text field's used length, or a counted
 // array's live count. Those are the only two write-side checks this form has,

--- a/ir/tablekind.go
+++ b/ir/tablekind.go
@@ -359,32 +359,6 @@ func TableTypeSpelling(f *Field) string {
 	return "?"
 }
 
-// ArmFixedWidth is the payload width a union ARM's `L` must equal, or 0 where
-// the arm's payload is length-shaped (docs/SPEC-TABLES.md §2.6, §3). AN ARM
-// CARRIES NO KIND BYTE, so this is the whole of what a reader can check about
-// an arm's declared type: a length that is not this width is a KIND MISMATCH,
-// and an arm retyped under one width is §4.1's silent class, which §18's
-// baseline refuses.
-func ArmFixedWidth(f *Field) int {
-	if f == nil || f.Array != ArrayNone || f.Type.Kind == TString || f.Type.Kind == TWString || f.Type.Kind == TBytes {
-		return 0
-	}
-	if f.Type.Pointer {
-		return 4 // a node index (§3.1)
-	}
-	kind := TableScalarKind(f)
-	switch kind {
-	case TableKindTable, TableKindUnion:
-		return 0
-	}
-	if f.Type.Kind == TNamed {
-		if _, isEnum := f.Type.Ref.(*Enum); isEnum {
-			return 2 // the u16 hash of the variant's name (§3)
-		}
-	}
-	return TableKindWidth(kind)
-}
-
 func itoa(v int) string { return big.NewInt(int64(v)).String() }
 
 func itoa64(v int64) string { return big.NewInt(v).String() }
@@ -473,8 +447,8 @@ type WideTableKindScope struct {
 // WideTableKinds answers [WideTableKindScope] for one backend. `fixedForm` is
 // the BACKEND'S OWN answer to "do I emit a form-3 codec for this unit", because
 // which types a port lays out in the fixed form is that port's own state and
-// not a fact about the unit — [TableFixedAnyEmitted] is the answer a port whose
-// coverage matches the reference's passes.
+// not a fact about the unit: each port answers it from its OWN roots, which is
+// why there is no helper here to answer it for them.
 func WideTableKinds(u *Unit, backend string, fixedForm bool) WideTableKindScope {
 	refusal := RefuseWideTableKinds(u, backend)
 	if refusal == nil {


### PR DESCRIPTION
A dead-code sweep of the fixed form — `deadcode -test ./...`, staticcheck U1000, per-leg reachability. Every name below was grepped across tests, bench, tools, comparison, examples and `generated/` before it went.

## 1. `ir.ArmFixedWidth` — REMOVED

Unreachable. Its comment said an arm carries no kind byte, so a same-width retype is §4.1's silent class. Under reads-backward that class is **closed by the lock**: the lock refuses an arm retype outright (kinds never change under the monotone rule, `internal/lockfile/monotone.go`), and a known hash's layout is byte-compared, so a retyped arm is `layout_malformed` at run time. Nothing called the helper.

**No doc edit was owed.** The instruction was to add a sentence to the §4.1 paragraph in `docs/FIXED-FORM-ALGORITHM.md` *if that paragraph still names the silent class as open* — it does not: §4.1 there is "The plan", the phrase "silent class" appears nowhere in the file, and `docs/SPEC-TABLES.md` §4.1 ("The silent class, in full") enumerates exactly four members, none of them an arm retype. The stale claim lived only in the comment that is now gone.

## 2. `ir.TableFixedAnyEmitted` — REMOVED, and JavaScript now answers for itself

Unreachable: every leg answers `ir.WideTableKinds`'s question itself — `javatable.go` and `elixirtable.go` with `len(fixedRoots(u)) > 0`, `rusttable.go` with a local, and `jstable.go` hard-coded `true`.

The helper is gone, and jstable now answers from its **own roots** (`len(jsFixedUnitRoots(u)) > 0`), the way java and elixir do. That is a fix, not just a tidy: a unit this leg lays no fixed table out for used to answer `true`, which told `ir` there was a wire left to emit and withheld §15's whole-unit refusal (the later `len(wide) > 0 && len(fixed) == 0` check caught it, one screen down). `TestFixedUnitRootsFalseWithoutAFixedTable` pins both directions — a unit whose only table the form refuses answers 0 roots, a plain scalar table answers one.

The two doc comments that named the removed helper (`ir/tablekind.go`'s `WideTableKinds`, `elixirtable.go`'s §15 note) now say the rule instead: each port answers from its own roots.

## 3. The emitted JS `TableFixedTextBytes` — REMOVED

No emitted JS read it; the discrimination is baked at generate time by `fixedTextBytes` (`ir/fixedform.go`). Its `internal/tablenames/js.go` claim went with it, which is what the JS `DefinedBy` gate in `compiler/tablesjs_test.go` asks for. `TableFixedTextUtf8` and `TableFixedTextWide` stay — the emitted compiler compares against both.

Regen sweep run for the JS roots (`generated/bench/paired/js/BenchTable.js`).

## 4. The emitted JS `TableFixedPlanCache` — KEPT, with the retention note

Retained by §5.9 #16, and its comment now says so in the wording the C leg carries (`ctable/fixedform.go`): every older plan is static and built from the lock's bytes, so the cache has nothing left to hold, and it stays because **§5.6 retires mechanisms, not API**.

## 5. Outside the fixed form

Removed — nothing references each, and no `docs/` page names it:

- `ir/blocklayout.go` `BlockUnit.InClosure`
- `ir/doctags.go` `QuoteDocDart`
- `internal/tablenames/tablenames.go` `All`
- `internal/tablepack/pack.go` `PackMessage`, `internal/tablepack/unpack.go` `UnpackMessage` (the singular wrappers over the batch primitive)
- `internal/tabletext/maps.go` `MapEntryStruct`, `internal/tabletext/value.go` `IsArrayShaped`
- `internal/tablewire/message.go` `Trailer` (a thin exported wrapper over the unexported `trailer`)

Left:

- **left: exported API** — `compiler/pack.go` `Compiler.UnpackMessage`. No doc names it, but it is the `compiler` package's exported surface and the singular twin of `Compiler.PackMessage`, which `compiler/fixedmessageform_test.go` reaches; removing one half of the pair is an API break for a caller outside this repo, not a sweep.
- **left: touches the wire fuzzer's oracle** — `internal/tablewire/scan.go` `NodeRecordTypes` / `nodeRecordTypes`. Its doc states the consumer by name: "the wire fuzzer's oracle... a reader's `LoadMeasure` sums each record's storage from exactly this scan", beside `testdata/wire/tables/fuzz-vectors`.

## 6. Go's emitted runtime — one removal, the rest are NOT dead

- `tableFixedHashOf` — **REMOVED**. A §5.6 retirement (a recompute of the header hash): no emitted unit calls it and no test calls it. Its `internal/tablenames/go.go` claim went with it, for the Go `DefinedBy` gate. Regen sweep run for the Go roots.
- `tableFixedSelect` — **KEPT, and the sweep was wrong about it.** The emitted `FixedLoad` calls it by name to pick the lineage entry (`pick := tableFixedSelect(TableEntityFixedKnown, hash)` and its three siblings in `generated/bench/tables/go/BenchTableTable.go`, plus `generated/bench/paired/go/FixedTableTable.go`). The selection is neither inlined nor missing — nothing to stop for.
- `tableFixedBuildPlan` — **KEPT**: every unit's plan is built through it (`var TableEntityFixedPlan = tableFixedBuildPlan(...)`, three more beside it).
- `tableFixedOverlay`, `tableFixedPut8` / `Put16` / `PutF32` / `Put128` — **KEPT**: all reached from the emitted writers in the bench units, and each putter serves a width a schema kind can write.

## Gates

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `deadcode -test ./...` filtered to the fixed-form packages is **empty**. `go test ./ir/ ./compiler/ ./internal/codegen/jstable/ ./internal/codegen/gotable/` green. Goldens re-pinned (`internal/goldens -update`) — no pin moved, the removed names live in no golden. Regen sweep done with `rm -f bin/schema`; the three generated hunks are read and are exactly the two removals plus the retention note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
