### PR TITLE
ci-fast: go-test-touched clones the sibling runtimes (G4)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -335,6 +335,38 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # THE GO TESTS LINK SIBLING RUNTIMES, so this job clones them exactly as
+      # ci-full.yml's `go-test` does. A dozen tests under compiler/ and
+      # internal/codegen/ write a probe module whose go.mod carries
+      # `replace github.com/mas-bandwidth/serialize.go => <abs ../serialize.go>`
+      # (compiler/tableclosuredefaults_test.go:79,
+      # internal/codegen/golang/golang_test.go:557, seven more under
+      # internal/codegen/gotable) and then `go build` it; the C++, C and C#
+      # probes do the same with ../serialize, ../serialize.c and ../serialize.cs.
+      # Without the sibling checkouts every one of those is a `setup failed`,
+      # not a verdict on the diff.
+      #
+      # THE PINS ARE THE FILE'S OWN, the same SERIALIZE*_TAG values ci-full.yml
+      # reads, so this lane compiles against the runtime the full lane does.
+      #
+      # Measured on the Studio's own network: the four shallow clones are
+      # ~0.6 s each, ~2.5 s total for ~4.8 MB — inside the floor named at the
+      # top of this file, not a new minute.
+      - name: Check out the C++, C, C# and Go serialize runtimes (pinned releases)
+        run: |
+          set -euo pipefail
+          cd ..
+          # A self-hosted runner's workspace PARENT persists between runs, so a
+          # previous run's clones are still sitting here. They are removed and
+          # re-cloned at the pinned tag every time, never reused: the sibling
+          # pins are part of what a green means.
+          rm -rf serialize serialize.c serialize.cs serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+
       # the Studio's own go already satisfies go.mod; hosted fallback only
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         if: runner.environment == 'github-hosted'
@@ -357,6 +389,25 @@ jobs:
           path: ${{ env.GO_BUILD_CACHE }}
           key: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-${{ hashFiles('**/*.go', 'go.mod') }}
           restore-keys: go-build-${{ runner.os }}-${{ env.GO_CACHE_ID }}-
+
+      # THE SIBLINGS ARE THERE OR THIS JOB IS NOT A VERDICT. Refusing by name
+      # here, before `go test`, turns a future missing checkout into one line
+      # that says which runtime and which pin, instead of forty
+      # `replacement directory ... does not exist` lines inside unrelated tests.
+      - name: the sibling runtimes are present
+        run: |
+          set -euo pipefail
+          missing=
+          for d in serialize serialize.c serialize.cs serialize.go; do
+            [ -d "../$d" ] || missing="$missing $d"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::the Go probes link sibling runtimes this runner does not have:$missing." \
+                 "Clone them beside the checkout at the pins this file names" \
+                 "(SERIALIZE_TAG=$SERIALIZE_TAG, SERIALIZE_C_TAG=$SERIALIZE_C_TAG," \
+                 "SERIALIZE_CS_TAG=$SERIALIZE_CS_TAG, SERIALIZE_GO_TAG=$SERIALIZE_GO_TAG)."
+            exit 1
+          fi
 
       - name: go test the touched packages
         env:


### PR DESCRIPTION
G4 of the red-lane grouping on #898 ([comment](https://github.com/mas-bandwidth/schema/issues/898#issuecomment-5646608629)). The grouping filed this one as **the runner's** — "a filesystem path on `actions-runner-2`, no repo content involved … No schema commit can fix it." That reading is wrong, and this is the schema commit that fixes it.

## The cause, one line

`ci-fast.yml`'s `go-test-touched` never grew the sibling-runtime checkout step that `ci-full.yml`'s `go-test` has, so every Go test that builds a probe module against `../serialize.go` fails at module setup on any box without a sibling clone.

## Red

CI fast run [34610527893](https://github.com/mas-bandwidth/schema/actions/runs/34610527893) on `ad636dfb`, job `go-test-touched`, both failures:

```
--- FAIL: TestTableClosureCountDefaults/go (0.04s)
    tableclosuredefaults_test.go:88: generated Go: exit status 1
        Probe.go:12:2: github.com/mas-bandwidth/serialize.go@v0.0.0: replacement directory /Users/glenn/actions-runner-2/_work/schema/serialize.go does not exist
        FAIL	probe [setup failed]
FAIL	github.com/mas-bandwidth/schema/v2/compiler	26.218s
--- FAIL: TestEnumNameTakesTheEnumType (0.03s)
    golang_test.go:575: a typed EnumName call does not compile: exit status 1
        Typed.go:12:2: github.com/mas-bandwidth/serialize.go@v0.0.0: replacement directory /Users/glenn/actions-runner-2/_work/schema/serialize.go does not exist
FAIL	github.com/mas-bandwidth/schema/v2/internal/codegen/golang	16.205s
```

## The evidence it is ours, not the box's

1. **The path is written by the test, not by the runner.** `internal/codegen/golang/golang_test.go:557-561` does `filepath.Abs("../../../../serialize.go")` and writes it into a probe `go.mod` as a `replace`. `/Users/glenn/actions-runner-2/_work/schema/serialize.go` is just what `../serialize.go` resolves to on that box. Same pattern at `compiler/tableclosuredefaults_test.go:79` and at seven sites under `internal/codegen/gotable` (`fixedform_test.go:237,802`, `fixedversioning_test.go:529`, `fixedlayout_test.go:41`, `values_test.go:49`, `fixedredteam_test.go:33`, `fixedcfloat_test.go:35`). The C++, C and C# probes do the same with `../serialize`, `../serialize.c`, `../serialize.cs`.

2. **The full lane already provides it; the fast lane does not.** `ci-full.yml` `go-test` → step *"Check out the C, C++, C# and Go serialize runtimes (pinned releases)"*, four shallow clones at `$SERIALIZE*_TAG`. `ci-fast.yml` `leg-gate` → step *"Check out the sibling runtimes this leg needs (pinned releases)"*. `ci-fast.yml` `go-test-touched` → **no such step**: `actions/checkout`, then `setup-go`/cache (both `if: runner.environment == 'github-hosted'`), then `go test`. Nothing ever puts a sibling beside the checkout.

3. **It is not the toolchain and not the image.** Every other Go package in that same job passed. The clone is not stale, missing or version-skewed — it was never made.

4. **Reproduced off the runner, on this laptop**, in a fresh clone with no sibling:

```
--- FAIL: TestEnumNameTakesTheEnumType (0.02s)
    golang_test.go:575: a typed EnumName call does not compile: exit status 1
        Typed.go:12:2: github.com/mas-bandwidth/serialize.go@v0.0.0: replacement directory .../ft-gotest/serialize.go does not exist
FAIL	github.com/mas-bandwidth/schema/v2/internal/codegen/golang	0.261s
```

Then `git clone --depth 1 --branch v1.15.1 …/serialize.go.git` beside it, nothing else changed:

```
ok  	github.com/mas-bandwidth/schema/v2/internal/codegen/golang	0.340s
ok  	github.com/mas-bandwidth/schema/v2/compiler	0.956s
```

Host-independent: the same missing sibling, the same error, on a machine that is not `actions-runner-2`.

## The fix

Two steps in `go-test-touched`, and nothing else in the repository:

* **Clone the four siblings `ci-full.yml`'s `go-test` clones** — `serialize`, `serialize.c`, `serialize.cs`, `serialize.go` — at this file's own `SERIALIZE_TAG` / `SERIALIZE_C_TAG` / `SERIALIZE_CS_TAG` / `SERIALIZE_GO_TAG`, so the fast lane compiles the probes against the runtime the full lane does. Four, not one, because `go-test-touched` runs `./...` on a broad diff and the C++/C/C# probes read the same way; the pins make the clone part of what a green means. `rm -rf` first, copied from `leg-gate`, because a self-hosted workspace parent persists between runs.
* **Refuse by name when a sibling is absent** rather than letting `go test` produce the failure. One `::error::` line naming the missing runtimes and the pins to clone them at. No silent skip: the step exits 1.

Cost, measured on this network: ~0.6 s per shallow clone, **~2.5 s and ~4.8 MB for all four** — inside the floor this file already names (checkout 10-15 s), not a new minute against the 1-2 minute rule.

## Green

CI fast run [34702772088](https://github.com/mas-bandwidth/schema/actions/runs/34702772088) on this branch — **the whole run success, 13/13 jobs**, `go-test-touched` green in **31 s**. Touching `.github/workflows/ci-fast.yml` matches `plan`'s broad rule (`ci-fast.yml:36`), so the job ran the same selection that was red on `ad636dfb`:

```
packages: ./...
##[notice]broad diff — the whole suite runs in ci-full.yml; this lane runs it with -short
...
ok  	github.com/mas-bandwidth/schema/v2/compiler	12.649s
...
ok  	github.com/mas-bandwidth/schema/v2/internal/codegen/golang	1.991s
ok  	github.com/mas-bandwidth/schema/v2/internal/codegen/gotable	4.116s
```

Both packages that were `FAIL … [setup failed]` are `ok`; nothing else in the suite moved. On the runner the four clones cost **3.0 s** (step start 15:37:22.44, next step start 15:37:25.43), against a job that was 45 s before and is 31 s now.

## What this does not claim

Only G4. G1 (18 dead negative controls), G2 (the Java arm neuter) and G3 (the stale `generated/` tree) are untouched and still red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
