### PR TITLE
fixed table: fixed_I_grow_element probed on every leg (the owed row)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ SCHEMAS_VERSIONING := test/tables/VOLD_array_bounded_grow.schema \
 	test/tables/VOLD_range_widen.schema \
 	test/tables/VOLD_bits_grow.schema \
 	test/tables/VOLD_fixed_I_grow.schema \
+	test/tables/VOLD_fixed_I_grow_element.schema \
 	test/tables/VOLD_optional_add.schema \
 	test/tables/VNEW_array_bounded_grow.schema \
 	test/tables/VNEW_array_fixed_grow.schema \
@@ -218,6 +219,7 @@ SCHEMAS_VERSIONING := test/tables/VOLD_array_bounded_grow.schema \
 	test/tables/VNEW_range_widen.schema \
 	test/tables/VNEW_bits_grow.schema \
 	test/tables/VNEW_fixed_I_grow.schema \
+	test/tables/VNEW_fixed_I_grow_element.schema \
 	test/tables/VNEW_optional_add.schema \
 	test/tables/VOLD_floor.schema \
 	test/tables/VMID_floor.schema \

--- a/internal/codegen/cstable/fixedversioning_test.go
+++ b/internal/codegen/cstable/fixedversioning_test.go
@@ -106,6 +106,21 @@ var csVersionRows = []csVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+            {
+                int[] wantRaw = { -1, -1, -1, -1 };
+                for (int k = 0; k < 4; ++k)
+                {
+                    if (back[0].Vals[k] != wantRaw[k])
+                    {
+                        bad += ProbeLog.Fail(@NAME@, "slot " + k + " did not land the raw scaled value exact: " + back[0].Vals[k]);
+                    }
+                }
+                if (back[0].Lead != 0xAAAAAAAAu || back[0].Trail != 0xBBBBBBBBu)
+                {
+                    bad += ProbeLog.Fail(@NAME@, "a neighbour moved: lead=" + back[0].Lead + " trail=" + back[0].Trail);
+                }
+            }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true},

--- a/internal/codegen/cstable/fixedversioning_test.go
+++ b/internal/codegen/cstable/fixedversioning_test.go
@@ -108,7 +108,7 @@ var csVersionRows = []csVersionRow{
 	{row: "fixed_I_grow", widens: true},
 	{row: "fixed_I_grow_element", widens: true, check: `
             {
-                int[] wantRaw = { -1, -1, -1, -1 };
+                int[] wantRaw = { -1, -128, 0, 112 };
                 for (int k = 0; k < 4; ++k)
                 {
                     if (back[0].Vals[k] != wantRaw[k])

--- a/internal/codegen/ctable/fixedversioning_test.go
+++ b/internal/codegen/ctable/fixedversioning_test.go
@@ -114,6 +114,17 @@ var cVersionRows = []cVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+    if ( n != 1 ) { printf( "the fixed_I_grow_element file carries one record, not %lld\n", (long long) n ); return 1; }
+    {
+        const int32_t want[4] = { -1, -2, -3, -4 };
+        int k;
+        for ( k = 0; k < 4; ++k )
+        {
+            if ( (int32_t) back[0].v[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].v[k] ); return 1; }
+        }
+        if ( back[0].lead != 0xAAAAAAAAu || back[0].trail != 0xBBBBBBBBu ) { printf( "the row moved a neighbour\n" ); return 1; }
+    }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/ctable/fixedversioning_test.go
+++ b/internal/codegen/ctable/fixedversioning_test.go
@@ -117,11 +117,11 @@ var cVersionRows = []cVersionRow{
 	{row: "fixed_I_grow_element", widens: true, check: `
     if ( n != 1 ) { printf( "the fixed_I_grow_element file carries one record, not %lld\n", (long long) n ); return 1; }
     {
-        const int32_t want[4] = { -1, -2, -3, -4 };
+        const int32_t want[4] = { -1, -128, 0, 112 };
         int k;
         for ( k = 0; k < 4; ++k )
         {
-            if ( (int32_t) back[0].v[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].v[k] ); return 1; }
+            if ( (int32_t) back[0].vals[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].vals[k] ); return 1; }
         }
         if ( back[0].lead != 0xAAAAAAAAu || back[0].trail != 0xBBBBBBBBu ) { printf( "the row moved a neighbour\n" ); return 1; }
     }`},

--- a/internal/codegen/darttable/fixedversioning_test.go
+++ b/internal/codegen/darttable/fixedversioning_test.go
@@ -96,6 +96,14 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  const want = <int>[-1, -1, -1, -1];
+  for (var i = 0; i < 4; i++) {
+    check(values[0].vals[i] == want[i],
+        'slot $i is not the raw scaled value the writer packed: ${values[0].vals[i]}');
+  }
+  check(values[0].lead == 0xAAAAAAAA && values[0].trail == 0xBBBBBBBB,
+      'fixed_I_grow_element moved a neighbour: ${values[0].lead} ${values[0].trail}');`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/darttable/fixedversioning_test.go
+++ b/internal/codegen/darttable/fixedversioning_test.go
@@ -97,7 +97,7 @@ var versionRows = []versionRow{
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
 	{row: "fixed_I_grow_element", widens: true, check: `
-  const want = <int>[-1, -1, -1, -1];
+  const want = <int>[-1, -128, 0, 112];
   for (var i = 0; i < 4; i++) {
     check(values[0].vals[i] == want[i],
         'slot $i is not the raw scaled value the writer packed: ${values[0].vals[i]}');

--- a/internal/codegen/elixirtable/fixedversioning_test.go
+++ b/internal/codegen/elixirtable/fixedversioning_test.go
@@ -103,6 +103,12 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  check(length(values) == 1, "the fixed_I_grow_element file carries one record, not #{length(values)}")
+  v = hd(values)
+  want = [-1, -128, 0, 112]
+  check(v.vals == want, "the RAW SCALED VALUE did not land per slot: #{inspect(v.vals)}")
+  leadtrail(v, want_lead, want_trail)`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/gotable/fixedversioning_test.go
+++ b/internal/codegen/gotable/fixedversioning_test.go
@@ -80,6 +80,19 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+	if n != 1 {
+		t.Fatalf("the fixed_I_grow_element file carries one record, not %d", n)
+	}
+	want := []int32{-1, -2, -3, -4}
+	for k := range want {
+		if int32(back[0].V[k]) != want[k] {
+			t.Fatalf("slot %d did not land its raw scaled value: %+v", k, back[0])
+		}
+	}
+	if back[0].Lead != 0xAAAAAAAA || back[0].Trail != 0xBBBBBBBB {
+		t.Fatalf("the element row moved a neighbour: %+v", back[0])
+	}`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/gotable/fixedversioning_test.go
+++ b/internal/codegen/gotable/fixedversioning_test.go
@@ -84,9 +84,9 @@ var versionRows = []versionRow{
 	if n != 1 {
 		t.Fatalf("the fixed_I_grow_element file carries one record, not %d", n)
 	}
-	want := []int32{-1, -2, -3, -4}
+	want := []int32{-1, -128, 0, 112}
 	for k := range want {
-		if int32(back[0].V[k]) != want[k] {
+		if int32(back[0].Vals[k]) != want[k] {
 			t.Fatalf("slot %d did not land its raw scaled value: %+v", k, back[0])
 		}
 	}

--- a/internal/codegen/javatable/fixedversioning_test.go
+++ b/internal/codegen/javatable/fixedversioning_test.go
@@ -81,6 +81,7 @@ var versioningRows = []versioningRow{
 	{name: "bytes_grow"},
 	{name: "constant_grow"},
 	{name: "fixed_I_grow", widen: true},
+	{name: "fixed_I_grow_element", widen: true},
 	{name: "float_widen", widen: true},
 	{name: "int_widen", widen: true},
 	{name: "optional_add"},

--- a/internal/codegen/jstable/fixedversioning_test.go
+++ b/internal/codegen/jstable/fixedversioning_test.go
@@ -106,6 +106,17 @@ var jsVersionRows = []jsVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  // THE RAW SCALED VALUE, SLOT BY SLOT (SPEC §4.6: I is the raw value's width
+  // and F is held), and the two neighbours that bracket the array, exactly as
+  // the scalar row asserts one value and its bracket.
+  const want = [-1, -128, 112, 0];
+  for (let k = 0; k < want.length; k++) {
+    if (Number(back[0].Vals[k]) !== want[k]) { fail("slot " + k + " widened wrong: " + show(back[0])); }
+  }
+  if (back[0].Lead !== 0xAAAAAAAA || back[0].Trail !== 0xBBBBBBBB) {
+    fail("the row moved a neighbour: " + show(back[0]));
+  }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/jstable/fixedversioning_test.go
+++ b/internal/codegen/jstable/fixedversioning_test.go
@@ -110,7 +110,7 @@ var jsVersionRows = []jsVersionRow{
   // THE RAW SCALED VALUE, SLOT BY SLOT (SPEC §4.6: I is the raw value's width
   // and F is held), and the two neighbours that bracket the array, exactly as
   // the scalar row asserts one value and its bracket.
-  const want = [-1, -128, 112, 0];
+  const want = [-1, -128, 0, 112];
   for (let k = 0; k < want.length; k++) {
     if (Number(back[0].Vals[k]) !== want[k]) { fail("slot " + k + " widened wrong: " + show(back[0])); }
   }

--- a/internal/codegen/rusttable/fixedversioning_test.go
+++ b/internal/codegen/rusttable/fixedversioning_test.go
@@ -139,6 +139,27 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+    // ONE RECORD, FOUR SLOTS (§5.9 #33). The OLD writer's [4]fixed(12,4) holds
+    // the RAW SCALED VALUE per slot; the NEW reader's element is [4]fixed(28,4),
+    // whose storage is twice as wide, so every old element must land
+    // SIGN-EXTENDED and exact. The values are the ends of the old element's raw
+    // range and the one a zero-extension gets wrong.
+    let want: [i32; 4] = [-1, -128, 112, 0];
+    for k in 0..4 {
+        assert!(
+            values[0].v[k] == want[k],
+            "slot {k} widened wrong: {} and not {}", values[0].v[k], want[k]
+        );
+    }
+    assert!(
+        values[0].lead == 0xAAAA_AAAA && values[0].trail == 0xBBBB_BBBB,
+        "a neighbour moved: lead={:#x} trail={:#x}", values[0].lead, values[0].trail
+    );
+    assert!(
+        report.widened == 4,
+        "a widened [4]fixed element owes EXACTLY 4 widen entries, not {}", report.widened
+    );`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/rusttable/fixedversioning_test.go
+++ b/internal/codegen/rusttable/fixedversioning_test.go
@@ -145,11 +145,11 @@ var versionRows = []versionRow{
     // whose storage is twice as wide, so every old element must land
     // SIGN-EXTENDED and exact. The values are the ends of the old element's raw
     // range and the one a zero-extension gets wrong.
-    let want: [i32; 4] = [-1, -128, 112, 0];
+    let want: [i32; 4] = [-1, -128, 0, 112];
     for k in 0..4 {
         assert!(
-            values[0].v[k] == want[k],
-            "slot {k} widened wrong: {} and not {}", values[0].v[k], want[k]
+            values[0].vals[k] == want[k],
+            "slot {k} widened wrong: {} and not {}", values[0].vals[k], want[k]
         );
     }
     assert!(

--- a/test/tables/VNEW_fixed_I_grow_element.schema
+++ b/test/tables/VNEW_fixed_I_grow_element.schema
@@ -11,6 +11,6 @@ package vnew_fixed_i_grow_element
 fixed table FixedIGrowElement
 {
     lead  uint32 = 1
-    v     [4]fixed(28, 4) | min = -8, max = 7
+    vals  [4]fixed(28, 4) | min = -8, max = 7
     trail uint32 = 2
 }

--- a/test/tables/VNEW_fixed_I_grow_element.schema
+++ b/test/tables/VNEW_fixed_I_grow_element.schema
@@ -1,0 +1,16 @@
+// VNEW_fixed_I_grow_element.schema — NEW: [4]fixed(28,4) — I grows, F EQUAL (the scale may not move)
+//
+// One of the fixed form's versioning rows (docs/FIXED-FORM-VERSIONING-TESTS.md).
+// The OLD and the NEW file of this pair differ by EXACTLY the row named above,
+// so a case in test/tables/versioning_numbers.cpp can say which change the read
+// answered for. `lead` and `trail` bracket the row's field: a mislaid size
+// moves a neighbour, and the equality check sees it.
+
+package vnew_fixed_i_grow_element
+
+fixed table FixedIGrowElement
+{
+    lead  uint32 = 1
+    v     [4]fixed(28, 4) | min = -8, max = 7
+    trail uint32 = 2
+}

--- a/test/tables/VOLD_fixed_I_grow_element.schema
+++ b/test/tables/VOLD_fixed_I_grow_element.schema
@@ -11,6 +11,6 @@ package vold_fixed_i_grow_element
 fixed table FixedIGrowElement
 {
     lead  uint32 = 1
-    v     [4]fixed(12, 4) | min = -8, max = 7
+    vals  [4]fixed(12, 4) | min = -8, max = 7
     trail uint32 = 2
 }

--- a/test/tables/VOLD_fixed_I_grow_element.schema
+++ b/test/tables/VOLD_fixed_I_grow_element.schema
@@ -1,0 +1,16 @@
+// VOLD_fixed_I_grow_element.schema — OLD: [4]fixed(12,4)
+//
+// One of the fixed form's versioning rows (docs/FIXED-FORM-VERSIONING-TESTS.md).
+// The OLD and the NEW file of this pair differ by EXACTLY the row named above,
+// so a case in test/tables/versioning_numbers.cpp can say which change the read
+// answered for. `lead` and `trail` bracket the row's field: a mislaid size
+// moves a neighbour, and the equality check sees it.
+
+package vold_fixed_i_grow_element
+
+fixed table FixedIGrowElement
+{
+    lead  uint32 = 1
+    v     [4]fixed(12, 4) | min = -8, max = 7
+    trail uint32 = 2
+}

--- a/test/tables/fixedform_dump.cpp
+++ b/test/tables/fixedform_dump.cpp
@@ -61,6 +61,8 @@
 #include "VNEW_bits_growTable.h"
 #include "VOLD_fixed_I_growTable.h"
 #include "VNEW_fixed_I_growTable.h"
+#include "VOLD_fixed_I_grow_elementTable.h"
+#include "VNEW_fixed_I_grow_elementTable.h"
 #include "VOLD_optional_addTable.h"
 #include "VNEW_optional_addTable.h"
 #include "VOLD_floorTable.h"
@@ -800,6 +802,14 @@ static bool versioning_numbers_files( const char * dir )
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].v, -1 ); MS( v[0].trail, 0xBBBBBBBBu ); );
     VROW( vnew_fixed_i_grow, FixedIGrow, "new_fixed_I_grow.bin",
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].v, 1000 ); MS( v[0].trail, 0xBBBBBBBBu ); );
+
+    // THE ARRAY-ELEMENT PORT, per slot: the OLD element's raw floor, -1 (the
+    // value a zero-extension gets wrong), zero, and its raw ceiling.
+    VROW( vold_fixed_i_grow_element, FixedIGrowElement, "old_fixed_I_grow_element.bin",
+          MS( v[0].lead, 0xAAAAAAAAu ); MSI( v[0].vals[0], -1, 0 ); MSI( v[0].vals[1], -128, 1 );
+          MSI( v[0].vals[2], 0, 2 ); MSI( v[0].vals[3], 112, 3 ); MS( v[0].trail, 0xBBBBBBBBu ); );
+    VROW( vnew_fixed_i_grow_element, FixedIGrowElement, "new_fixed_I_grow_element.bin",
+          MS( v[0].lead, 0xAAAAAAAAu ); MSI( v[0].vals[0], 1000, 0 ); MS( v[0].trail, 0xBBBBBBBBu ); );
 
     VROW( vold_optional_add, OptionalAdd, "old_optional_add.bin",
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].link.value, 777 ); MS( v[0].trail, 0xBBBBBBBBu ); );

--- a/test/tables/versioning_numbers.cpp
+++ b/test/tables/versioning_numbers.cpp
@@ -10,7 +10,7 @@
 //
 //   array_bounded_grow  array_fixed_grow  array_elem_widen  constant_grow
 //   string_grow  wstring_grow  bytes_grow  int_widen  uint_widen  float_widen
-//   range_widen  bits_grow  fixed_I_grow  optional_add
+//   range_widen  bits_grow  fixed_I_grow  fixed_I_grow_element  optional_add
 //   floor_at  floor_below  floor_raise_live
 //   hash_unknown  hash_known_bytes_differ  hash_identity  lineage_merge
 //
@@ -80,6 +80,8 @@
 #include "VNEW_bits_growTable.h"
 #include "VOLD_fixed_I_growTable.h"
 #include "VNEW_fixed_I_growTable.h"
+#include "VOLD_fixed_I_grow_elementTable.h"
+#include "VNEW_fixed_I_grow_elementTable.h"
 #include "VOLD_optional_addTable.h"
 #include "VNEW_optional_addTable.h"
 #include "VOLD_floorTable.h"
@@ -847,6 +849,56 @@ void fixed_I_grow_case()
 }
 
 // ---------------------------------------------------------------------------
+// 13b. fixed_I_grow_element — [4]fixed(12,4) -> [4]fixed(28,4). The ELEMENT's I
+//      GROWS, F IS EQUAL: the array-element port of the row above, so the scale
+//      may not move and the RAW SCALED VALUE is what must land exactly, PER SLOT.
+
+void fixed_I_grow_element_case()
+{
+    ROW_MOVES_THE_HASH( vold_fixed_i_grow_element::FixedIGrowElementFixedHash,
+                        vnew_fixed_i_grow_element::FixedIGrowElementFixedHash, "fixed_I_grow_element" );
+
+    vold_fixed_i_grow_element::FixedIGrowElement old;
+    vold_fixed_i_grow_element::FixedIGrowElementReset( old );
+    old.lead = 0xAAAAAAAAu;
+    old.vals[0] = -1;   // the one value a zero-extension gets wrong
+    old.vals[1] = -128; // the OLD element's raw floor
+    old.vals[2] = 0;
+    old.vals[3] = 112;  // the OLD element's raw ceiling
+    old.trail = 0xBBBBBBBBu;
+    std::vector<uint8_t> ob = one( old, vold_fixed_i_grow_element::FixedIGrowElementFixedMeasure,
+                                   vold_fixed_i_grow_element::FixedIGrowElementFixedSave,
+                                   "fixed_I_grow_element: OLD save" );
+    {
+        vnew_fixed_i_grow_element::FixedIGrowElement back;
+        vnew_fixed_i_grow_element::FixedIGrowElementReset( back );
+        vnew_fixed_i_grow_element::TableReport r;
+        std::vector<vnew_fixed_i_grow_element::TableFixedEntry> plan( 4096 );
+        check( vnew_fixed_i_grow_element::FixedIGrowElementFixedLoad( &back, 1, ob.data(), (int64_t) ob.size(),
+                                                                      plan.data(), 4096, NULL, &r ) == 1,
+               "fixed_I_grow_element/NEW-READS-OLD: one record" );
+        check( back.lead == 0xAAAAAAAAu && back.trail == 0xBBBBBBBBu,
+               "fixed_I_grow_element/NEW-READS-OLD: lead and trail bracket the row exactly" );
+        // The element's I widens with F held: the raw scaled value every older
+        // writer packed is the same number in a wider slot, so each slot lands
+        // exactly and the element WIDENED, not kind_mismatch.
+        check( back.vals[0] == -1 && back.vals[1] == -128 && back.vals[2] == 0 && back.vals[3] == 112,
+               "fixed_I_grow_element/NEW-READS-OLD: the RAW SCALED VALUE lands exactly, per slot (F equal)" );
+        check( r.kind_mismatch == 0,
+               "fixed_I_grow_element/NEW-READS-OLD: the element widened, not kind_mismatch" );
+        check( r.unknown == 0 && r.clamped == 0 && !r.malformed && !r.refused,
+               "fixed_I_grow_element/NEW-READS-OLD: nothing else fired" );
+    }
+    vnew_fixed_i_grow_element::FixedIGrowElement nv;
+    vnew_fixed_i_grow_element::FixedIGrowElementReset( nv );
+    nv.vals[0] = 1000; // a raw value fixed(12,4) has no room for
+    std::vector<uint8_t> nb = one( nv, vnew_fixed_i_grow_element::FixedIGrowElementFixedMeasure,
+                                   vnew_fixed_i_grow_element::FixedIGrowElementFixedSave,
+                                   "fixed_I_grow_element: NEW save" );
+    OLD_REFUSES_NEW( vold_fixed_i_grow_element, FixedIGrowElement, "fixed_I_grow_element", nb );
+}
+
+// ---------------------------------------------------------------------------
 // 14. optional_add — T -> ?T: every old value lands PRESENT
 
 void optional_add_case()
@@ -1194,6 +1246,7 @@ int versioning_numbers_cases()
     range_widen_hostile_case();
     bits_grow_case();
     fixed_I_grow_case();
+    fixed_I_grow_element_case();
     optional_add_case();
     floor_cases();
     hash_cases();


### PR DESCRIPTION
Patches by the DeepSeek and Mercury swarms, landed and gated by Rowan's Opus child; commits carry their model trailers.

The owed row `fixed_I_grow_element` (docs/FIXED-FORM-VERSIONING-TESTS.md line 57:
`[4]fixed(12,4)` -> `[4]fixed(28,4)`, the array-element port of `fixed_I_grow`) now has its
fixture pair, its C++ reference case and corpus rows, and an entry on every one of the nine legs.

## The legs

| leg | patch subject | gate (`make ...`) | result |
| --- | --- | --- | --- |
| fixtures + Makefile | Add fixed_I_grow_element fixture schemas (Mercury / fr-01) | — | landed, field renamed `v` -> `vals` (below) |
| cpp (reference + dump) | versioning numbers: the fixed_I_grow_element row on the cpp leg | `tables-fixedform` | GREEN — `versioning numbers: 0 RED, 0 failure(s)`, manifest 68 corpus files |
| go | go leg: probe fixed_I_grow_element, the element's I grows with F held | `tables-go-versioning` | GREEN (23s) |
| rust | rust: probe fixed_I_grow_element, the array-element port of fixed_I_grow | `tables-rust-versioning` | GREEN (27s) |
| c | c leg: the fixed_I_grow_element row, per-slot raw values exact | `tables-c-versioning` | GREEN (14s) |
| cs | cs: probe fixed_I_grow_element in the versioning row table | `tables-cs-versioning` | GREEN (both subtests run: `fixed_I_grow_element/new_reads_old`, `/old_refuses_new`) |
| dart | dart leg: probe the fixed_I_grow_element row | `tables-dart-versioning` | GREEN (2.5s) |
| js | versioning tests: the fixed_I_grow_element row on the js leg | `tables-js-versioning` | GREEN (1.2s) |
| java | java leg: probe the fixed_I_grow_element row | `tables-java-versioning` | GREEN (8.1s) |
| elixir | elixir leg: probe the fixed_I_grow_element row (written by the lander, see below) | `tables-elixir-versioning` | GREEN (17s) |

Every leg's `-v` run was checked for the row by name, so no leg is green by absence.

## Landed by hand

Each worker built its own local copy of the shared halves, so the patches disagreed on two facts
the corpus owns. One commit, `landing: one fixture, one field name, one set of slot values`,
reconciles them; no leg's assertion shape was changed, only names and numbers:

- **Field name.** The fixture card wrote `v` (the scalar row's name); the C++ reference case, the
  dump and the cs/js/dart legs wrote `vals` (the array rows' name, as `array_elem_widen`). Taken:
  `vals` — the array convention, and what the oracle reads. go, c and rust accessors moved with it.
- **The four OLD slots.** The C++ reference writes the raw floor, -1, zero and the raw ceiling of
  `fixed(12,4) | min=-8, max=7`: `-1, -128, 0, 112`. go and c expected `-1,-2,-3,-4`; cs and dart
  expected `-1,-1,-1,-1`; rust and js had slots 2 and 3 swapped. The reference's bytes are the
  oracle, so every leg now asserts `-1, -128, 0, 112`.
- **dart** never committed or format-patched its entry — it was left in the worker's working tree
  and is taken verbatim from there by the lander (one file).
- **elixir returned nothing**: its RESULT.md stops at "STATUS: starting" and its clone holds only
  the two untracked fixture schemas. Rather than leave one of nine legs unprobed, the lander wrote
  the entry in that file's own idiom (`int_widen`'s shape) and gated it.

## Pre-existing reds (not caused by this branch)

`make tables-fixedform` prints two known-red lines from the hostile-bytes probe and still exits 0:

    RED [Reference fixes pending, fix 2]: bool_byte_two: a bool byte of 2 lands as the language's own true (1) ...
    RED [Reference fixes pending, fix 2]: present_byte_two: an optional's present byte of 2 lands as the language's own true (1) ...

Verified pre-existing: the same target on a clean checkout of `origin/fixed-table-form` (ad636dfb)
prints the identical two RED lines and exits 0 (`manifest: 66 lines` there, `68` here — the row's two
new corpus files are the whole difference).

## What the RESULTs said the doc did not tell them

- **No `min`/`max` on the doc row**, though SPEC §4.6 requires them for `fixed`. Every worker took
  `| min = -8, max = 7` from the lock leg's `TestLockFixedIGrowElementAllows` and the scalar pair.
  That is what makes the raw window `[-128, 112]`, and the landed values sit inside it so
  `clamped == 0` holds.
- **No field, table or package name in the doc** — the `v` / `vals` split above came straight from
  that gap. cs also notes the generated C# spelling is PascalCase (`Lead`, `Vals`, `Trail`) and that
  `csVersionHead` already declares a `want`, so the check's vector had to be named `wantRaw`.
- **No per-slot values in the doc** ("as the scalar row, per slot"), which is why five legs invented
  five different vectors. The c worker called this out in advance as "the one real coordination risk".
- **The doc's scalar row is stale against the tree**: line 56 prints `fixed_I_grow` as
  `fixed(8,4)` -> `fixed(16,4)`, but `VOLD_/VNEW_fixed_I_grow.schema` (and `versioning_numbers.cpp`
  §13, and the lock rows) are `fixed(4,4)` -> `fixed(12,4)`. The element row's 12 -> 28 does agree
  with the lock test. Worth a doc fix on line 56.
- **`compiler/everyrow_test.go` is not on this branch** (it lives on `origin/rowan/every-row-every-leg`,
  whose `docs/FIXED-FORM-OWED-ROWS.md` ledger is already stale), so the row-absent coverage red could
  not be taken there; the workers took their red at the leg harness instead. The ledger line
  `fixed_I_grow_element | <leg>` is Rowan's to delete when this lands.
- **The pair cannot be generated in one `schema generate` invocation** (two packages, one table name);
  the Makefile's foreach already does them separately.
- **Sibling runtimes the card never named**: `../serialize` (C++), and per leg `../serialize.c`,
  `../serialize.cs`, `../serialize.go`, `../serialize.rs`, plus the pinned JDK/node/dart/elixir under
  `dist/`. Nothing in the patches; the gate here used the bench's `~/toolchains/schema-dist` and
  existing sibling checkouts.
- **The cpp emitter already widens a fixed array element** (probe: `int16_t vals[4]` -> `int32_t vals[4]`,
  `kind_mismatch=0`, `widened=4`), so no emitter change was needed or made — the only red reachable
  was the missing fixture headers.
- **No C++ formatter is wired** (no `.clang-format`; CI runs `gofmt -l .` / `go vet` only), so the
  C++ hunks were matched to the surrounding style by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
