### PR TITLE
ci-fast plan: only main-module packages reach go-test-touched

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -164,6 +164,14 @@ jobs:
           # package path `go test` takes, plus the codegen package of each
           # selected leg — a make include or a generated tree changing is a
           # reason to run that leg's harness even with no .go file in the diff.
+          #
+          # ONLY A PACKAGE OF THE MAIN MODULE, the set `./...` names. A
+          # generated tree (generated/go, generated/bench/go, test/go) is its
+          # own module, and a testdata/ directory is invisible to the go tool;
+          # a .go file there is the leg gate's business, and naming its
+          # directory here fails by name — #958 and #960, go-test-touched:
+          #   main module (github.com/mas-bandwidth/schema/v2) does not
+          #   contain package .../generated/go
           if [ "$broad" = yes ]; then
             packages="./..."
           else
@@ -171,6 +179,8 @@ jobs:
             for f in $files; do
               case "$f" in
                 *.go) d=$(dirname "$f"); [ -d "$d" ] || continue
+                      case "/$d/" in */testdata/*) continue ;; esac
+                      m=$d; while [ "$m" != . ]; do [ -f "$m/go.mod" ] && continue 2; m=$(dirname "$m"); done
                       case " $packages " in *" ./$d "*) ;; *) packages="$packages ./$d" ;; esac ;;
               esac
             done


### PR DESCRIPTION
## Why

go-test-touched reddened on #958 and #960, hosted and local alike, before a single test ran:

    main module (github.com/mas-bandwidth/schema/v2) does not contain package github.com/mas-bandwidth/schema/v2/generated/go
    FAIL ./generated/go [setup failed]
    testdata/golden/go/ArmDefaults.go:10:2: no required module provides package github.com/mas-bandwidth/serialize.go
    FAIL github.com/mas-bandwidth/schema/v2/testdata/golden/go [setup failed]

The plan's package rule hands `go test` every directory holding a changed `.go` file. Four of those are their own modules (`generated/go`, `generated/bench/go`, `generated/bench/paired/go`, `test/go`) and one is under `testdata/`, which the go tool does not see. `./...` skips all five; a named path does not. Every PR that regenerates the Go trees hits this; earlier PRs passed because their diffs held no `.go` file in those trees.

## What

Two lines in the plan's loop: skip a directory under `testdata/`, skip a directory inside a nested `go.mod`. Those trees are the leg gates' business (`make tables-go-fixed-form`, the goldens suite). `~/rowan-working/bin/local-gate.sh` carries the same lines in its verbatim copy of the plan.

## Proof

On #958's tip with the patched plan: packages = the 13 codegen/goldens packages, `go test` all ok in 36.7 s (was `FAIL [setup failed]` at 63.8 s). `go test ./internal/ci/` ok.

Note for #980: it rewrites ci-fast.yml around the same plan block; carry these lines across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)