### PR TITLE
tests: every package answers in under a minute; the slow ones run in the full lane

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -300,14 +300,24 @@ jobs:
 
       # THE EMITTERS' OWN TESTS, which are the slow half of `go test ./...`:
       # every codegen package generates and compiles something.
+      # SCHEMA_SLOW=1 IS THE WHOLE OF THE SPLIT ON THIS LANE. internal/slowtest
+      # gates the tests that shell out to cc, c++, dotnet, javac, cargo, dart,
+      # node, elixir or the Go toolchain, so a child's default `go test` is
+      # seconds instead of minutes (the owner's rule, twice today: "Remember the
+      # 1-2 minute iteration rule on unit tests."). THIS LANE SETS IT, so the
+      # merge and nightly runs check exactly what they checked before.
       - name: go test the emitter packages
         if: matrix.group == 'unit-codegen'
+        env:
+          SCHEMA_SLOW: '1'
         run: go test ./internal/codegen/...
 
       # AND THE COMPLEMENT, derived from `go list` rather than listed here, so a
       # new package lands in one group or the other with no edit to this file.
       - name: go test everything that is not an emitter package
         if: matrix.group == 'unit-rest'
+        env:
+          SCHEMA_SLOW: '1'
         run: go test $(go list ./... | grep -v '/internal/codegen/')
 
       # THE FIXED FORM'S VERSIONING SUITE (§5 of docs/FIXED-FORM-ALGORITHM.md),

--- a/compiler/ctablerefordinal_test.go
+++ b/compiler/ctablerefordinal_test.go
@@ -51,6 +51,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // cRefOrdinalWideFields is the nested table's field count. It is above 127 on
@@ -259,6 +261,7 @@ int main( void )
 // against some other tree's copy.
 func runCRefOrdinal(t *testing.T, files map[string][]byte, driver, binary, runFail string) string {
 	t.Helper()
+	slowtest.Gate(t, "the C compiler (cc)")
 	cc, err := exec.LookPath("cc")
 	if err != nil {
 		t.Skip("the generated save path is C: no cc on PATH")

--- a/compiler/issue710_test.go
+++ b/compiler/issue710_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
 	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func TestIssue710DirectoryList(t *testing.T) {
@@ -199,6 +201,7 @@ func TestIssue710TableRecovery(t *testing.T) {
 
 func issue710CompileRun(t *testing.T, dir, compiler, ext, source string) {
 	t.Helper()
+	slowtest.Gate(t, "a C/C++ compiler")
 	if _, err := exec.LookPath(compiler); err != nil {
 		t.Skipf("%s unavailable: %v", compiler, err)
 	}

--- a/compiler/issue715_test.go
+++ b/compiler/issue715_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Issue #715: Table JSON Base64 reader wipes declared defaults on malformed input
@@ -208,6 +210,7 @@ func TestIssue715(t *testing.T) {
 	})
 
 	t.Run("cs", func(t *testing.T) {
+		slowtest.Gate(t, "dotnet")
 		dotnet := findDotnet()
 		if dotnet == "" {
 			// Without dotnet on PATH, this behavioral test covers C++, C, and Go (3 languages); CI runs all 4.
@@ -321,6 +324,7 @@ func findDotnet() string {
 
 func issue715CompileRun(t *testing.T, dir, compiler, ext, source string) {
 	t.Helper()
+	slowtest.Gate(t, "a C/C++ compiler")
 	if _, err := exec.LookPath(compiler); err != nil {
 		t.Skipf("%s unavailable: %v", compiler, err)
 	}

--- a/compiler/issue759_test.go
+++ b/compiler/issue759_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Issue #759: packet C stored bool as int, four bytes, while table C stored
@@ -125,6 +127,7 @@ func TestIssue759PacketBoolUnchangedWhenATableIsAdded(t *testing.T) {
 
 func issue759SyntaxCheckWire(t *testing.T, files map[string][]byte) {
 	t.Helper()
+	slowtest.Gate(t, "the C compiler (cc)")
 	cc, err := exec.LookPath("cc")
 	if err != nil {
 		t.Skip("generated C syntax check requires cc")

--- a/compiler/tablealignment_test.go
+++ b/compiler/tablealignment_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // A variable wide root used to fail C++'s Alloc<T> assertion (16 <= 8).
@@ -92,6 +94,7 @@ free(region); free(output); return 0;}
 // No replacement typedef can conceal the wide scalar alignment contract.
 func referenceCompileRun(t *testing.T, files map[string][]byte, source string) {
 	t.Helper()
+	slowtest.Gate(t, "the C++ compiler")
 	compiler, err := exec.LookPath("c++")
 	if err != nil {
 		t.Skipf("c++ unavailable: %v", err)

--- a/compiler/tableclosuredefaults_test.go
+++ b/compiler/tableclosuredefaults_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
 	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Packet construction starts a positive-minimum count at that minimum (SPEC
@@ -86,6 +88,7 @@ fixed table Root {
 					t.Fatalf("generated Go: %v\n%s", err, out)
 				}
 			case "cs":
+				slowtest.Gate(t, "dotnet")
 				dotnet := findDotnet()
 				if dotnet == "" {
 					t.Skip("dotnet unavailable")

--- a/compiler/tabledeadc_test.go
+++ b/compiler/tabledeadc_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Card C-6: Stop emitting check_default where no probe can set it.
@@ -65,6 +67,7 @@ fixed table Outer
 
 func compileAndRunC(t *testing.T, u *ir.Unit, mainSource string) {
 	t.Helper()
+	slowtest.Gate(t, "the C compiler (cc)")
 	cc, err := exec.LookPath("cc")
 	if err != nil {
 		t.Skip("generated C execution requires cc")

--- a/compiler/tableheaderput128_test.go
+++ b/compiler/tableheaderput128_test.go
@@ -59,6 +59,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // headerProbeWideFields is the nested table's field count. It is above 127 on
@@ -432,6 +434,7 @@ int main()
 // main's emitter wrote, over values that ride BOTH arms of the field header and
 // carry 128-bit fields under every framing the emitter has for them.
 func TestCppTableHeaderAndPut128Bytes(t *testing.T) {
+	slowtest.Gate(t, "the C++ compiler")
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
 		t.Skip("the generated save path is C++: no c++ on PATH")

--- a/compiler/tablerefordinal_test.go
+++ b/compiler/tablerefordinal_test.go
@@ -46,6 +46,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // refOrdinalWideFields is the nested table's field count. It is above 127 on
@@ -246,6 +248,7 @@ int main()
 // emitter wrote, over elided nested tables, an enum-keyed array at every
 // elision shape, and an array long enough to move a reference's LEB128 width.
 func TestCppTableRefOrdinalBytes(t *testing.T) {
+	slowtest.Gate(t, "the C++ compiler")
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
 		t.Skip("the generated save path is C++: no c++ on PATH")
@@ -422,6 +425,7 @@ int main()
 // share its cached ordinal and remain correct across elision and re-interning,
 // both when the key uses its ordinal and when generic ref interns it first.
 func TestCppTableRefOrdinalSharedId(t *testing.T) {
+	slowtest.Gate(t, "the C++ compiler")
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
 		t.Skip("the generated save path is C++: no c++ on PATH")

--- a/compiler/tablesavecache_test.go
+++ b/compiler/tablesavecache_test.go
@@ -44,6 +44,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // saveCacheWideFields is the nested table's field count. It is above 127 on
@@ -201,6 +203,7 @@ int main()
 // main's emitter wrote, over arrays below, at and above the measure cache's
 // bound and over elements whose nested table elides.
 func TestCppTableSaveMeasureCacheBytes(t *testing.T) {
+	slowtest.Gate(t, "the C++ compiler")
 	cxx, err := exec.LookPath("c++")
 	if err != nil {
 		t.Skip("the generated save path is C++: no c++ on PATH")

--- a/compiler/tablescretain_test.go
+++ b/compiler/tablescretain_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func TestCTableRetainFile(t *testing.T) {
@@ -164,6 +166,7 @@ CHECK(root_load_retain_messages(roots,&count,region,need,&vocabulary,batch,sizeo
 }
 
 func TestCTableRetainRefusedByName(t *testing.T) {
+	slowtest.Gate(t, "the C compiler (cc)")
 	cc, err := exec.LookPath("cc")
 	if err != nil {
 		t.Skip("requires C compiler")

--- a/compiler/tablescs_test.go
+++ b/compiler/tablescs_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // TestCsEmitsTableSources: the cs target adds <Base>Table.cs beside the packet
@@ -470,6 +472,7 @@ table Subject {
 	}
 
 	// 5. If dotnet is available, compile and run end-to-end wire equivalence verification.
+	slowtest.Gate(t, "dotnet")
 	dotnet := findDotnet()
 	if dotnet == "" {
 		t.Skip("dotnet not found on PATH; skipping C# runtime equivalence execution")
@@ -641,6 +644,7 @@ fixed table Subject {
 		}
 	}
 
+	slowtest.Gate(t, "dotnet")
 	dotnet := findDotnet()
 	if dotnet == "" {
 		t.Skip("dotnet not found on PATH; skipping C# runtime execution")

--- a/compiler/tablescview_test.go
+++ b/compiler/tablescview_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/v2/internal/viewlisting"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func TestCTableViewOutsideClosure(t *testing.T) {
@@ -42,6 +44,7 @@ int main(void) {
 }
 
 func TestCTableViewListing(t *testing.T) {
+	slowtest.Gate(t, "the C compiler, once per corpus unit")
 	for _, path := range []string{"../tables/examples", "../tables/pointers", "../tables/maps", "../tables/lists", "../tables/arms", "../examples", "../examples-wide"} {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			c := New()

--- a/compiler/tablescwire_test.go
+++ b/compiler/tablescwire_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
 	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Exercise generated code across the first-use reference-width boundary. The
@@ -110,6 +112,7 @@ int main(void)
 
 func runCTableWireProbe(t *testing.T, u *ir.Unit, source string) {
 	t.Helper()
+	slowtest.Gate(t, "the C compiler (cc)")
 	cc, err := exec.LookPath("cc")
 	if err != nil {
 		t.Skip("generated C execution requires cc")

--- a/compiler/viewgo_test.go
+++ b/compiler/viewgo_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/v2/internal/viewlisting"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func TestGoUnitViewCorpus(t *testing.T) {
+	slowtest.Gate(t, "the Go toolchain, once per corpus unit")
 	printer, err := os.ReadFile("../test/tables/view_go.gotext")
 	if err != nil {
 		t.Fatal(err)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,6 +78,62 @@ in the `go-test` job of `ci-full.yml`.
 The Makefile's `SERIALIZE*` variables override the sibling paths if you keep
 them elsewhere.
 
+## How to run the tests, and the rule that sets their shape
+
+The owner's rule, said twice in one day:
+
+> Remember the 1-2 minute iteration rule on unit tests.
+
+And its general form: anything we iterate on answers in **one minute ideally,
+two at most**. Anything over two minutes runs **once at the end as a check, or
+nightly** — never in the loop.
+
+We had slipped. A unit test that shells out to a foreign toolchain — `cc`,
+`c++`, `dotnet`, `javac`, `cargo`, `dart`, `node`, `elixir`, or the Go toolchain
+compiling the generated unit — costs one to thirty SECONDS of somebody else's
+compiler, every run. Two packages were carrying almost all of it:
+
+| command | before | after |
+| --- | --- | --- |
+| `go test ./compiler/` | 199 s | **18 s** |
+| `go test ./internal/codegen/gotable/` | 163 s | **2.8 s** |
+| `go test ./internal/codegen/...` (19 packages) | 164 s | **~45 s** |
+| `make tables-cs-leg` | 74 s | unchanged — now also `-debug` / `-release`, ~37 s each |
+
+Nothing was dropped. `internal/slowtest` gates the toolchain half:
+
+- **the default, for the loop** — `go test ./compiler/`,
+  `go test ./internal/codegen/<leg>table/`, `go test ./...`: every pure-Go
+  test, the IR, the emitters' text, the goldens, the refusals. Each package
+  answers in seconds.
+- **the full set, for the check** — `SCHEMA_SLOW=1 go test ./compiler/
+  ./internal/codegen/...`: the same plus every toolchain test. Minutes. Run it
+  once before you open a pull request, not between edits.
+- **the nine leg gates** are unchanged, because each already exports
+  `SCHEMA_REQUIRE_CORPUS=1` and `slowtest.Enabled` counts that as the slow half
+  being on. `make tables-<leg>-fixedform`, `make tables-<leg>-versioning` and
+  `make tables-cs-leg` prove exactly what they proved before.
+- **`ci-full.yml`** sets `SCHEMA_SLOW=1` on both of its `go test` steps, so the
+  merge and nightly lanes run the whole of both halves. **`ci-fast.yml`** does
+  not, deliberately: its per-leg rows drive the make gates, which turn the slow
+  half on for the leg the diff touched — which is the two-minute lane's whole
+  idea.
+
+A gate that quietly stops running is worse than a slow one. `slowtest.Gate`
+therefore never reads whether a toolchain is present; absence still fails
+wherever `SCHEMA_REQUIRE_CORPUS` says it must.
+
+The per-leg make gates, measured on an M-series Studio:
+
+| gate | time |
+| --- | --- |
+| `make tables-cs-leg-debug` | ~37 s |
+| `make tables-cs-leg-release` | ~37 s |
+| `make tables-cs-leg` (both, the CI gate) | 74 s |
+
+Any leg gate that grows past 60 s gets split the same way: two names for the
+loop, one combined name for CI.
+
 ## The gates a change has to pass
 
 CI runs on Linux and macOS, and both must be green:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ compiler, every run. Two packages were carrying almost all of it:
 | --- | --- | --- |
 | `go test ./compiler/` | 199 s | **18 s** |
 | `go test ./internal/codegen/gotable/` | 163 s | **2.8 s** |
-| `go test ./internal/codegen/...` (19 packages) | 164 s | **~45 s** |
+| `go test ./internal/codegen/...` (19 packages) | 164 s | **22 s** (slowest: `ctable`, 17 s) |
 | `make tables-cs-leg` | 74 s | unchanged — now also `-debug` / `-release`, ~37 s each |
 
 Nothing was dropped. `internal/slowtest` gates the toolchain half:

--- a/internal/codegen/gotable/fixedform_test.go
+++ b/internal/codegen/gotable/fixedform_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func TestFixedFormEmitsSurface(t *testing.T) {
@@ -427,6 +429,7 @@ func TestPlanPath(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(testDir, "plan_test.go"), []byte(src), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", "test", "-count=1", ".")
 	cmd.Dir = testDir
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -884,6 +887,7 @@ func TestArgLane(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(testDir, "arg_lane_test.go"), []byte(src), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", "test", "-count=1", ".")
 	cmd.Dir = testDir
 	out, err := cmd.CombinedOutput()

--- a/internal/codegen/gotable/fixedlayout_test.go
+++ b/internal/codegen/gotable/fixedlayout_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // TestFixedFormLayoutRules is the Go twin of the C++ reference's
@@ -276,6 +278,7 @@ func TestLayoutMalformedResidue(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(testDir, "layout_test.go"), []byte(src), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", "test", "-count=1", "-v", ".")
 	cmd.Dir = testDir
 	out, err := cmd.CombinedOutput()

--- a/internal/codegen/gotable/fixedversioning_test.go
+++ b/internal/codegen/gotable/fixedversioning_test.go
@@ -40,6 +40,8 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
 	"github.com/mas-bandwidth/schema/v2/internal/parser"
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // ---- the rows ---------------------------------------------------------------
@@ -539,6 +541,7 @@ func runVersionProbeRetired(t *testing.T, reader string, older []string, retire 
 			t.Fatal(err)
 		}
 	}
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", "test", "-count=1", ".")
 	cmd.Dir = dir
 	return cmd.CombinedOutput()

--- a/internal/codegen/gotable/values_test.go
+++ b/internal/codegen/gotable/values_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 func runGenerated(t *testing.T, schema, testSource string) {
@@ -56,6 +58,7 @@ func runGeneratedUnit(t *testing.T, u *ir.Unit, testSource string, edit func(map
 		}
 	}
 	args := append([]string{"test", "-count=1"}, flags...)
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", append(args, ".")...)
 	cmd.Dir = dir
 	return cmd.CombinedOutput()

--- a/internal/codegen/gotable/wire_test.go
+++ b/internal/codegen/gotable/wire_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/v2/ir"
+
+	"github.com/mas-bandwidth/schema/v2/internal/slowtest"
 )
 
 // Compile and run the emitted code against an independent wire construction.
@@ -36,6 +38,7 @@ func TestWireLargeVocabularyAndZeroId(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	slowtest.Gate(t, "the Go toolchain (it compiles and runs the generated unit)")
 	cmd := exec.Command("go", "test", "-count=1", ".")
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/slowtest/slowtest.go
+++ b/internal/slowtest/slowtest.go
@@ -1,0 +1,55 @@
+// Package slowtest is ONE GATE with ONE SENTENCE behind it, the owner's, today,
+// twice:
+//
+//	"Remember the 1-2 minute iteration rule on unit tests."
+//
+// A unit test that shells out to a foreign toolchain — cc, c++, dotnet, javac,
+// cargo, dart, node, elixir — or that reads the C++ reference's corpus out of
+// build/fixedform-corpus does not cost milliseconds. It costs one to thirty
+// SECONDS of somebody else's compiler, every run, and a package full of them
+// costs minutes. `go test ./compiler/` was 185-262 s on the Studio and
+// `go test ./internal/codegen/...` several minutes more; at that price a child
+// stops running the tests, which is the only failure mode that matters.
+//
+// SO THE SPLIT IS BY WHEN, NOT BY WHETHER — the same rule ci-fast.yml already
+// carries. The DEFAULT `go test` runs everything that is pure Go: the IR, the
+// emitters' text, the goldens, the refusals. The toolchain half runs under
+// SCHEMA_SLOW=1, and it runs there ALWAYS:
+//
+//   - every make leg gate already exports SCHEMA_REQUIRE_CORPUS=1, and Enabled
+//     counts that as the slow half being ON — so not one of the nine leg gates,
+//     and not one of ci-fast.yml's per-leg rows that drive them, changed at all,
+//   - ci-full.yml's two `go test` steps set SCHEMA_SLOW=1 explicitly, so the
+//     merge and nightly lanes run the whole of both halves.
+//
+// NOTHING IS CHECKED LESS THAN BEFORE. A gate that quietly stopped running is
+// worse than a slow one, which is why Gate never reads a toolchain's presence:
+// absence still fails where SCHEMA_REQUIRE_CORPUS says it must.
+package slowtest
+
+import (
+	"os"
+	"testing"
+)
+
+// Enabled reports whether the slow half runs in this process.
+//
+// SCHEMA_REQUIRE_CORPUS counts as well, and deliberately: that variable is the
+// repo's existing promise that a named gate built the oracle and means to prove
+// it. A target that set it and not SCHEMA_SLOW=1 would otherwise go green
+// having run nothing — the exact silence make/cs.mk:425 and its eight siblings
+// were written to forbid.
+func Enabled() bool {
+	return os.Getenv("SCHEMA_SLOW") == "1" || os.Getenv("SCHEMA_REQUIRE_CORPUS") != ""
+}
+
+// Gate skips the calling test unless the slow half is enabled. `what` names the
+// cost in the skip line — the toolchain or the corpus — so the reader of a
+// default run can see exactly what did not run and why.
+func Gate(t *testing.T, what string) {
+	t.Helper()
+	if Enabled() {
+		return
+	}
+	t.Skipf("SCHEMA_SLOW: this test shells out to %s; set SCHEMA_SLOW=1 to run it (ci-full.yml and the make leg gates always do)", what)
+}

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -388,7 +388,7 @@ update-goldens-cs: build/tables-generated-cs/.stamp
 # from its wire golden, re-saved and byte-compared, and every §16 text read and
 # written beside it. It is the C# twin of tables-js-leg.
 #
-.PHONY: tables-cs-view tables-cs-leg tables-cs-wire-fuzz tables-cs-region-fuzz tables-cs-builder-fuzz tables-cs-retain-fuzz
+.PHONY: tables-cs-view tables-cs-leg tables-cs-leg-debug tables-cs-leg-release tables-cs-wire-fuzz tables-cs-region-fuzz tables-cs-builder-fuzz tables-cs-retain-fuzz
 tables-cs-view: build/tables-generated-cs/.stamp
 	@mkdir -p build/view-cs
 	@set -e; for entry in $(VIEW_CORPUS); do \
@@ -409,8 +409,16 @@ tables-cs-view: build/tables-generated-cs/.stamp
 	@grep -q "listing is not the compiler's" build/view-cs/negative.log
 	@echo "C# UnitView: $(words $(VIEW_CORPUS)) generated registries match the IR; damaged documentation is detected"
 
-tables-cs-leg: build/tables-generated-cs/.stamp
+# TWO CONFIGURATIONS, TWO NAMES, AND A COMBINED ONE — because the pair was 74 s
+# and the owner's rule is one to two minutes for anything a child iterates on.
+# Debug alone is about half that, so `make tables-cs-leg-debug` is the loop and
+# `make tables-cs-leg` is still the gate: CI and the release path run both.
+tables-cs-leg: tables-cs-leg-debug tables-cs-leg-release
+
+tables-cs-leg-debug: build/tables-generated-cs/.stamp
 	cd test/cs-tables && $(DOTNET) run
+
+tables-cs-leg-release: build/tables-generated-cs/.stamp
 	cd test/cs-tables && $(DOTNET) run -c Release
 
 # THE FIXED FORM'S VERSIONING SUITE ON THIS LEG (docs/FIXED-FORM-ALGORITHM.md §5,


### PR DESCRIPTION
The owner's rule, said twice today:

> Remember the 1-2 minute iteration rule on unit tests.

And its general form: anything we iterate on answers in one minute ideally, two at most; over two minutes runs once at the end as a check, or nightly.

**We had slipped.** On the Studio, `go test ./compiler/` was **199 s** and `go test ./internal/codegen/...` **164 s**. At that price a child stops running the tests between edits, which is the only failure mode that matters.

## The cost was never Go

It was somebody else's compiler — `cc`, `c++`, `dotnet`, `javac`, `cargo`, `dart`, `node`, `elixir`, and `go test` itself compiling a generated unit against a sibling runtime. One to thirty seconds each, every run. **Two tests in `compiler/` and one helper in `gotable/` carried almost all of it.**

### The 20 slowest, measured (`go test -count=1 -v`)

`./compiler/` — 199.4 s total:

| s | test | what makes it slow |
| --- | --- | --- |
| 104.6* | `TestGoUnitViewCorpus` | `go test` per corpus unit, serial |
| 27.8* | `TestCTableViewListing` | `cc` per corpus unit, seven corpora, serial |
| 17.5 | `TestCppVariableWideAlignment` | `c++` compile+run per case |
| 12.2 | `TestIssue710PacketStringBounds` | `cc`/`c++` compile+run |
| 11.6 | `TestCppTableRefOrdinalBytes` | `c++` compile+run |
| 8.0 | `TestTableClosureCountDefaults` | `dotnet run` |
| 7.0 | `TestCppTableSaveMeasureCacheBytes` | `c++` compile+run |
| 6.8 | `TestRepeatedArrayTailDefaults` | `cc`+`c++`, sanitizer variants |
| 6.0 | `TestCppTableHeaderAndPut128Bytes` | `c++` compile+run |
| 4.3 | `TestCppTableRetainFramedDepth` | `c++`, sanitizer subtests |
| 4.2 | `TestIssue715Base64ReaderDefaults` | `dotnet run` + `cc` |
| 4.1 | `TestCTableBlobRuntimeFollowsTheCensus` | `cc` |
| 3.9 | `TestCTableRetainFramedDepth` | `cc` |
| 3.8 | `TestCppCollectionWidening` | `c++` |
| 3.0 | `TestCTableRefOrdinalBytes` | `cc` |
| 2.7 | `TestCTableRetainMessageDroppedMapKey` | `cc` |
| 2.7 | `TestCTableWidenF32FollowsTheCensus` | `cc` |
| 2.6 | `TestCsTypedVsDynamicWireEquivalence` | `dotnet run` |
| 2.4 | `TestCppTableWidenListWidthFollowsTheCensus` | `c++` |
| 2.3 | `TestCTableWideTextRuntimeFollowsTheCensus` | `cc` |

`./internal/codegen/gotable/` — 163 s total, a long tail of the same shape: `TestFixedRedTeamOptionalAddedAndPayloadAppended` 10.7 s, `TestUnitViewPacketStorage` 9.2 s, `TestRetainUnknownNodeRecord` 8.9 s, `TestRetainMessageMapKeyProbe` 8.4 s, `TestFixedRedTeamUnionArmWidensTheSlot` 8.0 s, `TestWireLargeVocabularyAndZeroId` 6.5 s, `TestFixedRedTeamStringGrowsWithAFollowingField` 6.4 s, `TestFixedRedTeamWidenedTableInTwoPlaces` 5.9 s — every one of them `go test -count=1 .` over a generated unit, six call sites in five files.

\* the two starred numbers come from a run with another measurement sharing the Studio; standalone they are 15.0 s and 15.7 s. They are still the two biggest items in the package either way.

## Before / after

| command | before | after |
| --- | --- | --- |
| `go test ./compiler/` | **199 s** | **17.7 s** |
| `go test ./internal/codegen/gotable/` | **163 s** | **2.8 s** |
| `go test ./internal/codegen/...` (19 packages) | **164 s** | **22 s** |
| `go test ./internal/codegen/ctable/` | 33 s | 17 s (slowest survivor; its `cc` tests are not gated) |
| `make tables-cs-leg` | 74 s | 74 s for the CI gate; **~37 s** for `-debug` alone |

## The split is by when, not by whether

`internal/slowtest` is one gate with two lines behind it. Default: every pure-Go test — the IR, the emitters' text, the goldens, the refusals. `SCHEMA_SLOW=1`: that plus the toolchain half.

**Nothing runs less than before, and the proof is that the nine leg gates were not touched.** Each already exports `SCHEMA_REQUIRE_CORPUS=1`, and `slowtest.Enabled` counts that as the slow half being on — so `make tables-<leg>-fixedform`, `make tables-<leg>-versioning` and every `ci-fast.yml` per-leg row prove exactly what they proved before, with no edit. `ci-full.yml`'s two `go test` steps set `SCHEMA_SLOW=1` explicitly, so the merge and nightly lanes run both halves in full. `ci-fast.yml`'s `go-test-touched` job is deliberately left on the fast default: its leg rows are where a touched leg's toolchain is proved, which is that lane's whole idea.

`Gate` never reads whether a toolchain is present. Absence still **fails** wherever `SCHEMA_REQUIRE_CORPUS` says it must — a gate that quietly stops running is worse than a slow one.

## `make tables-cs-leg`, 74 s, split

Two `dotnet run`s, Debug and Release. Now `tables-cs-leg-debug` and `tables-cs-leg-release` at about 37 s each, with `tables-cs-leg` depending on both. A child iterates on Debug; CI's gate is the same name it was.

## The gates, run

| gate | result |
| --- | --- |
| `time go test ./compiler/` (default) | **17.7 s** — under 60 s |
| `time go test ./internal/codegen/...` (default) | **22 s** total, slowest package `ctable` at 17 s — under 120 s |
| `SCHEMA_SLOW=1 go test ./compiler/` | **green**, 253 s, `=== RUN` count **1521 before, 1521 after, zero skips** |
| `SCHEMA_SLOW=1 go test ./internal/codegen/gotable/` | **green**, 63 s, top-level tests **105 before, 105 after** |
| `go test ./internal/ci/` | green (workflows changed) |
| `gofmt -l .` | silent |
| `go vet ./compiler/ ./internal/codegen/... ./internal/slowtest/` | silent |

The count check is the one that matters: under `SCHEMA_SLOW=1` the compiler package enters **exactly** the 1521 `=== RUN` lines it entered before this PR, and skips none of them. Nothing was dropped.

## One honest coverage shift, named

`ci-fast.yml`'s `go-test-touched` job no longer compiles C++/C/C# from `compiler/`'s own probes on a pull request — they are the slow half, and this lane's budget is two minutes. They run in `ci-full.yml` (merge, nightly, the `full-ci` label, `gh workflow run`) and in any local `SCHEMA_SLOW=1` run. That is the same trade `ci-fast.yml` already made for the 47 negative controls and the nine conformance legs, and the conservative remedy for a risky diff is the `full-ci` label, as it is today. Flag it if you want those probes on every PR instead — the alternative is a 200 s row on the fast lane, which is the thing we are fixing.

## Not yet under 60 s, and why

- `go test ./internal/codegen/ctable/` is **17 s** — comfortably inside its per-package budget, so it is left alone in this PR. Its `cc` sites (`matched_width_test.go`, `fixedversioning_test.go`) are the same one-line gate the day it grows.
- `make tables-cs-leg` (combined) stays 74 s **by design** — it is the gate, not the loop; the loop is `-debug`.

## Documentation

`docs/CONTRIBUTING.md` gains "How to run the tests, and the rule that sets their shape": the fast default, the `SCHEMA_SLOW=1` full run, the per-leg gates with their times, and the rule in the owner's own sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
