### PR TITLE
ci: nothing runs on a PR; the fast lane on push to our branches, the full lane where a merge lands

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -410,6 +410,28 @@ jobs:
       # THE TWO GATES. The target names are the tree's own — the same ones
       # `make test` and ci-full.yml run — so a leg that renames a gate renames
       # it in one place and this row follows.
+      #
+      # AND THE OVERRIDES ARE THE ONES ci-full.yml PASSES, NOT THE ONES
+      # test/conformance/<leg>/ci.json PASSES, and the difference cost this
+      # lane its first red (run 34600421804, the rust row on PR #949): the
+      # rust row here was written with `RUSTUP_BIN=/usr/bin`, which is what the
+      # conformance registry hands the CONFORMANCE leg — correct there, where
+      # every target it names is a `cargo build`. But `tables-rust-versioning`
+      # is A GO TEST that shells out to cargo (make/rust.mk:309), and make
+      # prepends $(RUSTUP_BIN) to PATH around the whole recipe. /usr/bin is
+      # where the runner image keeps its OWN go — 1.24.13 — so prepending it
+      # put that Go in front of the 1.26 actions/setup-go had just installed,
+      # and the gate died before asserting anything:
+      #
+      #   go: go.mod requires go >= 1.26 (running go 1.24.13; GOTOOLCHAIN=local)
+      #   make: *** [make/rust.mk:309: tables-rust-versioning] Error 1
+      #
+      # So the rust row passes NO RUSTUP_BIN, exactly as ci-full.yml's rust
+      # versioning step does, and for the reason that step names: the default
+      # is a homebrew keg that does not exist on a runner, prepending a
+      # directory that is not there costs nothing, and cargo resolves out of
+      # the toolchain the `dtolnay/rust-toolchain` step above installed.
+      # internal/ci's TestNoWorkflowShadowsTheGoToolchain keeps it that way.
       - name: the ${{ matrix.leg }} leg's fixed form and versioning rows
         run: |
           set -euo pipefail
@@ -417,7 +439,7 @@ jobs:
             cpp)    make tables-fixedform ;;
             go)     make tables-go-fixed-form tables-go-versioning ;;
             c)      make tables-c-fixedform tables-c-versioning ;;
-            rust)   make tables-rust-fixedform tables-rust-versioning RUSTUP_BIN=/usr/bin ;;
+            rust)   make tables-rust-fixedform tables-rust-versioning ;;
             js)     make tables-js-fixed-form tables-js-versioning NODE=node ;;
             cs)     make tables-cs-leg tables-cs-versioning ;;
             java)   make tables-java-fixedform JAVA=java JAVAC=javac ;;

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -29,15 +29,16 @@ name: CI fast
 # treats a queue as a budget.
 #
 # SO THE SPLIT IS BY WHEN, NOT BY WHETHER. Nothing is checked less than before.
-#   * THIS FILE runs on every pull-request push. Five jobs, selected BY PATH,
+#   * THIS FILE runs on every push to one of our branches (see `on:` below —
+#     it no longer runs on a pull request at all). Five jobs, selected BY PATH,
 #     targeting two minutes wall: the cheap lints, the block zero-cost gate,
 #     `go test` of the packages the diff touches, and the fixed-form and
 #     versioning gates of the LEGS the diff touches.
 #   * ci-full.yml runs everything — the whole go-test, pins, the nine
 #     conformance legs, the 47 negative controls, windows, msvc, big-endian,
 #     vuln — on merge to main or fixed-table-form, nightly, on
-#     `gh workflow run ci-full.yml --ref <branch>`, and on any pull request
-#     carrying the `full-ci` label.
+#     `gh workflow run ci-full.yml --ref <branch>`, and on a pull request only
+#     when somebody adds the `full-ci` label to ask for it.
 #
 # THE SELECTION IS BY PATH AND NEVER BY DROPPING A GATE. A diff that touches
 # ir/, compiler/, docs/FIXED-FORM-*, the C++ reference's emitters, tables/, the
@@ -74,15 +75,16 @@ name: CI fast
 # dist toolchains. The `actions/cache` restores are skipped on self-hosted for
 # the same reason: what they were restoring is already there.
 #
-# ci-full.yml IS UNCHANGED and still runs on GitHub's hosted Linux runners. The
-# full lane is the one that proves the bytes on an x86-64 box we do not own, and
-# the merge gate is not where we trade breadth for speed.
+# ci-full.yml RUNS WHERE A MERGE LANDS: on the studio pool for a merge into
+# fixed-table-form, and on GitHub's hosted Linux runners for the one run per
+# merge into main — the x86-64 box we do not own is what proves the bytes, and
+# the merge into main is not where we trade breadth for speed.
 #
-# ONLY THE TABLE PUSHES TO THIS REPOSITORY. A self-hosted runner executes a pull
-# request's own code on our hardware, so a pull request from a FORK MUST NEVER
-# reach these machines: every job below carries
-#   if: github.event.pull_request.head.repo.full_name == github.repository
-# and a fork's pull request is covered by ci-full.yml on hosted runners.
+# ONLY THE TABLE PUSHES TO THIS REPOSITORY. A self-hosted runner executes the
+# pushed code on our hardware, so code from a FORK MUST NEVER reach these
+# machines. That is now structural rather than a job-level `if:`: the only
+# trigger is a push to a branch of this repository, and a fork's pull request
+# is covered by ci-full.yml on hosted runners when its merge lands.
 #
 # SPACE IS NOT IN THE POOL, and the reason is worth writing down: the x86-64
 # Linux box has ONE CORE. It is registered as `space-x64` for a future
@@ -93,9 +95,33 @@ name: CI fast
 #   for d in ~/actions-runner ~/actions-runner-[2-6]; do (cd "$d" && ./svc.sh stop); done
 # and `./svc.sh start` the same way to bring it back.
 
+# NOTHING HERE RUNS ON A PULL REQUEST, and the ruling that changed it is the
+# owner's, 2026-09-11, verbatim:
+#
+#   "Here is another option to speed up, check in to branches without PRs. Only
+#    run tests when merging into main, local runners elsewhere."
+#
+# So the trigger is THE PUSH TO OUR OWN BRANCH, not the pull request on it. A
+# pull request stays the READ SURFACE — the diff, the body, the owed lists, the
+# verdict another line records — and it costs no hosted minutes and starts no
+# run. The merge condition is the LOCAL GATE (`merge-lane.sh --local-gates`,
+# which runs this file's own steps on the Studio) plus that read, and the full
+# lane runs WHERE A MERGE LANDS (ci-full.yml).
+#
+# THE BRANCH PREFIXES ARE THE FAMILY'S. One line per line of work, so a push to
+# a branch of ours gets a second-opinion fast run on our own hardware for free,
+# and a push to a fork or to a branch nobody here owns starts nothing. Every job
+# below is `runs-on: [self-hosted, studio]` and NEVER a hosted runner: this
+# trigger fires only for a branch inside this repository, so no fork's code can
+# reach the pool through it.
 on:
-  pull_request:
-    branches: [ main, fixed-table-form ]
+  push:
+    branches:
+      - 'rowan/**'
+      - 'johnny/**'
+      - 'emma/**'
+      - 'freddy/**'
+      - 'stella/**'
   workflow_dispatch:
 
 # A superseded push cancels its predecessor: this lane is for the tip of a
@@ -122,7 +148,6 @@ jobs:
   # It is deliberately the only `needs:` in this file — every gate that can
   # start immediately does.
   plan:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [ self-hosted, studio ]
     timeout-minutes: 5
     outputs:
@@ -248,7 +273,6 @@ jobs:
   # compiles a tool of its own, which is a minute this lane does not have, and
   # they run in ci-full.yml.
   lint-fast:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [ self-hosted, studio ]
     timeout-minutes: 5
     steps:
@@ -308,7 +332,6 @@ jobs:
   # IT TAKES NO CACHE, deliberately, like the job it comes from: this is where
   # "the build did no work" must not be an available explanation for a green.
   block-gate:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [ self-hosted, studio ]
     timeout-minutes: 5
     steps:
@@ -330,7 +353,7 @@ jobs:
   # below are where they are made to run.
   go-test-touched:
     needs: plan
-    if: needs.plan.outputs.packages != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: needs.plan.outputs.packages != ''
     runs-on: [ self-hosted, studio ]
     timeout-minutes: 10
     steps:
@@ -391,7 +414,7 @@ jobs:
   # that failed to build is a failure here, never a quiet skip.
   leg-gate:
     needs: plan
-    if: needs.plan.outputs.legs != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: needs.plan.outputs.legs != '[]'
     name: fixed form + versioning (${{ matrix.leg }})
     runs-on: [ self-hosted, studio ]
     timeout-minutes: 10

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -381,6 +381,28 @@ jobs:
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
           restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
+      # THE SIBLING RUNTIMES, AND THIS STEP IS POOL DEFECT (4). A touched-package
+      # run can reach any leg's table codegen test, and those generate a probe
+      # whose go.mod REPLACES github.com/mas-bandwidth/serialize.go with
+      # ../serialize.go. With no sibling here the gate does not skip, it fails
+      # by name — run 34603030435, internal/codegen/gotable at 190 s:
+      #   replacement directory /Users/glenn/actions-runner-3/_work/schema/serialize.go
+      #   does not exist
+      # It is every sibling because `plan` can hand this job ./..., and it is
+      # rm -rf first because a self-hosted workspace parent is warm: a previous
+      # run's clones are still here and `git clone` fails by name on them.
+      - name: Check out the sibling runtimes (pinned releases)
+        run: |
+          set -euo pipefail
+          cd ..
+          rm -rf serialize serialize.c serialize.go serialize.rs serialize.cs serialize.js
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
+
       - name: go test the touched packages
         env:
           PACKAGES: ${{ needs.plan.outputs.packages }}

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -88,6 +88,20 @@ name: CI full
 # The fix is to rebase the branch; the mitigation is below on `cpp-lock`, which
 # no longer skips itself on the workflow_dispatch runs a worker falls back to.
 
+# THE FULL LANE RUNS WHERE A MERGE LANDS, and the ruling that decided it is the
+# owner's, 2026-09-11, verbatim:
+#
+#   "Here is another option to speed up, check in to branches without PRs. Only
+#    run tests when merging into main, local runners elsewhere."
+#
+# So: nothing in this file runs because a pull request exists or because somebody
+# pushed to it. A merge into fixed-table-form runs the whole of it ON OUR OWN
+# HARDWARE (the studio pool), a merge into main runs it on GitHub's hosted Linux
+# — the one hosted run per main merge, on the x86-64 box we do not own, which is
+# what proves the bytes — and the nightly stays hosted for the same reason. The
+# `full-ci` LABEL path remains for an explicit ask and for nothing else: it fires
+# on `labeled` only, so adding the label asks for one run and a later push to
+# that branch does not silently ask again.
 on:
   push:
     # THE MERGE GATE. main, and the fixed-form integration branch while the
@@ -96,13 +110,12 @@ on:
     # every merge into that branch.
     branches: [ main, fixed-table-form ]
   pull_request:
-    # A pull request runs this file only when it carries the `full-ci` label —
-    # every job below is gated on that. The label is how a branch near the hot
-    # paths, or anything that moves the C++ emitters, asks for the whole suite
-    # before merging; `gh workflow run ci-full.yml --ref <branch>` is the other
-    # way, and needs no label.
+    # NOT A PLAIN PULL-REQUEST TRIGGER: `labeled` only. Adding `full-ci` is how a
+    # branch near the hot paths, or anything that moves the C++ emitters, asks
+    # for the whole suite before merging. `gh workflow run ci-full.yml --ref
+    # <branch>` is the other way, needs no label, and lands on the studio pool.
     branches: [ main, fixed-table-form ]
-    types: [ opened, synchronize, reopened, labeled ]
+    types: [ labeled ]
   schedule:
     # nightly, so a tree nobody pushed to is still checked against the
     # toolchains and the vulnerability database, which move on their own
@@ -166,7 +179,7 @@ jobs:
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: go-test (${{ matrix.group }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     # THREE PACKAGE GROUPS, ONE PER ROW, because this job was 650 s median
     # (2026-09-11) and a matrix row is a job: the emitter packages, everything
@@ -401,8 +414,11 @@ jobs:
       # launcher. The corpus it reads is the one the Rust step above already
       # built, and SCHEMA_REQUIRE_CORPUS=1 makes a missing corpus or a missing
       # Elixir a failure rather than a silent skip.
+      # `runner.environment == 'github-hosted'` because erlef/setup-beam does not
+      # support macOS and the studio pool is macOS: there the BEAM comes from
+      # /Users/Shared/schema-dist, already on the runner's PATH.
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
-        if: matrix.group == 'versioning'
+        if: matrix.group == 'versioning' && runner.environment == 'github-hosted'
         with:
           otp-version: '27'
           elixir-version: '1.18'
@@ -469,7 +485,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -550,7 +566,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -582,7 +598,7 @@ jobs:
           restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
 
       - name: rewrite every pin under testdata/ from the reference
-        run: make -j"$(nproc)" conformance-pin update-goldens
+        run: make -j"$(getconf _NPROCESSORS_ONLN)" conformance-pin update-goldens
 
       - name: the pins are current
         run: |
@@ -624,7 +640,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
@@ -663,7 +679,7 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: conformance (${{ matrix.lang }})
     needs: conformance-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -745,8 +761,10 @@ jobs:
       # The BEAM is two versions and one step. No ELIXIRC override is needed:
       # make/elixir.mk's default prefixes the repo-local dist/ onto PATH and
       # falls through to the toolchain this step installed.
+      # hosted only: erlef/setup-beam does not support macOS (the studio pool),
+      # where dist/ already carries the BEAM on PATH.
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
-        if: matrix.otp != ''
+        if: matrix.otp != '' && runner.environment == 'github-hosted'
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
@@ -777,7 +795,7 @@ jobs:
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: C# fuzz (${{ matrix.name }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -859,6 +877,11 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # STAYS HOSTED ON EVERY EVENT: this row apt-installs the s390x cross gcc and
+    # qemu-user at pinned Ubuntu versions. The studio pool is macOS and has
+    # neither, so big-endian, `windows` and `msvc` are the three rows the pool
+    # cannot take — a merge into fixed-table-form runs those three hosted and
+    # everything else on our own hardware.
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -915,7 +938,7 @@ jobs:
       # bin/schema and the generated tree, which make builds once. The runner
       # has four cores and the leg was spending them one at a time.
       - name: the big-endian leg, and its negative control
-        run: make -j"$(nproc)" tables-big-endian-negative-control BE_CXX=s390x-linux-gnu-g++-13 BE_CC=s390x-linux-gnu-gcc-13
+        run: make -j"$(getconf _NPROCESSORS_ONLN)" tables-big-endian-negative-control BE_CXX=s390x-linux-gnu-g++-13 BE_CC=s390x-linux-gnu-gcc-13
 
       # The C twin of that control: put16 never reaches table_writer_finish's
       # #else arm, so a C-side byte-order defect there would leave the job green.
@@ -950,7 +973,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1038,7 +1061,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1311,7 +1334,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1354,7 +1377,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1457,7 +1480,7 @@ jobs:
     # merge, the nightly and a dispatch it always runs. The expression is
     # repeated per job because a job-level `if:` cannot read `env`.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -1501,7 +1524,7 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     name: negative controls (${{ matrix.name }})
     needs: negative-controls-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ ((github.event_name == 'push' && github.ref_name == 'fixed-table-form') || github.event_name == 'workflow_dispatch') && fromJSON('["self-hosted","studio"]') || 'ubuntu-latest' }}
     # THE RULE, ENFORCING ITSELF. Every row here is cut to 120 s of control
     # time and pays about 25 s of checkout, sibling clones and first build on
     # top, so five minutes is generous and a row that reaches it is a row that
@@ -1578,8 +1601,10 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # hosted only: erlef/setup-beam does not support macOS (the studio pool),
+      # where dist/ already carries the BEAM on PATH.
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
-        if: matrix.otp != ''
+        if: matrix.otp != '' && runner.environment == 'github-hosted'
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
@@ -1589,7 +1614,7 @@ jobs:
       # building them here keeps the build cost out of the first control's
       # timing and out of its log.
       - name: build bin/schema and the generated tree once
-        run: make -j"$(nproc)" bin/schema build/tables-generated/.stamp
+        run: make -j"$(getconf _NPROCESSORS_ONLN)" bin/schema build/tables-generated/.stamp
 
       # ONE make invocation for the whole group, with -k so a control that
       # refuses does not hide the ones behind it: every control in the group

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -201,7 +201,14 @@ jobs:
 
       - name: Check out the C, C++, C# and Go serialize runtimes (pinned releases)
         run: |
+          set -euo pipefail
           cd ..
+          # A SELF-HOSTED RUNNER'S WORKSPACE PARENT PERSISTS BETWEEN RUNS, so a
+          # previous run's sibling clones are still sitting here and `git clone`
+          # fails by name on them ("destination path already exists"). They are
+          # removed and re-cloned at the pinned tag every time, never reused:
+          # the sibling pins are part of what a green means.
+          rm -rf serialize serialize.c serialize.cs serialize.go
           git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"   https://github.com/mas-bandwidth/serialize.git   serialize
           git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG" https://github.com/mas-bandwidth/serialize.c.git serialize.c
           git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
@@ -221,8 +228,18 @@ jobs:
         if: matrix.group == 'versioning'
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
+      # HOSTED ONLY, and that gate is the whole of pool defect (2). All six
+      # studio runners share one $HOME, so six concurrent setup-dotnet steps
+      # install the same SDK into the same ~/.dotnet at the same time; run
+      # 34603066277 caught one of them reading a half-written 10.0.401 —
+      #   the library 'libhostpolicy.dylib' required to execute the application
+      #   was not found in '/Users/glenn/.dotnet/sdk/10.0.401/'
+      # — and every cs row went red on a probe that never built. The Studio
+      # already carries an SDK inside the pin's band (10.0.400 and 10.0.401,
+      # .github/dotnet-version says 10.0) on PATH at ~/.local/bin, so the pool
+      # needs no install at all. Same gate ci-fast.yml's cs row already uses.
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        if: matrix.group == 'versioning'
+        if: matrix.group == 'versioning' && runner.environment == 'github-hosted'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 
@@ -367,10 +384,13 @@ jobs:
       - name: the fixed form's versioning suite on the Rust leg
         if: matrix.group == 'versioning'
         run: |
-          if [ ! -d ../serialize.rs ]; then
-            git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" \
-              https://github.com/mas-bandwidth/serialize.rs.git ../serialize.rs
-          fi
+          set -euo pipefail
+          # NOT `if [ ! -d ]`: on a warm self-hosted workspace that arm REUSES a
+          # previous run's clone, which is how a stale sibling would survive a
+          # pin bump. Removed and re-cloned at the pin every time.
+          rm -rf ../serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" \
+            https://github.com/mas-bandwidth/serialize.rs.git ../serialize.rs
           make tables-rust-versioning
 
       # THE SAME GATE ON THE JAVASCRIPT LEG (§5.9 #11: every leg owes both
@@ -573,7 +593,14 @@ jobs:
 
       - name: Check out the C++, C# and Go serialize runtimes (pinned releases)
         run: |
+          set -euo pipefail
           cd ..
+          # A SELF-HOSTED RUNNER'S WORKSPACE PARENT PERSISTS BETWEEN RUNS, so a
+          # previous run's sibling clones are still sitting here and `git clone`
+          # fails by name on them ("destination path already exists"). They are
+          # removed and re-cloned at the pinned tag every time, never reused:
+          # the sibling pins are part of what a green means.
+          rm -rf serialize serialize.cs serialize.go
           git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git serialize
           git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
           git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
@@ -698,7 +725,10 @@ jobs:
       - name: Check out the sibling runtime this leg needs (pinned release)
         if: matrix.runtime != ''
         run: |
+          set -euo pipefail
           tag=$(printenv "${{ matrix.runtime_tag }}")
+          # warm self-hosted workspace: the parent persists, so remove first
+          rm -rf "../${{ matrix.runtime }}"
           git clone --quiet --depth 1 --branch "$tag" "https://github.com/mas-bandwidth/${{ matrix.runtime }}.git" "../${{ matrix.runtime }}"
 
       # bin/schema and the generated table units come out of Go in every leg.
@@ -734,8 +764,10 @@ jobs:
         if: matrix.dotnet != ''
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
+      # hosted only: the studio pool shares one ~/.dotnet across six runners
+      # and already carries an SDK in the pin's band (pool defect 2).
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        if: matrix.dotnet != ''
+        if: matrix.dotnet != '' && runner.environment == 'github-hosted'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 
@@ -811,6 +843,9 @@ jobs:
 
       - name: Check out the serialize.cs runtime (pinned release)
         run: |
+          set -euo pipefail
+          # warm self-hosted workspace: the parent persists, so remove first
+          rm -rf ../serialize.cs
           git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git ../serialize.cs
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -835,7 +870,10 @@ jobs:
       - name: read the .NET SDK pin
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
+      # hosted only: the studio pool shares one ~/.dotnet across six runners
+      # and already carries an SDK in the pin's band (pool defect 2).
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        if: runner.environment == 'github-hosted'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 
@@ -923,7 +961,11 @@ jobs:
       # other job uses: a table unit declaring a 128-bit field takes its
       # storage type (serialize::int128_t / uint128_t) from serialize.h.
       - name: Check out the serialize runtime (pinned release)
-        run: git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git ../serialize
+        run: |
+          set -euo pipefail
+          # warm self-hosted workspace: the parent persists, so remove first
+          rm -rf ../serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git ../serialize
 
       # The battery on the target, then the control that proves it can fail.
       # BE_CXX and BE_CC name the pinned compilers: the exact-version package
@@ -961,7 +1003,10 @@ jobs:
       # package as its table sources, and those import it.
       - name: Check out the Go serialize runtime (pinned release)
         run: |
+          set -euo pipefail
           cd ..
+          # warm self-hosted workspace: the parent persists, so remove first
+          rm -rf serialize.go
           git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
 
       - name: the Go table leg, big-endian
@@ -1212,7 +1257,11 @@ jobs:
       # reach for it — a table header includes nothing of it.
       - name: Check out the serialize runtime (pinned release)
         shell: bash
-        run: git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git ../serialize
+        run: |
+          set -euo pipefail
+          # a persistent workspace parent would fail the clone by name
+          rm -rf ../serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git ../serialize
 
       # Generation and script emission happen in bash because they are readable
       # there; the cl steps stay short. The corpus list mirrors the Makefile's
@@ -1543,7 +1592,14 @@ jobs:
       # remove the whole class of "the group forgot a sibling".
       - name: Check out the serialize runtimes (pinned releases)
         run: |
+          set -euo pipefail
           cd ..
+          # A SELF-HOSTED RUNNER'S WORKSPACE PARENT PERSISTS BETWEEN RUNS, so a
+          # previous run's sibling clones are still sitting here and `git clone`
+          # fails by name on them ("destination path already exists"). They are
+          # removed and re-cloned at the pinned tag every time, never reused:
+          # the sibling pins are part of what a green means.
+          rm -rf serialize serialize.c serialize.go serialize.rs serialize.cs serialize.js
           git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
           git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
           git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
@@ -1580,8 +1636,10 @@ jobs:
         if: matrix.dotnet != ''
         run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
 
+      # hosted only: the studio pool shares one ~/.dotnet across six runners
+      # and already carries an SDK in the pin's band (pool defect 2).
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        if: matrix.dotnet != ''
+        if: matrix.dotnet != '' && runner.environment == 'github-hosted'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -106,6 +106,59 @@ pool cannot take stay hosted on every event, because they need an OS it does not
 have: `big-endian` (s390x cross gcc and qemu-user on pinned Ubuntu), `windows`
 and `msvc`.
 
+### The studio pool
+
+**Six self-hosted runners on the Studio** (Apple M3 Ultra, macOS), labelled
+`[self-hosted, studio]`, one directory each:
+
+```
+~/actions-runner  ~/actions-runner-2  ~/actions-runner-3
+~/actions-runner-4  ~/actions-runner-5  ~/actions-runner-6
+```
+
+Six is the matrix width that matters: the fast lane's nine leg rows and the full
+lane's job groups fan out across them, and a seventh would contend for the same
+cores. One runner takes one job at a time.
+
+**Stopping and starting them** — each directory carries its own service script:
+
+```
+cd ~/actions-runner-3 && ./svc.sh stop      # also: start, status
+```
+
+**Never stop or start a runner during a benchmark window, and never let the pool
+run one.** A benchmark measures this machine; a CI job on the same cores makes
+the number a fiction. Stop all six before a benchmark window and start them
+after.
+
+**The warm-workspace rule.** A self-hosted runner's workspace — and, more
+importantly, its **parent** — persists between runs. `actions/checkout` cleans
+the repository directory itself (nothing in either workflow sets `clean: false`,
+and nothing may), but the sibling checkouts every leg's Makefile reaches for as
+`../serialize*` sit in that parent and survive. So **every step that clones a
+sibling runtime `rm -rf` the directory first and re-clones at the pinned tag** —
+never `if [ ! -d ]`, never a bare `git clone`. Two ways that rule is earned:
+
+- A bare clone fails by name on the second run —
+  `fatal: destination path 'serialize' already exists and is not an empty directory`.
+- A `[ ! -d ]` guard succeeds and reuses whatever the previous run left, which
+  is how a stale sibling survives a pin bump. The sibling pins are part of what
+  a green means.
+
+**A toolchain install is not a per-job step on the pool.** All six runners share
+one `$HOME`, so six concurrent `setup-*` actions write the same directory at the
+same time; one job reading a half-written SDK is enough to go red. Every
+toolchain step in both workflows is therefore gated
+`if: runner.environment == 'github-hosted'`, and the pool uses what the Studio
+already has:
+
+| toolchain | where it lives on the Studio |
+| --- | --- |
+| Go, clang, make, rustup | the keeper's own PATH |
+| .NET SDK | `~/.local/bin/dotnet` → `~/.dotnet` (10.0.400 and 10.0.401; `.github/dotnet-version` pins the band, `10.0`) |
+| JDK 21, Elixir, OTP, Dart, Node | `/Users/Shared/schema-dist` — the same `dist/` the Makefiles take |
+
+
 CI runs on Linux and macOS, and both must be green:
 
 - `make test` — the cross-language corpus and the goldens.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -80,6 +80,32 @@ them elsewhere.
 
 ## The gates a change has to pass
 
+**The loop, in five lines** (the owner's ruling, 2026-09-11: *"Here is another
+option to speed up, check in to branches without PRs. Only run tests when
+merging into main, local runners elsewhere."*):
+
+1. Run the local gate on your own machine — `make test` and
+   `go test ./internal/fuzz/`, or `merge-lane.sh gate <pr> <head> green <summary>`
+   from a recorded local fast-lane run.
+2. Push the branch. A push to `rowan/**`, `johnny/**`, `emma/**`, `freddy/**` or
+   `stella/**` runs `ci-fast.yml` on our own self-hosted studio pool — a free
+   second opinion on our hardware, never on a hosted runner.
+3. Open the pull request as **the record**: the diff, the body and the owed lists
+   live there. **No hosted workflow runs on a pull-request event at all** (only
+   the Contributor Assignment Agreement check, which is not a test).
+4. Get a read from another line and record it (`merge-lane.sh read <pr> <who>
+   approve`).
+5. The lane merges on **local green plus that read** — and the full lane runs
+   **where the merge lands**: `ci-full.yml` on the studio pool for a merge into
+   `fixed-table-form`, and on hosted `ubuntu-latest` for a merge into `main`.
+
+**Hosted CI runs only on a merge into `main` and nightly** — plus the two
+explicit asks: `gh workflow run ci-full.yml --ref <branch>` (which lands on the
+studio pool) and adding the `full-ci` label to a pull request. Three rows the
+pool cannot take stay hosted on every event, because they need an OS it does not
+have: `big-endian` (s390x cross gcc and qemu-user on pinned Ubuntu), `windows`
+and `msvc`.
+
 CI runs on Linux and macOS, and both must be green:
 
 - `make test` — the cross-language corpus and the goldens.

--- a/internal/ci/ci_test.go
+++ b/internal/ci/ci_test.go
@@ -333,3 +333,109 @@ func gitLsFiles(t *testing.T, root, dir string) []string {
 	}
 	return paths
 }
+
+// pathPrependingMakeVars DISCOVERS, from the make includes themselves, every
+// variable whose value a recipe prepends to PATH — `PATH="$(RUSTUP_BIN):$$PATH"`
+// and its kind. It is discovered rather than listed because the set grows with
+// the legs: a tenth language that hands its toolchain in the same way lands in
+// this gate with no edit here.
+func pathPrependingMakeVars(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(root, "make", "*.mk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths = append(paths, filepath.Join(root, "Makefile"))
+	prepend := regexp.MustCompile(`PATH="\$\(([A-Z_][A-Z0-9_]*)\):`)
+	out := map[string]bool{}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatal(err)
+		}
+		for _, m := range prepend.FindAllStringSubmatch(string(data), -1) {
+			out[m[1]] = true
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no PATH-prepending make variable found under make/ — this gate would pass over an empty set")
+	}
+	return out
+}
+
+// theImagesOwnToolchainDirs are the directories a GitHub runner image keeps its
+// own, older compilers in. They are on PATH already and BEHIND what
+// actions/setup-go and its siblings install, which is the whole point of a
+// setup step: the installed toolchain goes in front.
+var theImagesOwnToolchainDirs = []string{"/usr/bin", "/bin", "/usr/local/bin", "/usr/sbin"}
+
+// TestNoWorkflowShadowsTheGoToolchain refuses a workflow that hands a make
+// target a toolchain directory make will PREPEND TO PATH, when that directory
+// is one of the runner image's own bin directories.
+//
+// THE RED THIS GATE COMES FROM (run 34600421804, the fast lane's rust row on
+// PR #949). ci-fast.yml's leg-gate ran
+//
+//	make tables-rust-fixedform tables-rust-versioning RUSTUP_BIN=/usr/bin
+//
+// copying the override out of test/conformance/rust/ci.json, where it is
+// correct: every target that row names is a `cargo build`, and the image's
+// cargo is the one it wants. But make prepends $(RUSTUP_BIN) to PATH around the
+// WHOLE recipe, and `tables-rust-versioning` is a GO TEST that shells out to
+// cargo — so /usr/bin went in front of the Go 1.26 actions/setup-go had just
+// installed, the image's own go 1.24.13 answered, and the gate died on
+// `go.mod requires go >= 1.26` without asserting one row of §5. A gate that
+// cannot run is indistinguishable from a gate nobody wrote.
+//
+// THE RULE, THEN: a workflow names a toolchain by installing it, never by
+// prepending the image's own bin directory over what it installed. Where a leg
+// genuinely needs nothing but the image's tool, the make default — a homebrew
+// keg that does not exist on a runner — already resolves it: prepending a
+// directory that is not there costs nothing and leaves every setup step's
+// toolchain in front, which is what ci-full.yml's rust versioning step does.
+//
+// THE GATE IS SCOPED TO THE FAST LANE, AND THE REST IS A REPORTED FINDING
+// RATHER THAN A SILENT EXEMPTION. `RUSTUP_BIN=/usr/bin` is also handed to whole
+// suites in certify.yml's `test` and `inline-gate` jobs and to ci-full.yml's
+// negative-control groups, where it was written when the only recipes that read
+// it were `cargo` lines. `make test` now reaches `tables-rust-versioning`
+// through `test-rust`, so certify's ubuntu-latest row carries the same
+// shadowing this gate names — on a runner whose /usr/bin holds an older go. That
+// is a change to certify.yml and to a job this branch does not own, so it is
+// named here and left to its own commit; widening the glob below is the second
+// half of that fix.
+func TestNoWorkflowShadowsTheGoToolchain(t *testing.T) {
+	root := repoRoot(t)
+	vars := pathPrependingMakeVars(t, root)
+	names := make([]string, 0, len(vars))
+	for name := range vars {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	watched := 0
+	for name, data := range workflows(t, root) {
+		if name != "ci-fast.yml" {
+			continue
+		}
+		watched++
+		for _, l := range lines(name, data) {
+			for _, v := range names {
+				for _, dir := range theImagesOwnToolchainDirs {
+					if !strings.Contains(l.full, v+"="+dir) {
+						continue
+					}
+					t.Errorf("%s: %q hands make %s=%s, which make PREPENDS to PATH — that puts the image's own toolchain in front of every setup step's (run 34600421804: go 1.24.13 shadowed the installed 1.26 and the rust versioning gate died before asserting anything). Install the toolchain and leave the make default alone.",
+						l.where, l.full, v, dir)
+				}
+			}
+		}
+	}
+	if watched == 0 {
+		t.Fatal("ci-fast.yml is not under .github/workflows — this gate would pass over an empty set")
+	}
+	t.Logf("PATH-prepending make variables watched: %s", strings.Join(names, " "))
+}

--- a/make/rust.mk
+++ b/make/rust.mk
@@ -298,6 +298,13 @@ tables-rust-fixedform: build/tables-generated-rust/.stamp build/fixedform-corpus
 # sets SCHEMA_REQUIRE_CORPUS=1, which turns that skip into a FAILURE: under this
 # name a missing corpus can never pass silently.
 #
+# AND BECAUSE IT IS A GO TEST UNDER A PREPENDED PATH, RUSTUP_BIN MUST NOT NAME A
+# DIRECTORY HOLDING A SECOND go: CI fast's rust row handed /usr/bin here and the
+# runner image's go 1.24.13 answered in front of the installed 1.26, so the gate
+# died on `go.mod requires go >= 1.26` with no row asserted (run 34600421804).
+# The default below is a homebrew keg that does not exist on a runner, which is
+# why prepending it is harmless there.
+#
 # AND IT IS A GO TEST THAT SHELLS OUT TO CARGO, so the PATH carries $(RUSTUP_BIN)
 # the way every other Rust row in this file does: the suite's one `cargo test
 # --workspace` resolves cargo out of the environment it is handed and nothing


### PR DESCRIPTION
**The owner's ruling, 2026-09-11, verbatim:**

> "Here is another option to speed up, check in to branches without PRs. Only run tests when merging into main, local runners elsewhere."

This pull request is the shape of that ruling. It also carries the merges of #975 (the fast lane on the six studio self-hosted runners) and #974 (the rust row stops shadowing its own Go toolchain), resolved in favour of both.

## What changes

**The pull request stays the READ surface and starts nothing.** The diff, the body and the owed lists live here; Emma, Johnny and DeepSeek read them. No workflow of ours is triggered by a `pull_request` event any more, so an open pull request costs zero hosted minutes and zero queue.

**`ci-fast.yml` — the push to one of our branches.** Trigger: `push` to `rowan/**`, `johnny/**`, `emma/**`, `freddy/**`, `stella/**`, plus `workflow_dispatch`. No `pull_request` trigger at all. Every job stays `runs-on: [self-hosted, studio]` and never a hosted runner, so a push to a branch of ours gets a second-opinion fast run on our own hardware for free. The fork guard becomes structural rather than a job-level `if:` — the only trigger is a push to a branch *in this repository*, so no fork's code can reach the pool.

**`ci-full.yml` — where a merge lands.**

| event | runners |
| --- | --- |
| push to `fixed-table-form` | the studio pool (self-hosted) |
| push to `main` | hosted `ubuntu-latest` — the one hosted run per main merge |
| nightly schedule | hosted |
| `gh workflow run ci-full.yml --ref <branch>` | the studio pool |
| `full-ci` label | hosted, and now on `labeled` **only** — an explicit ask, not a plain pull-request trigger |

Three rows cannot move and say so in place: `big-endian` (s390x cross gcc and `qemu-user` at pinned Ubuntu versions), `windows` and `msvc`. The pool is macOS and has none of those.

Two portability fixes for the pool: `$(nproc)` becomes `$(getconf _NPROCESSORS_ONLN)` (three rows), and `erlef/setup-beam` — which has no macOS support — is gated on `runner.environment == 'github-hosted'`, where `dist/` already carries the BEAM on PATH.

**The merge condition** is the local gate (`merge-lane.sh run --local-gates`) plus a read. The lane already supports a pull request with NO hosted checks at all: `pr_checks` reports `g0/p0/r0` when `gh pr checks` returns nothing, and `one_pass`'s `(( C_PENDING > 0 || C_GREEN == 0 ))` branch does not wait when a green gate exists for the PR's *current* head. No lane change was needed; a hosted RED still stops a PR, as before.

**Not touched:** `cla.yml` (the Contributor Assignment Agreement, `pull_request_target`). It is not a test and not ours to change — it is the one check that still appears on a pull request.

**`docs/CONTRIBUTING.md`** states the loop in five lines — local gate, push the branch, open the PR as the record, a read from another line, the lane merges on local green + read, the full lane runs on the merge — and says hosted CI runs only on main and nightly, citing the ruling with its date.

## Gates

- `go test ./internal/ci/` green (pins, and the Go-shadowing gate).
- `gofmt -l .` prints nothing.
- Measured wall times are in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## The studio pool's three defects, found by #980's own first dispatch

The first full-lane dispatch on the pool (run 34603066277) went **52 of 72 jobs
red**, and the fast lane's `go-test-touched` went red with it (run 34603030435).
None of the three causes was the diff; all three were the pool.

### (1) The sibling clones were not idempotent on a warm workspace

A self-hosted runner's workspace **parent** persists between runs, and the
sibling runtimes the Makefiles reach for as `../serialize*` live there.
`actions/checkout` cleans the repository directory; it does not touch the
parent. So the second run of any job that clones a sibling dies by name:

```
fatal: destination path 'serialize' already exists and is not an empty directory
```

Every clone step in **both** workflows now `rm -rf` the target and re-clones at
the pinned tag — ten sites in `ci-full.yml`, and the fast lane's `leg-gate`
already had it. The rust versioning row's `if [ ! -d ../serialize.rs ]` guard
goes with them: it did not fail, it **reused** whatever the previous run left,
which is how a stale sibling outlives a pin bump. The repository checkout itself
is untouched and still cleans on every run — nothing in either file sets
`clean: false`, and nothing may.

### (2) The cs rows — the pin was never the problem

The decision asked for was install-10.0.400 or move-the-pin-to-10.0.401.
Neither: `.github/dotnet-version` holds the **band** `10.0`, and the Studio has
`10.0.400` **and** `10.0.401` under `~/.dotnet`, both inside the band, both
complete, both working (`dotnet --version` under a `global.json` pinning either
answers). **The pin and the Studio already match.**

The defect is that `ci-full.yml`'s four `setup-dotnet` steps were **not gated to
hosted runners**, unlike `ci-fast.yml`'s. All six studio runners share one
`$HOME`, so the pool ran six concurrent installs of the same SDK into the same
`~/.dotnet`, and a job read one of them half-written:

```
A fatal error was encountered. The library 'libhostpolicy.dylib' required to
execute the application was not found in '/Users/glenn/.dotnet/sdk/10.0.401/'.
```

— every `TestFixedVersioning` row failing on a probe that never built. All four
steps are now `if: runner.environment == 'github-hosted'`, so the pool installs
nothing and uses the SDK already on its PATH at `~/.local/bin/dotnet`. No SDK
was installed and the pin did not move; matching the pin is what this does.

### (3) `go-test-touched` had no sibling checkout at all

This is the `internal/codegen/gotable` FAIL at 190 s. A broad diff hands the job
`./...`, which reaches every leg's table codegen test, and those generate a probe
whose `go.mod` **replaces** `github.com/mas-bandwidth/serialize.go` with
`../serialize.go`. With no sibling the gate does not skip — it fails by name:

```
Probe.go:12:2: github.com/mas-bandwidth/serialize.go@v0.0.0: replacement
directory /Users/glenn/actions-runner-3/_work/schema/serialize.go does not exist
```

It now clones **all six** siblings, idempotently, for the same reason the
negative-control matrix clones all six: the job's package list is not known when
the step is written.

### (4) The java row — noted, not chased

`REFUSED BY NAME` on the java row is the tip's pre-§5 Java leg. **PR #920 carries
the fix.** Nothing here touches it, and it is the one row expected red until #920
lands.

### The pool's operating notes, in `docs/CONTRIBUTING.md`

A new **The studio pool** subsection under the gates: the six runners and their
directories (`~/actions-runner`, `~/actions-runner-2..6`), `./svc.sh stop|start`
per directory and the rule never to touch them during a benchmark window, the
warm-workspace rule with **both** ways it was earned (a bare clone fails by name;
a `[ ! -d ]` guard quietly reuses a stale sibling), why a toolchain install is
not a per-job step on a pool that shares one `$HOME`, and a table of where each
toolchain lives on the Studio.

### Gates

- `go test ./internal/ci/` green.
- `gofmt -l .` prints nothing.
