### PR TITLE
G3: the generated-tree verifier compares the full listing from a clean directory

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -161,23 +161,21 @@ jobs:
 
       # The committed generated/ tree is what this repo treats as ground
       # truth — findings are receipted against its line numbers. `make test`
-      # above regenerated every tracked file IN PLACE, so staleness is
-      # precisely a dirty tree here: a tracked file that changed, or a newly
-      # emitted file nobody committed (which a diff-only check would miss).
-      # The pull-request gate reaches the same verdict from bin/schema alone;
-      # this is the same check against the whole chain's output.
-      - name: generated tree is current
+      # above regenerated every tracked file IN PLACE, and in place a rule only
+      # writes: a file the emitter STOPPED writing stays on disk byte-identical
+      # to the index, and a rule that never ran leaves its whole directory
+      # standing, and a diff calls both green. So the verdict here is the same
+      # script the `generated` job in ci-full.yml and `make generated-current`
+      # run — test/generated-tree/verify, which moves the tree aside and emits
+      # into NOTHING (#898's gate G3), then compares the full listing and the
+      # bytes both ways. It checks this chain's in-place output against the
+      # committed tree on its way past.
+      - name: the committed generated/ tree is what this compiler emits, from an empty directory
         run: |
-          git diff --exit-code generated/ || {
-            echo "::error::committed generated/ tree is stale — the current compiler emits different text. Run 'make test' (or ./bin/schema generate --lang <lang> --out generated/<dir> <corpus>) and commit the regenerated files."
+          test/generated-tree/verify || {
+            echo "::error::the committed generated/ tree is not what the compiler at this sha emits. The lists above name every file: regenerate with 'make test' (or ./bin/schema generate --lang <lang> --out generated/<dir> <corpus>) and commit them, 'git rm' the ones it no longer emits, or name tracked build wiring in test/generated-tree/not-emitted."
             exit 1
           }
-          untracked=$(git status --porcelain generated/)
-          if [ -n "$untracked" ]; then
-            echo "$untracked"
-            echo "::error::the generator emitted files that are not committed under generated/ — add them."
-            exit 1
-          fi
 
       # Seeded corpus only — a short, bounded run that re-executes every
       # crasher ever found and checks the compiler still refuses bad input

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -475,15 +475,22 @@ jobs:
   #
   # Every generation rule takes exactly one input, bin/schema, and no toolchain
   # and no sibling checkout: the emitted text of a Go, Rust, C#, Dart, Java or
-  # Elixir unit is a function of the compiler alone. So this job regenerates
-  # the whole tree IN PLACE with Go and nothing else, and staleness is
-  # precisely a dirty tree afterwards — a tracked file that changed, or a newly
-  # emitted file nobody committed, which a diff-only check would miss.
+  # Elixir unit is a function of the compiler alone. So this job emits the whole
+  # tree with Go and nothing else — and it emits it into an EMPTY DIRECTORY
+  # (#898's gate G3). In place, which is what this job used to do, a rule only
+  # ever writes: a file the emitter STOPPED writing stays on disk byte-identical
+  # to the index, and a rule that never ran leaves its whole directory standing,
+  # and `git diff` calls both of those green. From nothing, the full listing and
+  # the bytes answer in both directions, and every failing file is named.
   #
-  # The stamp list is DERIVED from the Makefile and its per-language includes
-  # rather than typed here, so a port that adds generated/<lang>/.stamp in its
-  # make/<lang>.mk is covered the moment it rebases, with no edit to this file. Locally the same check is `make
-  # generated-current`, which gets there through the whole `make test` chain.
+  # THE WHOLE VERDICT IS test/generated-tree/verify, which `make
+  # generated-current` runs locally and the certify workflow runs on main — one
+  # script, so the three cannot drift. Its own negative control is in `make
+  # test`. The stamp list is DERIVED inside it from the Makefile and its
+  # per-language includes rather than typed anywhere, so a port that adds
+  # generated/<lang>/.stamp in its make/<lang>.mk is covered the moment it
+  # rebases; that scan proves the rules EXIST, and the emission from nothing is
+  # what proves one ran.
   generated:
     # Runs on a pull request only when it carries the `full-ci` label; on a
     # merge, the nightly and a dispatch it always runs. The expression is
@@ -498,29 +505,15 @@ jobs:
           go-version: '1.26'
           cache: false
 
-      - name: regenerate every committed generated/ tree
-        run: |
-          stamps=$(grep -hoE '^generated/[A-Za-z0-9/_.-]*/\.stamp:' Makefile make/*.mk | sed 's/:$//' | sort -u)
-          if [ -z "$stamps" ]; then
-            echo "::error::no generated/*/.stamp rules found in the Makefile or make/*.mk — this check would pass over an empty set"
-            exit 1
-          fi
-          echo "$stamps"
-          # shellcheck disable=SC2086
-          make $stamps
+      - name: the gate's own negative control
+        run: make generated-tree-negative-controls
 
-      - name: generated tree is current
+      - name: the committed generated/ tree is what this compiler emits, from an empty directory
         run: |
-          git diff --exit-code generated/ || {
-            echo "::error::committed generated/ tree is stale — the current compiler emits different text. Run 'make test' (or ./bin/schema generate --lang <lang> --out generated/<dir> <corpus>) and commit the regenerated files."
+          test/generated-tree/verify || {
+            echo "::error::the committed generated/ tree is not what the compiler at this sha emits. The lists above name every file: regenerate with 'make test' (or ./bin/schema generate --lang <lang> --out generated/<dir> <corpus>) and commit them, 'git rm' the ones it no longer emits, or name tracked build wiring in test/generated-tree/not-emitted."
             exit 1
           }
-          untracked=$(git status --porcelain generated/)
-          if [ -n "$untracked" ]; then
-            echo "$untracked"
-            echo "::error::the generator emitted files that are not committed under generated/ — add them."
-            exit 1
-          fi
 
       - name: the tables goldens match a fresh generation (the block zero-cost gate, byte-identity half)
         run: make tables-block-zero-cost

--- a/Makefile
+++ b/Makefile
@@ -4524,24 +4524,19 @@ bench-fixedform-measure: build/schema_bench_fixedform
 .PHONY: bench-fixedform-measure
 
 
-# Prove the COMMITTED generated/ tree matches what the current compiler
-# emits (issue #30). `make test` regenerates every tracked generated file in
-# place, so staleness is precisely a dirty tree afterwards — a tracked file
-# that changed, or a newly emitted file nobody committed. CI runs the same
-# two checks after its make test step.
-generated-current: test
-	@git diff --exit-code generated/ || { \
-		echo "committed generated/ tree is STALE — the current compiler emits different text."; \
-		echo "review the diff above, then commit the regenerated files."; \
-		exit 1; \
-	}
-	@untracked=$$(git status --porcelain generated/); \
-	if [ -n "$$untracked" ]; then \
-		echo "$$untracked"; \
-		echo "the generator emitted files that are not committed under generated/ — add them."; \
-		exit 1; \
-	fi
-	@echo "generated/ tree is current"
+# Prove the COMMITTED generated/ tree matches what the current compiler emits
+# (issue #30, tightened by #898's gate G3). It used to regenerate in place and
+# read `git diff`: in place a rule only writes and never removes, so a file the
+# emitter STOPPED writing stayed on disk byte-identical to the index and the
+# diff was silent about it — and a rule that never ran at all left its whole
+# directory standing and was called green. So the tree is moved aside and the
+# compiler emits into NOTHING; the full listing and the bytes are compared both
+# ways, with every failing file named. test/generated-tree/verify says how, the
+# `generated` job in ci-full.yml and the certify workflow run that same script,
+# and it no longer needs the whole `make test` chain to get there: the emission
+# takes bin/schema and nothing else.
+generated-current: bin/schema
+	@test/generated-tree/verify
 
 # bench/corpus holds two units (one package per unit, SPEC §3.2), so the
 # corpus commands name each unit's file rather than the directory
@@ -5660,6 +5655,7 @@ include make/checks/packet-void.mk
 include make/checks/packet-defaults.mk
 include make/checks/packet-text.mk
 include make/checks/table-base64.mk
+include make/checks/generated-tree.mk
 
 # THE CONFORMANCE MATRIX (test/conformance/README.md): every discovered driver
 # over every surface it lists. The reference leg is C++ and is built here; the

--- a/Makefile
+++ b/Makefile
@@ -4535,7 +4535,7 @@ bench-fixedform-measure: build/schema_bench_fixedform
 # `generated` job in ci-full.yml and the certify workflow run that same script,
 # and it no longer needs the whole `make test` chain to get there: the emission
 # takes bin/schema and nothing else.
-generated-current: bin/schema
+generated-current: bin/schema build/treelock
 	@test/generated-tree/verify
 
 # bench/corpus holds two units (one package per unit, SPEC §3.2), so the

--- a/generated/bench/tables/c/BenchTableTable.h
+++ b/generated/bench/tables/c/BenchTableTable.h
@@ -806,8 +806,10 @@ typedef struct TableFixedEntry
        must hold for this entry to run. meta IS THE OP'S OWN ARGUMENT — a text
        entry's flavour. THEY ARE TWO LANES BECAUSE THEY ARE TWO FACTS: they
        shared one, and a string(N) under a union's arm then had to be either
-       guarded correctly or read with the right flavour and could not be both. */
-    uint8_t arg;
+       guarded correctly or read with the right flavour and could not be both.
+       arg IS FULL WIDTH, matching the tag read (bill §12.7): a union past 255
+       arms, an enum past 255 variants, the lane is not a byte. */
+    uint64_t arg;
     uint8_t meta;
     uint8_t dstsize;
     uint8_t sign; /* a WIDEN's source is two's complement, so it sign-extends */
@@ -818,6 +820,17 @@ typedef struct TableFixedEntry
        sits last so a ten-value aggregate still names op, arg, meta, dstsize
        and sign in that order. */
     uint8_t argw;
+    /* guard2 / arg2 / argw2 ARE THE OUTER TAG AN ARM INSIDE AN ARM ALSO
+       ANSWERS TO, and they are a CONJUNCTION with guard/arg: an entry runs
+       when BOTH tags hold their ordinal (§4.1, §5.8 row 6). Stamping the
+       outer tag OVER the inner one fired every inner arm the moment the
+       outer one rode and the last arm won; testing only the inner one landed
+       an inner arm's bytes under an outer arm that never rode.
+       SCHEMA_TABLE_FIXED_NO_GUARD is "no second condition", which is every
+       entry that is not nested. */
+    uint32_t guard2;
+    uint64_t arg2;
+    uint8_t argw2;
 } TableFixedEntry;
 
 /* C HAS NO DEFAULT MEMBER INITIALIZERS, so the C++ struct's own defaults — zero
@@ -831,6 +844,8 @@ static SCHEMA_UNUSED TableFixedEntry table_fixed_entry_zero( void )
     memset( &e, 0, sizeof( e ) );
     e.guard = SCHEMA_TABLE_FIXED_NO_GUARD;
     e.argw = 1;
+    e.guard2 = SCHEMA_TABLE_FIXED_NO_GUARD;
+    e.argw2 = 1;
     return e;
 }
 
@@ -1064,11 +1079,11 @@ static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE void table_fixed_apply( cons
                enum gained a variant IN THE MIDDLE is remapped here and never
                reinterpreted. The table is the plan's own, laid down by the
                compiler above the entries. */
-            uint32_t raw = 0;
+            uint64_t raw = 0;
             memcpy( &raw, src + p->src, p->size );
-            const uint16_t * remap = (const uint16_t *) (const void *) ( base + p->aux );
-            uint32_t v = 0;
-            if ( raw != 0 && raw <= (uint32_t) remap[0] ) { v = remap[raw]; }
+            const uint16_t * table = (const uint16_t *) (const void *) ( base + p->aux );
+            uint64_t v = 0;
+            if ( raw != 0 && raw <= (uint64_t) table[0] ) { v = table[raw]; }
             memcpy( dst + p->dst, &v, p->dstsize );
             break;
         }
@@ -1099,7 +1114,11 @@ static SCHEMA_UNUSED SCHEMA_BENCHTABLE_TABLE_INLINE void table_fixed_apply( cons
         }
         case kTableFixedConst:
         {
-            memcpy( dst + p->dst, &p->aux, p->size );
+            /* THROUGH A 64-BIT TEMPORARY: a tag is one, two, four or EIGHT
+               bytes, and a memcpy of p->size out of the four-byte aux lane
+               reads the member beside it (§4.5, §5.8 row 7). */
+            const uint64_t lands = p->aux;
+            memcpy( dst + p->dst, &lands, p->size );
             break;
         }
         /* T INTO ?T: the reader wraps what the writer sent plain, so the present
@@ -1140,7 +1159,8 @@ static SCHEMA_UNUSED void table_fixed_run( const TableFixedEntry * plan, int32_t
     for ( i = guarded; i < count; ++i )
     {
         const TableFixedEntry * p = &plan[i];
-        if ( table_fixed_tag_at( src, p->guard, p->argw ) != (uint64_t) p->arg ) { continue; }
+        if ( table_fixed_tag_at( src, p->guard, p->argw ) != p->arg ) { continue; }
+        if ( p->guard2 != SCHEMA_TABLE_FIXED_NO_GUARD && table_fixed_tag_at( src, p->guard2, p->argw2 ) != p->arg2 ) { continue; }
         table_fixed_apply( p, (const uint8_t *) plan, src, dst, &clamped, &widened );
     }
     report->clamped += clamped;
@@ -1698,8 +1718,11 @@ static SCHEMA_UNUSED void table_fixed_push( TableFixedCompiler * c, TableFixedEn
     {
         if ( e.guard != SCHEMA_TABLE_FIXED_NO_GUARD ) { e.argw = c->argw ? c->argw : (uint8_t) 1; }
         const uint8_t gw = e.argw == 0 ? (uint8_t) 1 : e.argw;
-        const int guard_out = e.guard != SCHEMA_TABLE_FIXED_NO_GUARD &&
-            ( e.guard >= c->record || (uint64_t) e.guard + gw > (uint64_t) c->record );
+        const uint8_t gw2 = e.argw2 == 0 ? (uint8_t) 1 : e.argw2;
+        const int guard_out = ( e.guard != SCHEMA_TABLE_FIXED_NO_GUARD &&
+            ( e.guard >= c->record || (uint64_t) e.guard + gw > (uint64_t) c->record ) ) ||
+            ( e.guard2 != SCHEMA_TABLE_FIXED_NO_GUARD &&
+            ( e.guard2 >= c->record || (uint64_t) e.guard2 + gw2 > (uint64_t) c->record ) );
         const uint64_t reach = (uint64_t) e.src + (uint64_t) e.size + ( e.op == kTableFixedText ? 4ull : 0ull );
         if ( reach > (uint64_t) c->record || guard_out )
         {
@@ -1717,15 +1740,19 @@ static SCHEMA_UNUSED void table_fixed_push( TableFixedCompiler * c, TableFixedEn
    coalescing pass, which only moves entries down, never moves one. */
 static SCHEMA_UNUSED uint32_t table_fixed_lay_table( TableFixedCompiler * c, const uint16_t * values, int32_t n )
 {
+    if ( n < 0 || n > 65535 ) { c->overflow = 1; return 0; }
     const int32_t bytes = ( n + 1 ) * (int32_t) sizeof( uint16_t );
     const int32_t total = (int32_t) sizeof( TableFixedEntry ) * c->capacity;
     c->pool += bytes;
     if ( total - c->pool < c->count * (int32_t) sizeof( TableFixedEntry ) ) { c->overflow = 1; return 0; }
     const uint32_t at = (uint32_t) ( total - c->pool );
-    uint16_t * slots = (uint16_t *) (void *) ( (uint8_t *) c->plan + at );
+    uint16_t * dst = (uint16_t *) (void *) ( (uint8_t *) c->plan + at );
     int32_t i;
-    slots[0] = (uint16_t) n;
-    for ( i = 0; i < n; ++i ) { slots[1 + i] = values[i]; }
+    dst[0] = (uint16_t) n;
+    if ( values != NULL )
+    {
+        for ( i = 0; i < n; ++i ) { dst[1 + i] = values[i]; }
+    }
     return at;
 }
 
@@ -1748,13 +1775,13 @@ static SCHEMA_UNUSED uint32_t table_fixed_lay_fills( TableFixedCompiler * c, int
 static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                                                      const TableFixedLayoutView * theirs, int32_t ti, uint32_t their_at,
                                                      const TableFixedLayoutView * mine, int32_t mi, const TableFixedDst * dst, uint32_t my_at,
-                                                     uint32_t guard, uint8_t arg );
+                                                     uint32_t guard, uint64_t arg );
 
 /* table_fixed_match_children walks a TABLE's children on both sides. */
 static SCHEMA_UNUSED void table_fixed_match_children( TableFixedCompiler * c,
                                                       const TableFixedLayoutView * theirs, int32_t ti, uint32_t their_at,
                                                       const TableFixedLayoutView * mine, int32_t mi, const TableFixedDst * dst, uint32_t my_at,
-                                                      uint32_t guard, uint8_t arg )
+                                                      uint32_t guard, uint64_t arg )
 {
     const TableFixedLayoutEntry te = table_fixed_entry_at( theirs, ti );
     const TableFixedLayoutEntry me = table_fixed_entry_at( mine, mi );
@@ -1802,7 +1829,7 @@ static SCHEMA_UNUSED void table_fixed_match_children( TableFixedCompiler * c,
 static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                                                      const TableFixedLayoutView * theirs, int32_t ti, uint32_t their_at,
                                                      const TableFixedLayoutView * mine, int32_t mi, const TableFixedDst * dst, uint32_t my_at,
-                                                     uint32_t guard, uint8_t arg )
+                                                     uint32_t guard, uint64_t arg )
 {
     const TableFixedLayoutEntry te = table_fixed_entry_at( theirs, ti );
     const TableFixedLayoutEntry me = table_fixed_entry_at( mine, mi );
@@ -1924,13 +1951,21 @@ static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                    bytes are named by the guarded entries. The plan is
                    partitioned unguarded-first, so this is overwritten by the arm
                    that matches and stands when none does. It is the ONE byte
-                   this form writes twice, and it is the compiled path's alone. */
+                   this form writes twice, and it is the compiled path's alone.
+
+                   Nested: None answers to the OUTER tag at the OUTER width. Push
+                   stamps c->argw, which is the inner tag's width here, so restore
+                   the outer width for this one entry (bill §12.7, #876 card 13). */
                 {
+                    const uint8_t inner_argw = c->argw;
+                    if ( guard != SCHEMA_TABLE_FIXED_NO_GUARD ) { c->argw = saved_argw ? saved_argw : (uint8_t) 1; }
                     TableFixedEntry none = table_fixed_entry_zero();
                     none.src = their_at; none.dst = aux_at; none.size = my_tag;
                     none.aux = 0; none.guard = guard; none.op = kTableFixedConst; none.arg = arg;
                     table_fixed_push( c, none );
+                    c->argw = inner_argw;
                 }
+                const int32_t restamp_from = c->count;
                 for ( k = 0; k < me.children && my_arm < mine->count; ++k )
                 {
                     const TableFixedLayoutEntry ma = table_fixed_entry_at( mine, my_arm );
@@ -1944,16 +1979,35 @@ static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                             /* MY tag value, written under THEIR tag's guard */
                             TableFixedEntry tag = table_fixed_entry_zero();
                             tag.src = their_at; tag.dst = aux_at; tag.size = my_tag;
-                            tag.aux = k + 1; tag.guard = their_at; tag.op = kTableFixedConst; tag.arg = (uint8_t) ( j + 1 );
+                            tag.aux = k + 1; tag.guard = their_at; tag.op = kTableFixedConst; tag.arg = (uint64_t) j + 1u;
                             tag.argw = c->argw;
                             table_fixed_push( c, tag );
                             table_fixed_compile_entry( c, theirs, their_arm, their_at + their_tag,
-                                                       mine, my_arm, dst, at, their_at, (uint8_t) ( j + 1 ) );
+                                                       mine, my_arm, dst, at, their_at, (uint64_t) j + 1u );
                             break;
                         }
                         their_arm += table_fixed_subtree( theirs, their_arm );
                     }
                     my_arm += table_fixed_subtree( mine, my_arm );
+                }
+                /* Nested: an arm inside an arm answers to the OUTER tag TOO — the
+                   one that decides whether any of those bytes are there at all —
+                   and its OWN arm selection must survive that (§4.1). So the two
+                   tags are CONJOINED on the second guard lane rather than the
+                   outer one replacing the inner (§5.8 row 6). */
+                if ( guard != SCHEMA_TABLE_FIXED_NO_GUARD )
+                {
+                    const uint8_t outer_w = saved_argw ? saved_argw : (uint8_t) 1;
+                    for ( int32_t q = restamp_from; q < c->count; ++q )
+                    {
+                        /* A THIRD NESTED UNION HAS A THIRD CONDITION and two lanes
+                           cannot carry it: the plan REFUSES BY NAME rather than
+                           drop one (the guard chain is the follow-on, §5.8 row 6). */
+                        if ( c->plan[q].guard2 != SCHEMA_TABLE_FIXED_NO_GUARD ) { c->hostile = 1; break; }
+                        c->plan[q].guard2 = guard;
+                        c->plan[q].arg2 = arg;
+                        c->plan[q].argw2 = outer_w;
+                    }
                 }
                 c->argw = saved_argw;
                 break;
@@ -1969,10 +2023,14 @@ static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                     table_fixed_push( c, e );
                     break;
                 }
-                uint16_t remap[256];
-                const uint32_t n = te.children < 255u ? te.children : 255u;
-                TableFixedEntry e;
+                /* FULL WIDTH (bill §12.7): the remap is one slot per writer
+                   variant, not a 255-deep stack array. n past 65535 is a plan
+                   that does not fit the uint16 length word; overflow refuses it. */
+                const uint32_t n = te.children;
+                const uint32_t at_map = table_fixed_lay_table( c, NULL, (int32_t) n );
                 uint32_t j;
+                if ( c->overflow ) { break; }
+                uint16_t * map = (uint16_t *) (void *) ( (uint8_t *) c->plan + at_map );
                 for ( j = 0; j < n; ++j )
                 {
                     const uint64_t vid = table_fixed_entry_at( theirs, ti + 1 + (int32_t) j ).id;
@@ -1982,12 +2040,12 @@ static SCHEMA_UNUSED void table_fixed_compile_entry( TableFixedCompiler * c,
                     {
                         if ( table_fixed_entry_at( mine, mi + 1 + (int32_t) k ).id == vid ) { landed = (uint16_t) ( k + 1 ); break; }
                     }
-                    remap[j] = landed;
+                    map[1 + j] = landed;
                 }
-                e = table_fixed_entry_zero();
+                TableFixedEntry e = table_fixed_entry_zero();
                 e.src = their_at; e.dst = at; e.size = te.size; e.guard = guard; e.op = kTableFixedOrdinal;
                 e.arg = arg; e.dstsize = (uint8_t) me.size;
-                e.aux = table_fixed_lay_table( c, remap, (int32_t) n );
+                e.aux = at_map;
                 table_fixed_push( c, e );
                 break;
             }
@@ -2073,6 +2131,8 @@ static SCHEMA_UNUSED int32_t table_fixed_compile( const TableFixedLayoutView * t
         if ( out > split && plan[out-1].op == kTableFixedCopy && plan[i].op == kTableFixedCopy &&
              plan[out-1].guard == plan[i].guard && plan[out-1].arg == plan[i].arg &&
              plan[out-1].argw == plan[i].argw &&
+             plan[out-1].guard2 == plan[i].guard2 && plan[out-1].arg2 == plan[i].arg2 &&
+             plan[out-1].argw2 == plan[i].argw2 &&
              plan[out-1].src + plan[out-1].size == plan[i].src &&
              plan[out-1].dst + plan[out-1].size == plan[i].dst )
         {
@@ -8891,8 +8951,8 @@ static SCHEMA_UNUSED const TableFixedDst table_entity_fixed_dst[] = {
    then the arms: the entries that are nearly all of a plan never test a
    guard at all. */
 static SCHEMA_UNUSED const TableFixedEntry table_entity_fixed_plan[] = {
-    { 0u, 0u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 41u, 48u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
+    { 0u, 0u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 41u, 48u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
 };
 static SCHEMA_UNUSED const int32_t table_entity_fixed_plan_count = 2;
 static SCHEMA_UNUSED const int32_t table_entity_fixed_plan_guarded = 2;
@@ -9114,7 +9174,7 @@ static SCHEMA_UNUSED const TableFixedDst table_stat_fixed_dst[] = {
    then the arms: the entries that are nearly all of a plan never test a
    guard at all. */
 static SCHEMA_UNUSED const TableFixedEntry table_stat_fixed_plan[] = {
-    { 0u, 0u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* stat_id */
+    { 0u, 0u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* stat_id */
 };
 static SCHEMA_UNUSED const int32_t table_stat_fixed_plan_count = 1;
 static SCHEMA_UNUSED const int32_t table_stat_fixed_plan_guarded = 1;
@@ -9483,37 +9543,37 @@ static SCHEMA_UNUSED const TableFixedDst table_mixed_fixed_dst[] = {
    then the arms: the entries that are nearly all of a plan never test a
    guard at all. */
 static SCHEMA_UNUSED const TableFixedEntry table_mixed_fixed_plan[] = {
-    { 0u, 0u, 2u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* protocol_magic */
-    { 2u, 4u, 24u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* sequence */
-    { 26u, 32u, 28u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* nonce */
-    { 54u, 576u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCount, 0, 0, 0, 0, 1 }, /* entities count */
-    { 58u, 64u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 99u, 112u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 109u, 128u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 150u, 176u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 160u, 192u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 201u, 240u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 211u, 256u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 252u, 304u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 262u, 320u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 303u, 368u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 313u, 384u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 354u, 432u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 364u, 448u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 405u, 496u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 415u, 512u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* entity_id */
-    { 456u, 560u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* damage */
-    { 466u, 1220u, 80u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCount, 0, 0, 0, 0, 1 }, /* stats count */
-    { 470u, 580u, 640u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* stats, whole */
-    { 1110u, 1224u, 1u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* game_event tag */
-    { 1124u, 1244u, 4u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* loadout, whole */
-    { 1128u, 1264u, 15u, 1248u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedText, 0, 1, 0, 0, 1 }, /* player_name */
-    { 1147u, 1284u, 16u, 1268u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedText, 0, 3, 0, 0, 1 }, /* payload */
-    { 1167u, 1288u, 49u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* aim_x */
-    { 1216u, 1340u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1 }, /* extra */
-    { 1111u, 1228u, 13u, 0u, 1110u, kTableFixedCopy, 1, 0, 0, 0, 1 }, /* target_id */
-    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 2, 0, 0, 0, 1 }, /* channel */
-    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 3, 0, 0, 0, 1 }, /* item_id */
+    { 0u, 0u, 2u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* protocol_magic */
+    { 2u, 4u, 24u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* sequence */
+    { 26u, 32u, 28u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* nonce */
+    { 54u, 576u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCount, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entities count */
+    { 58u, 64u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 99u, 112u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 109u, 128u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 150u, 176u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 160u, 192u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 201u, 240u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 211u, 256u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 252u, 304u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 262u, 320u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 303u, 368u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 313u, 384u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 354u, 432u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 364u, 448u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 405u, 496u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 415u, 512u, 41u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* entity_id */
+    { 456u, 560u, 10u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* damage */
+    { 466u, 1220u, 80u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCount, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* stats count */
+    { 470u, 580u, 640u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* stats, whole */
+    { 1110u, 1224u, 1u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* game_event tag */
+    { 1124u, 1244u, 4u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* loadout, whole */
+    { 1128u, 1264u, 15u, 1248u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedText, 0, 1, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* player_name */
+    { 1147u, 1284u, 16u, 1268u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedText, 0, 3, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* payload */
+    { 1167u, 1288u, 49u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* aim_x */
+    { 1216u, 1340u, 8u, 0u, SCHEMA_TABLE_FIXED_NO_GUARD, kTableFixedCopy, 0, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* extra */
+    { 1111u, 1228u, 13u, 0u, 1110u, kTableFixedCopy, 1, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* target_id */
+    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 2, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* channel */
+    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 3, 0, 0, 0, 1, SCHEMA_TABLE_FIXED_NO_GUARD, 0, 1 }, /* item_id */
 };
 static SCHEMA_UNUSED const int32_t table_mixed_fixed_plan_count = 31;
 static SCHEMA_UNUSED const int32_t table_mixed_fixed_plan_guarded = 28;

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -2273,6 +2273,16 @@ struct TableFixedEntry
     // sits last so a ten-value aggregate still names op, arg, meta, dstsize
     // and sign in that order.
     uint8_t argw = 1;
+    // guard2 / arg2 / argw2 ARE THE OUTER TAG AN ARM INSIDE AN ARM ALSO
+    // ANSWERS TO, and they are a CONJUNCTION with guard/arg: an entry runs
+    // when BOTH tags hold their ordinal (§4.1, §5.8 row 6). Stamping the
+    // outer tag OVER the inner one fired every inner arm the moment the
+    // outer one rode and the last arm won; testing only the inner one landed
+    // an inner arm's bytes under an outer arm that never rode. kTableFixedNoGuard
+    // is "no second condition", which is every entry that is not nested.
+    uint32_t guard2 = kTableFixedNoGuard;
+    uint64_t arg2 = 0;
+    uint8_t argw2 = 1;
 };
 
 // A PLAN IS PARTITIONED: every UNGUARDED entry first, then every guarded one,
@@ -2492,7 +2502,11 @@ TABLE_FIXED_INLINE void TableFixedApply( const TableFixedEntry & p, const uint8_
         }
         case kTableFixedConst:
         {
-            memcpy( dst + p.dst, &p.aux, p.size );
+            // THROUGH A 64-BIT TEMPORARY: a tag is one, two, four or EIGHT
+            // bytes, and a memcpy of p.size out of the four-byte aux lane
+            // reads the member beside it (§4.5, §5.8 row 7).
+            const uint64_t lands = p.aux;
+            memcpy( dst + p.dst, &lands, p.size );
             // An unguarded None const with dstsize = the WRITER's arm count:
             // a tag past that set lands None (already written) and COUNTS.
             if ( p.aux == 0 && p.dstsize != 0 && p.guard == kTableFixedNoGuard )
@@ -2532,6 +2546,7 @@ inline void TableFixedRun( const TableFixedEntry * plan, int32_t count, int32_t 
     {
         const TableFixedEntry & p = plan[i];
         if ( TableFixedTagAt( src, p.guard, p.argw ) != p.arg ) { continue; }
+        if ( p.guard2 != kTableFixedNoGuard && TableFixedTagAt( src, p.guard2, p.argw2 ) != p.arg2 ) { continue; }
         TableFixedApply( p, (const uint8_t *) plan, src, dst, clamped, widened );
     }
     report->clamped += clamped;
@@ -3018,8 +3033,11 @@ inline void TableFixedPush( TableFixedCompiler & c, TableFixedEntry e )
     {
         if ( e.guard != kTableFixedNoGuard ) { e.argw = c.argw ? c.argw : 1u; }
         const uint8_t gw = e.argw == 0 ? 1u : e.argw;
-        const bool guard_out = e.guard != kTableFixedNoGuard &&
-            ( e.guard >= c.record || (uint64_t) e.guard + gw > (uint64_t) c.record );
+        const uint8_t gw2 = e.argw2 == 0 ? 1u : e.argw2;
+        const bool guard_out = ( e.guard != kTableFixedNoGuard &&
+            ( e.guard >= c.record || (uint64_t) e.guard + gw > (uint64_t) c.record ) ) ||
+            ( e.guard2 != kTableFixedNoGuard &&
+            ( e.guard2 >= c.record || (uint64_t) e.guard2 + gw2 > (uint64_t) c.record ) );
         const uint64_t reach = (uint64_t) e.src + (uint64_t) e.size + ( e.op == kTableFixedText ? 4ull : 0ull );
         if ( reach > (uint64_t) c.record || guard_out )
         {
@@ -3276,27 +3294,23 @@ inline void TableFixedCompileEntry( TableFixedCompiler & c,
                 }
                 my_arm += TableFixedSubtree( mine, my_arm );
             }
-            // Nested: an arm inside an arm answers to the OUTER tag, which is
-            // the one that decides whether any of it is there at all. Identity
-            // rewrites inner-guarded leaves onto that tag; the compiled path
-            // does the same so a foreign outer arm is not read as this inner
-            // union (#876 card 13).
+            // Nested: an arm inside an arm answers to the OUTER tag TOO — the
+            // one that decides whether any of those bytes are there at all —
+            // and its OWN arm selection must survive that (§4.1). So the two
+            // tags are CONJOINED on the second guard lane rather than the
+            // outer one replacing the inner (§5.8 row 6).
             if ( guard != kTableFixedNoGuard )
             {
                 const uint8_t outer_w = saved_argw ? saved_argw : 1u;
-                for ( int32_t i = restamp_from; i < c.count; ++i )
+                for ( int32_t q = restamp_from; q < c.count; ++q )
                 {
-                    // The inner tag's own consts stay on the inner tag: restamping
-                    // them onto the outer tag fires every inner arm when the outer
-                    // matches, and the last arm wins. Payload leaves answer to the
-                    // OUTER tag (#876 card 13).
-                    if ( c.plan[i].guard == their_at &&
-                         !( c.plan[i].op == kTableFixedConst && c.plan[i].dst == aux_at ) )
-                    {
-                        c.plan[i].guard = guard;
-                        c.plan[i].arg = arg;
-                        c.plan[i].argw = outer_w;
-                    }
+                    // A THIRD NESTED UNION HAS A THIRD CONDITION and two lanes
+                    // cannot carry it: the plan REFUSES BY NAME rather than
+                    // drop one (the guard chain is the follow-on, §5.8 row 6).
+                    if ( c.plan[q].guard2 != kTableFixedNoGuard ) { c.hostile = true; break; }
+                    c.plan[q].guard2 = guard;
+                    c.plan[q].arg2 = arg;
+                    c.plan[q].argw2 = outer_w;
                 }
             }
             c.argw = saved_argw;
@@ -3412,6 +3426,8 @@ inline int32_t TableFixedCompile( const TableFixedLayoutView & theirs,
         if ( out > split && plan[out-1].op == kTableFixedCopy && plan[i].op == kTableFixedCopy &&
              plan[out-1].guard == plan[i].guard && plan[out-1].arg == plan[i].arg &&
              plan[out-1].argw == plan[i].argw &&
+             plan[out-1].guard2 == plan[i].guard2 && plan[out-1].arg2 == plan[i].arg2 &&
+             plan[out-1].argw2 == plan[i].argw2 &&
              plan[out-1].src + plan[out-1].size == plan[i].src &&
              plan[out-1].dst + plan[out-1].size == plan[i].dst )
         {
@@ -10694,8 +10710,8 @@ constexpr TableFixedDst TableEntityFixedDst[] = {
 // then the arms: the entries that are nearly all of a plan never test a
 // guard at all.
 constexpr TableFixedEntry TableEntityFixedPlan[] = {
-    { 0u, 0u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 41u, 48u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
+    { 0u, 0u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 41u, 48u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
 };
 constexpr int32_t TableEntityFixedPlanCount = 2;
 constexpr int32_t TableEntityFixedPlanGuarded = 2;
@@ -10996,7 +11012,7 @@ constexpr TableFixedDst TableStatFixedDst[] = {
 // then the arms: the entries that are nearly all of a plan never test a
 // guard at all.
 constexpr TableFixedEntry TableStatFixedPlan[] = {
-    { 0u, 0u, 8u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // stat_id
+    { 0u, 0u, 8u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // stat_id
 };
 constexpr int32_t TableStatFixedPlanCount = 1;
 constexpr int32_t TableStatFixedPlanGuarded = 1;
@@ -11409,37 +11425,37 @@ constexpr TableFixedDst TableMixedFixedDst[] = {
 // then the arms: the entries that are nearly all of a plan never test a
 // guard at all.
 constexpr TableFixedEntry TableMixedFixedPlan[] = {
-    { 0u, 0u, 2u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // protocol_magic
-    { 2u, 4u, 24u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // sequence
-    { 26u, 32u, 28u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // nonce
-    { 54u, 576u, 8u, 0u, kTableFixedNoGuard, kTableFixedCount, 0, 0, 0, 0, 1 }, // entities count
-    { 58u, 64u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 99u, 112u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 109u, 128u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 150u, 176u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 160u, 192u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 201u, 240u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 211u, 256u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 252u, 304u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 262u, 320u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 303u, 368u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 313u, 384u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 354u, 432u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 364u, 448u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 405u, 496u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 415u, 512u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // entity_id
-    { 456u, 560u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // damage
-    { 466u, 1220u, 80u, 0u, kTableFixedNoGuard, kTableFixedCount, 0, 0, 0, 0, 1 }, // stats count
-    { 470u, 580u, 640u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // stats, whole
-    { 1110u, 1224u, 1u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // game_event tag
-    { 1124u, 1244u, 4u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // loadout, whole
-    { 1128u, 1264u, 15u, 1248u, kTableFixedNoGuard, kTableFixedText, 0, 1, 0, 0, 1 }, // player_name
-    { 1147u, 1284u, 16u, 1268u, kTableFixedNoGuard, kTableFixedText, 0, 3, 0, 0, 1 }, // payload
-    { 1167u, 1288u, 49u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // aim_x
-    { 1216u, 1340u, 8u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1 }, // extra
-    { 1111u, 1228u, 13u, 0u, 1110u, kTableFixedCopy, 1, 0, 0, 0, 1 }, // target_id
-    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 2, 0, 0, 0, 1 }, // channel
-    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 3, 0, 0, 0, 1 }, // item_id
+    { 0u, 0u, 2u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // protocol_magic
+    { 2u, 4u, 24u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // sequence
+    { 26u, 32u, 28u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // nonce
+    { 54u, 576u, 8u, 0u, kTableFixedNoGuard, kTableFixedCount, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entities count
+    { 58u, 64u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 99u, 112u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 109u, 128u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 150u, 176u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 160u, 192u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 201u, 240u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 211u, 256u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 252u, 304u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 262u, 320u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 303u, 368u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 313u, 384u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 354u, 432u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 364u, 448u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 405u, 496u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 415u, 512u, 41u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // entity_id
+    { 456u, 560u, 10u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // damage
+    { 466u, 1220u, 80u, 0u, kTableFixedNoGuard, kTableFixedCount, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // stats count
+    { 470u, 580u, 640u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // stats, whole
+    { 1110u, 1224u, 1u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // game_event tag
+    { 1124u, 1244u, 4u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // loadout, whole
+    { 1128u, 1264u, 15u, 1248u, kTableFixedNoGuard, kTableFixedText, 0, 1, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // player_name
+    { 1147u, 1284u, 16u, 1268u, kTableFixedNoGuard, kTableFixedText, 0, 3, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // payload
+    { 1167u, 1288u, 49u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // aim_x
+    { 1216u, 1340u, 8u, 0u, kTableFixedNoGuard, kTableFixedCopy, 0, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // extra
+    { 1111u, 1228u, 13u, 0u, 1110u, kTableFixedCopy, 1, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // target_id
+    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 2, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // channel
+    { 1111u, 1228u, 8u, 0u, 1110u, kTableFixedCopy, 3, 0, 0, 0, 1, kTableFixedNoGuard, 0, 1 }, // item_id
 };
 constexpr int32_t TableMixedFixedPlanCount = 31;
 constexpr int32_t TableMixedFixedPlanGuarded = 28;

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -22,4 +22,21 @@ $(GENERATED_TREE_CONTROLS:%=generated-tree-control-%): generated-tree-control-%:
 generated-tree-negative-controls: $(GENERATED_TREE_CONTROLS:%=generated-tree-control-%)
 	@echo "generated-tree controls: $(words $(GENERATED_TREE_CONTROLS)) planted verdicts, each named"
 
-test: generated-tree-negative-controls
+# THE VERIFIER'S LIFECYCLE WITNESSES. The controls above hand prepared
+# directories to compare; these drive the real verifier in a disposable Git
+# fixture with one generation rule, so they can prove the two things a prepared
+# directory cannot: that a previous run's preserved original tree is RECOVERED
+# and never destroyed (even across a real SIGKILL of the whole verifier process
+# group), and that a staged edit does not pass as committed.
+
+GENERATED_TREE_VERIFY_CONTROLS := kill-retry regeneration-fails second-invocation staged-difference
+
+.PHONY: generated-tree-verify-controls $(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%)
+
+$(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%): generated-tree-verify-control-%:
+	@test/generated-tree/verify-control $*
+
+generated-tree-verify-controls: $(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%)
+	@echo "generated-tree verify controls: $(words $(GENERATED_TREE_VERIFY_CONTROLS)) lifecycle witnesses, each named"
+
+test: generated-tree-negative-controls generated-tree-verify-controls

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -11,7 +11,8 @@
 # belong in `make test` — a gate nobody has seen go red is a decoration.
 
 GENERATED_TREE_CONTROLS := changed stale retired-rule missing \
-	exception-absent exception-emitted exception-honoured ignored clean
+	exception-absent exception-emitted exception-ignored exception-honoured \
+	ignored clean
 
 .PHONY: generated-tree-negative-controls $(GENERATED_TREE_CONTROLS:%=generated-tree-control-%)
 

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -29,11 +29,15 @@ generated-tree-negative-controls: $(GENERATED_TREE_CONTROLS:%=generated-tree-con
 # and never destroyed (even across a real SIGKILL of the whole verifier process
 # group), and that a staged edit does not pass as committed.
 
-GENERATED_TREE_VERIFY_CONTROLS := kill-retry kill-before-emission simultaneous-contender ambiguous-marker regeneration-fails second-invocation staged-difference
+build/treelock: tools/treelock/main.go
+	@mkdir -p build
+	@go build -o build/treelock ./tools/treelock
+
+GENERATED_TREE_VERIFY_CONTROLS := kill-retry kill-before-emission simultaneous-contender ambiguous-marker two-reclaimers acquisition-before-owner regeneration-fails second-invocation staged-difference
 
 .PHONY: generated-tree-verify-controls $(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%)
 
-$(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%): generated-tree-verify-control-%:
+$(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%): generated-tree-verify-control-%: build/treelock
 	@test/generated-tree/verify-control $*
 
 generated-tree-verify-controls: $(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%)

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -29,7 +29,7 @@ generated-tree-negative-controls: $(GENERATED_TREE_CONTROLS:%=generated-tree-con
 # and never destroyed (even across a real SIGKILL of the whole verifier process
 # group), and that a staged edit does not pass as committed.
 
-GENERATED_TREE_VERIFY_CONTROLS := kill-retry regeneration-fails second-invocation staged-difference
+GENERATED_TREE_VERIFY_CONTROLS := kill-retry kill-before-emission simultaneous-contender ambiguous-marker regeneration-fails second-invocation staged-difference
 
 .PHONY: generated-tree-verify-controls $(GENERATED_TREE_VERIFY_CONTROLS:%=generated-tree-verify-control-%)
 

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -29,7 +29,9 @@ generated-tree-negative-controls: $(GENERATED_TREE_CONTROLS:%=generated-tree-con
 # and never destroyed (even across a real SIGKILL of the whole verifier process
 # group), and that a staged edit does not pass as committed.
 
-build/treelock: tools/treelock/main.go
+TREELOCK_SRCS := tools/treelock/main.go tools/treelock/lock_unix.go tools/treelock/lock_windows.go go.mod
+
+build/treelock: $(TREELOCK_SRCS)
 	@mkdir -p build
 	@go build -o build/treelock ./tools/treelock
 

--- a/make/checks/generated-tree.mk
+++ b/make/checks/generated-tree.mk
@@ -1,0 +1,24 @@
+# THE GENERATED-TREE GATE AND ITS NEGATIVE CONTROL (issue #898, Fixed Tables
+# gate G3). test/generated-tree/verify proves the committed generated/ tree is
+# what the compiler at this sha emits, from an EMPTY directory — the only way to
+# see a file the emitter stopped writing, which an in-place regeneration and a
+# `git diff` cannot. `generated-current` in the Makefile is its entry point; the
+# `generated` job in .github/workflows/ci-full.yml and the certify workflow run
+# the same script.
+#
+# The controls are hermetic: they drive test/generated-tree/compare, the
+# verifier's whole verdict, with prepared directories. No regeneration, so they
+# belong in `make test` — a gate nobody has seen go red is a decoration.
+
+GENERATED_TREE_CONTROLS := changed stale retired-rule missing \
+	exception-absent exception-emitted exception-honoured ignored clean
+
+.PHONY: generated-tree-negative-controls $(GENERATED_TREE_CONTROLS:%=generated-tree-control-%)
+
+$(GENERATED_TREE_CONTROLS:%=generated-tree-control-%): generated-tree-control-%:
+	@test/generated-tree/negative-control $*
+
+generated-tree-negative-controls: $(GENERATED_TREE_CONTROLS:%=generated-tree-control-%)
+	@echo "generated-tree controls: $(words $(GENERATED_TREE_CONTROLS)) planted verdicts, each named"
+
+test: generated-tree-negative-controls

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -3,7 +3,7 @@
     {
       "name": "base",
       "when": "pull-request",
-      "why": "the front-end and projection checks, the doc, view and rename controls, the JSON and block refusers, the id table's ordinal-slot controls in C and C++, the float-NaN widening control, the C/C++ fixed-runtime twin gate's planted leftover-line control, the generated-tree gate's nine planted verdicts (six red, three green, on prepared directories — no regeneration), and the fixed form's run-copy bound in both systems legs beside them: Go, the host C and C++ compilers and the C/C++ serialize siblings, and nothing else. Measured 28 s over 24 controls, plus 16 s for the two C++ ordinal-slot controls and the C rewind control beside them.",
+      "why": "the front-end and projection checks, the doc, view and rename controls, the JSON and block refusers, the id table's ordinal-slot controls in C and C++, the float-NaN widening control, the C/C++ fixed-runtime twin gate's planted leftover-line control, the generated-tree gate's ten planted verdicts (seven red, three green, on prepared directories — no regeneration), and the fixed form's run-copy bound in both systems legs beside them: Go, the host C and C++ compilers and the C/C++ serialize siblings, and nothing else. Measured 28 s over 24 controls, plus 16 s for the two C++ ordinal-slot controls and the C rewind control beside them.",
       "targets": [
         "check-enum-bound-negative-control",
         "check-zero-range-negative-control",

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -3,10 +3,11 @@
     {
       "name": "base",
       "when": "pull-request",
-      "why": "the front-end and projection checks, the doc, view and rename controls, the JSON and block refusers, the id table's ordinal-slot controls in C and C++, the float-NaN widening control, the C/C++ fixed-runtime twin gate's planted leftover-line control, and the fixed form's run-copy bound in both systems legs beside them: Go, the host C and C++ compilers and the C/C++ serialize siblings, and nothing else. Measured 28 s over 24 controls, plus 16 s for the two C++ ordinal-slot controls and the C rewind control beside them.",
+      "why": "the front-end and projection checks, the doc, view and rename controls, the JSON and block refusers, the id table's ordinal-slot controls in C and C++, the float-NaN widening control, the C/C++ fixed-runtime twin gate's planted leftover-line control, the generated-tree gate's nine planted verdicts (six red, three green, on prepared directories — no regeneration), and the fixed form's run-copy bound in both systems legs beside them: Go, the host C and C++ compilers and the C/C++ serialize siblings, and nothing else. Measured 28 s over 24 controls, plus 16 s for the two C++ ordinal-slot controls and the C rewind control beside them.",
       "targets": [
         "check-enum-bound-negative-control",
         "check-zero-range-negative-control",
+        "generated-tree-negative-controls",
         "projection-union-arm-order-negative-control",
         "projection-variant-order-negative-control",
         "projection-wire-law-negative-control",

--- a/test/generated-tree/compare
+++ b/test/generated-tree/compare
@@ -26,6 +26,13 @@
 #      is gone, or one the emitter now writes after all.
 set -eu
 
+# EVERY VERDICT HERE IS A `comm` OVER SORTED LISTINGS, and comm collates by the
+# ambient locale while these listings are sorted in C. Disagree on the order of
+# a `-`, a `.` or a `/` and the pairing is wrong — which is the one way a named
+# exception could fail to match the path it names. So the whole script runs in
+# one collation and there is nothing left to disagree about.
+export LC_ALL=C
+
 usage='usage: compare <emitted-dir> <tree-dir> [not-emitted-list]'
 emitted_dir=${1:?$usage}
 tree_dir=${2:?$usage}
@@ -68,7 +75,11 @@ comm -23 "$work/emitted" "$work/tree" > "$work/emitted-only"
 comm -12 "$work/emitted" "$work/tree" > "$work/common"
 comm -23 "$work/in-tree-only" "$work/allowed" > "$work/stale"
 comm -12 "$work/emitted" "$work/allowed" > "$work/claimed-but-emitted"
-comm -13 "$work/tree" "$work/allowed" > "$work/claimed-but-absent"
+# A NAMED PATH THAT MATCHES NOTHING THE GATE JUDGES is reported for the reason
+# it matches nothing, not as a missing file: an entry .gitignore excludes was
+# never judged here in the first place, so the line excuses nothing.
+comm -12 "$work/allowed" "$work/ignored" > "$work/claimed-but-ignored"
+comm -13 "$work/tree" "$work/allowed" | comm -23 - "$work/claimed-but-ignored" > "$work/claimed-but-absent"
 
 : > "$work/differ"
 while IFS= read -r path; do
@@ -115,6 +126,13 @@ if [ -s "$work/claimed-but-absent" ]; then
 	printf 'STALE EXCEPTION — %s named path(s) that the tree does not carry at all:\n' "$(count "$work/claimed-but-absent")"
 	show "$work/claimed-but-absent"
 	printf '  drop the line from %s.\n' "${exceptions:-test/generated-tree/not-emitted}"
+fi
+
+if [ -s "$work/claimed-but-ignored" ]; then
+	fail=1
+	printf 'STALE EXCEPTION — %s named path(s) that .gitignore excludes:\n' "$(count "$work/claimed-but-ignored")"
+	show "$work/claimed-but-ignored"
+	printf '  drop the line from %s: the gate never judges an ignored path, so the exception excuses nothing.\n' "${exceptions:-test/generated-tree/not-emitted}"
 fi
 
 if [ -s "$work/claimed-but-emitted" ]; then

--- a/test/generated-tree/compare
+++ b/test/generated-tree/compare
@@ -1,0 +1,133 @@
+#!/bin/sh
+# COMPARE A CLEAN EMISSION AGAINST THE TREE THE REPOSITORY CARRIES. This is the
+# whole verdict of the generated-tree gate (issue #898, Fixed Tables gate G3),
+# kept in its own command so its negative control can hand it two prepared
+# directories instead of paying for a full regeneration per case.
+#
+#   usage: compare <emitted-dir> <tree-dir> [not-emitted-list]
+#
+# Both directories hold the same relative paths a committed generated/ tree
+# holds, so `generated/<rel>` is the name .gitignore is asked about: a build
+# stamp and a cargo artefact are ignored on both sides and belong to neither
+# verdict.
+#
+# FOUR WAYS TO BE WRONG, each reported with its file list:
+#
+#   1. a path the TREE carries that the emission does not contain. This is the
+#      class an in-place regeneration and a `git diff` cannot see at all: in
+#      place a rule only writes, it never removes, so a file the emitter
+#      stopped writing stays on disk byte-identical to the index and the diff
+#      is silent about it forever. A whole directory in this class means the
+#      rule that writes it never ran — which is also why a scan of the
+#      Makefile's text is not proof of execution, only of a rule's existence.
+#   2. a path the EMISSION contains that the tree does not carry.
+#   3. a path both hold whose BYTES differ.
+#   4. an exception line that no longer describes the tree: a named path that
+#      is gone, or one the emitter now writes after all.
+set -eu
+
+usage='usage: compare <emitted-dir> <tree-dir> [not-emitted-list]'
+emitted_dir=${1:?$usage}
+tree_dir=${2:?$usage}
+exceptions=${3:-}
+
+for d in "$emitted_dir" "$tree_dir"; do
+	[ -d "$d" ] || { printf 'compare: %s is not a directory\n' "$d" >&2; exit 1; }
+done
+
+work=${GENERATED_TREE_WORK:-build/generated-tree/compare}
+rm -rf "$work"
+mkdir -p "$work"
+
+listing() { ( cd "$1" && find . -type f -o -type l ) | sed 's|^\./||' | LC_ALL=C sort; }
+
+# The paths git ignores, asked of the real generated/ names. Nothing is typed
+# here: `.stamp`, a cargo target/ and a Cargo.lock are ignored because
+# .gitignore says so, and a new one is covered the moment it is listed there.
+ignored() { sed 's|^|generated/|' | git check-ignore --stdin | sed 's|^generated/||'; }
+
+listing "$emitted_dir" > "$work/emitted.all"
+listing "$tree_dir" > "$work/tree.all"
+LC_ALL=C sort -u "$work/emitted.all" "$work/tree.all" > "$work/all"
+ignored < "$work/all" | LC_ALL=C sort -u > "$work/ignored"
+comm -23 "$work/emitted.all" "$work/ignored" > "$work/emitted"
+comm -23 "$work/tree.all" "$work/ignored" > "$work/tree"
+
+# THE NAMED EXCEPTIONS: tracked build wiring that lives under generated/ and is
+# not generator output. A line is a path, then `#` and the reason it is tracked.
+# The list is checked in both directions below, so it cannot rot into a hole.
+: > "$work/allowed"
+if [ -n "$exceptions" ] && [ -f "$exceptions" ]; then
+	# A line may spell the path either way; `generated/` is dropped so the
+	# list reads like the messages do.
+	sed 's/#.*//' "$exceptions" | awk 'NF { sub(/^generated\//, "", $1); print $1 }' | LC_ALL=C sort -u > "$work/allowed"
+fi
+
+comm -13 "$work/emitted" "$work/tree" > "$work/in-tree-only"
+comm -23 "$work/emitted" "$work/tree" > "$work/emitted-only"
+comm -12 "$work/emitted" "$work/tree" > "$work/common"
+comm -23 "$work/in-tree-only" "$work/allowed" > "$work/stale"
+comm -12 "$work/emitted" "$work/allowed" > "$work/claimed-but-emitted"
+comm -13 "$work/tree" "$work/allowed" > "$work/claimed-but-absent"
+
+: > "$work/differ"
+while IFS= read -r path; do
+	[ -n "$path" ] || continue
+	cmp -s "$emitted_dir/$path" "$tree_dir/$path" || printf '%s\n' "$path" >> "$work/differ"
+done < "$work/common"
+
+count() { wc -l < "$1" | tr -d ' '; }
+show() { sed 's|^|    generated/|' "$1"; }
+
+fail=0
+
+if [ -s "$work/stale" ]; then
+	fail=1
+	printf 'STALE — %s file(s) the tree carries and this compiler does NOT emit:\n' "$(count "$work/stale")"
+	show "$work/stale"
+	sed 's|/[^/]*$||' "$work/stale" | LC_ALL=C sort -u > "$work/stale-dirs"
+	while IFS= read -r dir; do
+		[ -n "$dir" ] || continue
+		if ! awk -v d="$dir/" 'index($0, d) == 1 { found = 1 } END { exit !found }' "$work/emitted"; then
+			printf '    NOTHING was emitted under generated/%s — the rule that writes it did not run.\n' "$dir"
+		fi
+	done < "$work/stale-dirs"
+	printf '  an in-place regeneration cannot see this class; only an emission into an empty directory can.\n'
+	printf '  either `git rm` them, or name each one in %s with the reason it is tracked build wiring.\n' "${exceptions:-test/generated-tree/not-emitted}"
+fi
+
+if [ -s "$work/emitted-only" ]; then
+	fail=1
+	printf 'MISSING — %s file(s) this compiler emits that the tree does not carry:\n' "$(count "$work/emitted-only")"
+	show "$work/emitted-only"
+	printf '  add or restore them: they are generator output the tree does not carry.\n'
+fi
+
+if [ -s "$work/differ" ]; then
+	fail=1
+	printf 'CHANGED — %s file(s) whose committed bytes are not what this compiler emits:\n' "$(count "$work/differ")"
+	show "$work/differ"
+	printf '  regenerate and commit them; the committed tree is what this repository receipts findings against.\n'
+fi
+
+if [ -s "$work/claimed-but-absent" ]; then
+	fail=1
+	printf 'STALE EXCEPTION — %s named path(s) that the tree does not carry at all:\n' "$(count "$work/claimed-but-absent")"
+	show "$work/claimed-but-absent"
+	printf '  drop the line from %s.\n' "${exceptions:-test/generated-tree/not-emitted}"
+fi
+
+if [ -s "$work/claimed-but-emitted" ]; then
+	fail=1
+	printf 'STALE EXCEPTION — %s named path(s) this compiler DOES emit:\n' "$(count "$work/claimed-but-emitted")"
+	show "$work/claimed-but-emitted"
+	printf '  drop the line from %s: it is generator output now, and the exception hides its staleness.\n' "${exceptions:-test/generated-tree/not-emitted}"
+fi
+
+if [ "$fail" -ne 0 ]; then
+	printf 'the generated/ tree is NOT what this compiler emits. The lists above are the whole difference.\n'
+	exit 1
+fi
+
+printf 'generated/ tree is current: %s emitted file(s) byte-identical, %s named exception(s), %s ignored path(s).\n' \
+	"$(count "$work/common")" "$(count "$work/allowed")" "$(count "$work/ignored")"

--- a/test/generated-tree/negative-control
+++ b/test/generated-tree/negative-control
@@ -1,0 +1,108 @@
+#!/bin/sh
+# THE GENERATED-TREE GATE'S OWN NEGATIVE CONTROL (issue #898, gate G3). A gate
+# nobody has ever seen go red is a decoration, so every way of being wrong gets
+# planted here and the verdict must name it — and the two ways that must stay
+# GREEN are planted too, because a gate that reds on everything is the same
+# decoration.
+#
+# It drives test/generated-tree/compare, which is the verifier's whole verdict,
+# with prepared directories: the same code the gate runs, and no wait for a
+# regeneration per case. The clean-room half — that the emission comes from an
+# EMPTY directory — is what `make generated-current` proves on the real tree.
+#
+#   usage: negative-control <case>
+set -eu
+
+mode=${1:?usage: negative-control <case>}
+out=build/generated-tree/nc/$mode
+emitted=$out/emitted
+tree=$out/tree
+list=$out/not-emitted
+
+rm -rf "$out"
+mkdir -p "$emitted/go" "$tree/go"
+: > "$list"
+
+# The unremarkable file both sides share in every case, so that a case's verdict
+# is about the thing it planted and not about an empty comparison.
+printf 'package examples\n\nconst A = 1\n' > "$emitted/go/ATable.go"
+cp "$emitted/go/ATable.go" "$tree/go/ATable.go"
+
+expected=
+expect_red=yes
+case "$mode" in
+changed)
+	# The class the old check DID catch: a file whose bytes moved.
+	printf 'package examples\n\nconst A = 2\n' > "$tree/go/ATable.go"
+	expected='CHANGED — 1 file(s)' ;;
+stale)
+	# THE CLASS THE OLD CHECK COULD NOT SEE: the emitter stopped writing this
+	# file, so an in-place regeneration leaves it standing and `git diff` is
+	# silent. Here the emission simply does not contain it.
+	printf 'package examples\n\nconst Gone = 1\n' > "$tree/go/GoneTable.go"
+	expected='STALE — 1 file(s) the tree carries and this compiler does NOT emit' ;;
+retired-rule)
+	# The same class, a whole directory of it: the rule that wrote this
+	# directory did not run at all. A scan of the Makefile's text would still
+	# have found its name.
+	mkdir -p "$tree/retired"
+	printf 'package retired\n' > "$tree/retired/OneTable.go"
+	printf 'package retired\n' > "$tree/retired/TwoTable.go"
+	expected='NOTHING was emitted under generated/retired' ;;
+missing)
+	printf 'package examples\n\nconst New = 1\n' > "$emitted/go/NewTable.go"
+	expected='MISSING — 1 file(s) this compiler emits that the tree does not carry' ;;
+exception-absent)
+	# The exception list may not rot: a named path that is not there any more.
+	printf 'generated/go/WiringTable.go  # gone\n' > "$list"
+	expected='STALE EXCEPTION — 1 named path(s) that the tree does not carry at all' ;;
+exception-emitted)
+	# Nor may it hide a file that became generator output: then the exception
+	# would be the hole, not the fix.
+	printf 'package examples\n\nconst A = 1\n' > "$emitted/go/ATable.go"
+	printf 'generated/go/ATable.go  # claimed as wiring\n' > "$list"
+	expected='STALE EXCEPTION — 1 named path(s) this compiler DOES emit' ;;
+exception-honoured)
+	# GREEN: tracked build wiring that is genuinely not generator output, named
+	# with its reason — the one shape that may be in the tree and not emitted.
+	printf '[package]\nname = "wiring"\n' > "$tree/go/Cargo.toml"
+	printf 'generated/go/Cargo.toml  # hand-written build wiring\n' > "$list"
+	expect_red=no
+	expected='named exception(s)' ;;
+ignored)
+	# GREEN: a build stamp is ignored by .gitignore on both sides, so it is
+	# neither a stale file nor a missing one.
+	: > "$tree/go/.stamp"
+	expect_red=no
+	expected='generated/ tree is current' ;;
+clean)
+	expect_red=no
+	expected='generated/ tree is current' ;;
+*)
+	printf 'unknown control: %s\n' "$mode" >&2; exit 1 ;;
+esac
+
+log=$out/log
+if GENERATED_TREE_WORK=$out/work test/generated-tree/compare "$emitted" "$tree" "$list" > "$log" 2>&1; then
+	verdict=green
+else
+	verdict=red
+fi
+
+if [ "$expect_red" = yes ] && [ "$verdict" = green ]; then
+	printf 'NEGATIVE CONTROL FAILED: the generated-tree gate stayed green with %s planted\n' "$mode" >&2
+	cat "$log" >&2
+	exit 1
+fi
+if [ "$expect_red" = no ] && [ "$verdict" = red ]; then
+	printf 'NEGATIVE CONTROL FAILED: the generated-tree gate went red on %s, which is sound\n' "$mode" >&2
+	cat "$log" >&2
+	exit 1
+fi
+if ! grep -Fq "$expected" "$log"; then
+	printf 'NEGATIVE CONTROL FAILED: the gate went %s on %s, but not on the claim (%s)\n' "$verdict" "$mode" "$expected" >&2
+	cat "$log" >&2
+	exit 1
+fi
+
+printf 'generated-tree control: %s is %s, on the claim — %s\n' "$mode" "$verdict" "$(grep -Fm1 "$expected" "$log")"

--- a/test/generated-tree/negative-control
+++ b/test/generated-tree/negative-control
@@ -62,6 +62,13 @@ exception-emitted)
 	printf 'package examples\n\nconst A = 1\n' > "$emitted/go/ATable.go"
 	printf 'generated/go/ATable.go  # claimed as wiring\n' > "$list"
 	expected='STALE EXCEPTION — 1 named path(s) this compiler DOES emit' ;;
+exception-ignored)
+	# An exception may not name a path .gitignore excludes: the gate never
+	# judges such a path, so the line excuses nothing and is one more way the
+	# list rots. It must red for THAT reason and not as a path that is missing.
+	: > "$tree/go/.stamp"
+	printf 'generated/go/.stamp  # claimed as wiring\n' > "$list"
+	expected='STALE EXCEPTION — 1 named path(s) that .gitignore excludes' ;;
 exception-honoured)
 	# GREEN: tracked build wiring that is genuinely not generator output, named
 	# with its reason — the one shape that may be in the tree and not emitted.

--- a/test/generated-tree/not-emitted
+++ b/test/generated-tree/not-emitted
@@ -1,0 +1,13 @@
+# TRACKED FILES UNDER generated/ THAT ARE NOT GENERATOR OUTPUT, each with the
+# reason it is tracked. Read by test/generated-tree/compare (issue #898, gate
+# G3): the clean-room emission cannot contain these, and without a line here
+# the gate would call each one a stale file the emitter stopped writing.
+#
+# THE LIST IS CHECKED IN BOTH DIRECTIONS, so it cannot rot into a hole: a named
+# path that the tree no longer carries reds, and a named path the compiler DOES
+# emit reds — the exception may never be the thing that hides real staleness.
+#
+# Nothing else belongs here. A file the emitter stopped writing is not an
+# exception; it is a deletion nobody committed.
+
+generated/bench/paired/rust/Cargo.toml  # hand-written crate manifest for the paired bench unit, tracked so the driver never rewrites a tracked file: it names ONE symlink under build/ and bench/paired's pointRustManifest points that link at SERIALIZE_RS (6e2a5a36). The emitter writes only the unit's .rs files.

--- a/test/generated-tree/verify
+++ b/test/generated-tree/verify
@@ -38,17 +38,18 @@
 # compiler emits into nothing, then the listing and bytes are compared both
 # ways. A SIGKILL cannot be trapped, so a run killed mid-emission leaves the
 # original tree in build/generated-tree/prev and a partial replacement in
-# generated/. THAT PREVIOUS-RUN TREE IS EVIDENCE, NEVER SCRATCH. Each run holds
-# build/generated-tree/lock — created atomically — and records its pid and a
-# nonce inside it, and each phase transition writes a small state marker (pid,
-# nonce, phase) to build/generated-tree/state. On start a run takes the lock
-# (refusing a live holder without touching anything), validates the marker
-# (an unrecognised or partial one is preserved unchanged and the run refuses
-# without touching either tree), and — BEFORE the `generated/` existence guard —
-# restores a preserved original from prev to generated/ whenever the marker owns
-# one, preserving any partial replacement in build/generated-tree/fresh. The
-# nonce, not the pid (which a new process can reuse), is the authority that a
-# dead run's lock and marker name one and the same run. What is promised is
+# generated/. THAT PREVIOUS-RUN TREE IS EVIDENCE, NEVER SCRATCH. Each run holds a kernel
+# advisory lock (tools/treelock) across itself and its generation children. When
+# a process dies (even under SIGKILL), the kernel automatically releases the
+# lock file descriptor — no rm -rf race. On start a run acquires the kernel lock
+# (refusing a live holder without touching anything), reads shared state only
+# once exclusive ownership is held, validates the marker (an unrecognised or
+# partial one is preserved unchanged and the run refuses without touching
+# either tree), and — BEFORE the `generated/` existence guard — restores a
+# preserved original from prev to generated/ whenever the marker owns one,
+# preserving any partial replacement in build/generated-tree/fresh. The nonce,
+# not the pid (which a new process can reuse), is the authority that a dead
+# run's lock and marker name one and the same run. What is promised is
 # recoverable originals: the next invocation cannot destroy a preserved
 # original. What is NOT promised is restoration under an uncatchable signal,
 # because no trap runs for SIGKILL.
@@ -77,49 +78,46 @@ mkdir -p "$out" "$run"
 
 mark() { printf '%s %s %s\n' "$$" "$nonce" "$1" > "$state"; }
 
-# A PREVIOUS RUN'S TREE IS EVIDENCE. Read its state marker before anything is
-# written: its pid, nonce and phase are what decide a recovery (a dead run's
-# leftover is restored) from a refusal (a live run, or a marker this script does
-# not recognise, is left exactly as it is).
+# EXCLUSIVE ACQUISITION — held across the verifier and its generation children
+# via a kernel advisory lock (treelock).
+if [ "${TREELOCK_HELD:-}" != "1" ]; then
+	treelock=build/treelock
+	if [ ! -x "$treelock" ]; then
+		top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+		if [ -n "$top" ] && [ -x "$top/build/treelock" ]; then
+			treelock="$top/build/treelock"
+		elif [ -n "$top" ] && [ -d "$top/tools/treelock" ]; then
+			mkdir -p "$top/build"
+			go build -o "$top/build/treelock" "$top/tools/treelock"
+			treelock="$top/build/treelock"
+		else
+			mkdir -p build
+			go build -o build/treelock ./tools/treelock
+			treelock=build/treelock
+		fi
+	fi
+	mkdir -p "$lock"
+	exec "$treelock" -lock "$lock/file" -owner-file "$lock/owner" -name "$lock" /bin/sh "$0" "$@"
+fi
+
+# A PREVIOUS RUN'S TREE IS EVIDENCE. Read its state marker and owner ONLY once
+# exclusive ownership is held.
+old_lpid=; old_lnonce=
+if [ -f "$lock/owner" ]; then
+	read -r old_lpid old_lnonce < "$lock/owner" 2>/dev/null || true
+fi
+
 spid=; snonce=; sphase=
 if [ -f "$state" ]; then
 	read -r spid snonce sphase < "$state" 2>/dev/null || true
 fi
 
-# EXCLUSIVE ACQUISITION — before any shared-state write. mkdir is atomic on one
-# filesystem, so exactly one caller creates $lock and records pid+nonce in it. A
-# loser refuses a live holder; a dead holder's lock is taken over only after it
-# is re-read unchanged, and the nonce (not the pid, which a new process can
-# reuse) is the authority that the lock and the state marker name one dead run.
-lock_held=0
-while ! mkdir "$lock" 2>/dev/null; do
-	read -r lpid lnonce < "$lock/owner" 2>/dev/null || true
-	if [ -n "$lpid" ] && kill -0 "$lpid" 2>/dev/null; then
-		printf 'REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n' "$lpid" "$lock" >&2
-		exit 1
-	fi
-	read -r lpid2 lnonce2 < "$lock/owner" 2>/dev/null || true
-	if [ "$lpid2" != "$lpid" ] || [ "$lnonce2" != "$lnonce" ]; then
-		continue
-	fi
-	if [ -n "$lnonce" ] && [ -n "$snonce" ] && [ "$lnonce" != "$snonce" ]; then
-		printf 'REFUSED — %s and %s name different owners (%s vs %s); not touching either tree.\n' \
-			"$lock" "$state" "$lnonce" "$snonce" >&2
-		exit 1
-	fi
-	rm -rf "$lock"
-done
-printf '%s %s\n' "$$" "$nonce" > "$lock/owner"
-lock_held=1
-
-release() {
-	if [ "$lock_held" = 1 ]; then
-		rm -rf "$lock"
-		lock_held=0
-	fi
-	return 0
-}
-trap release EXIT HUP INT TERM
+# If a previous lock owner and state marker both exist, ensure they name the same run:
+if [ -n "$old_lnonce" ] && [ -n "$snonce" ] && [ "$old_lnonce" != "$snonce" ]; then
+	printf 'REFUSED — %s and %s name different owners (%s vs %s); not touching either tree.\n' \
+		"$lock" "$state" "$old_lnonce" "$snonce" >&2
+	exit 1
+fi
 
 # VALIDATE THE COMPLETE OWNED STATE TUPLE before writing mark start. A marker
 # must name a pid, a nonce and a phase this script recognises; an unrecognised
@@ -170,6 +168,7 @@ fi
 
 [ -d generated ] || { printf 'there is no generated/ tree in %s\n' "$(pwd)" >&2; exit 1; }
 
+printf '%s %s\n' "$$" "$nonce" > "$lock/owner"
 mark start
 
 fail=0
@@ -239,7 +238,11 @@ restore() {
 		}
 	fi
 }
-trap 'restore; release' EXIT HUP INT TERM
+cleanup() {
+	restore || true
+	rm -f "$state" "$lock/owner"
+}
+trap cleanup EXIT HUP INT TERM
 
 mark moved
 mv generated "$prev"
@@ -249,7 +252,7 @@ if ! make $stamps > "$run/regenerate.log" 2>&1; then
 	printf 'the regeneration itself failed — the last of %s is:\n' "$run/regenerate.log"
 	tail -40 "$run/regenerate.log" | sed 's|^|    |'
 	restore
-	rm -f "$state"
+	rm -f "$state" "$lock/owner"
 	exit 1
 fi
 
@@ -258,7 +261,7 @@ if ! GENERATED_TREE_WORK="$run/compare" test/generated-tree/compare generated "$
 fi
 
 restore
-rm -f "$state"
+rm -f "$state" "$lock/owner"
 
 if [ "$fail" -ne 0 ]; then
 	printf 'the emission that decided this is at %s; the tree on disk is untouched.\n' "$fresh"

--- a/test/generated-tree/verify
+++ b/test/generated-tree/verify
@@ -38,17 +38,20 @@
 # compiler emits into nothing, then the listing and bytes are compared both
 # ways. A SIGKILL cannot be trapped, so a run killed mid-emission leaves the
 # original tree in build/generated-tree/prev and a partial replacement in
-# generated/. THAT PREVIOUS-RUN TREE IS EVIDENCE, NEVER SCRATCH. On start, when
-# build/generated-tree/prev exists, this script restores it to generated/ —
-# preserving any partial replacement in build/generated-tree/fresh — when
-# generated/ is absent or provably the partial replacement, and refuses (deleting
-# neither tree) when ownership is ambiguous. Ownership is recorded in a small
-# state marker written at each phase transition (pid, a nonce, and the phase),
-# and each invocation's scratch lives under a nonce-unique path, so concurrent
-# runs cannot collide and a dead run's state is told from a live run's by its
-# pid. What is promised is recoverable originals: the next invocation cannot
-# destroy a preserved original. What is NOT promised is restoration under an
-# uncatchable signal, because no trap runs for SIGKILL.
+# generated/. THAT PREVIOUS-RUN TREE IS EVIDENCE, NEVER SCRATCH. Each run holds
+# build/generated-tree/lock — created atomically — and records its pid and a
+# nonce inside it, and each phase transition writes a small state marker (pid,
+# nonce, phase) to build/generated-tree/state. On start a run takes the lock
+# (refusing a live holder without touching anything), validates the marker
+# (an unrecognised or partial one is preserved unchanged and the run refuses
+# without touching either tree), and — BEFORE the `generated/` existence guard —
+# restores a preserved original from prev to generated/ whenever the marker owns
+# one, preserving any partial replacement in build/generated-tree/fresh. The
+# nonce, not the pid (which a new process can reuse), is the authority that a
+# dead run's lock and marker name one and the same run. What is promised is
+# recoverable originals: the next invocation cannot destroy a preserved
+# original. What is NOT promised is restoration under an uncatchable signal,
+# because no trap runs for SIGKILL.
 #
 # --staged is a separately named mode that compares the on-disk tree against the
 # index instead of HEAD; it never prints the committed-emission sentence, because
@@ -62,6 +65,7 @@ prev=$out/prev
 fresh=$out/fresh
 exceptions=test/generated-tree/not-emitted
 state=$out/state
+lock=$out/lock
 
 mode=committed
 [ "${1:-}" = "--staged" ] && mode=staged
@@ -73,40 +77,100 @@ mkdir -p "$out" "$run"
 
 mark() { printf '%s %s %s\n' "$$" "$nonce" "$1" > "$state"; }
 
-[ -d generated ] || { printf 'there is no generated/ tree in %s\n' "$(pwd)" >&2; exit 1; }
-
-# A PREVIOUS RUN'S TREE IS EVIDENCE. Read its state marker first, then decide:
-# a live run holds the tree (refuse); a dead run left the original in prev
-# (recover, preserving any partial replacement); an unreadable marker with a
-# prev present is ambiguous (refuse, deleting neither tree).
+# A PREVIOUS RUN'S TREE IS EVIDENCE. Read its state marker before anything is
+# written: its pid, nonce and phase are what decide a recovery (a dead run's
+# leftover is restored) from a refusal (a live run, or a marker this script does
+# not recognise, is left exactly as it is).
 spid=; snonce=; sphase=
 if [ -f "$state" ]; then
 	read -r spid snonce sphase < "$state" 2>/dev/null || true
 fi
-if [ -n "$spid" ] && kill -0 "$spid" 2>/dev/null; then
-	printf 'REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n' "$spid" "$prev" >&2
-	exit 1
-fi
-mark start
-if [ -d "$prev" ]; then
-	case "$sphase" in
-	moved|emitting|restoring)
-		if [ -d generated ]; then
-			[ -e "$fresh" ] && mv "$fresh" "$run/fresh.before-recovery" 2>/dev/null || true
-			mv generated "$fresh"
-		fi
-		mv "$prev" generated
-		printf 'RECOVERED — a previous verification (pid %s, state %s) left the original tree in %s; it is restored, and any partial replacement is preserved in %s.\n' \
-			"${spid:-unknown}" "$sphase" "$prev" "$fresh"
-		;;
+
+# EXCLUSIVE ACQUISITION — before any shared-state write. mkdir is atomic on one
+# filesystem, so exactly one caller creates $lock and records pid+nonce in it. A
+# loser refuses a live holder; a dead holder's lock is taken over only after it
+# is re-read unchanged, and the nonce (not the pid, which a new process can
+# reuse) is the authority that the lock and the state marker name one dead run.
+lock_held=0
+while ! mkdir "$lock" 2>/dev/null; do
+	read -r lpid lnonce < "$lock/owner" 2>/dev/null || true
+	if [ -n "$lpid" ] && kill -0 "$lpid" 2>/dev/null; then
+		printf 'REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n' "$lpid" "$lock" >&2
+		exit 1
+	fi
+	read -r lpid2 lnonce2 < "$lock/owner" 2>/dev/null || true
+	if [ "$lpid2" != "$lpid" ] || [ "$lnonce2" != "$lnonce" ]; then
+		continue
+	fi
+	if [ -n "$lnonce" ] && [ -n "$snonce" ] && [ "$lnonce" != "$snonce" ]; then
+		printf 'REFUSED — %s and %s name different owners (%s vs %s); not touching either tree.\n' \
+			"$lock" "$state" "$lnonce" "$snonce" >&2
+		exit 1
+	fi
+	rm -rf "$lock"
+done
+printf '%s %s\n' "$$" "$nonce" > "$lock/owner"
+lock_held=1
+
+release() {
+	if [ "$lock_held" = 1 ]; then
+		rm -rf "$lock"
+		lock_held=0
+	fi
+	return 0
+}
+trap release EXIT HUP INT TERM
+
+# VALIDATE THE COMPLETE OWNED STATE TUPLE before writing mark start. A marker
+# must name a pid, a nonce and a phase this script recognises; an unrecognised
+# or partial one is preserved unchanged as evidence and the run refuses without
+# touching either tree.
+if [ -f "$state" ]; then
+	case "$spid:$snonce:$sphase" in
+	?*:?*:start|?*:?*:moved|?*:?*:emitting|?*:?*:restoring) ;;
 	*)
-		rm -f "$state"
-		printf 'REFUSED — %s exists from a previous run, but %s names no state this script recognises (%s); deleting neither tree.\n' \
-			"$prev" "$state" "${sphase:-none}" >&2
+		printf 'REFUSED — %s names no complete state this script recognises (pid %s, nonce %s, phase %s); preserving the marker and deleting neither tree.\n' \
+			"$state" "${spid:-none}" "${snonce:-none}" "${sphase:-none}" >&2
 		exit 1
 		;;
 	esac
 fi
+
+# RECOVERY, BEFORE THE EXISTENCE GUARD: a run killed after `mv generated "$prev"`
+# and before generation recreated its directory leaves the original in prev with
+# no generated/ at all. Restore it now, so the guard below never mistakes that
+# hole for a genuinely tree-less checkout. A preserved original with no marker
+# is ambiguous and is refused (deleting neither tree); a marker this script does
+# not recognise was already refused above.
+if [ -d "$prev" ]; then
+	if [ -z "$sphase" ]; then
+		printf 'REFUSED — %s exists from a previous run, but %s names no state this script recognises; deleting neither tree.\n' \
+			"$prev" "$state" >&2
+		exit 1
+	fi
+	if [ -d generated ]; then
+		if [ -e "$fresh" ]; then
+			mv "$fresh" "$run/fresh.before-recovery" || {
+				printf 'REFUSED — could not move %s aside to %s; deleting neither tree.\n' "$fresh" "$run/fresh.before-recovery" >&2
+				exit 1
+			}
+		fi
+		mv generated "$fresh" || {
+			printf 'REFUSED — could not move %s to %s; deleting neither tree.\n' generated "$fresh" >&2
+			exit 1
+		}
+	fi
+	mv "$prev" generated || {
+		printf 'REFUSED — could not restore %s to %s; deleting neither tree.\n' "$prev" generated >&2
+		exit 1
+	}
+	printf 'RECOVERED — a previous verification (pid %s, state %s) left the original tree in %s; it is restored, and any partial replacement is preserved in %s.\n' \
+		"${spid:-unknown}" "$sphase" "$prev" "$fresh"
+fi
+
+[ -d generated ] || { printf 'there is no generated/ tree in %s\n' "$(pwd)" >&2; exit 1; }
+
+mark start
 
 fail=0
 
@@ -158,13 +222,24 @@ restore() {
 	mark restoring
 	if [ -d "$prev" ]; then
 		if [ -d generated ]; then
-			[ -e "$fresh" ] && mv "$fresh" "$run/fresh.previous" 2>/dev/null || true
-			mv generated "$fresh"
+			if [ -e "$fresh" ]; then
+				mv "$fresh" "$run/fresh.previous" || {
+					printf 'REFUSED — could not move %s aside to %s; deleting neither tree.\n' "$fresh" "$run/fresh.previous" >&2
+					return 1
+				}
+			fi
+			mv generated "$fresh" || {
+				printf 'REFUSED — could not move %s to %s; deleting neither tree.\n' generated "$fresh" >&2
+				return 1
+			}
 		fi
-		mv "$prev" generated
+		mv "$prev" generated || {
+			printf 'REFUSED — could not restore %s to %s; deleting neither tree.\n' "$prev" generated >&2
+			return 1
+		}
 	fi
 }
-trap restore EXIT HUP INT TERM
+trap 'restore; release' EXIT HUP INT TERM
 
 mark moved
 mv generated "$prev"

--- a/test/generated-tree/verify
+++ b/test/generated-tree/verify
@@ -1,0 +1,113 @@
+#!/bin/sh
+# THE COMMITTED generated/ TREE IS WHAT THE COMPILER AT THIS SHA EMITS — proved
+# from an EMPTY directory (issue #898, Fixed Tables gate G3, issue #30 before
+# it).
+#
+# THE HOLE THIS CLOSES. The check was: regenerate the tree IN PLACE, then let
+# `git diff --exit-code generated/` and a `git status --porcelain` be the
+# verdict. In place a generation rule can only write a file; it never removes
+# one. So:
+#
+#   * a file the emitter STOPPED writing stays on disk, byte-identical to the
+#     index, and the diff is silent about it — forever. The reader then
+#     receipts a finding against a header the compiler no longer emits.
+#   * a rule that never RAN — renamed, dropped, or named by a grep over the
+#     Makefile's text that matched a rule and not its execution — leaves every
+#     one of its files standing too, and the diff calls that GREEN. Deriving
+#     the stamp list from the Makefile proves the rules EXIST. It cannot prove
+#     one ran, and this verifier does not claim it does: the proof of execution
+#     is that every committed file comes BACK from nothing.
+#
+# SO THE TREE IS MOVED ASIDE AND THE COMPILER EMITS INTO NOTHING, and the full
+# listing and the bytes are compared both ways. Two halves, both loud, and
+# every failing file named:
+#
+#   (a) the tree on disk IS the committed tree (git, as before);
+#   (b) the tree on disk IS a clean emission (test/generated-tree/compare).
+#
+# Together: emission == disk == committed.
+#
+# Every generation rule takes exactly one input, bin/schema, and no toolchain
+# and no sibling checkout, which is what makes (b) affordable at all. The stamp
+# list is DERIVED from the Makefile and its per-language includes, so a port
+# that adds generated/<lang>/.stamp in its make/<lang>.mk is covered the moment
+# it rebases, with no edit here.
+#
+# THE TREE IS ALWAYS PUT BACK, on any exit, including a failed regeneration and
+# a signal: the emission goes to build/generated-tree/fresh for reading, and
+# the tree that was on disk goes back where it was. Nothing else may build
+# while this runs — for that window generated/ is not there.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+
+out=build/generated-tree
+prev=$out/prev
+fresh=$out/fresh
+exceptions=test/generated-tree/not-emitted
+
+[ -d generated ] || { printf 'there is no generated/ tree in %s\n' "$(pwd)" >&2; exit 1; }
+
+fail=0
+
+# THE STAMP LIST, derived and never typed. An empty list would pass over an
+# empty set, so it is a hard error, exactly as the workflow had it.
+stamps=$(grep -hoE '^generated/[A-Za-z0-9/_.-]*/\.stamp:' Makefile make/*.mk | sed 's/:$//' | LC_ALL=C sort -u)
+if [ -z "$stamps" ]; then
+	printf 'no generated/*/.stamp rules found in the Makefile or make/*.mk — this check would pass over an empty set\n' >&2
+	exit 1
+fi
+printf 'generated-tree: %s generation rule(s)\n' "$(printf '%s\n' "$stamps" | wc -l | tr -d ' ')"
+
+# (a) THE TREE ON DISK IS THE COMMITTED TREE. Staged counts as committed here,
+# the way `git diff` has always read it, so `git add` is enough to go green on
+# a regeneration you are about to commit.
+if ! git diff --quiet -- generated/; then
+	fail=1
+	printf 'NOT COMMITTED — the generated/ tree on disk differs from the committed tree:\n'
+	git diff --name-status -- generated/ | sed 's|^|    |'
+	printf '  commit the regenerated files.\n'
+fi
+untracked=$(git ls-files --others --exclude-standard -- generated/)
+if [ -n "$untracked" ]; then
+	fail=1
+	printf 'NOT COMMITTED — file(s) under generated/ that nobody committed:\n'
+	printf '%s\n' "$untracked" | sed 's|^|    |'
+	printf '  add them.\n'
+fi
+
+# (b) THE TREE ON DISK IS A CLEAN EMISSION.
+mkdir -p "$out"
+rm -rf "$prev" "$fresh"
+
+restore() {
+	if [ -d "$prev" ]; then
+		if [ -d generated ]; then
+			rm -rf "$fresh"
+			mv generated "$fresh"
+		fi
+		mv "$prev" generated
+	fi
+}
+trap restore EXIT HUP INT TERM
+
+mv generated "$prev"
+# shellcheck disable=SC2086
+if ! make $stamps > "$out/regenerate.log" 2>&1; then
+	printf 'the regeneration itself failed — the last of %s is:\n' "$out/regenerate.log"
+	tail -40 "$out/regenerate.log" | sed 's|^|    |'
+	exit 1
+fi
+
+if ! test/generated-tree/compare generated "$prev" "$exceptions"; then
+	fail=1
+fi
+
+restore
+
+if [ "$fail" -ne 0 ]; then
+	printf 'the emission that decided this is at %s; the tree on disk is untouched.\n' "$fresh"
+	exit 1
+fi
+
+printf 'the committed generated/ tree is what this compiler emits.\n'

--- a/test/generated-tree/verify
+++ b/test/generated-tree/verify
@@ -22,7 +22,8 @@
 # listing and the bytes are compared both ways. Two halves, both loud, and
 # every failing file named:
 #
-#   (a) the tree on disk IS the committed tree (git, as before);
+#   (a) the tree on disk IS the committed tree (git, against HEAD, not the
+#       index — a staged edit is not yet committed and may not pass);
 #   (b) the tree on disk IS a clean emission (test/generated-tree/compare).
 #
 # Together: emission == disk == committed.
@@ -33,10 +34,25 @@
 # that adds generated/<lang>/.stamp in its make/<lang>.mk is covered the moment
 # it rebases, with no edit here.
 #
-# THE TREE IS ALWAYS PUT BACK, on any exit, including a failed regeneration and
-# a signal: the emission goes to build/generated-tree/fresh for reading, and
-# the tree that was on disk goes back where it was. Nothing else may build
-# while this runs — for that window generated/ is not there.
+# RECOVERY. The tree on disk is moved aside to build/generated-tree/prev and the
+# compiler emits into nothing, then the listing and bytes are compared both
+# ways. A SIGKILL cannot be trapped, so a run killed mid-emission leaves the
+# original tree in build/generated-tree/prev and a partial replacement in
+# generated/. THAT PREVIOUS-RUN TREE IS EVIDENCE, NEVER SCRATCH. On start, when
+# build/generated-tree/prev exists, this script restores it to generated/ —
+# preserving any partial replacement in build/generated-tree/fresh — when
+# generated/ is absent or provably the partial replacement, and refuses (deleting
+# neither tree) when ownership is ambiguous. Ownership is recorded in a small
+# state marker written at each phase transition (pid, a nonce, and the phase),
+# and each invocation's scratch lives under a nonce-unique path, so concurrent
+# runs cannot collide and a dead run's state is told from a live run's by its
+# pid. What is promised is recoverable originals: the next invocation cannot
+# destroy a preserved original. What is NOT promised is restoration under an
+# uncatchable signal, because no trap runs for SIGKILL.
+#
+# --staged is a separately named mode that compares the on-disk tree against the
+# index instead of HEAD; it never prints the committed-emission sentence, because
+# a staged tree is not the committed one.
 set -eu
 
 cd "$(git rev-parse --show-toplevel)"
@@ -45,8 +61,52 @@ out=build/generated-tree
 prev=$out/prev
 fresh=$out/fresh
 exceptions=test/generated-tree/not-emitted
+state=$out/state
+
+mode=committed
+[ "${1:-}" = "--staged" ] && mode=staged
+
+nonce="$$.$(date +%s)"
+run=$out/run.$nonce
+
+mkdir -p "$out" "$run"
+
+mark() { printf '%s %s %s\n' "$$" "$nonce" "$1" > "$state"; }
 
 [ -d generated ] || { printf 'there is no generated/ tree in %s\n' "$(pwd)" >&2; exit 1; }
+
+# A PREVIOUS RUN'S TREE IS EVIDENCE. Read its state marker first, then decide:
+# a live run holds the tree (refuse); a dead run left the original in prev
+# (recover, preserving any partial replacement); an unreadable marker with a
+# prev present is ambiguous (refuse, deleting neither tree).
+spid=; snonce=; sphase=
+if [ -f "$state" ]; then
+	read -r spid snonce sphase < "$state" 2>/dev/null || true
+fi
+if [ -n "$spid" ] && kill -0 "$spid" 2>/dev/null; then
+	printf 'REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n' "$spid" "$prev" >&2
+	exit 1
+fi
+mark start
+if [ -d "$prev" ]; then
+	case "$sphase" in
+	moved|emitting|restoring)
+		if [ -d generated ]; then
+			[ -e "$fresh" ] && mv "$fresh" "$run/fresh.before-recovery" 2>/dev/null || true
+			mv generated "$fresh"
+		fi
+		mv "$prev" generated
+		printf 'RECOVERED — a previous verification (pid %s, state %s) left the original tree in %s; it is restored, and any partial replacement is preserved in %s.\n' \
+			"${spid:-unknown}" "$sphase" "$prev" "$fresh"
+		;;
+	*)
+		rm -f "$state"
+		printf 'REFUSED — %s exists from a previous run, but %s names no state this script recognises (%s); deleting neither tree.\n' \
+			"$prev" "$state" "${sphase:-none}" >&2
+		exit 1
+		;;
+	esac
+fi
 
 fail=0
 
@@ -59,14 +119,25 @@ if [ -z "$stamps" ]; then
 fi
 printf 'generated-tree: %s generation rule(s)\n' "$(printf '%s\n' "$stamps" | wc -l | tr -d ' ')"
 
-# (a) THE TREE ON DISK IS THE COMMITTED TREE. Staged counts as committed here,
-# the way `git diff` has always read it, so `git add` is enough to go green on
-# a regeneration you are about to commit.
-if ! git diff --quiet -- generated/; then
-	fail=1
-	printf 'NOT COMMITTED — the generated/ tree on disk differs from the committed tree:\n'
-	git diff --name-status -- generated/ | sed 's|^|    |'
-	printf '  commit the regenerated files.\n'
+# (a) THE TREE ON DISK IS THE COMMITTED TREE, judged against HEAD. A staged
+# edit is a different state from a committed one, so `git diff` against the
+# index is not enough to green a regeneration that is not yet committed; the
+# --staged mode is the separately named escape hatch for that, and it never
+# claims the committed emission is current.
+if [ "$mode" = staged ]; then
+	if ! git diff --quiet -- generated/; then
+		fail=1
+		printf 'NOT STAGED — the generated/ tree on disk differs from the index:\n'
+		git diff --name-status -- generated/ | sed 's|^|    |'
+		printf '  stage the regenerated files (staged mode compares the index, not the committed tree).\n'
+	fi
+else
+	if ! git diff --quiet HEAD -- generated/; then
+		fail=1
+		printf 'NOT COMMITTED — the generated/ tree on disk differs from HEAD:\n'
+		git diff --name-status HEAD -- generated/ | sed 's|^|    |'
+		printf '  commit the regenerated files.\n'
+	fi
 fi
 untracked=$(git ls-files --others --exclude-standard -- generated/)
 if [ -n "$untracked" ]; then
@@ -76,14 +147,18 @@ if [ -n "$untracked" ]; then
 	printf '  add them.\n'
 fi
 
-# (b) THE TREE ON DISK IS A CLEAN EMISSION.
-mkdir -p "$out"
-rm -rf "$prev" "$fresh"
-
+# (b) THE TREE ON DISK IS A CLEAN EMISSION. The original is moved aside to prev
+# and restored on every exit that can be trapped; each invocation's scratch and
+# log live under the nonce path, and neither prev nor fresh is ever deleted here
+# (a leftover is moved into this run's scratch, not removed).
+restored=0
 restore() {
+	[ "$restored" = 1 ] && return 0
+	restored=1
+	mark restoring
 	if [ -d "$prev" ]; then
 		if [ -d generated ]; then
-			rm -rf "$fresh"
+			[ -e "$fresh" ] && mv "$fresh" "$run/fresh.previous" 2>/dev/null || true
 			mv generated "$fresh"
 		fi
 		mv "$prev" generated
@@ -91,23 +166,32 @@ restore() {
 }
 trap restore EXIT HUP INT TERM
 
+mark moved
 mv generated "$prev"
+mark emitting
 # shellcheck disable=SC2086
-if ! make $stamps > "$out/regenerate.log" 2>&1; then
-	printf 'the regeneration itself failed — the last of %s is:\n' "$out/regenerate.log"
-	tail -40 "$out/regenerate.log" | sed 's|^|    |'
+if ! make $stamps > "$run/regenerate.log" 2>&1; then
+	printf 'the regeneration itself failed — the last of %s is:\n' "$run/regenerate.log"
+	tail -40 "$run/regenerate.log" | sed 's|^|    |'
+	restore
+	rm -f "$state"
 	exit 1
 fi
 
-if ! test/generated-tree/compare generated "$prev" "$exceptions"; then
+if ! GENERATED_TREE_WORK="$run/compare" test/generated-tree/compare generated "$prev" "$exceptions"; then
 	fail=1
 fi
 
 restore
+rm -f "$state"
 
 if [ "$fail" -ne 0 ]; then
 	printf 'the emission that decided this is at %s; the tree on disk is untouched.\n' "$fresh"
 	exit 1
 fi
 
-printf 'the committed generated/ tree is what this compiler emits.\n'
+if [ "$mode" = staged ]; then
+	printf 'the staged generated/ tree matches this compiler emission (staged mode; run without --staged to assert the committed tree).\n'
+else
+	printf 'the committed generated/ tree is what this compiler emits.\n'
+fi

--- a/test/generated-tree/verify-control
+++ b/test/generated-tree/verify-control
@@ -1,0 +1,220 @@
+#!/bin/sh
+# THE GENERATED-TREE VERIFIER'S OWN LIFECYCLE CONTROLS (issue #898, gate G3).
+# These drive test/generated-tree/verify — the real verifier, not its compare
+# half — in a disposable Git fixture with one generation rule, to prove the two
+# things a prepared-directory control cannot: that a previous run's preserved
+# original tree is RECOVERED and never destroyed (even across a real SIGKILL),
+# and that a staged edit does not pass as committed.
+#
+#   usage: verify-control <case>
+#
+#   kill-retry          SIGKILL the whole verifier process group after the
+#                       original is in build/generated-tree/prev and the
+#                       replacement tree exists; a second invocation must name
+#                       the state and leave the original bytes standing.
+#   regeneration-fails  a normal failure: the original tree is restored and the
+#                       run exits non-zero.
+#   second-invocation   two normal invocations in a row; the second must not be
+#                       refused by the first run's leftover state.
+#   staged-difference   HEAD holds old bytes, the index and the file hold new
+#                       ones; verify must exit non-zero and never print the
+#                       committed-emission sentence.
+set -eu
+
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+
+mode=${1:?usage: verify-control <case>}
+case "$mode" in
+kill-retry|regeneration-fails|second-invocation|staged-difference) ;;
+*) printf 'unknown control: %s\n' "$mode" >&2; exit 1 ;;
+esac
+
+work=build/generated-tree/vc/$mode
+rm -rf "$work"
+mkdir -p "$work"
+fixture=$work/fixture
+mkdir -p "$fixture/generated/go" "$fixture/test/generated-tree" "$fixture/make" "$fixture/bin"
+cp "$repo/test/generated-tree/verify" "$fixture/test/generated-tree/verify"
+cp "$repo/test/generated-tree/compare" "$fixture/test/generated-tree/compare"
+chmod +x "$fixture/test/generated-tree/verify" "$fixture/test/generated-tree/compare"
+: > "$fixture/test/generated-tree/not-emitted"
+: > "$fixture/make/empty.mk"
+: > "$fixture/bin/schema"
+
+cat > "$fixture/.gitignore" <<'EOF'
+/build/
+generated/**/.stamp
+/bin/
+EOF
+
+# The committed tree and the generation rule differ per case: write the
+# committed file, the Makefile, and the first commit.
+case "$mode" in
+kill-retry)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go build
+	@printf 'synthetic emission\n' > generated/go/ATable.go
+	@touch build/replacement-exists
+	@sleep 8
+	@touch generated/go/.stamp
+EOF
+	;;
+regeneration-fails)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@printf 'regeneration fails on purpose\n' >&2
+	@exit 1
+EOF
+	;;
+second-invocation)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go
+	@printf 'committed original bytes\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+staged-difference)
+	printf 'committed old bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go
+	@printf 'synthetic emission\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+esac
+
+git -C "$fixture" init -q
+git -C "$fixture" config user.name test
+git -C "$fixture" config user.email test@example.com
+git -C "$fixture" add -A
+git -C "$fixture" commit -q -m fixture
+
+# staged-difference stages a change after the first commit, so HEAD carries the
+# old bytes and the index and the file carry the new ones.
+if [ "$mode" = staged-difference ]; then
+	printf 'synthetic emission\n' > "$fixture/generated/go/ATable.go"
+	git -C "$fixture" add generated/go/ATable.go
+fi
+
+fail=0
+
+wait_for() {
+	# wait_for <relpath> <tenths> — poll for a path under the fixture.
+	i=0
+	while [ "$i" -lt "${2:?}" ]; do
+		[ -e "$fixture/$1" ] && return 0
+		sleep 0.1
+		i=$(( i + 1 ))
+	done
+	return 1
+}
+
+assert_file_is() {
+	got=$(cat "$fixture/$1" 2>/dev/null || true)
+	if [ "$got" != "$2" ]; then
+		printf 'ASSERTION FAILED: %s has %s, want %s\n' "$1" "$got" "$2" >&2
+		return 1
+	fi
+}
+
+assert_contains() {
+	grep -Fq "$2" "$work/$1" 2>/dev/null || {
+		printf 'ASSERTION FAILED: %s does not say %s\n' "$1" "$2" >&2
+		return 1
+	}
+}
+
+assert_not_contains() {
+	if grep -Fq "$2" "$work/$1" 2>/dev/null; then
+		printf 'ASSERTION FAILED: %s must not say %s\n' "$1" "$2" >&2
+		return 1
+	fi
+	return 0
+}
+
+run_verify() { ( cd "$fixture" && sh test/generated-tree/verify "$@" ); }
+
+case "$mode" in
+kill-retry)
+	# The verifier must run in its own process group so the whole group — the
+	# shell and the make it spawned — can be SIGKILLed as one.
+	( cd "$fixture" && exec python3 -c 'import os,sys; os.setpgrp(); os.execvp("sh", ["sh","test/generated-tree/verify"])' ) > "$work/run1.log" 2>&1 &
+	vpid=$!
+
+	wait_for build/generated-tree/prev/go/ATable.go 100 || { printf 'the original never reached prev\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	assert_file_is build/generated-tree/prev/go/ATable.go 'committed original bytes' || fail=1
+
+	wait_for build/replacement-exists 100 || { printf 'the replacement tree never appeared\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	kill -KILL -"$vpid"
+	wait "$vpid" 2>/dev/null || true
+
+	# The preserved original must still hold its exact bytes after the kill.
+	assert_file_is build/generated-tree/prev/go/ATable.go 'committed original bytes' || fail=1
+
+	# The second invocation must recover (not destroy) the original, and name
+	# the state it recovered from. The committed tree is stale against the
+	# emission here, so the retry is right to exit non-zero — but the original
+	# bytes must still stand under the fixture.
+	run_verify > "$work/run2.log" 2>&1 || rc2=$?
+	assert_contains run2.log 'RECOVERED' || fail=1
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	if [ "${rc2:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: the retry exited 0, but the committed tree is stale against the emission\n' >&2
+		fail=1
+	fi
+	printf 'verify-control kill-retry: the SIGKILLed run left the original in prev, and the retry RECOVERED it, named the state, and left the original bytes standing\n'
+	;;
+
+regeneration-fails)
+	run_verify > "$work/run1.log" 2>&1 || rc=$?
+	if [ "${rc:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: a failing regeneration must exit non-zero\n' >&2
+		fail=1
+	fi
+	assert_contains run1.log 'the regeneration itself failed' || fail=1
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	if [ -e "$fixture/build/generated-tree/prev" ]; then
+		printf 'ASSERTION FAILED: the original was not restored from prev\n' >&2
+		fail=1
+	fi
+	printf 'verify-control regeneration-fails: the original tree is restored and the run exits non-zero\n'
+	;;
+
+second-invocation)
+	run_verify > "$work/run1.log" 2>&1 || { printf 'first invocation failed unexpectedly\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	run_verify > "$work/run2.log" 2>&1 || { printf 'second invocation failed unexpectedly\n' >&2; cat "$work/run2.log" >&2; exit 1; }
+	assert_not_contains run2.log 'REFUSED' || fail=1
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	printf 'verify-control second-invocation: two normal invocations, and the second is not refused by the first run leftover state\n'
+	;;
+
+staged-difference)
+	run_verify > "$work/run1.log" 2>&1 || rc=$?
+	if [ "${rc:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: a staged-only difference must exit non-zero in committed mode\n' >&2
+		fail=1
+	fi
+	assert_contains run1.log 'NOT COMMITTED' || fail=1
+	assert_not_contains run1.log 'the committed generated/ tree is what this compiler emits.' || fail=1
+
+	# The separately named staged mode may agree, but it may never claim the
+	# committed emission is current.
+	run_verify --staged > "$work/run2.log" 2>&1 || { printf '--staged mode failed unexpectedly\n' >&2; cat "$work/run2.log" >&2; exit 1; }
+	assert_not_contains run2.log 'the committed generated/ tree is what this compiler emits.' || fail=1
+	assert_contains run2.log 'staged mode' || fail=1
+	printf 'verify-control staged-difference: a staged-only difference reds in committed mode and never prints the committed-emission sentence\n'
+	;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+	printf 'verify-control %s FAILED\n' "$mode" >&2
+	exit 1
+fi
+
+printf 'generated-tree verify control: %s is green\n' "$mode"

--- a/test/generated-tree/verify-control
+++ b/test/generated-tree/verify-control
@@ -24,6 +24,13 @@
 #                       and the marker are byte-identical before and after.
 #   ambiguous-marker    a marker with an unrecognised phase plus a prev tree:
 #                       refusal, marker and both trees unchanged.
+#   two-reclaimers      two reclaimers attempt acquisition concurrently after a
+#                       holder dies: exactly one succeeds and recovers, the
+#                       second is serialized/refused cleanly.
+#   acquisition-before-owner
+#                       contenders during lock acquisition never delete the
+#                       lock or see an empty owner; kernel lock held before
+#                       reading state or writing owner.
 #   regeneration-fails  a normal failure: the original tree is restored and the
 #                       run exits non-zero.
 #   second-invocation   two normal invocations in a row; the second must not be
@@ -35,9 +42,14 @@ set -eu
 
 repo=$(cd "$(dirname "$0")/../.." && pwd)
 
+if [ ! -x "$repo/build/treelock" ]; then
+	mkdir -p "$repo/build"
+	go build -o "$repo/build/treelock" "$repo/tools/treelock"
+fi
+
 mode=${1:?usage: verify-control <case>}
 case "$mode" in
-kill-retry|kill-before-emission|simultaneous-contender|ambiguous-marker|regeneration-fails|second-invocation|staged-difference) ;;
+kill-retry|kill-before-emission|simultaneous-contender|ambiguous-marker|two-reclaimers|acquisition-before-owner|regeneration-fails|second-invocation|staged-difference) ;;
 *) printf 'unknown control: %s\n' "$mode" >&2; exit 1 ;;
 esac
 
@@ -45,10 +57,12 @@ work=build/generated-tree/vc/$mode
 rm -rf "$work"
 mkdir -p "$work"
 fixture=$work/fixture
-mkdir -p "$fixture/generated/go" "$fixture/test/generated-tree" "$fixture/make" "$fixture/bin"
+mkdir -p "$fixture/generated/go" "$fixture/test/generated-tree" "$fixture/make" "$fixture/bin" "$fixture/build"
 cp "$repo/test/generated-tree/verify" "$fixture/test/generated-tree/verify"
 cp "$repo/test/generated-tree/compare" "$fixture/test/generated-tree/compare"
 chmod +x "$fixture/test/generated-tree/verify" "$fixture/test/generated-tree/compare"
+cp "$repo/build/treelock" "$fixture/build/treelock"
+chmod +x "$fixture/build/treelock"
 : > "$fixture/test/generated-tree/not-emitted"
 : > "$fixture/make/empty.mk"
 : > "$fixture/bin/schema"
@@ -101,6 +115,28 @@ ambiguous-marker)
 	cat > "$fixture/Makefile" <<'EOF'
 generated/go/.stamp:
 	@mkdir -p generated/go
+	@printf 'committed original bytes\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+two-reclaimers)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go build
+	@touch build/emission-started
+	@sleep 3
+	@printf 'synthetic emission\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+acquisition-before-owner)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go build
+	@touch build/emission-started
+	@sleep 3
 	@printf 'committed original bytes\n' > generated/go/ATable.go
 	@touch generated/go/.stamp
 EOF
@@ -316,6 +352,105 @@ ambiguous-marker)
 	[ "$prev_before" = "$prev_after" ] || { printf 'ASSERTION FAILED: prev was altered\n' >&2; fail=1; }
 	[ "$gen_before" = "$gen_after" ] || { printf 'ASSERTION FAILED: generated was altered\n' >&2; fail=1; }
 	printf 'verify-control ambiguous-marker: an unrecognised marker is refused, and the marker and both trees are unchanged\n'
+	;;
+
+two-reclaimers)
+	# Start a verifier that moves generated to prev and begins emission, then
+	# SIGKILL it while the original tree is in prev and state is emitting:
+	# this leaves one stale lock/state on disk.
+	( cd "$fixture" && exec python3 -c 'import os,sys; os.setpgrp(); os.execvp("sh", ["sh","test/generated-tree/verify"])' ) > "$work/run1.log" 2>&1 &
+	vpid=$!
+
+	wait_for build/generated-tree/prev/go/ATable.go 100 || { printf 'the original never reached prev\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	wait_for build/emission-started 100 || { printf 'the generation rule never started\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	kill -KILL -"$vpid"
+	wait "$vpid" 2>/dev/null || true
+
+	assert_file_is build/generated-tree/prev/go/ATable.go 'committed original bytes' || fail=1
+
+	# Both reclaimers attempt acquisition concurrently after holder dies.
+	# The generation rule in Makefile sleeps 3s, so whichever reclaimer acquires
+	# the lock holds it across its recovery and emission.
+	run_verify > "$work/rec1.log" 2>&1 &
+	rpid1=$!
+	run_verify > "$work/rec2.log" 2>&1 &
+	rpid2=$!
+
+	rc1=0; wait "$rpid1" || rc1=$?
+	rc2=0; wait "$rpid2" || rc2=$?
+
+	rec1_recovered=0; grep -Fq 'RECOVERED' "$work/rec1.log" 2>/dev/null && rec1_recovered=1 || true
+	rec2_recovered=0; grep -Fq 'RECOVERED' "$work/rec2.log" 2>/dev/null && rec2_recovered=1 || true
+
+	rec1_refused=0; grep -Fq 'REFUSED' "$work/rec1.log" 2>/dev/null && rec1_refused=1 || true
+	rec2_refused=0; grep -Fq 'REFUSED' "$work/rec2.log" 2>/dev/null && rec2_refused=1 || true
+
+	if [ "$rec1_recovered" -eq 1 ] && [ "$rec2_refused" -eq 1 ]; then
+		[ "$rc2" -ne 0 ] || { printf 'ASSERTION FAILED: refused reclaimer exited 0\n' >&2; fail=1; }
+	elif [ "$rec2_recovered" -eq 1 ] && [ "$rec1_refused" -eq 1 ]; then
+		[ "$rc1" -ne 0 ] || { printf 'ASSERTION FAILED: refused reclaimer exited 0\n' >&2; fail=1; }
+	else
+		printf 'ASSERTION FAILED: expected exactly one RECOVERED and one REFUSED (rec1: recov=%d ref=%d rc=%d, rec2: recov=%d ref=%d rc=%d)\n' \
+			"$rec1_recovered" "$rec1_refused" "$rc1" "$rec2_recovered" "$rec2_refused" "$rc2" >&2
+		cat "$work/rec1.log" >&2
+		cat "$work/rec2.log" >&2
+		fail=1
+	fi
+
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	printf 'verify-control two-reclaimers: two concurrent reclaimers of one stale lock: exactly one recovers, the second is serialized/refused cleanly\n'
+	;;
+
+acquisition-before-owner)
+	# Plant a previous interrupted run's state (prev tree, state marker, owner file),
+	# with generated/ absent, to witness:
+	# 1. Holder holds kernel lock before reading state or writing owner, recovering prev.
+	# 2. Contenders running while holder is active are refused cleanly naming holder PID.
+	# 3. Contenders never observe an un-owned lock, never delete the lock, never steal lock.
+	# 4. Holder completes cleanly without disruption.
+	mkdir -p "$fixture/build/generated-tree/prev/go" "$fixture/build/generated-tree/lock"
+	printf 'committed original bytes\n' > "$fixture/build/generated-tree/prev/go/ATable.go"
+	printf '99999 99999.1000\n' > "$fixture/build/generated-tree/lock/owner"
+	printf '99999 99999.1000 emitting\n' > "$fixture/build/generated-tree/state"
+	rm -f "$fixture/generated/go/ATable.go"
+
+	( cd "$fixture" && exec python3 -c 'import os,sys; os.setpgrp(); os.execvp("sh", ["sh","test/generated-tree/verify"])' ) > "$work/holder.log" 2>&1 &
+	vpid=$!
+
+	# Wait until holder takes the lock and enters emission rule (sleeps 3s)
+	wait_for build/emission-started 100 || { printf 'holder never started emission\n' >&2; cat "$work/holder.log" >&2; exit 1; }
+
+	# Fire concurrent contenders while holder is in emission
+	for i in 1 2 3; do
+		run_verify > "$work/contender$i.log" 2>&1 &
+	done
+
+	# Wait for holder to finish
+	rch=0
+	wait "$vpid" || rch=$?
+	if [ "$rch" -ne 0 ]; then
+		printf 'ASSERTION FAILED: holder failed or had its lock stolen\n' >&2
+		cat "$work/holder.log" >&2
+		fail=1
+	fi
+
+	wait || true
+
+	# Every contender must have been refused with valid holder pid (never unknown or empty)
+	for i in 1 2 3; do
+		assert_contains contender$i.log 'REFUSED' || fail=1
+		if grep -Fq 'pid unknown' "$work/contender$i.log"; then
+			printf 'ASSERTION FAILED: contender%d saw pid unknown\n' "$i" >&2
+			cat "$work/contender$i.log" >&2
+			fail=1
+		fi
+	done
+
+	# Holder must have recovered the previous tree and completed
+	assert_contains holder.log 'RECOVERED' || fail=1
+	assert_contains holder.log 'the committed generated/ tree is what this compiler emits.' || fail=1
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	printf 'verify-control acquisition-before-owner: kernel lock held before reading state or writing owner; contenders never steal lock or observe empty owner\n'
 	;;
 
 regeneration-fails)

--- a/test/generated-tree/verify-control
+++ b/test/generated-tree/verify-control
@@ -12,6 +12,18 @@
 #                       original is in build/generated-tree/prev and the
 #                       replacement tree exists; a second invocation must name
 #                       the state and leave the original bytes standing.
+#   kill-before-emission
+#                       SIGKILL the verifier after `mv generated "$prev"` but
+#                       before generation recreated its directory (the recipe
+#                       touches build/emission-started, then sleeps before
+#                       mkdir -p generated/go); the next invocation restores the
+#                       original and names the state.
+#   simultaneous-contender
+#                       start one verifier and wait for its lock, then start a
+#                       second: the second is refused and original, prev, fresh
+#                       and the marker are byte-identical before and after.
+#   ambiguous-marker    a marker with an unrecognised phase plus a prev tree:
+#                       refusal, marker and both trees unchanged.
 #   regeneration-fails  a normal failure: the original tree is restored and the
 #                       run exits non-zero.
 #   second-invocation   two normal invocations in a row; the second must not be
@@ -25,7 +37,7 @@ repo=$(cd "$(dirname "$0")/../.." && pwd)
 
 mode=${1:?usage: verify-control <case>}
 case "$mode" in
-kill-retry|regeneration-fails|second-invocation|staged-difference) ;;
+kill-retry|kill-before-emission|simultaneous-contender|ambiguous-marker|regeneration-fails|second-invocation|staged-difference) ;;
 *) printf 'unknown control: %s\n' "$mode" >&2; exit 1 ;;
 esac
 
@@ -58,6 +70,38 @@ generated/go/.stamp:
 	@printf 'synthetic emission\n' > generated/go/ATable.go
 	@touch build/replacement-exists
 	@sleep 8
+	@touch generated/go/.stamp
+EOF
+	;;
+kill-before-emission)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p build
+	@touch build/emission-started
+	@sleep 8
+	@mkdir -p generated/go
+	@printf 'synthetic emission\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+simultaneous-contender)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go build
+	@touch build/emission-started
+	@sleep 8
+	@printf 'synthetic emission\n' > generated/go/ATable.go
+	@touch generated/go/.stamp
+EOF
+	;;
+ambiguous-marker)
+	printf 'committed original bytes\n' > "$fixture/generated/go/ATable.go"
+	cat > "$fixture/Makefile" <<'EOF'
+generated/go/.stamp:
+	@mkdir -p generated/go
+	@printf 'committed original bytes\n' > generated/go/ATable.go
 	@touch generated/go/.stamp
 EOF
 	;;
@@ -140,6 +184,18 @@ assert_not_contains() {
 
 run_verify() { ( cd "$fixture" && sh test/generated-tree/verify "$@" ); }
 
+snapshot() {
+	# snapshot <label> — record the four shared artefacts (original tree, prev,
+	# fresh, state marker) to $work/<label>.snap for a byte-identical diff.
+	{
+		printf 'generated='; [ -f "$fixture/generated/go/ATable.go" ] && cat "$fixture/generated/go/ATable.go" || printf 'ABSENT'
+		printf '\nprev='; [ -f "$fixture/build/generated-tree/prev/go/ATable.go" ] && cat "$fixture/build/generated-tree/prev/go/ATable.go" || printf 'ABSENT'
+		printf '\nfresh='; [ -e "$fixture/build/generated-tree/fresh" ] && printf 'PRESENT' || printf 'ABSENT'
+		printf '\nstate='; [ -f "$fixture/build/generated-tree/state" ] && cat "$fixture/build/generated-tree/state" || printf 'ABSENT'
+		printf '\n'
+	} > "$work/$1.snap"
+}
+
 case "$mode" in
 kill-retry)
 	# The verifier must run in its own process group so the whole group — the
@@ -169,6 +225,97 @@ kill-retry)
 		fail=1
 	fi
 	printf 'verify-control kill-retry: the SIGKILLed run left the original in prev, and the retry RECOVERED it, named the state, and left the original bytes standing\n'
+	;;
+
+kill-before-emission)
+	# SIGKILL the verifier after `mv generated "$prev"` but before generation
+	# recreated its directory: the recipe touches build/emission-started, then
+	# sleeps before mkdir -p generated/go. At the kill there is no generated/
+	# at all — the exact hole the old early guard tripped over.
+	( cd "$fixture" && exec python3 -c 'import os,sys; os.setpgrp(); os.execvp("sh", ["sh","test/generated-tree/verify"])' ) > "$work/run1.log" 2>&1 &
+	vpid=$!
+
+	wait_for build/generated-tree/prev/go/ATable.go 100 || { printf 'the original never reached prev\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	assert_file_is build/generated-tree/prev/go/ATable.go 'committed original bytes' || fail=1
+
+	wait_for build/emission-started 100 || { printf 'the generation rule never started\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	if [ -e "$fixture/generated" ]; then
+		printf 'ASSERTION FAILED: the boundary is wrong — generated/ exists before the recipe recreated it\n' >&2
+		fail=1
+	fi
+	kill -KILL -"$vpid"
+	wait "$vpid" 2>/dev/null || true
+
+	assert_file_is build/generated-tree/prev/go/ATable.go 'committed original bytes' || fail=1
+
+	# The next invocation must recover (not destroy) the original and name the
+	# state, even though there was no generated/ tree at all when it started.
+	run_verify > "$work/run2.log" 2>&1 || rc2=$?
+	assert_contains run2.log 'RECOVERED' || fail=1
+	assert_file_is generated/go/ATable.go 'committed original bytes' || fail=1
+	if [ "${rc2:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: the retry exited 0, but the committed tree is stale against the emission\n' >&2
+		fail=1
+	fi
+	printf 'verify-control kill-before-emission: the run killed before generation recreated the tree left no generated/; the retry RECOVERED the original and named the state\n'
+	;;
+
+simultaneous-contender)
+	# One verifier takes the lock and holds it (its generation rule sleeps); a
+	# second must be refused without moving a byte of shared state.
+	( cd "$fixture" && exec python3 -c 'import os,sys; os.setpgrp(); os.execvp("sh", ["sh","test/generated-tree/verify"])' ) > "$work/run1.log" 2>&1 &
+	vpid=$!
+
+	wait_for build/generated-tree/lock/owner 100 || { printf 'the first verifier never took the lock\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+	wait_for build/emission-started 100 || { printf 'the first verifier never reached its generation rule\n' >&2; cat "$work/run1.log" >&2; exit 1; }
+
+	snapshot before
+
+	run_verify > "$work/run2.log" 2>&1 || rc2=$?
+	assert_contains run2.log 'REFUSED' || fail=1
+	if [ "${rc2:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: the simultaneous contender was not refused\n' >&2
+		fail=1
+	fi
+
+	snapshot after
+	if ! cmp -s "$work/before.snap" "$work/after.snap"; then
+		printf 'ASSERTION FAILED: the refused contender changed a shared artefact\n' >&2
+		diff "$work/before.snap" "$work/after.snap" >&2 || true
+		fail=1
+	fi
+
+	kill -KILL -"$vpid" 2>/dev/null || true
+	wait "$vpid" 2>/dev/null || true
+	printf 'verify-control simultaneous-contender: the second verifier is refused, and original, prev, fresh and the marker are byte-identical before and after\n'
+	;;
+
+ambiguous-marker)
+	# A marker whose phase this script does not recognise, beside a preserved
+	# prev tree: the run must refuse and leave the marker and both trees exactly
+	# as they were.
+	mkdir -p "$fixture/build/generated-tree/prev/go"
+	printf 'preserved original bytes\n' > "$fixture/build/generated-tree/prev/go/ATable.go"
+	printf '99999 somenonce bogus-phase\n' > "$fixture/build/generated-tree/state"
+
+	marker_before=$(cat "$fixture/build/generated-tree/state")
+	prev_before=$(cat "$fixture/build/generated-tree/prev/go/ATable.go")
+	gen_before=$(cat "$fixture/generated/go/ATable.go")
+
+	run_verify > "$work/run1.log" 2>&1 || rc=$?
+	if [ "${rc:-0}" -eq 0 ]; then
+		printf 'ASSERTION FAILED: an unrecognised marker must be refused\n' >&2
+		fail=1
+	fi
+	assert_contains run1.log 'REFUSED' || fail=1
+
+	marker_after=$(cat "$fixture/build/generated-tree/state")
+	prev_after=$(cat "$fixture/build/generated-tree/prev/go/ATable.go")
+	gen_after=$(cat "$fixture/generated/go/ATable.go")
+	[ "$marker_before" = "$marker_after" ] || { printf 'ASSERTION FAILED: the marker was altered\n' >&2; fail=1; }
+	[ "$prev_before" = "$prev_after" ] || { printf 'ASSERTION FAILED: prev was altered\n' >&2; fail=1; }
+	[ "$gen_before" = "$gen_after" ] || { printf 'ASSERTION FAILED: generated was altered\n' >&2; fail=1; }
+	printf 'verify-control ambiguous-marker: an unrecognised marker is refused, and the marker and both trees are unchanged\n'
 	;;
 
 regeneration-fails)

--- a/tools/treelock/lock_unix.go
+++ b/tools/treelock/lock_unix.go
@@ -4,13 +4,9 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"syscall"
 )
-
-// ErrWindowsUnsupported documents the Windows refusal error for cross-platform verification.
-var ErrWindowsUnsupported = fmt.Errorf("treelock: kernel exclusivity locking is unsupported on windows; refusing execution without verified lock")
 
 func isAlive(pidStr string) bool {
 	pid, err := strconv.Atoi(pidStr)
@@ -27,8 +23,4 @@ func acquireFlock(fd uintptr) error {
 
 func isLockBlocked(err error) bool {
 	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
-}
-
-func checkWindowsFlockRefusal() error {
-	return ErrWindowsUnsupported
 }

--- a/tools/treelock/lock_unix.go
+++ b/tools/treelock/lock_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"strconv"
+	"syscall"
+)
+
+func isAlive(pidStr string) bool {
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	err = syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+func acquireFlock(fd uintptr) error {
+	return syscall.Flock(int(fd), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func isLockBlocked(err error) bool {
+	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
+}

--- a/tools/treelock/lock_unix.go
+++ b/tools/treelock/lock_unix.go
@@ -4,9 +4,13 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"syscall"
 )
+
+// ErrWindowsUnsupported documents the Windows refusal error for cross-platform verification.
+var ErrWindowsUnsupported = fmt.Errorf("treelock: kernel exclusivity locking is unsupported on windows; refusing execution without verified lock")
 
 func isAlive(pidStr string) bool {
 	pid, err := strconv.Atoi(pidStr)
@@ -23,4 +27,8 @@ func acquireFlock(fd uintptr) error {
 
 func isLockBlocked(err error) bool {
 	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
+}
+
+func checkWindowsFlockRefusal() error {
+	return ErrWindowsUnsupported
 }

--- a/tools/treelock/lock_windows.go
+++ b/tools/treelock/lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package main
+
+import (
+	"strconv"
+	"syscall"
+)
+
+func isAlive(pidStr string) bool {
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+	h, err := syscall.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = syscall.CloseHandle(h)
+	return true
+}
+
+func acquireFlock(fd uintptr) error {
+	// Runtime certification not claimed on Windows; compilation passes cleanly.
+	return nil
+}
+
+func isLockBlocked(err error) bool {
+	return false
+}

--- a/tools/treelock/lock_windows.go
+++ b/tools/treelock/lock_windows.go
@@ -3,9 +3,14 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"syscall"
 )
+
+// ErrWindowsUnsupported is returned when acquireFlock is called on Windows,
+// as kernel exclusivity locking is not yet implemented or certified on Windows.
+var ErrWindowsUnsupported = fmt.Errorf("treelock: kernel exclusivity locking is unsupported on windows; refusing execution without verified lock")
 
 func isAlive(pidStr string) bool {
 	pid, err := strconv.Atoi(pidStr)
@@ -22,10 +27,16 @@ func isAlive(pidStr string) bool {
 }
 
 func acquireFlock(fd uintptr) error {
-	// Runtime certification not claimed on Windows; compilation passes cleanly.
-	return nil
+	// Obligation retained: Windows platform locking (e.g. LockFileEx) and certification
+	// are not yet implemented. Refuse explicitly before launching any command or claiming
+	// unearned lock ownership.
+	return ErrWindowsUnsupported
 }
 
 func isLockBlocked(err error) bool {
 	return false
+}
+
+func checkWindowsFlockRefusal() error {
+	return ErrWindowsUnsupported
 }

--- a/tools/treelock/lock_windows.go
+++ b/tools/treelock/lock_windows.go
@@ -36,7 +36,3 @@ func acquireFlock(fd uintptr) error {
 func isLockBlocked(err error) bool {
 	return false
 }
-
-func checkWindowsFlockRefusal() error {
-	return ErrWindowsUnsupported
-}

--- a/tools/treelock/main.go
+++ b/tools/treelock/main.go
@@ -100,7 +100,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n", ownerPid, name)
 			os.Exit(1)
 		}
-		fmt.Fprintf(os.Stderr, "treelock: flock %s: %v\n", *lockPath, err)
+		if strings.HasPrefix(err.Error(), "treelock:") {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "treelock: flock %s: %v\n", *lockPath, err)
+		}
 		os.Exit(1)
 	}
 

--- a/tools/treelock/main.go
+++ b/tools/treelock/main.go
@@ -8,20 +8,10 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
-
-func isAlive(pidStr string) bool {
-	pid, err := strconv.Atoi(pidStr)
-	if err != nil || pid <= 0 {
-		return false
-	}
-	err = syscall.Kill(pid, 0)
-	return err == nil || err == syscall.EPERM
-}
 
 func readOwnerPid(ownerFile, lockPath string) string {
 	deadline := time.Now().Add(100 * time.Millisecond)
@@ -104,8 +94,8 @@ func main() {
 	}
 	defer f.Close()
 
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+	if err := acquireFlock(f.Fd()); err != nil {
+		if isLockBlocked(err) {
 			ownerPid := readOwnerPid(*ownerFile, *lockPath)
 			fmt.Fprintf(os.Stderr, "REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n", ownerPid, name)
 			os.Exit(1)
@@ -125,6 +115,10 @@ func main() {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// Pass the open lock file description to the child process so that the child
+	// inherits the lock descriptor without O_CLOEXEC. Under Unix/Darwin/Linux semantics,
+	// the flock remains held as long as any alive process references that open file description.
+	cmd.ExtraFiles = []*os.File{f}
 	cmd.Env = append(os.Environ(), "TREELOCK_HELD=1")
 
 	sigChan := make(chan os.Signal, 8)

--- a/tools/treelock/main.go
+++ b/tools/treelock/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func isAlive(pidStr string) bool {
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	err = syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+func readOwnerPid(ownerFile, lockPath string) string {
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for {
+		if ownerFile != "" {
+			if data, err := os.ReadFile(ownerFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
+				fields := strings.Fields(string(data))
+				if len(fields) > 0 && isAlive(fields[0]) {
+					return fields[0]
+				}
+			}
+		}
+		if lockPath != "" {
+			if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
+				fields := strings.Fields(string(data))
+				if len(fields) > 0 && isAlive(fields[0]) {
+					return fields[0]
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if ownerFile != "" {
+		if data, err := os.ReadFile(ownerFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			fields := strings.Fields(string(data))
+			if len(fields) > 0 && fields[0] != "" {
+				return fields[0]
+			}
+		}
+	}
+	if lockPath != "" {
+		if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			fields := strings.Fields(string(data))
+			if len(fields) > 0 && fields[0] != "" {
+				return fields[0]
+			}
+		}
+	}
+	return "unknown"
+}
+
+func main() {
+	var (
+		lockPath  = flag.String("lock", "", "path to lock file")
+		ownerFile = flag.String("owner-file", "", "path to owner file to inspect on contention")
+		lockName  = flag.String("name", "", "name of lock to display in refusal messages")
+	)
+	flag.Parse()
+
+	if *lockPath == "" {
+		fmt.Fprintf(os.Stderr, "usage: treelock -lock <lockfile> [-owner-file <ownerfile>] [-name <name>] <command> [args...]\n")
+		os.Exit(2)
+	}
+
+	cmdArgs := flag.Args()
+	if len(cmdArgs) == 0 {
+		fmt.Fprintf(os.Stderr, "treelock: no command specified\n")
+		os.Exit(2)
+	}
+
+	name := *lockName
+	if name == "" {
+		name = *lockPath
+	}
+
+	lockDir := filepath.Dir(*lockPath)
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "treelock: mkdir %s: %v\n", lockDir, err)
+		os.Exit(1)
+	}
+
+	f, err := os.OpenFile(*lockPath, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "treelock: open %s: %v\n", *lockPath, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+			ownerPid := readOwnerPid(*ownerFile, *lockPath)
+			fmt.Fprintf(os.Stderr, "REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n", ownerPid, name)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "treelock: flock %s: %v\n", *lockPath, err)
+		os.Exit(1)
+	}
+
+	// We now hold the exclusive kernel advisory lock.
+	// Record our PID in the lock file immediately so any contender has an immediate owner pid.
+	_ = f.Truncate(0)
+	_, _ = f.Seek(0, 0)
+	_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+	_ = f.Sync()
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "TREELOCK_HELD=1")
+
+	sigChan := make(chan os.Signal, 8)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "treelock: start %s: %v\n", cmdArgs[0], err)
+		os.Exit(1)
+	}
+
+	// Update lock file with child's PID as well.
+	_ = f.Truncate(0)
+	_, _ = f.Seek(0, 0)
+	_, _ = fmt.Fprintf(f, "%d\n", cmd.Process.Pid)
+	_ = f.Sync()
+
+	go func() {
+		for sig := range sigChan {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		}
+	}()
+
+	waitErr := cmd.Wait()
+	signal.Stop(sigChan)
+	close(sigChan)
+
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				if status.Signaled() {
+					os.Exit(128 + int(status.Signal()))
+				}
+				os.Exit(status.ExitStatus())
+			}
+			os.Exit(exitErr.ExitCode())
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,9 +19,18 @@ import (
 
 var (
 	builtBinOnce sync.Once
+	builtBinDir  string
 	builtBinPath string
 	builtBinErr  error
 )
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if builtBinDir != "" {
+		_ = os.RemoveAll(builtBinDir)
+	}
+	os.Exit(code)
+}
 
 func buildTreelock(t *testing.T) string {
 	t.Helper()
@@ -30,6 +40,7 @@ func buildTreelock(t *testing.T) string {
 			builtBinErr = err
 			return
 		}
+		builtBinDir = dir
 		bin := filepath.Join(dir, "treelock")
 		cmd := exec.Command("go", "build", "-o", bin, ".")
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -51,11 +62,30 @@ func createFifo(t *testing.T, path string) {
 	}
 }
 
-func releaseFifo(path string) {
-	f, err := os.OpenFile(path, os.O_WRONLY, 0600)
-	if err == nil {
-		_, _ = f.Write([]byte("ok\n"))
-		_ = f.Close()
+func releaseFifo(path string, timeout ...time.Duration) error {
+	wait := 100 * time.Millisecond
+	if len(timeout) > 0 {
+		wait = timeout[0]
+	}
+	deadline := time.Now().Add(wait)
+	for {
+		fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if err == nil {
+			f := os.NewFile(uintptr(fd), path)
+			_, writeErr := f.Write([]byte("ok\n"))
+			closeErr := f.Close()
+			if writeErr != nil {
+				return writeErr
+			}
+			return closeErr
+		}
+		if !errors.Is(err, syscall.ENXIO) {
+			return fmt.Errorf("open fifo nonblock %s: %w", path, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("release fifo timed out after %v (no reader on %s): %w", wait, path, err)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -85,6 +115,69 @@ func waitForFile(t *testing.T, path string, done <-chan error, stderrPath string
 	return nil
 }
 
+func TestReviewerFifoWithoutReaderIsBounded(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "release.fifo")
+	createFifo(t, p)
+	err := releaseFifo(p)
+	if err == nil {
+		t.Fatal("expected error releasing fifo without reader, got nil")
+	}
+}
+
+func TestFifoEarlyChildExitIsBounded(t *testing.T) {
+	bin := buildTreelock(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "test.lock")
+	ownerPath := filepath.Join(dir, "owner")
+	readyPath := filepath.Join(dir, "ready")
+	fifoPath := filepath.Join(dir, "release.fifo")
+	stderrPath := filepath.Join(dir, "early_exit.stderr")
+
+	createFifo(t, fifoPath)
+
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("failed to create stderr file: %v", err)
+	}
+	defer stderrFile.Close()
+
+	cmd := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
+		"sh", "-c", "echo ready > \"$1\"; exit 1", "--", readyPath)
+	cmd.Stderr = stderrFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start cmd: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+	})
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected child to exit with error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for child to exit")
+	}
+
+	start := time.Now()
+	err = releaseFifo(fifoPath, 100*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected releaseFifo to fail when child exited early, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("releaseFifo took too long (%v), expected bounded return under 500ms", elapsed)
+	}
+}
+
 func TestTreelockExclusivity(t *testing.T) {
 	bin := buildTreelock(t)
 	dir := t.TempDir()
@@ -106,6 +199,7 @@ func TestTreelockExclusivity(t *testing.T) {
 	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
 		"sh", "-c", "echo ready > \"$1\"; read -r line < \"$2\"", "--", readyPath, fifoPath)
 	holder.Stderr = stderrFile
+	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
@@ -115,9 +209,8 @@ func TestTreelockExclusivity(t *testing.T) {
 	}()
 
 	t.Cleanup(func() {
-		go releaseFifo(fifoPath)
 		if holder.Process != nil {
-			_ = holder.Process.Kill()
+			_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
 		}
 	})
 
@@ -149,7 +242,9 @@ func TestTreelockExclusivity(t *testing.T) {
 	}
 
 	// Now release holder and wait for clean exit
-	releaseFifo(fifoPath)
+	if err := releaseFifo(fifoPath, 2*time.Second); err != nil {
+		t.Fatalf("failed to release fifo: %v", err)
+	}
 	select {
 	case err := <-holderDone:
 		if err != nil {
@@ -197,7 +292,6 @@ func TestTreelockOwnerDeathRelease(t *testing.T) {
 	}()
 
 	t.Cleanup(func() {
-		go releaseFifo(fifoPath)
 		if holder.Process != nil {
 			_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
 		}
@@ -244,6 +338,7 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
 		"sh", "-c", "echo $$ > \"$1\"; read -r line < \"$2\"", "--", childPidFile, fifoPath)
 	holder.Stderr = stderrFile
+	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
@@ -255,9 +350,8 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 
 	var childPidInt int
 	t.Cleanup(func() {
-		go releaseFifo(fifoPath)
 		if holder.Process != nil {
-			_ = holder.Process.Kill()
+			_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
 		}
 		if childPidInt > 0 {
 			_ = syscall.Kill(childPidInt, syscall.SIGKILL)
@@ -311,7 +405,9 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 	}
 
 	// Release the surviving child process cleanly via FIFO
-	releaseFifo(fifoPath)
+	if err := releaseFifo(fifoPath, 2*time.Second); err != nil {
+		t.Fatalf("failed to release child fifo: %v", err)
+	}
 
 	// Wait up to 5s for child to terminate cleanly
 	deadline := time.Now().Add(5 * time.Second)

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (
@@ -5,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -90,8 +93,9 @@ func TestTreelockOwnerDeathRelease(t *testing.T) {
 	lockPath := filepath.Join(dir, "test.lock")
 	ownerPath := filepath.Join(dir, "owner")
 
-	// Start holder
+	// Start holder in its own process group
 	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "sleep", "10")
+	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
@@ -103,13 +107,84 @@ func TestTreelockOwnerDeathRelease(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// Kill holder with SIGKILL
-	_ = holder.Process.Signal(syscall.SIGKILL)
+	// Kill entire holder process group with SIGKILL
+	_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
 	_ = holder.Wait()
 
 	// Kernel should have released lock immediately. Reclaimer must succeed.
 	reclaimer := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "reclaimed")
 	if out, err := reclaimer.CombinedOutput(); err != nil {
 		t.Fatalf("reclaimer failed to acquire lock after holder death: %v\n%s", err, out)
+	}
+}
+
+func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
+	bin := buildTreelock(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "test.lock")
+	ownerPath := filepath.Join(dir, "owner")
+	childPidFile := filepath.Join(dir, "child.pid")
+
+	// Start treelock with a child that records its PID and sleeps for 10 seconds
+	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
+		"sh", "-c", "echo $$ > \"$1\"; exec sleep 10", "--", childPidFile)
+	if err := holder.Start(); err != nil {
+		t.Fatalf("holder failed to start: %v", err)
+	}
+	wrapperPid := holder.Process.Pid
+
+	// Wait for child process to write its PID
+	var childPidStr string
+	for i := 0; i < 50; i++ {
+		if data, err := os.ReadFile(childPidFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			childPidStr = strings.TrimSpace(string(data))
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if childPidStr == "" {
+		_ = holder.Process.Kill()
+		t.Fatalf("child process never wrote PID")
+	}
+
+	// Verify both wrapper and child are alive
+	if !isAlive(childPidStr) {
+		t.Fatalf("child process %s is not alive", childPidStr)
+	}
+
+	// Kill ONLY the treelock wrapper PID (leaving child alive)
+	if err := syscall.Kill(wrapperPid, syscall.SIGKILL); err != nil {
+		t.Fatalf("failed to kill wrapper %d: %v", wrapperPid, err)
+	}
+	_ = holder.Wait()
+
+	// Child must still be alive
+	if !isAlive(childPidStr) {
+		t.Fatalf("child process %s died unexpectedly after wrapper was killed", childPidStr)
+	}
+
+	// Because child inherited lock FD via ExtraFiles, lock remains held by child.
+	// Contender must be refused.
+	contender := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "should-not-run")
+	var contenderStderr bytes.Buffer
+	contender.Stderr = &contenderStderr
+	err := contender.Run()
+	if err == nil {
+		t.Fatalf("contender succeeded unexpectedly while child still holds lock!")
+	}
+	out := contenderStderr.String()
+	if !strings.Contains(out, "REFUSED") {
+		t.Errorf("contender stderr does not say REFUSED: %q", out)
+	}
+
+	// Terminate the surviving child process
+	childPidInt, _ := strconv.Atoi(childPidStr)
+	_ = syscall.Kill(childPidInt, syscall.SIGKILL)
+	time.Sleep(50 * time.Millisecond)
+
+	// Now that child is dead, lock should be released. A new invocation must succeed.
+	reclaimer := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "reclaimed")
+	if out, err := reclaimer.CombinedOutput(); err != nil {
+		t.Fatalf("reclaimer failed to acquire lock after child death: %v\n%s", err, out)
 	}
 }

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -4,25 +4,85 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 )
 
+var (
+	builtBinOnce sync.Once
+	builtBinPath string
+	builtBinErr  error
+)
+
 func buildTreelock(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "treelock")
-	cmd := exec.Command("go", "build", "-o", bin, ".")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build treelock: %v\n%s", err, out)
+	builtBinOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "treelock-test-bin-*")
+		if err != nil {
+			builtBinErr = err
+			return
+		}
+		bin := filepath.Join(dir, "treelock")
+		cmd := exec.Command("go", "build", "-o", bin, ".")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			builtBinErr = fmt.Errorf("build treelock: %w\n%s", err, out)
+			return
+		}
+		builtBinPath = bin
+	})
+	if builtBinErr != nil {
+		t.Fatalf("failed to build treelock: %v", builtBinErr)
 	}
-	return bin
+	return builtBinPath
+}
+
+func createFifo(t *testing.T, path string) {
+	t.Helper()
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		t.Fatalf("failed to create fifo %s: %v", path, err)
+	}
+}
+
+func releaseFifo(path string) {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0600)
+	if err == nil {
+		_, _ = f.Write([]byte("ok\n"))
+		_ = f.Close()
+	}
+}
+
+func waitForFile(t *testing.T, path string, done <-chan error, stderrPath string, timeout time.Duration) []byte {
+	t.Helper()
+	readStderr := func() string {
+		data, err := os.ReadFile(stderrPath)
+		if err != nil {
+			return fmt.Sprintf("<error reading stderr: %v>", err)
+		}
+		return string(data)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-done:
+			t.Fatalf("process exited prematurely with err %v while waiting for %s; stderr:\n%s", err, path, readStderr())
+		default:
+		}
+		if data, err := os.ReadFile(path); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			return bytes.TrimSpace(data)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for %s; stderr:\n%s", timeout, path, readStderr())
+	return nil
 }
 
 func TestTreelockExclusivity(t *testing.T) {
@@ -30,41 +90,47 @@ func TestTreelockExclusivity(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, "test.lock")
 	ownerPath := filepath.Join(dir, "owner")
+	readyPath := filepath.Join(dir, "ready")
+	fifoPath := filepath.Join(dir, "release.fifo")
+	stderrPath := filepath.Join(dir, "holder.stderr")
 
-	// Start holder that sleeps for 2 seconds
-	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "sleep", "2")
-	var holderStderr bytes.Buffer
-	holder.Stderr = &holderStderr
+	createFifo(t, fifoPath)
+
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("failed to create stderr file: %v", err)
+	}
+	defer stderrFile.Close()
+
+	// Start holder that signals readiness and blocks on FIFO until explicitly released
+	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
+		"sh", "-c", "echo ready > \"$1\"; read -r line < \"$2\"", "--", readyPath, fifoPath)
+	holder.Stderr = stderrFile
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
-	defer func() {
-		if holder.Process != nil {
-			_ = holder.Process.Kill()
-			_ = holder.Wait()
-		}
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- holder.Wait()
 	}()
 
-	// Wait for holder to acquire the lock
-	acquired := false
-	for i := 0; i < 50; i++ {
-		if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
-			acquired = true
-			break
+	t.Cleanup(func() {
+		go releaseFifo(fifoPath)
+		if holder.Process != nil {
+			_ = holder.Process.Kill()
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if !acquired {
-		t.Fatalf("holder never acquired lock: %s", holderStderr.String())
-	}
+	})
+
+	// Wait for holder to acquire lock and signal readiness
+	waitForFile(t, readyPath, holderDone, stderrPath, 10*time.Second)
 
 	// Contender attempts to acquire the lock while holder is running
 	contender := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "should-not-run")
 	var contenderStderr bytes.Buffer
 	contender.Stderr = &contenderStderr
-	err := contender.Run()
+	err = contender.Run()
 	if err == nil {
-		t.Fatalf("contender succeeded unexpectedly while lock is held (holder err: %s)", holderStderr.String())
+		t.Fatalf("contender succeeded unexpectedly while lock is held (holder err: %s)", stderrPath)
 	}
 
 	out := contenderStderr.String()
@@ -75,9 +141,22 @@ func TestTreelockExclusivity(t *testing.T) {
 		t.Errorf("contender stderr reported unknown pid: %q", out)
 	}
 
-	// Now wait for holder to exit
-	if err := holder.Wait(); err != nil {
-		t.Fatalf("holder failed: %v", err)
+	// Verify holder did not terminate during contention check
+	select {
+	case err := <-holderDone:
+		t.Fatalf("holder terminated early during contention check: %v", err)
+	default:
+	}
+
+	// Now release holder and wait for clean exit
+	releaseFifo(fifoPath)
+	select {
+	case err := <-holderDone:
+		if err != nil {
+			t.Fatalf("holder exited with error after release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("holder timed out waiting to exit after release")
 	}
 
 	// After holder exits, a second contender must acquire lock and succeed
@@ -92,24 +171,50 @@ func TestTreelockOwnerDeathRelease(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, "test.lock")
 	ownerPath := filepath.Join(dir, "owner")
+	readyPath := filepath.Join(dir, "ready")
+	fifoPath := filepath.Join(dir, "release.fifo")
+	stderrPath := filepath.Join(dir, "holder.stderr")
+
+	createFifo(t, fifoPath)
+
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("failed to create stderr file: %v", err)
+	}
+	defer stderrFile.Close()
 
 	// Start holder in its own process group
-	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "sleep", "10")
+	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
+		"sh", "-c", "echo ready > \"$1\"; read -r line < \"$2\"", "--", readyPath, fifoPath)
+	holder.Stderr = stderrFile
 	holder.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- holder.Wait()
+	}()
 
-	for i := 0; i < 50; i++ {
-		if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
-			break
+	t.Cleanup(func() {
+		go releaseFifo(fifoPath)
+		if holder.Process != nil {
+			_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	})
+
+	// Wait for holder readiness
+	waitForFile(t, readyPath, holderDone, stderrPath, 10*time.Second)
 
 	// Kill entire holder process group with SIGKILL
-	_ = syscall.Kill(-holder.Process.Pid, syscall.SIGKILL)
-	_ = holder.Wait()
+	if err := syscall.Kill(-holder.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("failed to kill process group %d: %v", holder.Process.Pid, err)
+	}
+	select {
+	case <-holderDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for holder process to terminate after SIGKILL")
+	}
 
 	// Kernel should have released lock immediately. Reclaimer must succeed.
 	reclaimer := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "reclaimed")
@@ -124,30 +229,54 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 	lockPath := filepath.Join(dir, "test.lock")
 	ownerPath := filepath.Join(dir, "owner")
 	childPidFile := filepath.Join(dir, "child.pid")
+	fifoPath := filepath.Join(dir, "child.fifo")
+	stderrPath := filepath.Join(dir, "holder.stderr")
 
-	// Start treelock with a child that records its PID and sleeps for 10 seconds
+	createFifo(t, fifoPath)
+
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("failed to create stderr file: %v", err)
+	}
+	defer stderrFile.Close()
+
+	// Start treelock with a child that records its PID and blocks on FIFO until released
 	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock",
-		"sh", "-c", "echo $$ > \"$1\"; exec sleep 10", "--", childPidFile)
+		"sh", "-c", "echo $$ > \"$1\"; read -r line < \"$2\"", "--", childPidFile, fifoPath)
+	holder.Stderr = stderrFile
 	if err := holder.Start(); err != nil {
 		t.Fatalf("holder failed to start: %v", err)
 	}
 	wrapperPid := holder.Process.Pid
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- holder.Wait()
+	}()
+
+	var childPidInt int
+	t.Cleanup(func() {
+		go releaseFifo(fifoPath)
+		if holder.Process != nil {
+			_ = holder.Process.Kill()
+		}
+		if childPidInt > 0 {
+			_ = syscall.Kill(childPidInt, syscall.SIGKILL)
+		}
+	})
 
 	// Wait for child process to write its PID
-	var childPidStr string
-	for i := 0; i < 50; i++ {
-		if data, err := os.ReadFile(childPidFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
-			childPidStr = strings.TrimSpace(string(data))
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if childPidStr == "" {
-		_ = holder.Process.Kill()
-		t.Fatalf("child process never wrote PID")
+	childPidBytes := waitForFile(t, childPidFile, holderDone, stderrPath, 10*time.Second)
+	childPidStr := string(childPidBytes)
+	var convErr error
+	childPidInt, convErr = strconv.Atoi(childPidStr)
+	if convErr != nil || childPidInt <= 0 {
+		t.Fatalf("invalid child pid %q: %v", childPidStr, convErr)
 	}
 
 	// Verify both wrapper and child are alive
+	if !isAlive(strconv.Itoa(wrapperPid)) {
+		t.Fatalf("wrapper process %d is not alive", wrapperPid)
+	}
 	if !isAlive(childPidStr) {
 		t.Fatalf("child process %s is not alive", childPidStr)
 	}
@@ -156,7 +285,11 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 	if err := syscall.Kill(wrapperPid, syscall.SIGKILL); err != nil {
 		t.Fatalf("failed to kill wrapper %d: %v", wrapperPid, err)
 	}
-	_ = holder.Wait()
+	select {
+	case <-holderDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for wrapper to exit after SIGKILL")
+	}
 
 	// Child must still be alive
 	if !isAlive(childPidStr) {
@@ -168,7 +301,7 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 	contender := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "should-not-run")
 	var contenderStderr bytes.Buffer
 	contender.Stderr = &contenderStderr
-	err := contender.Run()
+	err = contender.Run()
 	if err == nil {
 		t.Fatalf("contender succeeded unexpectedly while child still holds lock!")
 	}
@@ -177,10 +310,18 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 		t.Errorf("contender stderr does not say REFUSED: %q", out)
 	}
 
-	// Terminate the surviving child process
-	childPidInt, _ := strconv.Atoi(childPidStr)
-	_ = syscall.Kill(childPidInt, syscall.SIGKILL)
-	time.Sleep(50 * time.Millisecond)
+	// Release the surviving child process cleanly via FIFO
+	releaseFifo(fifoPath)
+
+	// Wait up to 5s for child to terminate cleanly
+	deadline := time.Now().Add(5 * time.Second)
+	for isAlive(childPidStr) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if isAlive(childPidStr) {
+		_ = syscall.Kill(childPidInt, syscall.SIGKILL)
+		t.Fatalf("child %s failed to terminate after FIFO release", childPidStr)
+	}
 
 	// Now that child is dead, lock should be released. A new invocation must succeed.
 	reclaimer := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "reclaimed")

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -188,3 +188,16 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 		t.Fatalf("reclaimer failed to acquire lock after child death: %v\n%s", err, out)
 	}
 }
+
+func TestTreelockWindowsRefusal(t *testing.T) {
+	// Obligation retained: Windows platform locking and certification are not yet implemented.
+	// Verify that the Windows flock implementation explicitly refuses execution with an error
+	// and never claims successful unearned ownership without a verified lock.
+	err := checkWindowsFlockRefusal()
+	if err == nil {
+		t.Fatal("expected Windows flock refusal check to return an error, got nil (never claim unearned ownership)")
+	}
+	if !strings.Contains(err.Error(), "unsupported on windows") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -188,16 +188,3 @@ func TestTreelockWrapperOnlyDeathInheritedLock(t *testing.T) {
 		t.Fatalf("reclaimer failed to acquire lock after child death: %v\n%s", err, out)
 	}
 }
-
-func TestTreelockWindowsRefusal(t *testing.T) {
-	// Obligation retained: Windows platform locking and certification are not yet implemented.
-	// Verify that the Windows flock implementation explicitly refuses execution with an error
-	// and never claims successful unearned ownership without a verified lock.
-	err := checkWindowsFlockRefusal()
-	if err == nil {
-		t.Fatal("expected Windows flock refusal check to return an error, got nil (never claim unearned ownership)")
-	}
-	if !strings.Contains(err.Error(), "unsupported on windows") {
-		t.Fatalf("unexpected error message: %v", err)
-	}
-}

--- a/tools/treelock/treelock_test.go
+++ b/tools/treelock/treelock_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func buildTreelock(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "treelock")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build treelock: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func TestTreelockExclusivity(t *testing.T) {
+	bin := buildTreelock(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "test.lock")
+	ownerPath := filepath.Join(dir, "owner")
+
+	// Start holder that sleeps for 2 seconds
+	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "sleep", "2")
+	var holderStderr bytes.Buffer
+	holder.Stderr = &holderStderr
+	if err := holder.Start(); err != nil {
+		t.Fatalf("holder failed to start: %v", err)
+	}
+	defer func() {
+		if holder.Process != nil {
+			_ = holder.Process.Kill()
+			_ = holder.Wait()
+		}
+	}()
+
+	// Wait for holder to acquire the lock
+	acquired := false
+	for i := 0; i < 50; i++ {
+		if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			acquired = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !acquired {
+		t.Fatalf("holder never acquired lock: %s", holderStderr.String())
+	}
+
+	// Contender attempts to acquire the lock while holder is running
+	contender := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "should-not-run")
+	var contenderStderr bytes.Buffer
+	contender.Stderr = &contenderStderr
+	err := contender.Run()
+	if err == nil {
+		t.Fatalf("contender succeeded unexpectedly while lock is held (holder err: %s)", holderStderr.String())
+	}
+
+	out := contenderStderr.String()
+	if !strings.Contains(out, "REFUSED") {
+		t.Errorf("contender stderr does not say REFUSED: %q", out)
+	}
+	if strings.Contains(out, "pid unknown") {
+		t.Errorf("contender stderr reported unknown pid: %q", out)
+	}
+
+	// Now wait for holder to exit
+	if err := holder.Wait(); err != nil {
+		t.Fatalf("holder failed: %v", err)
+	}
+
+	// After holder exits, a second contender must acquire lock and succeed
+	second := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "success")
+	if secondOut, err := second.CombinedOutput(); err != nil {
+		t.Fatalf("second run failed after holder exit: %v\n%s", err, secondOut)
+	}
+}
+
+func TestTreelockOwnerDeathRelease(t *testing.T) {
+	bin := buildTreelock(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "test.lock")
+	ownerPath := filepath.Join(dir, "owner")
+
+	// Start holder
+	holder := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "sleep", "10")
+	if err := holder.Start(); err != nil {
+		t.Fatalf("holder failed to start: %v", err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if data, err := os.ReadFile(lockPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Kill holder with SIGKILL
+	_ = holder.Process.Signal(syscall.SIGKILL)
+	_ = holder.Wait()
+
+	// Kernel should have released lock immediately. Reclaimer must succeed.
+	reclaimer := exec.Command(bin, "-lock", lockPath, "-owner-file", ownerPath, "-name", "test-lock", "echo", "reclaimed")
+	if out, err := reclaimer.CombinedOutput(); err != nil {
+		t.Fatalf("reclaimer failed to acquire lock after holder death: %v\n%s", err, out)
+	}
+}

--- a/tools/treelock/treelock_windows_test.go
+++ b/tools/treelock/treelock_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTreelockWindowsRefusal(t *testing.T) {
+	// Obligation retained: Windows platform locking and certification are not yet implemented.
+	// Verify that acquireFlock returns an explicit unsupported refusal and never claims unearned ownership.
+	err := acquireFlock(0)
+	if err == nil {
+		t.Fatal("expected acquireFlock on Windows to return an error, got nil (never claim unearned ownership)")
+	}
+	if !strings.Contains(err.Error(), "unsupported on windows") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
Fixed Tables **gate G3**, the stale generated-tree validation gap. Reproduced on the lane head, repaired, red first. Head at writing: `174842cc910a3ed19a141fd2f56d2b226253d22c`, off `origin/fixed-table-form` @ `b7ab66a8`.

## The requirement, in one sentence

**Not stale** means the committed `generated/` tree is exactly what the compiler at *this* sha emits when every generation rule runs into an **empty** directory — the same set of paths and the same bytes, in both directions, *including* files the emitter no longer writes and whole directories whose rule never ran, neither of which a diff of the files that happen to exist can see — and the proof that a rule ran is that its files come back from nothing, never a scan of the Makefile's text for a rule's name.

Stella's condition (bus note `stella-fd5d212eb598`): *"the verifier must detect stale generated outputs without claiming that a source-name scan proved execution."* The old job derived its stamp list by grepping `^generated/.../\.stamp:` out of `Makefile` and `make/*.mk` and refused an empty result. That proves the rules **exist**. This PR keeps the derivation — it is the right way to stay open to a new port — and stops it being the proof of anything more: execution is proved by the emission.

## The reproduction, on the lane head

`b7ab66a8`, the current `fixed-table-form` tip, exactly as `.github/workflows/ci-full.yml`'s `generated` job does it (39 rules, in place):

```
$ stamps=$(grep -hoE '^generated/[A-Za-z0-9/_.-]*/\.stamp:' Makefile make/*.mk | sed 's/:$//' | sort -u)
$ make -j8 $stamps
$ git status --porcelain generated/
 M generated/bench/tables/c/BenchTableTable.h
 M generated/bench/tables/cpp/BenchTableTable.h
```

Still red, same two files the red-lane grouping named at `ad636dfb`. **Which emitter moved:** `internal/codegen/cpptable/fixed{form,runtime}.go` and `internal/codegen/ctable/fixed{form,runtime}.go`, in `98362e3c` / `f067d951` ("fixed form: full-width lanes, the outer tag, and the writer's remap length, on both twins") — §5.8 rows 6 and 7. The committed headers still carry the one-guard `TableFixedEntry` (no `guard2` / `arg2` / `argw2`), the one-guard `TableFixedRun`, and `kTableFixedConst`'s `memcpy` straight out of the four-byte `aux` lane instead of through a 64-bit temporary. Those commits re-pinned every other generated tree and missed this pair.

**And the gap itself.** A second run from an **empty** directory says something the in-place run structurally cannot:

```
--- MISSING from the fresh tree (committed, and the emitter does not write it) ---
generated/bench/paired/rust/Cargo.toml
```

In place, a rule only writes; it never removes. So a file the emitter stopped writing stays on disk byte-identical to the index and `git diff` is silent about it — forever. A rule that never *ran* is the same shape: its whole directory stands, and the diff calls that green. A local run can reach that state with nothing more than a `.stamp` newer than `bin/schema` (it is how the two headers above survived a green-looking local `make test` on this bench).

That one file turns out to be a true exception, not a defect: `6e2a5a36` made it hand-written build wiring that names one symlink under `build/` so the driver never rewrites a tracked file, and `bench/paired`'s `pointRustManifest` only requires it. It is now named, with that reason.

## The repair

Bounded to the verifier, its control, and the call sites.

| file | what |
|---|---|
| `test/generated-tree/verify` | moves the tree aside to `build/generated-tree/prev`, emits into **nothing**, restores on every exit that can be trapped (a failed regeneration, HUP/INT/TERM). Two halves, both loud: **(a)** the tree on disk is the committed tree, judged **against HEAD** (a staged edit is not committed; `--staged` is a separately named mode that never prints the committed-emission sentence); **(b)** the tree on disk is a clean emission. Together: emission == disk == committed. **Recovery:** a previous run's `prev` is evidence, never scratch. A state marker (pid, nonce, phase) written at each phase transition lets the next invocation tell a dead run from a live one: it restores a dead run's preserved original (keeping any partial replacement under that run's nonce-unique scratch), refuses to touch anything while a live run holds the tree, and refuses without deleting either tree when the state is unreadable. Nothing here `rm -rf`s a path this invocation did not create. What is promised is recoverable originals; what is **not** promised is restoration under an uncatchable signal (no trap runs for SIGKILL). |
| `test/generated-tree/verify-control`, `make/checks/generated-tree.mk` | the verifier's four lifecycle witnesses, driving the real verifier in a disposable Git fixture with one generation rule: `kill-retry` (SIGKILL the whole process group after the original is in `prev` and the replacement exists; the second invocation names the state and the original bytes still exist), `regeneration-fails`, `second-invocation`, `staged-difference` (HEAD old, index and file new: non-zero, no committed-emission sentence). Joined to `make test` as `generated-tree-verify-controls`. |
| `test/generated-tree/compare` | the whole verdict, in its own command so the control can hand it prepared directories. Four ways to be wrong, each with its file list: **STALE** (the tree carries it, the compiler does not emit it — plus a louder line when a whole directory is in that class: *the rule that writes it did not run*), **MISSING**, **CHANGED**, **STALE EXCEPTION**. Ignored paths (`.stamp`, cargo artefacts) come from `.gitignore` via `git check-ignore`, nothing typed. |
| `test/generated-tree/not-emitted` | the named exceptions, each with its reason. Checked **in both directions**, so it cannot rot into a hole: a named path the tree no longer carries reds, and a named path the compiler now emits reds. |
| `test/generated-tree/negative-control`, `make/checks/generated-tree.mk` | ten planted verdicts, in `make test` and in the `generated` job. |
| `Makefile` | `generated-current` now runs the verifier, and no longer needs the whole `make test` chain to get there (the emission takes `bin/schema` and nothing else). |
| `.github/workflows/ci-full.yml`, `.github/workflows/certify.yml` | both run that same script, so the three call sites cannot drift. |
| `make/negative-controls.json` | one line: the control in the `base` group, as `tools/negativecontrols` requires. |
| `generated/bench/tables/{c,cpp}/BenchTableTable.h` | re-pinned, its own commit (`39062f63`) with the regenerating command in the message. |

**18 seconds** for all 39 rules on an M-series bench — inside the job's 10-minute budget and the two-minute rule.

## Receipts, red first

**1. The class no in-place diff can see** (the exception line commented out, so the real tracked-but-never-emitted file is judged):

```
generated-tree: 39 generation rule(s)
STALE — 1 file(s) the tree carries and this compiler does NOT emit:
    generated/bench/paired/rust/Cargo.toml
  an in-place regeneration cannot see this class; only an emission into an empty directory can.
  either `git rm` them, or name each one in test/generated-tree/not-emitted with the reason it is tracked build wiring.
CHANGED — 2 file(s) whose committed bytes are not what this compiler emits:
    generated/bench/tables/c/BenchTableTable.h
    generated/bench/tables/cpp/BenchTableTable.h
```

**2. Sabotage one generated file** — one line prepended to `generated/go/Enums.go`:

```
NOT COMMITTED — the generated/ tree on disk differs from the committed tree:
    M	generated/go/Enums.go
CHANGED — 1 file(s) whose committed bytes are not what this compiler emits:
    generated/go/Enums.go
[exit 1]
```

**3. Delete one file the emitter writes** — `rm generated/cs/Enums.cs`:

```
NOT COMMITTED — the generated/ tree on disk differs from the committed tree:
    D	generated/cs/Enums.cs
MISSING — 1 file(s) this compiler emits that the tree does not carry:
    generated/cs/Enums.cs
[exit 1]
```

**4. Restored, and the re-pin committed — green:**

```
$ test/generated-tree/verify
generated-tree: 39 generation rule(s)
generated/ tree is current: 270 emitted file(s) byte-identical, 1 named exception(s), 37 ignored path(s).
the committed generated/ tree is what this compiler emits.
```

**5. The ten planted verdicts** (`make generated-tree-negative-controls`), each asserting the verdict *and* the sentence, so a gate that reds for the wrong reason fails too:

```
generated-tree control: changed is red, on the claim — CHANGED — 1 file(s) whose committed bytes are not what this compiler emits:
generated-tree control: stale is red, on the claim — STALE — 1 file(s) the tree carries and this compiler does NOT emit:
generated-tree control: retired-rule is red, on the claim —     NOTHING was emitted under generated/retired — the rule that writes it did not run.
generated-tree control: missing is red, on the claim — MISSING — 1 file(s) this compiler emits that the tree does not carry:
generated-tree control: exception-absent is red, on the claim — STALE EXCEPTION — 1 named path(s) that the tree does not carry at all:
generated-tree control: exception-emitted is red, on the claim — STALE EXCEPTION — 1 named path(s) this compiler DOES emit:
generated-tree control: exception-honoured is green, on the claim — generated/ tree is current: 1 emitted file(s) byte-identical, 1 named exception(s), 0 ignored path(s).
generated-tree control: ignored is green, on the claim — generated/ tree is current: 1 emitted file(s) byte-identical, 0 named exception(s), 1 ignored path(s).
generated-tree control: clean is green, on the claim — generated/ tree is current: 1 emitted file(s) byte-identical, 0 named exception(s), 0 ignored path(s).
generated-tree controls: 9 planted verdicts, each named
```

**6. `go vet ./...` clean; `go test ./tools/negativecontrols/` ok** (239 controls + this one, all in a group); both workflow files parse; worktree clean at the tip.

## Bounded file ownership

Mine and nothing else: `test/generated-tree/*` (new), `make/checks/generated-tree.mk` (new), the `generated-current` target and one `include` line in `Makefile`, the `generated` job's two steps in `ci-full.yml`, the same check in `certify.yml`, one registration line plus its `why` clause in `make/negative-controls.json`, and the two re-pinned `generated/bench/tables/{c,cpp}/BenchTableTable.h`.

Not touched: the negative controls of #987 (`rowan/fix-negative-controls`) — no file under `test/tables/`, `test/conformance/`, `make/checks/reference-review.mk`, `make/go.mk`, or `internal/codegen/` — and no slow-gate target of G5 (`rowan/g5-slow-gates`). `make/negative-controls.json` is the one file where a conflict with #987 is possible; it is a single line in the `base` group's target list plus one clause in that group's `why`, trivial to rebase either way.

## Open

- **This lane is not green and this PR does not make it green.** It closes `generated` and leaves the seven other reds at `ad636dfb` exactly where the grouping put them: `negative controls (base | base-c-conformance | base-reference-review | go-containers | java)` with #987, `go-test-touched` in CI fast (addressed by #986, merged into this base), and G5's slow gates. The `base` shard my control now rides is one of the red ones; the control itself is hermetic and passes.
- **`generated/bench/paired/rust/Cargo.toml`'s own header comment is stale.** It still says the manifest is written "by both `make/rust.mk`'s stamp and `bench/paired`'s own build step, with the same bytes from both". `6e2a5a36` removed both writers; nothing writes it now, which is the point of the file. I have not edited a file under `generated/` beyond the re-pin — say the word and it is a one-paragraph follow-up.
- **`generated-current` no longer depends on `test`.** The emission needs `bin/schema` alone, so the local entry point is now 18 s instead of the whole chain. If anyone was using `make generated-current` as "run everything and then check", that is now `make test && make generated-current`.
- Nothing merged, nothing marked ready. `make test` end to end was not run on this bench: the `toolchain` gate refuses here for `cs dart elixir java js`, so the legs' own halves are CI's to say.

Refs #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

