### PR TITLE
negative controls: the gate must RUN, and a skip is diagnosed by name (G1 + G2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4823,9 +4823,11 @@ tables-ref-ordinal-negative-control:
 		"$(CURDIR)" "$(CURDIR)" > build/ref-ordinal-nc/overlay.json
 	@if SCHEMA_SLOW=1 go test -v -overlay build/ref-ordinal-nc/overlay.json -count=1 ./compiler \
 			-run TestCppTableRefOrdinalBytes > build/ref-ordinal-nc/log 2>&1; then \
-		grep -q -- '--- PASS' build/ref-ordinal-nc/log || \
-			{ echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
-			  cat build/ref-ordinal-nc/log; exit 1; }; \
+		if grep -q -- '--- SKIP' build/ref-ordinal-nc/log || \
+				! grep -q -- '--- PASS' build/ref-ordinal-nc/log; then \
+			echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
+			cat build/ref-ordinal-nc/log; exit 1; \
+		fi; \
 		echo "NEGATIVE CONTROL FAILED: truncate leaves the ordinal slot standing and the byte pin stayed green"; \
 		cat build/ref-ordinal-nc/log; exit 1; \
 	fi
@@ -4856,9 +4858,11 @@ tables-ref-ordinal-shared-negative-control:
 		"$(CURDIR)" "$(CURDIR)" > build/ref-ordinal-shared-nc/overlay.json
 	@if SCHEMA_SLOW=1 go test -v -overlay build/ref-ordinal-shared-nc/overlay.json -count=1 ./compiler \
 			-run TestCppTableRefOrdinalSharedId > build/ref-ordinal-shared-nc/log 2>&1; then \
-		grep -q -- '--- PASS' build/ref-ordinal-shared-nc/log || \
-			{ echo "NEGATIVE CONTROL FAILED: the shared-id driver did not run (skipped), so this control is watching nothing"; \
-			  cat build/ref-ordinal-shared-nc/log; exit 1; }; \
+		if grep -q -- '--- SKIP' build/ref-ordinal-shared-nc/log || \
+				! grep -q -- '--- PASS' build/ref-ordinal-shared-nc/log; then \
+			echo "NEGATIVE CONTROL FAILED: the shared-id driver did not run (skipped), so this control is watching nothing"; \
+			cat build/ref-ordinal-shared-nc/log; exit 1; \
+		fi; \
 		echo "NEGATIVE CONTROL FAILED: only the miss path records the ordinal and the shared-id driver stayed green"; \
 		cat build/ref-ordinal-shared-nc/log; exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -4821,8 +4821,11 @@ tables-ref-ordinal-negative-control:
 		{ echo "NEGATIVE CONTROL: the truncate sabotage patched nothing"; exit 1; } || true
 	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/ref-ordinal-nc/emitter.go.txt"}}\n' \
 		"$(CURDIR)" "$(CURDIR)" > build/ref-ordinal-nc/overlay.json
-	@if go test -overlay build/ref-ordinal-nc/overlay.json -count=1 ./compiler \
+	@if SCHEMA_SLOW=1 go test -v -overlay build/ref-ordinal-nc/overlay.json -count=1 ./compiler \
 			-run TestCppTableRefOrdinalBytes > build/ref-ordinal-nc/log 2>&1; then \
+		grep -q -- '--- PASS' build/ref-ordinal-nc/log || \
+			{ echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
+			  cat build/ref-ordinal-nc/log; exit 1; }; \
 		echo "NEGATIVE CONTROL FAILED: truncate leaves the ordinal slot standing and the byte pin stayed green"; \
 		cat build/ref-ordinal-nc/log; exit 1; \
 	fi
@@ -4851,8 +4854,11 @@ tables-ref-ordinal-shared-negative-control:
 		{ echo "NEGATIVE CONTROL: the hit-path sabotage patched nothing"; exit 1; } || true
 	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/ref-ordinal-shared-nc/emitter.go.txt"}}\n' \
 		"$(CURDIR)" "$(CURDIR)" > build/ref-ordinal-shared-nc/overlay.json
-	@if go test -overlay build/ref-ordinal-shared-nc/overlay.json -count=1 ./compiler \
+	@if SCHEMA_SLOW=1 go test -v -overlay build/ref-ordinal-shared-nc/overlay.json -count=1 ./compiler \
 			-run TestCppTableRefOrdinalSharedId > build/ref-ordinal-shared-nc/log 2>&1; then \
+		grep -q -- '--- PASS' build/ref-ordinal-shared-nc/log || \
+			{ echo "NEGATIVE CONTROL FAILED: the shared-id driver did not run (skipped), so this control is watching nothing"; \
+			  cat build/ref-ordinal-shared-nc/log; exit 1; }; \
 		echo "NEGATIVE CONTROL FAILED: only the miss path records the ordinal and the shared-id driver stayed green"; \
 		cat build/ref-ordinal-shared-nc/log; exit 1; \
 	fi

--- a/make/c.mk
+++ b/make/c.mk
@@ -795,9 +795,11 @@ tables-c-ref-ordinal-negative-control:
 		"$(CURDIR)" "$(CURDIR)" > build/c-ref-ordinal-nc/overlay.json
 	@if SCHEMA_SLOW=1 go test -v -overlay build/c-ref-ordinal-nc/overlay.json -count=1 ./compiler \
 			-run TestCTableRefOrdinalBytes > build/c-ref-ordinal-nc/log 2>&1; then \
-		grep -q -- '--- PASS' build/c-ref-ordinal-nc/log || \
-			{ echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
-			  cat build/c-ref-ordinal-nc/log; exit 1; }; \
+		if grep -q -- '--- SKIP' build/c-ref-ordinal-nc/log || \
+				! grep -q -- '--- PASS' build/c-ref-ordinal-nc/log; then \
+			echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
+			cat build/c-ref-ordinal-nc/log; exit 1; \
+		fi; \
 		echo "NEGATIVE CONTROL FAILED: the rewind leaves the ordinal slot standing and the byte pin stayed green"; \
 		cat build/c-ref-ordinal-nc/log; exit 1; \
 	fi
@@ -1121,9 +1123,11 @@ tables-c-message-negative-control:
 	go run ./tools/sabotage -name message-c-wrong-slot -out build/c-message-negative/message_save.gotext internal/codegen/ctable/message_save.go
 	@printf '{"Replace":{"%s/internal/codegen/ctable/message_save.go":"%s/build/c-message-negative/message_save.gotext"}}\n' "$(CURDIR)" "$(CURDIR)" > build/c-message-negative/overlay.json
 	@if SCHEMA_SLOW=1 go test -v -count=1 -overlay=build/c-message-negative/overlay.json ./compiler -run '^TestCTableMessageSave$$' > build/c-message-negative/log 2>&1; then \
-		grep -q -- '--- PASS' build/c-message-negative/log || \
-			{ echo 'NEGATIVE CONTROL FAILED: the wire comparison did not run (skipped), so this control is watching nothing'; \
-			  cat build/c-message-negative/log; exit 1; }; \
+		if grep -q -- '--- SKIP' build/c-message-negative/log || \
+				! grep -q -- '--- PASS' build/c-message-negative/log; then \
+			echo 'NEGATIVE CONTROL FAILED: the wire comparison did not run (skipped), so this control is watching nothing'; \
+			cat build/c-message-negative/log; exit 1; \
+		fi; \
 		echo 'NEGATIVE CONTROL FAILED: the message slot changed without failing the wire comparison'; exit 1; \
 	fi
 	@grep -q -- '--- FAIL: TestCTableMessageSave' build/c-message-negative/log
@@ -1143,9 +1147,11 @@ tables-c-retain-negative-control:
 	go run ./tools/sabotage -name retain-c-drop-field -out build/c-retain-negative/retain.gotext internal/codegen/ctable/retain.go
 	@printf '{"Replace":{"%s/internal/codegen/ctable/retain.go":"%s/build/c-retain-negative/retain.gotext"}}\n' "$(CURDIR)" "$(CURDIR)" > build/c-retain-negative/overlay.json
 	@if SCHEMA_SLOW=1 go test -v -count=1 -overlay=build/c-retain-negative/overlay.json ./compiler -run '^TestCTableRetainFile$$' > build/c-retain-negative/log 2>&1; then \
-		grep -q -- '--- PASS' build/c-retain-negative/log || \
-			{ echo 'NEGATIVE CONTROL FAILED: the public round-trip report did not run (skipped), so this control is watching nothing'; \
-			  cat build/c-retain-negative/log; exit 1; }; \
+		if grep -q -- '--- SKIP' build/c-retain-negative/log || \
+				! grep -q -- '--- PASS' build/c-retain-negative/log; then \
+			echo 'NEGATIVE CONTROL FAILED: the public round-trip report did not run (skipped), so this control is watching nothing'; \
+			cat build/c-retain-negative/log; exit 1; \
+		fi; \
 		echo 'NEGATIVE CONTROL FAILED: silently dropped C retained field passed'; exit 1; fi
 	@grep -q -- '--- FAIL: TestCTableRetainFile' build/c-retain-negative/log
 	@grep -q -- 'report.retained==13' build/c-retain-negative/log

--- a/make/c.mk
+++ b/make/c.mk
@@ -793,8 +793,11 @@ tables-c-ref-ordinal-negative-control:
 		{ echo "NEGATIVE CONTROL: the rewind sabotage patched nothing"; exit 1; } || true
 	@printf '{"Replace":{"%s/internal/codegen/ctable/wire.go":"%s/build/c-ref-ordinal-nc/emitter.go.txt"}}\n' \
 		"$(CURDIR)" "$(CURDIR)" > build/c-ref-ordinal-nc/overlay.json
-	@if go test -overlay build/c-ref-ordinal-nc/overlay.json -count=1 ./compiler \
+	@if SCHEMA_SLOW=1 go test -v -overlay build/c-ref-ordinal-nc/overlay.json -count=1 ./compiler \
 			-run TestCTableRefOrdinalBytes > build/c-ref-ordinal-nc/log 2>&1; then \
+		grep -q -- '--- PASS' build/c-ref-ordinal-nc/log || \
+			{ echo "NEGATIVE CONTROL FAILED: the byte pin did not run (skipped), so this control is watching nothing"; \
+			  cat build/c-ref-ordinal-nc/log; exit 1; }; \
 		echo "NEGATIVE CONTROL FAILED: the rewind leaves the ordinal slot standing and the byte pin stayed green"; \
 		cat build/c-ref-ordinal-nc/log; exit 1; \
 	fi
@@ -1117,7 +1120,10 @@ tables-c-message-negative-control:
 	@mkdir -p build/c-message-negative
 	go run ./tools/sabotage -name message-c-wrong-slot -out build/c-message-negative/message_save.gotext internal/codegen/ctable/message_save.go
 	@printf '{"Replace":{"%s/internal/codegen/ctable/message_save.go":"%s/build/c-message-negative/message_save.gotext"}}\n' "$(CURDIR)" "$(CURDIR)" > build/c-message-negative/overlay.json
-	@if go test -count=1 -overlay=build/c-message-negative/overlay.json ./compiler -run '^TestCTableMessageSave$$' > build/c-message-negative/log 2>&1; then \
+	@if SCHEMA_SLOW=1 go test -v -count=1 -overlay=build/c-message-negative/overlay.json ./compiler -run '^TestCTableMessageSave$$' > build/c-message-negative/log 2>&1; then \
+		grep -q -- '--- PASS' build/c-message-negative/log || \
+			{ echo 'NEGATIVE CONTROL FAILED: the wire comparison did not run (skipped), so this control is watching nothing'; \
+			  cat build/c-message-negative/log; exit 1; }; \
 		echo 'NEGATIVE CONTROL FAILED: the message slot changed without failing the wire comparison'; exit 1; \
 	fi
 	@grep -q -- '--- FAIL: TestCTableMessageSave' build/c-message-negative/log
@@ -1136,7 +1142,10 @@ tables-c-retain-negative-control:
 	@mkdir -p build/c-retain-negative
 	go run ./tools/sabotage -name retain-c-drop-field -out build/c-retain-negative/retain.gotext internal/codegen/ctable/retain.go
 	@printf '{"Replace":{"%s/internal/codegen/ctable/retain.go":"%s/build/c-retain-negative/retain.gotext"}}\n' "$(CURDIR)" "$(CURDIR)" > build/c-retain-negative/overlay.json
-	@if go test -count=1 -overlay=build/c-retain-negative/overlay.json ./compiler -run '^TestCTableRetainFile$$' > build/c-retain-negative/log 2>&1; then \
+	@if SCHEMA_SLOW=1 go test -v -count=1 -overlay=build/c-retain-negative/overlay.json ./compiler -run '^TestCTableRetainFile$$' > build/c-retain-negative/log 2>&1; then \
+		grep -q -- '--- PASS' build/c-retain-negative/log || \
+			{ echo 'NEGATIVE CONTROL FAILED: the public round-trip report did not run (skipped), so this control is watching nothing'; \
+			  cat build/c-retain-negative/log; exit 1; }; \
 		echo 'NEGATIVE CONTROL FAILED: silently dropped C retained field passed'; exit 1; fi
 	@grep -q -- '--- FAIL: TestCTableRetainFile' build/c-retain-negative/log
 	@grep -q -- 'report.retained==13' build/c-retain-negative/log

--- a/test/conformance/go/container-negative-control
+++ b/test/conformance/go/container-negative-control
@@ -19,11 +19,14 @@ if cmp -s "$source" "$out/source.gotext"; then
 fi
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
-# test/tables/reference-review-control. A gated test SKIPS and `go test` exits
-# 0, which from out here is indistinguishable from a gate that stayed green.
+# SCHEMA_SLOW=1 IS THE FIX, and the scan under it is a DIAGNOSTIC on a branch
+# that already failed — see the block in test/tables/reference-review-control.
+# A gated test SKIPS and `go test` exits 0, which from out here is
+# indistinguishable from a gate that stayed green.
 if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
-    grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
+    if grep -q -- '--- SKIP' "$out/log" || ! grep -q -- '--- PASS' "$out/log"; then
+        echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1
+    fi
     echo "container control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/conformance/go/container-negative-control
+++ b/test/conformance/go/container-negative-control
@@ -19,7 +19,11 @@ if cmp -s "$source" "$out/source.gotext"; then
 fi
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-if go test -overlay "$out/overlay.json" ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
+# test/tables/reference-review-control. A gated test SKIPS and `go test` exits
+# 0, which from out here is indistinguishable from a gate that stayed green.
+if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+    grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
     echo "container control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/conformance/go/ownership-negative-control
+++ b/test/conformance/go/ownership-negative-control
@@ -21,7 +21,8 @@ frame) source=regions.go; sabotage=go-allocator-frame; expected='Go allocations 
 file-count-floor) source=retain.go; sabotage=go-retain-file-count-floor; test=TestRetainFileCapacityBeforeExpansion; expected='count expanded past available resolved capacity' ;;
 message-depth) source=retainmessage.go; sabotage=go-retain-message-depth; test=TestRetainMessage; expected='depth 65' ;;
 runtime)
-    if SCHEMA_GO_ALLOC_TOOLCHAIN=go1.27.1 SCHEMA_GO_ALLOC_ANY_GO=0 GOTOOLCHAIN=go1.27.1 go test ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+    if SCHEMA_SLOW=1 SCHEMA_GO_ALLOC_TOOLCHAIN=go1.27.1 SCHEMA_GO_ALLOC_ANY_GO=0 GOTOOLCHAIN=go1.27.1 go test -v ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+        grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the certification gate did not run (skipped), so this control is watching nothing: runtime" >&2; cat "$out/log" >&2; exit 1; }
         echo 'allocation certification accepted a different runtime' >&2; exit 1
     fi
     grep -Fq 'allocation certification requires go1.26.0, running go1.27.1' "$out/log"
@@ -32,7 +33,10 @@ source=internal/codegen/gotable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-if GOTOOLCHAIN=go1.26.0 go test -overlay "$out/overlay.json" ./internal/codegen/gotable -run "$test" -count=1 > "$out/log" 2>&1; then
+# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
+# test/tables/reference-review-control.
+if SCHEMA_SLOW=1 GOTOOLCHAIN=go1.26.0 go test -v -overlay "$out/overlay.json" ./internal/codegen/gotable -run "$test" -count=1 > "$out/log" 2>&1; then
+    grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
     echo "ownership control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/conformance/go/ownership-negative-control
+++ b/test/conformance/go/ownership-negative-control
@@ -22,7 +22,9 @@ file-count-floor) source=retain.go; sabotage=go-retain-file-count-floor; test=Te
 message-depth) source=retainmessage.go; sabotage=go-retain-message-depth; test=TestRetainMessage; expected='depth 65' ;;
 runtime)
     if SCHEMA_SLOW=1 SCHEMA_GO_ALLOC_TOOLCHAIN=go1.27.1 SCHEMA_GO_ALLOC_ANY_GO=0 GOTOOLCHAIN=go1.27.1 go test -v ./internal/codegen/gotable -run "^$test\$" -count=1 > "$out/log" 2>&1; then
-        grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the certification gate did not run (skipped), so this control is watching nothing: runtime" >&2; cat "$out/log" >&2; exit 1; }
+        if grep -q -- '--- SKIP' "$out/log" || ! grep -q -- '--- PASS' "$out/log"; then
+            echo "NEGATIVE CONTROL FAILED: the certification gate did not run (skipped), so this control is watching nothing: runtime" >&2; cat "$out/log" >&2; exit 1
+        fi
         echo 'allocation certification accepted a different runtime' >&2; exit 1
     fi
     grep -Fq 'allocation certification requires go1.26.0, running go1.27.1' "$out/log"
@@ -33,10 +35,12 @@ source=internal/codegen/gotable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
-# test/tables/reference-review-control.
+# SCHEMA_SLOW=1 IS THE FIX, and the scan under it is a DIAGNOSTIC on a branch
+# that already failed — see the block in test/tables/reference-review-control.
 if SCHEMA_SLOW=1 GOTOOLCHAIN=go1.26.0 go test -v -overlay "$out/overlay.json" ./internal/codegen/gotable -run "$test" -count=1 > "$out/log" 2>&1; then
-    grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
+    if grep -q -- '--- SKIP' "$out/log" || ! grep -q -- '--- PASS' "$out/log"; then
+        echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1
+    fi
     echo "ownership control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/tables/reference-review-control
+++ b/test/tables/reference-review-control
@@ -17,14 +17,23 @@ source=internal/codegen/cpptable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN. internal/slowtest gates every test
-# that shells out to a foreign toolchain, and a GATED TEST SKIPS, which `go
-# test` reports as exit 0 — indistinguishable, from the outside, from a gate
-# that stayed green under the sabotage. So the control sets the variable that
-# makes its gate run, and when the run comes back green it first asks whether
-# the gate ran at all: a skip is "watching nothing", never "stayed green".
+# SCHEMA_SLOW=1 IS THE FIX. internal/slowtest gates every test that shells out
+# to a foreign toolchain, and a GATED TEST SKIPS, which `go test` reports as
+# exit 0 — so the gate this control names was not running at all, and exit 0
+# was indistinguishable, from out here, from a gate that stayed green under the
+# sabotage. Setting the variable is what makes the gate run.
+#
+# THE SCAN BELOW IS A DIAGNOSTIC, NOT A SECOND GATE, and it changes no
+# outcome: this branch already failed the control ("stayed green", exit 1)
+# before it was added, and still does. All it changes is WHICH CAUSE the
+# failure names, so a skip is no longer reported as a sabotage the gate
+# survived. It asks for a `--- SKIP` as well as for a missing `--- PASS`
+# because a skipped SUBTEST still prints `--- PASS` for its parent, so the
+# PASS line alone cannot tell a subtest-shaped gate from a run.
 if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" ./compiler -run "^$test\$" -count=1 > "$out/log" 2>&1; then
- grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
+ if grep -q -- '--- SKIP' "$out/log" || ! grep -q -- '--- PASS' "$out/log"; then
+  echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1
+ fi
  echo "reference control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/tables/reference-review-control
+++ b/test/tables/reference-review-control
@@ -17,7 +17,14 @@ source=internal/codegen/cpptable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-if go test -overlay "$out/overlay.json" ./compiler -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN. internal/slowtest gates every test
+# that shells out to a foreign toolchain, and a GATED TEST SKIPS, which `go
+# test` reports as exit 0 — indistinguishable, from the outside, from a gate
+# that stayed green under the sabotage. So the control sets the variable that
+# makes its gate run, and when the run comes back green it first asks whether
+# the gate ran at all: a skip is "watching nothing", never "stayed green".
+if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" ./compiler -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+ grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
  echo "reference control stayed green: $mode" >&2; exit 1
 fi
 if grep -q '\[build failed\]' "$out/log"; then cat "$out/log"; exit 1; fi

--- a/test/tables/view-go-control
+++ b/test/tables/view-go-control
@@ -13,10 +13,12 @@ source=internal/codegen/gotable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
-# test/tables/reference-review-control.
+# SCHEMA_SLOW=1 IS THE FIX, and the scan under it is a DIAGNOSTIC on a branch
+# that already failed — see the block in test/tables/reference-review-control.
 if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" "$package" -run "^$test\$" -count=1 > "$out/log" 2>&1; then
- grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
+ if grep -q -- '--- SKIP' "$out/log" || ! grep -q -- '--- PASS' "$out/log"; then
+  echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1
+ fi
  echo "view control stayed green: $mode" >&2;exit 1
 fi
 if grep -q '\[build failed\]' "$out/log";then cat "$out/log";exit 1;fi

--- a/test/tables/view-go-control
+++ b/test/tables/view-go-control
@@ -13,7 +13,12 @@ source=internal/codegen/gotable/$source
 go run ./tools/sabotage -name "$sabotage" -out "$out/source.gotext" "$source"
 root=$(pwd)
 printf '{"Replace":{"%s/%s":"%s/%s/source.gotext"}}\n' "$root" "$source" "$root" "$out" > "$out/overlay.json"
-if go test -overlay "$out/overlay.json" "$package" -run "^$test\$" -count=1 > "$out/log" 2>&1; then echo "view control stayed green: $mode" >&2;exit 1;fi
+# SCHEMA_SLOW=1, AND THE PROOF THAT IT RAN — see the block in
+# test/tables/reference-review-control.
+if SCHEMA_SLOW=1 go test -v -overlay "$out/overlay.json" "$package" -run "^$test\$" -count=1 > "$out/log" 2>&1; then
+ grep -q -- '--- PASS' "$out/log" || { echo "NEGATIVE CONTROL FAILED: the gate did not run (skipped, or no test matched $test), so this control is watching nothing: $mode" >&2; cat "$out/log" >&2; exit 1; }
+ echo "view control stayed green: $mode" >&2;exit 1
+fi
 if grep -q '\[build failed\]' "$out/log";then cat "$out/log";exit 1;fi
 grep -Fq "$expected" "$out/log" || { cat "$out/log";exit 1; }
 echo "Go view control: $mode detected"

--- a/tools/sabotage/table_fixed_java_armtext.go
+++ b/tools/sabotage/table_fixed_java_armtext.go
@@ -16,9 +16,17 @@ package main
 
 func init() {
 	sabotages["fixed-form-java-arm-text-flavour"] = []edit{
+		// THE ARITY IS THE TEN-ARGUMENT `push`'s, AND `meta` IS ITS LAST
+		// PARAMETER. The encoding this plants had no meta lane at all: the
+		// flavour went into `arg`, the ARM ORDINAL's own slot, through the
+		// NINE-argument overload. Spelling it as a ten-argument call with
+		// `arg` last put a `long` in a `byte` parameter and javac refused the
+		// sabotaged tree outright (`possible lossy conversion from long to
+		// byte`) -- a control that cannot compile is a control that never
+		// reaches the gate it names.
 		{
 			old: "c.push(theirAt, at, units, auxAt, guard, opText, arg, (byte) 0, (byte) 0, meta);",
-			new: "c.push(theirAt, at, units, auxAt, guard, opText, meta, (byte) 0, (byte) 0, arg); // SABOTAGED: the flavour over the arm ordinal",
+			new: "c.push(theirAt, at, units, auxAt, guard, opText, meta, (byte) 0, (byte) 0); // SABOTAGED: the flavour over the arm ordinal",
 		},
 		{
 			old: "final int unit = (p.meta == textWide) ? 2 : 1;",


### PR DESCRIPTION
Makes the existing negative controls run their intended toolchain tests under `SCHEMA_SLOW=1`. Previously, a skipped test could leave a control testing nothing. The controls now distinguish a skipped/unselected test from a sabotage that survived; existing semantic-failure assertions remain intact.

The Java Fixed Tables arm-text sabotage now calls the intended nine-argument overload, so the corrupted generated source compiles and the wire test detects the defect instead of stopping at an unrelated argument-type error.

Validation: the author reports37 red-as-intended controls on Darwin/arm64, with representative unsabotaged PASS receipts retained in the discussion. Emma independently reviewed the987+990 join at0ccb4218, exercised reference/container/ownership/view defect controls and a skipped-gate refusal, and verified that the five temporary exceptions must be removed when990 joins. Stella read the complete seven-file implementation delta and confirmed the required fast CI checks are green at3bf02a4a.

This merges the negative-control repair as a component. Positive-gate coverage accounting remains in990/988, generated-tree preservation in989, and Linux/Windows/full-hour soak certification remains uncompleted. The later join must preserve991's JS/Dart selections. No test or assertion is removed by this change.
