### PR TITLE
ci: a two-minute fast lane on every push, the full lane at merge and nightly

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -9,7 +9,9 @@ name: Certify
 # owner's rule, 2026-09-07: CI that runs per commit finishes in one minute,
 # two at most; anything longer is nightly or manually triggered.
 #
-# THE PULL-REQUEST GATE IS ci.yml, and it is the fast half of this same set.
+# THE PULL-REQUEST GATE IS ci-fast.yml (per push, two minutes, selected by
+# path) and ci-full.yml (on merge, nightly, on demand, and on a `full-ci`
+# label), and together they are the fast half of this same set.
 # Nothing is checked less than it was before the split — what moved is WHEN a
 # certification instrument runs. A regression only this file can see fails
 # loudly at the next nightly, or the same hour when someone dispatches this
@@ -42,7 +44,7 @@ concurrency:
 
 # The runtimes the generated code targets, PINNED to each sibling's latest
 # RELEASED tag, never main: a sibling merging to main mid-day must not change
-# what a schema commit's CI proves. ci.yml carries the same block; the two must
+# what a schema commit's CI proves. ci-full.yml carries the same block; the two must
 # move together.
 # To bump a pin: edit the *_TAG line to the new release tag — nothing else
 # changes. Find the newest tag with:
@@ -103,7 +105,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # the stable BRANCH head — the SHA freezes the action, not the compiler: rustup resolves stable at run time
 
       # the .NET SDK, from the pin every C# project's TargetFramework
-      # names — .github/dotnet-version, read by ci.yml too (issue #470).
+      # names — .github/dotnet-version, read by ci-full.yml too (issue #470).
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
@@ -247,7 +249,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # the stable BRANCH head — the SHA freezes the action, not the compiler: rustup resolves stable at run time
 
       # the .NET SDK, from the pin every C# project's TargetFramework
-      # names — .github/dotnet-version, read by ci.yml too (issue #470).
+      # names — .github/dotnet-version, read by ci-full.yml too (issue #470).
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
@@ -347,7 +349,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # the stable BRANCH head — the SHA freezes the action, not the compiler: rustup resolves stable at run time
 
       # the .NET SDK, from the pin every C# project's TargetFramework
-      # names — .github/dotnet-version, read by ci.yml too (issue #470).
+      # names — .github/dotnet-version, read by ci-full.yml too (issue #470).
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
@@ -401,7 +403,7 @@ jobs:
 
   # A new CVE lands with no commit, so govulncheck is the one gate whose
   # verdict changes on its own — the nightly is the trigger that catches it.
-  # The same job rides every pull request in ci.yml, deliberately: neither
+  # The same job rides every merge in ci-full.yml, deliberately: neither
   # trigger substitutes for the other.
   vuln:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -21,7 +21,7 @@ name: CI fast
 #   conformance (9)           45        47 s         403 s
 #
 # END TO END those runs took 10:53, 15:08, 16:08, 15:45 and 24:42 — and THE
-# CRITICAL PATH IS NOT RUN TIME, IT IS QUEUE WAIT. ci.yml (now ci-full.yml)
+# CRITICAL PATH IS NOT RUN TIME, IT IS QUEUE WAIT. ci-full.yml dispatches SEVENTY
 # JOBS per pull request; with a dozen branches in flight the 47 negative-control
 # rows alone sat a median of 11m38s waiting for a runner, and the last job of a
 # run started up to 23 minutes after the push. No single job needed fixing: the

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,0 +1,428 @@
+name: CI fast
+
+# THE FAST LANE, and the rule it exists to keep (the owner's, today, verbatim):
+# "Remember that we desire the 1-2 minutes per-CI run for interactive fast
+# iteration. We keep slipping from this. If CI slows down iteration, it is our
+# job to realize this, and then fix it."
+#
+# WE HAD SLIPPED, and the measurement is the reason this file exists. Five
+# completed CI runs on fixed-table-form pull requests (34596169063,
+# 34596024573, 34595364248, 34595255044, 34594783777), job by job:
+#
+#   job                        n   median RUN   median QUEUE WAIT
+#   go-test                    5       650 s         216 s
+#   pins                       5       585 s         235 s
+#   big-endian                 5       514 s          11 s
+#   C# fuzz (matrix)          10       134 s         190 s
+#   negative controls (47)   235        93 s         698 s
+#   msvc                       5        85 s          30 s
+#   windows                    5        78 s          23 s
+#   lint                       5        62 s         161 s
+#   conformance (9)           45        47 s         403 s
+#
+# END TO END those runs took 10:53, 15:08, 16:08, 15:45 and 24:42 — and THE
+# CRITICAL PATH IS NOT RUN TIME, IT IS QUEUE WAIT. ci.yml (now ci-full.yml)
+# JOBS per pull request; with a dozen branches in flight the 47 negative-control
+# rows alone sat a median of 11m38s waiting for a runner, and the last job of a
+# run started up to 23 minutes after the push. No single job needed fixing: the
+# JOB COUNT did. A 15-minute timeout was raised this morning instead, which
+# treats a queue as a budget.
+#
+# SO THE SPLIT IS BY WHEN, NOT BY WHETHER. Nothing is checked less than before.
+#   * THIS FILE runs on every pull-request push. Five jobs, selected BY PATH,
+#     targeting two minutes wall: the cheap lints, the block zero-cost gate,
+#     `go test` of the packages the diff touches, and the fixed-form and
+#     versioning gates of the LEGS the diff touches.
+#   * ci-full.yml runs everything — the whole go-test, pins, the nine
+#     conformance legs, the 47 negative controls, windows, msvc, big-endian,
+#     vuln — on merge to main or fixed-table-form, nightly, on
+#     `gh workflow run ci-full.yml --ref <branch>`, and on any pull request
+#     carrying the `full-ci` label.
+#
+# THE SELECTION IS BY PATH AND NEVER BY DROPPING A GATE. A diff that touches
+# ir/, compiler/, docs/FIXED-FORM-*, the C++ reference's emitters, tables/, the
+# root Makefile or this file gets ALL NINE LEGS and `go test ./...` — the broad
+# rule is in `plan` below, and the conservative direction is always "run more".
+#
+# THE FLOOR, measured and named so the next reader does not chase it: a job on
+# this lane cannot finish under about 25-35 s. Runner assignment plus
+# actions/checkout is 10-15 s, actions/setup-go is another 8-12 s even with
+# `cache: false`, and the Go build cache restore is 5-10 s for ~100 MB. The legs
+# that need a sibling runtime (the C++ reference's byte oracle) pay a shallow
+# clone on top, and the Dart and Elixir legs pay their own SDK setup. Two
+# minutes is reachable; twenty seconds is not, without a self-hosted warm pool.
+
+on:
+  pull_request:
+    branches: [ main, fixed-table-form ]
+  workflow_dispatch:
+
+# A superseded push cancels its predecessor: this lane is for the tip of a
+# branch, and an interactive gate that queues behind its own stale runs is the
+# thing this file is fixing.
+concurrency:
+  group: ci-fast-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# The same sibling pins ci-full.yml and certify.yml carry, for the same reason: a
+# sibling merging to main mid-day must not change what a schema commit proves.
+# The three files move together.
+env:
+  SERIALIZE_TAG: v1.16.2
+  SERIALIZE_C_TAG: v1.10.0
+  SERIALIZE_GO_TAG: v1.15.1
+  SERIALIZE_RS_TAG: v2.4.0
+  SERIALIZE_CS_TAG: v1.9.1
+  SERIALIZE_JS_TAG: v1.4.2
+
+jobs:
+  # WHAT THE DIFF TOUCHES. One cheap job, no toolchain at all, whose outputs
+  # are the two selections the jobs below run: the Go packages, and the legs.
+  # It is deliberately the only `needs:` in this file — every gate that can
+  # start immediately does.
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      packages: ${{ steps.pick.outputs.packages }}
+      legs: ${{ steps.pick.outputs.legs }}
+      broad: ${{ steps.pick.outputs.broad }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the merge base with the target branch is what names the diff, so
+          # the whole history is needed rather than the single merge commit
+          fetch-depth: 0
+
+      - name: the diff, the packages and the legs
+        id: pick
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'fixed-table-form' }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin "$BASE"
+          files=$(git diff --name-only "origin/$BASE...HEAD")
+          if [ -z "$files" ]; then
+            echo "::notice::the diff is empty against origin/$BASE — running the broad selection"
+            files="ir/"
+          fi
+          echo "--- files in the diff"
+          echo "$files"
+
+          # THE BROAD RULE. These paths can change what EVERY leg emits or what
+          # every package compiles, so a diff that touches one of them gets the
+          # whole of both selections. The direction of the error is deliberate:
+          # a path nobody classified lands here, never in "skip it".
+          broad=no
+          if echo "$files" | grep -qE '^(ir/|compiler/|tables/|Makefile$|go\.mod$|docs/FIXED-FORM-|internal/codegen/cpp|internal/codegen/ccommon|test/cpp|\.github/workflows/ci-fast\.yml$)'; then
+            broad=yes
+          fi
+
+          # THE LEGS. One line per leg: the codegen packages that emit it, the
+          # generated tree it owns, its own test directory and its make include.
+          # A leg whose paths are untouched does not run here; ci-full.yml runs
+          # every leg on the merge regardless.
+          legs=""
+          add_leg() { case " $legs " in *" $1 "*) ;; *) legs="$legs $1" ;; esac; }
+          while read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              internal/codegen/gotable/*|internal/codegen/golang/*|generated/go/*|test/go-tables/*|make/go.mk) add_leg go ;;
+            esac
+            case "$f" in
+              internal/codegen/ctable/*|internal/codegen/c/*|generated/c/*|test/c-tables/*|make/c.mk) add_leg c ;;
+            esac
+            case "$f" in
+              internal/codegen/cpptable/*|test/cpp-tables/*) add_leg cpp ;;
+            esac
+            case "$f" in
+              internal/codegen/rusttable/*|internal/codegen/rust/*|generated/rust/*|test/rust-fixedform/*|make/rust.mk) add_leg rust ;;
+            esac
+            case "$f" in
+              internal/codegen/jstable/*|internal/codegen/js/*|generated/js/*|test/js-tables/*|make/js.mk) add_leg js ;;
+            esac
+            case "$f" in
+              internal/codegen/cstable/*|internal/codegen/csharp/*|generated/cs/*|test/cs-tables/*|make/cs.mk) add_leg cs ;;
+            esac
+            case "$f" in
+              internal/codegen/javatable/*|internal/codegen/java/*|generated/java/*|test/java-tables/*|test/java-fixedform/*|make/java.mk) add_leg java ;;
+            esac
+            case "$f" in
+              internal/codegen/darttable/*|internal/codegen/dart/*|generated/dart/*|test/dart-tables/*|make/dart.mk) add_leg dart ;;
+            esac
+            case "$f" in
+              internal/codegen/elixirtable/*|internal/codegen/elixir/*|generated/elixir/*|test/elixir-tables/*|test/elixir-fixedform/*|make/elixir.mk) add_leg elixir ;;
+            esac
+          done <<EOF
+          $files
+          EOF
+          if [ "$broad" = yes ]; then
+            legs="cpp go c rust js cs java dart elixir"
+          fi
+
+          # THE PACKAGES. Every directory holding a changed .go file, as the
+          # package path `go test` takes, plus the codegen package of each
+          # selected leg — a make include or a generated tree changing is a
+          # reason to run that leg's harness even with no .go file in the diff.
+          if [ "$broad" = yes ]; then
+            packages="./..."
+          else
+            packages=""
+            for f in $files; do
+              case "$f" in
+                *.go) d=$(dirname "$f"); [ -d "$d" ] || continue
+                      case " $packages " in *" ./$d "*) ;; *) packages="$packages ./$d" ;; esac ;;
+              esac
+            done
+            for leg in $legs; do
+              case "$leg" in
+                cpp) p=./internal/codegen/cpptable ;;
+                *)   p=./internal/codegen/${leg}table ;;
+              esac
+              [ -d "${p#./}" ] || continue
+              case " $packages " in *" $p "*) ;; *) packages="$packages $p" ;; esac
+            done
+            packages=$(echo "$packages" | xargs || true)
+          fi
+
+          # the legs as a JSON array, which is what a matrix reads
+          json=$(printf '%s' "$legs" | xargs -n1 2>/dev/null | sort -u | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $1} END{printf "]"}')
+          [ -n "$json" ] || json='[]'
+
+          echo "broad=$broad"        >> "$GITHUB_OUTPUT"
+          echo "packages=$packages"  >> "$GITHUB_OUTPUT"
+          echo "legs=$json"          >> "$GITHUB_OUTPUT"
+          {
+            echo "### what this push runs on the fast lane"
+            echo
+            echo "* broad selection: **$broad**"
+            echo "* packages: \`${packages:-(none)}\`"
+            echo "* legs: \`$json\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # THE CHEAP LINTS, the ones that answer in seconds and catch the mistake a
+  # human would otherwise find by reading. golangci-lint, modernize, the
+  # absolute ledger and the render smoke are NOT here: each downloads and
+  # compiles a tool of its own, which is a minute this lane does not have, and
+  # they run in ci-full.yml.
+  lint-fast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      # The Go build cache, restore only — ci-full.yml's `go-test` is the one
+      # Linux writer. The block on that job carries the reasoning.
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+
+      - name: gofmt
+        run: |
+          out=$(gofmt -l .)
+          if [ -n "$out" ]; then
+            echo "$out"
+            echo "::error::gofmt differs — run gofmt -w on the files above"
+            exit 1
+          fi
+      - name: go mod tidy
+        run: go mod tidy -diff
+      - name: go vet
+        run: go vet ./...
+      # CI LINTS ITSELF (issues #470, #472), over every workflow file in the
+      # tree — this one included: every `uses:` names a full commit SHA with the
+      # tag in a trailing comment, nothing runs @latest, and every csproj
+      # agrees with the one .NET SDK pin.
+      - name: CI lints itself — action pins and the .NET SDK pin
+        run: go test ./internal/ci/
+      - name: bench scripts parse
+        run: bash -n bench/run.sh
+
+  # THE BLOCK ZERO-COST GATE, byte-identity half (the `generated` job's third
+  # step in ci-full.yml). The committed tables goldens must equal a fresh
+  # generation byte for byte, which is the one gate that can redden from a
+  # one-character change to any emitter — so it rides every push. It takes
+  # bin/schema and nothing else: no toolchain, no sibling checkout.
+  #
+  # IT TAKES NO CACHE, deliberately, like the job it comes from: this is where
+  # "the build did no work" must not be an available explanation for a green.
+  block-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+      - name: the tables goldens match a fresh generation (the block zero-cost gate, byte-identity half)
+        run: make tables-block-zero-cost
+
+  # `go test` OF WHAT THE DIFF TOUCHES. The whole of `go test ./...` is 650 s
+  # median and lives in ci-full.yml; this job runs the packages `plan` picked,
+  # which for a single-leg diff is one or two of them. The corpus-reading
+  # suites behave exactly as they do today: without build/fixedform-corpus and
+  # without SCHEMA_REQUIRE_CORPUS=1 they skip themselves, and the leg gates
+  # below are where they are made to run.
+  go-test-touched:
+    needs: plan
+    if: needs.plan.outputs.packages != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+
+      - name: go test the touched packages
+        env:
+          PACKAGES: ${{ needs.plan.outputs.packages }}
+          BROAD: ${{ needs.plan.outputs.broad }}
+        run: |
+          set -euo pipefail
+          echo "packages: $PACKAGES"
+          if [ "$BROAD" = yes ]; then
+            # a broad diff's own gate is the full suite in ci-full.yml; here it
+            # is bounded so the lane keeps its budget, and the short run still
+            # catches the ordinary mistake in minutes rather than at merge
+            echo "::notice::broad diff — the whole suite runs in ci-full.yml; this lane runs it with -short"
+            # shellcheck disable=SC2086
+            go test -short $PACKAGES
+          else
+            # shellcheck disable=SC2086
+            go test $PACKAGES
+          fi
+
+  # THE TOUCHED LEG'S TWO GATES: the fixed form's bytes and §5's versioning
+  # rows, one matrix row per leg so nine legs cost nine parallel jobs rather
+  # than nine serial minutes. A leg gate is 5-30 s of work once its toolchain
+  # is up; the rest is the floor named at the top of this file.
+  #
+  # BOTH GATES, ALWAYS, per §5.9 #11 — a leg that proved its bytes and not its
+  # versioning rows has proved half of what it owes. The Java leg has no
+  # versioning target yet and the C++ reference IS the oracle, so those two
+  # rows run what exists; ci-full.yml is unchanged for both.
+  #
+  # SCHEMA_REQUIRE_CORPUS=1 is inside every one of these make targets: a corpus
+  # that failed to build is a failure here, never a quiet skip.
+  leg-gate:
+    needs: plan
+    if: needs.plan.outputs.legs != '[]'
+    name: fixed form + versioning (${{ matrix.leg }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        leg: ${{ fromJSON(needs.plan.outputs.legs) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # THE C++ REFERENCE IS EVERY LEG'S ORACLE: build/fixedform-corpus is dumped
+      # by ../serialize, so every row clones it. The leg's own sibling runtime
+      # comes with it where the probes link one.
+      - name: Check out the sibling runtimes this leg needs (pinned releases)
+        run: |
+          set -euo pipefail
+          cd ..
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git serialize
+          case "${{ matrix.leg }}" in
+            go)   git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go ;;
+            c)    git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c ;;
+            rust) git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs ;;
+            cs)   git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs ;;
+          esac
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: where this runner keeps the Go build cache
+        shell: bash
+        run: |
+          echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GO_CACHE_ID=$(go env GOVERSION)-$(go env GOARCH)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.GO_BUILD_CACHE }}
+          key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
+          restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+
+      # The leg's own toolchain, and only the leg's: a row that is not C# does
+      # not wait for the .NET SDK. The pins are the ones ci-full.yml carries.
+      - name: read the .NET SDK pin
+        if: matrix.leg == 'cs'
+        run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        if: matrix.leg == 'cs'
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_PIN }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: matrix.leg == 'js'
+        with:
+          # the version test/conformance/js/ci.json names
+          node-version: '26'
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # the stable BRANCH head — the SHA freezes the action, not the compiler: rustup resolves stable at run time
+        if: matrix.leg == 'rust'
+      - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
+        if: matrix.leg == 'dart'
+        with:
+          sdk: 3.13.2
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        if: matrix.leg == 'java'
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        if: matrix.leg == 'elixir'
+        with:
+          otp-version: '27'
+          elixir-version: '1.18'
+
+      # THE TWO GATES. The target names are the tree's own — the same ones
+      # `make test` and ci-full.yml run — so a leg that renames a gate renames
+      # it in one place and this row follows.
+      - name: the ${{ matrix.leg }} leg's fixed form and versioning rows
+        run: |
+          set -euo pipefail
+          case "${{ matrix.leg }}" in
+            cpp)    make tables-fixedform ;;
+            go)     make tables-go-fixed-form tables-go-versioning ;;
+            c)      make tables-c-fixedform tables-c-versioning ;;
+            rust)   make tables-rust-fixedform tables-rust-versioning RUSTUP_BIN=/usr/bin ;;
+            js)     make tables-js-fixed-form tables-js-versioning NODE=node ;;
+            cs)     make tables-cs-leg tables-cs-versioning ;;
+            java)   make tables-java-fixedform JAVA=java JAVAC=javac ;;
+            dart)   make tables-dart-fixed-form tables-dart-versioning DART=dart ;;
+            elixir) make tables-elixir-fixed-form tables-elixir-versioning \
+                      ELIXIR_BIN="$(command -v elixir)" ERL_BIN="$(dirname "$(command -v erl)")" ;;
+            *)      echo "::error::no fixed-form gate is registered for leg '${{ matrix.leg }}' — add it here and in ci-full.yml"; exit 1 ;;
+          esac

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,5 +1,31 @@
-name: CI
+name: CI full
 
+# THE FULL LANE. Everything this repository checks per commit is in this file,
+# and NOTHING HAS BEEN DROPPED from it — what changed is WHEN it runs.
+#
+# WHY IT MOVED (measured, 2026-09-11, five completed runs on fixed-table-form
+# pull requests: 34596169063, 34596024573, 34595364248, 34595255044,
+# 34594783777). This file dispatches SEVENTY JOBS per pull request, and the
+# binding constraint turned out not to be any job's run time but the QUEUE:
+# the 47 negative-control rows waited a median of 11m38s for a runner, the
+# conformance legs 6m43s, and the last job of a run started up to 23 minutes
+# after the push. End to end those five runs took 10:53, 15:08, 16:08, 15:45
+# and 24:42 against the owner's one-to-two-minute rule for interactive
+# iteration. A 15-minute job timeout was raised that morning instead of the
+# cause being fixed, which treats a queue as a budget.
+#
+# SO THIS FILE NOW RUNS: on every push to main and to fixed-table-form (the
+# merge gate), nightly at 07:10 UTC, on `gh workflow run ci-full.yml --ref
+# <branch>`, and on any pull request carrying the `full-ci` label. Every job
+# carries the same `if:` for that last case, which is why the expression is
+# repeated rather than named once: GitHub gives a job-level `if:` no access to
+# the `env` context.
+#
+# WHAT RUNS ON EVERY PUSH IS ci-fast.yml, five jobs selected by path, targeting
+# two minutes wall: the cheap lints, the block zero-cost gate, `go test` of the
+# packages the diff touches, and the fixed-form and versioning gates of the
+# legs the diff touches. Its header carries the measurement table in full.
+#
 # THE PULL-REQUEST GATE (issue #368). Every job in this file answers a question
 # about the CODE IN THE DIFF, and every one of them fits the owner's rule for
 # CI that runs on each pull request: one to two minutes.
@@ -64,12 +90,23 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    # main, and the fixed-form integration branch while the nine language legs
-    # land on it (2026-09-09): a leg PR into that branch is a pull request the
-    # gate must run on, or the batch to main is the first time anybody sees red.
+    # THE MERGE GATE. main, and the fixed-form integration branch while the
+    # nine language legs land on it (2026-09-09): the batch to main must never
+    # be the first time anybody sees red, so the whole of this file runs on
+    # every merge into that branch.
     branches: [ main, fixed-table-form ]
+  pull_request:
+    # A pull request runs this file only when it carries the `full-ci` label —
+    # every job below is gated on that. The label is how a branch near the hot
+    # paths, or anything that moves the C++ emitters, asks for the whole suite
+    # before merging; `gh workflow run ci-full.yml --ref <branch>` is the other
+    # way, and needs no label.
+    branches: [ main, fixed-table-form ]
+    types: [ opened, synchronize, reopened, labeled ]
+  schedule:
+    # nightly, so a tree nobody pushed to is still checked against the
+    # toolchains and the vulnerability database, which move on their own
+    - cron: '10 7 * * *'
   workflow_dispatch:
 
 # Superseded pushes to the same pull request cancel each other; a push to main
@@ -77,7 +114,7 @@ on:
 # and a queued dispatch run can never displace each other (a group holds only
 # one pending run).
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.ref }}
+  group: ci-full-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # The runtimes the generated code targets, PINNED to each sibling's latest
@@ -124,8 +161,28 @@ jobs:
   # another generator running a probe per row per column; fifteen is the budget
   # they share.
   go-test:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
+    name: go-test (${{ matrix.group }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # THREE PACKAGE GROUPS, ONE PER ROW, because this job was 650 s median
+    # (2026-09-11) and a matrix row is a job: the emitter packages, everything
+    # else, and the seven fixed-form versioning suites that cannot ride
+    # `go test ./...` at all. Every step below is the step it was; what is new
+    # is which row runs it, and no step runs in none of them.
+    #   unit-codegen — go test ./internal/codegen/...
+    #   unit-rest    — go vet ./..., go test over the complement, the
+    #                  projection's three controls, the toolchain control, and
+    #                  the one Linux cache write
+    #   versioning   — §5 on the Go, C, Rust, JavaScript, Dart, C# and Elixir
+    #                  legs, with the three SDKs only that row needs
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [ unit-codegen, unit-rest, versioning ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -148,9 +205,11 @@ jobs:
       # same .github/dotnet-version every other C# job reads, so a runner image
       # that ships a different SDK cannot change what this gate compiles.
       - name: read the .NET SDK pin
+        if: matrix.group == 'versioning'
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        if: matrix.group == 'versioning'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 
@@ -236,10 +295,20 @@ jobs:
           restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: go vet
+        if: matrix.group == 'unit-rest'
         run: go vet ./...
 
-      - name: go test
-        run: go test ./...
+      # THE EMITTERS' OWN TESTS, which are the slow half of `go test ./...`:
+      # every codegen package generates and compiles something.
+      - name: go test the emitter packages
+        if: matrix.group == 'unit-codegen'
+        run: go test ./internal/codegen/...
+
+      # AND THE COMPLEMENT, derived from `go list` rather than listed here, so a
+      # new package lands in one group or the other with no edit to this file.
+      - name: go test everything that is not an emitter package
+        if: matrix.group == 'unit-rest'
+        run: go test $(go list ./... | grep -v '/internal/codegen/')
 
       # THE FIXED FORM'S VERSIONING SUITE (§5 of docs/FIXED-FORM-ALGORITHM.md),
       # which the step above does NOT run. Its harness reads the C++
@@ -254,6 +323,7 @@ jobs:
       # minute, and the ../serialize checkout this job already makes is the
       # only thing the C++ dump needs.
       - name: the fixed form's versioning suite reads the reference's bytes
+        if: matrix.group == 'versioning'
         run: make tables-go-versioning
 
       # THE SAME TWO COLUMNS ON THE C LEG (§5, and §5.9 #11: every leg owes both
@@ -263,6 +333,7 @@ jobs:
       # here beside the Go one for the same reason: under SCHEMA_REQUIRE_CORPUS a
       # missing oracle is a failure, never a quiet skip.
       - name: the fixed form's versioning suite on the C leg
+        if: matrix.group == 'versioning'
         run: make tables-c-versioning
 
       # THE SAME SUITE ON THE RUST LEG, and it is in THIS job rather than a Rust
@@ -281,6 +352,7 @@ jobs:
       # uses. Without it the suite fails by name on the missing sibling rather
       # than skipping, which is the behaviour this whole gate is for.
       - name: the fixed form's versioning suite on the Rust leg
+        if: matrix.group == 'versioning'
         run: |
           if [ ! -d ../serialize.rs ]; then
             git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" \
@@ -293,6 +365,7 @@ jobs:
       # in this job, so NODE=node uses the runner's own — and the corpus is the
       # one the step above already built.
       - name: the fixed form's versioning suite on the JavaScript leg
+        if: matrix.group == 'versioning'
         run: make tables-js-versioning NODE=node
 
       # THE SAME SUITE ON THE DART LEG (§5.7 step 6: every leg owes BOTH gates,
@@ -302,9 +375,11 @@ jobs:
       # SCHEMA_REQUIRE_CORPUS=1 makes a missing corpus or a missing SDK a
       # failure rather than a silent skip.
       - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
+        if: matrix.group == 'versioning'
         with:
           sdk: 3.13.2
       - name: the Dart leg reads backward over every versioning row
+        if: matrix.group == 'versioning'
         run: make tables-dart-versioning DART=dart
 
       # THE SAME TWO COLUMNS ON THE C# LEG (§5, and §5.9 #11: every leg owes both
@@ -316,6 +391,7 @@ jobs:
       # other thing the probes need. Under SCHEMA_REQUIRE_CORPUS a missing oracle is
       # a failure here, never a quiet skip.
       - name: the fixed form's versioning suite on the C# leg
+        if: matrix.group == 'versioning'
         run: make tables-cs-versioning
 
       # THE SAME SUITE ON THE ELIXIR LEG (§5.7 step 6). Its probes are generated
@@ -326,10 +402,12 @@ jobs:
       # built, and SCHEMA_REQUIRE_CORPUS=1 makes a missing corpus or a missing
       # Elixir a failure rather than a silent skip.
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        if: matrix.group == 'versioning'
         with:
           otp-version: '27'
           elixir-version: '1.18'
       - name: the Elixir leg reads backward over every versioning row
+        if: matrix.group == 'versioning'
         run: |
           make tables-elixir-versioning \
             ELIXIR_BIN="$(command -v elixir)" ERL_BIN="$(dirname "$(command -v erl)")"
@@ -341,6 +419,7 @@ jobs:
       # red proves a gate is watching. All three are Go-only and take seconds,
       # so they belong on the diff.
       - name: the projection's gates go red without what they watch
+        if: matrix.group == 'unit-rest'
         run: |
           make projection-variant-order-negative-control
           make projection-wire-law-negative-control
@@ -355,6 +434,7 @@ jobs:
       # refusal, which is the state this runner is already in, and takes about
       # a second.
       - name: the toolchain gate goes red without the toolchains it pins
+        if: matrix.group == 'unit-rest'
         run: make toolchain-negative-control
 
       # THE ONE LINUX WRITER, per the block at the top of this job. It is last
@@ -363,6 +443,7 @@ jobs:
       # `actions/cache/save` cannot redden a job: a key another run reserved
       # first is a logged warning and this step's success.
       - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: matrix.group == 'unit-rest'
         with:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
@@ -384,6 +465,10 @@ jobs:
   # make/<lang>.mk is covered the moment it rebases, with no edit to this file. Locally the same check is `make
   # generated-current`, which gets there through the whole `make test` chain.
   generated:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -461,6 +546,10 @@ jobs:
   # duplicates the go-test job and is the time to reclaim when someone wants
   # it, which is a change to `update-goldens` and belongs to its own diff.
   pins:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -531,6 +620,10 @@ jobs:
   # its toolchain has no step yet, in which case it adds one step keyed on a
   # new field, which is the one edit this file still takes.
   conformance-matrix:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -564,6 +657,10 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   conformance:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: conformance (${{ matrix.lang }})
     needs: conformance-matrix
     runs-on: ubuntu-latest
@@ -675,6 +772,10 @@ jobs:
   # (wire fuzz ~26 s, region fuzz ~39 s) without bloating the conformance (cs)
   # leg over the 2-minute ceiling.
   cs-fuzz:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: C# fuzz (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -754,6 +855,10 @@ jobs:
   # from the policy the failing install prints. The step after the install
   # records the resolved closure both pins pull in.
   big-endian:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -841,6 +946,10 @@ jobs:
 
   # Self-contained Go lint job; .golangci.yml carries the config.
   lint:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -925,6 +1034,10 @@ jobs:
   # in certify.yml — the same job in both files, deliberately, because neither
   # trigger substitutes for the other.
   vuln:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -959,6 +1072,10 @@ jobs:
   # Windows: vet + build, cheap enough to ride every pull request. What it
   # EMITS is compiled with cl by the `msvc` job below.
   windows:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -1040,6 +1157,10 @@ jobs:
   # named one. It is also why /MP is absent: parallel TUs are faster and
   # unmeasurable, and here the measurement is worth more than the seconds.
   msvc:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: windows-2025
     timeout-minutes: 10
     steps:
@@ -1186,6 +1307,10 @@ jobs:
   # tooling, one beside each leg for its own — with an exact count that can
   # only shrink.
   shape-gate:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1225,6 +1350,10 @@ jobs:
   # which is the same comparison a dispatch on a branch wants. On a push to
   # main the diff against main is empty and the job is a no-op that says so.
   cpp-lock:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1324,6 +1453,10 @@ jobs:
   # between them, so it sits in the plan's exclusion list beside the other
   # umbrellas rather than in a job that would run one of those leaves twice.
   negative-controls-matrix:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1362,6 +1495,10 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   negative-controls:
+    # Runs on a pull request only when it carries the `full-ci` label; on a
+    # merge, the nightly and a dispatch it always runs. The expression is
+    # repeated per job because a job-level `if:` cannot read `env`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: negative controls (${{ matrix.name }})
     needs: negative-controls-matrix
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2802,7 +2802,7 @@ build/schema_test_tables_asan: build/tables-generated/.stamp test/tables/main.cp
 # order is proven to refuse rather than to garble.
 #
 # The toolchain is not a system binary and is not assumed: CI installs an
-# exact pinned version (.github/workflows/ci.yml) and these two variables name
+# exact pinned version (.github/workflows/ci-full.yml) and these two variables name
 # what it installed, so the leg runs anywhere the same pair is on PATH.
 BE_CXX ?= s390x-linux-gnu-g++
 BE_RUN ?= qemu-s390x

--- a/README-NEW.md
+++ b/README-NEW.md
@@ -1,6 +1,6 @@
 # schema
 
-[![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml)
+[![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci-fast.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci-fast.yml)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
 **Schema: the data schema language for games.**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # schema
 
-[![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml)
+[![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci-fast.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci-fast.yml)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
 **Schema. The data language for games.**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,7 +73,7 @@ certification installs every toolchain and overrides the pins, which resolve
 and pass the gate. `make toolchain` runs the gate alone, and
 `make toolchain-negative-control` proves it still has its blade, on every pin
 of every leg. That control runs inside `make test` and on every pull request,
-in the `go-test` job of `ci.yml`.
+in the `go-test` job of `ci-full.yml`.
 
 The Makefile's `SERIALIZE*` variables override the sibling paths if you keep
 them elsewhere.
@@ -252,7 +252,7 @@ column on [PORTING.md](PORTING.md), the techniques register, is written by
 hand — every technique carried, cited or stated impossible — and its gate
 reads the columns from the page and holds them to the discovered drivers, so
 the column is the edit and no other file lists the language; a toolchain with
-no step yet in `.github/workflows/ci.yml` (and the `test` job of
+no step yet in `.github/workflows/ci-full.yml` (and the `test` job of
 `certify.yml`) adds one step, keyed on a new `ci.json` field; and the
 per-language prose in [SPEC.md](SPEC.md), [SPEC-TABLES.md](SPEC-TABLES.md)
 and [USAGE.md](USAGE.md) is prose, written by hand where the language's

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -285,7 +285,7 @@ directory and touches nothing another port touches (`docs/CONTRIBUTING.md`,
 "Adding a language"). The reference leg is `cpp` — the harness's own constant,
 sorted first — and the rest follow by name.
 
-**`ci.json` is one JSON object of strings**, and `.github/workflows/ci.yml`'s
+**`ci.json` is one JSON object of strings**, and `.github/workflows/ci-full.yml`'s
 conformance job reads it as the leg's matrix row:
 
 | key | what it is |

--- a/tools/negativecontrols/negativecontrols_test.go
+++ b/tools/negativecontrols/negativecontrols_test.go
@@ -110,13 +110,14 @@ func TestEveryGroupRunsInATier(t *testing.T) {
 // package and the workflows. The enumeration is only worth its cost while a
 // leg's target list IS the manifest: a job that typed its own list would pass
 // every test above and still miss a control. So both workflows are read here,
-// and each must reach its matrix and its targets through this tool: ci.yml for
-// the pull-request tier, certify.yml for the nightly one, which is where this
-// repository's schedule lives.
+// and each must reach its matrix and its targets through this tool:
+// ci-full.yml for the merge tier (the 47 rows are too many runners for the
+// per-push fast lane; that split is in ci-fast.yml's header), certify.yml for
+// the nightly one, which is where this repository's schedule lives.
 func TestTheLegRunsTheManifestAndNotATypedList(t *testing.T) {
 	root := testRoot(t)
 	for workflow, wants := range map[string][]string{
-		"ci.yml": {
+		"ci-full.yml": {
 			"go run ./tools/negativecontrols check",
 			"go run ./tools/negativecontrols matrix",
 			"go run ./tools/negativecontrols targets",
@@ -258,7 +259,7 @@ var legs = []struct {
 	matrixJob string
 	command   string
 }{
-	{"ci.yml", "negative-controls", "negative-controls-matrix", "go run ./tools/negativecontrols matrix"},
+	{"ci-full.yml", "negative-controls", "negative-controls-matrix", "go run ./tools/negativecontrols matrix"},
 	{"certify.yml", "negative-controls-nightly", "negative-controls-nightly-matrix", "go run ./tools/negativecontrols matrix nightly"},
 }
 


### PR DESCRIPTION
The owner's rule, today, verbatim: **"Remember that we desire the 1-2 minutes per-CI run for interactive fast iteration. We keep slipping from this. If CI slows down iteration, it is our job to realize this, and then fix it."**

## What the measurement says, and it is not what this morning's timeout raise assumed

Five completed CI runs on fixed-table-form pull requests — 34596169063, 34596024573, 34595364248, 34595255044, 34594783777 — job by job, medians over the 350 job records in them:

| job | rows | median RUN | median QUEUE WAIT | median finish after push |
|---|---|---|---|---|
| go-test | 5 | 650 s | 216 s | 866 s |
| pins | 5 | 585 s | 235 s | 820 s |
| big-endian | 5 | 514 s | 11 s | 525 s |
| C# fuzz (matrix) | 10 | 134 s | 190 s | 324 s |
| negative controls (47 rows) | 235 | 93 s | **698 s** | 791 s |
| msvc | 5 | 85 s | 30 s | 115 s |
| windows | 5 | 78 s | 23 s | 101 s |
| lint | 5 | 62 s | 161 s | 223 s |
| conformance (9 legs) | 45 | 47 s | **403 s** | 450 s |
| vuln | 5 | 37 s | 253 s | 290 s |
| generated | 5 | 29 s | 172 s | 201 s |
| shape-gate | 5 | 25 s | 142 s | 167 s |

End to end those five runs took **10:53, 15:08, 16:08, 15:45 and 24:42**. The last job of a run started as much as 23 minutes after the push.

**The critical path is queue wait, not run time.** ci.yml dispatches **seventy jobs** per pull request. Each one is individually inside or near the two-minute rule — the file's own header holds every job to it, honestly — and the rule still cannot be kept, because seventy jobs across a dozen in-flight branches is a runner queue. The 47 negative-control rows waited a median of 11m38s to run 93 s of work. Raising a job timeout to 15 minutes treats that queue as a budget.

So the fix is the job count on the interactive path, and the split is by **when**, never by whether. Every check that runs today runs in one of the two lanes.

## FAST — `.github/workflows/ci-fast.yml`, every pull-request push, five jobs, selected by path

| job | what it runs | starts |
|---|---|---|
| `plan` | reads `git diff --name-only origin/<base>...HEAD`, outputs the Go packages and the legs | immediately |
| `lint-fast` | gofmt, `go mod tidy -diff`, `go vet ./...`, `go test ./internal/ci/` (the CI self-lint), `bash -n bench/run.sh` | immediately |
| `block-gate` | `make tables-block-zero-cost` — the `generated` job's byte-identity half, no cache by design | immediately |
| `go-test-touched` | `go test` of the packages `plan` picked (`-short` on a broad diff) | needs `plan` |
| `leg-gate` | one matrix row per touched leg: that leg's fixed-form byte gate **and** its §5 versioning rows, with only that leg's toolchain | needs `plan` |

The leg gates, per §5.9 #11 that every leg owes both: `tables-<leg>-fixed-form`/`-fixedform` plus `tables-<leg>-versioning`, with `tables-fixedform` for the C++ reference and `tables-java-fixedform` for the Java leg, which has no versioning target yet. `SCHEMA_REQUIRE_CORPUS=1` is inside every one of those targets, so a corpus that failed to build is a failure, never a quiet skip. Corpus-reading suites under `go-test-touched` skip exactly as they do today.

**The selection is by path and never by dropping a gate.** A diff touching `ir/`, `compiler/`, `tables/`, `Makefile`, `go.mod`, `docs/FIXED-FORM-*`, the C++ reference's emitters (`internal/codegen/cpp*`, `internal/codegen/ccommon`, `test/cpp*`) or `ci-fast.yml` itself gets **all nine legs** and the whole package list. An unclassified path lands in "run more", never in "skip it".

## FULL — `.github/workflows/ci-full.yml` (was `ci.yml`, every job intact)

Triggers: push to `main` and `fixed-table-form` (the merge gate), nightly at 07:10 UTC, `gh workflow run ci-full.yml --ref <branch>`, and any pull request carrying the **`full-ci`** label. Each of the 15 jobs carries `if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')` — repeated per job because a job-level `if:` cannot read `env`.

It holds everything: the whole `go test`, the seven versioning suites, `pins`, the nine conformance legs, the 47 negative-control rows and their matrix, `cs-fuzz`, `big-endian`, the full `lint` (golangci-lint, modernize, the absolute ledger, the render smoke), `vuln`, `windows`, `msvc`, `shape-gate`, `cpp-lock`, `generated`.

**`go-test` is split into three package groups** so the 650 s job parallelizes: `unit-codegen` (`go test ./internal/codegen/...`), `unit-rest` (`go vet ./...`, `go test` of the complement derived from `go list`, the projection's three controls, the toolchain control, and the one Linux cache write), and `versioning` (§5 on the Go, C, Rust, JavaScript, Dart, C# and Elixir legs, carrying the three SDKs only that row needs). No step moved out of the file; what changed is which row runs it.

## Caching and the floor

Every fast-lane job restores the Go build cache on the same content-addressed key ci.yml established (`go-build-<os>-<toolchain>-<hash of **/*.go, go.mod>`, one fallback rung); `ci-full.yml`'s `go-test` `unit-rest` row remains the single Linux writer. `block-gate` takes no cache, deliberately — it is the job where "the build did no work" must not be an available explanation for a green.

**The floor I could not get under: about 25–35 s per job.** Runner assignment plus `actions/checkout` is 10–15 s, `actions/setup-go` is 8–12 s even with `cache: false`, and restoring ~100 MB of build cache is 5–10 s. A leg row pays a shallow clone of the C++ reference on top (the byte oracle), and the Dart and Elixir rows pay their own SDK setup. Two minutes is reachable; twenty seconds is not, without a self-hosted warm pool.

## Also in this diff

`tools/negativecontrols`' leg test and the docs that named `ci.yml` by hand (`docs/CONTRIBUTING.md`, `test/conformance/README.md`, the `Makefile` comment, `certify.yml`'s header, the README badges) now name `ci-full.yml` / `ci-fast.yml`. `go test ./internal/ci/` and `go test ./tools/negativecontrols/` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
