### PR TITLE
G5: the fourteen positive gates run their slow tests (#988)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -290,6 +290,14 @@ jobs:
         run: go mod tidy -diff
       - name: go vet
         run: go vet ./...
+      # THE SLOW-GATE SCAN (schema#988, G5). internal/slowtest.Gate skips a test
+      # that shells out to a toolchain unless SCHEMA_SLOW=1 is set, and a skipped
+      # test exits 0 — so a make target running a bare `go test` on such a
+      # package goes GREEN HAVING RUN NOTHING. Fourteen did. This scan fails any
+      # such recipe line BY NAME, costs milliseconds, and is on the FAST lane
+      # because the regression it catches is somebody adding the fifteenth.
+      - name: the positive gate targets still set SCHEMA_SLOW (schema#988)
+        run: make slow-gate-scan
       # CI LINTS ITSELF (issues #470, #472), over every workflow file in the
       # tree — this one included: every `uses:` names a full commit SHA with the
       # tag in a trailing comment, nothing runs @latest, and every csproj

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -320,6 +320,18 @@ jobs:
           SCHEMA_SLOW: '1'
         run: go test $(go list ./... | grep -v '/internal/codegen/')
 
+      # AND THE ACCOUNTING FOR THE TWO STEPS ABOVE (schema#988, G5). The two
+      # steps set SCHEMA_SLOW=1, so on this lane every gated test runs; that is
+      # exactly why the accounting belongs here. It runs the DEFAULT half once
+      # (no SCHEMA_SLOW — the point is to see what a developer's `make test`
+      # skips), then places every gate skip in one of three buckets: run by a
+      # make target that sets the variable, run only by the two steps above, or
+      # run by NOBODY. The third bucket fails the job. The table is uploaded as
+      # build/slowgate/coverage.tsv so the accounting is read, not believed.
+      - name: every slowtest gate is run by somebody, by name (schema#988)
+        if: matrix.group == 'unit-rest'
+        run: make slow-gate-coverage
+
       # THE FIXED FORM'S VERSIONING SUITE (§5 of docs/FIXED-FORM-ALGORITHM.md),
       # which the step above does NOT run. Its harness reads the C++
       # reference's byte oracle out of build/fixedform-corpus and SKIPS itself

--- a/Makefile
+++ b/Makefile
@@ -6142,3 +6142,51 @@ tables-wasrows-negative-control: build/tables-generated/.stamp test/tables/wasro
 	@echo "negative control: stripping was from the variant, the arms and the type's field turns the cross read RED (unknown counted, the value at its default)"
 
 include make/checks/reference-review.mk
+
+# ---------------------------------------------------------------------------
+# THE SLOW-GATE SCAN (schema#988, G5) ---------------------------------------
+#
+# internal/slowtest.Gate SKIPS a test that shells out to a foreign toolchain or
+# reads the C++ reference corpus unless SCHEMA_SLOW=1 or SCHEMA_REQUIRE_CORPUS
+# is set — AND A SKIPPED TEST MAKES `go test` EXIT 0. So a make target that runs
+# a bare `go test` on such a package GOES GREEN HAVING RUN NOTHING. Fourteen
+# positive gate targets did, for a day, while internal/slowtest's own package
+# comment said every make gate set the variable. THE COMMENT WAS THE BUG: a
+# claim about this Makefile belongs in a check.
+#
+# slow-gate-scan IS THAT CHECK and it costs milliseconds, so it rides `test`:
+# every recipe line in Makefile, make/*.mk and make/checks/*.mk that runs
+# `go test` on a package holding gated tests must set SCHEMA_SLOW=1, set
+# SCHEMA_REQUIRE_CORPUS, or go through test/slowgate/proof. Anything else fails
+# BY NAME. A line deliberately left as it is must be named in
+# make/slow-gate-exceptions.txt WITH A REASON, and an entry there that matches
+# no line any more fails too — a stale excuse is how the next bare `go test`
+# slips in behind a line nobody reads.
+.PHONY: slow-gate-scan
+slow-gate-scan:
+	go run ./tools/slowgatescan
+
+test: slow-gate-scan
+
+# AND THE ACCOUNTING, test by test rather than target by target: a plain
+# `go test -v ./...` transcript (the DEFAULT half — no SCHEMA_SLOW, which is the
+# point) is read back and every test that skipped at the gate is placed in one
+# of three buckets — run by a make target that sets the variable, run only by
+# ci-full.yml's SCHEMA_SLOW=1 steps, or run by NOBODY. The third bucket is the
+# failure. The whole table lands in build/slowgate/coverage.tsv so the
+# accounting is READ, not believed.
+#
+# It costs one plain `go test ./...` — 27 s with a warm build cache, 2 m 35 s
+# cold, measured on the Studio — so it is NOT on `test`: it rides ci-full.yml
+# beside the two steps it credits. Nothing is MOVED to nightly by this; the scan
+# above, which is the gate, is on `test`.
+#
+# `|| true` ON THE TRANSCRIPT AND NOWHERE ELSE: this target's job is to read
+# which tests the gate skipped, and it must still read that when some unrelated
+# test is red. The red itself is `test`'s to report, not this target's, and the
+# accounting below exits nonzero on its own finding.
+.PHONY: slow-gate-coverage
+slow-gate-coverage:
+	@mkdir -p build/slowgate
+	go test -v ./... > build/slowgate/all-plain.log 2>&1 || true
+	go run ./tools/slowgatescan -coverage build/slowgate/all-plain.log

--- a/internal/slowtest/slowtest.go
+++ b/internal/slowtest/slowtest.go
@@ -16,11 +16,28 @@
 // emitters' text, the goldens, the refusals. The toolchain half runs under
 // SCHEMA_SLOW=1, and it runs there ALWAYS:
 //
-//   - every make leg gate already exports SCHEMA_REQUIRE_CORPUS=1, and Enabled
-//     counts that as the slow half being ON — so not one of the nine leg gates,
-//     and not one of ci-fast.yml's per-leg rows that drive them, changed at all,
+//   - every make leg gate exports SCHEMA_REQUIRE_CORPUS=1, and Enabled counts
+//     that as the slow half being ON — so not one of the nine leg gates, and
+//     not one of ci-fast.yml's per-leg rows that drive them, changed at all,
+//   - every POSITIVE gate target runs its `go test` through test/slowgate/proof,
+//     which sets SCHEMA_SLOW=1, refuses a slowtest skip in its own log, and
+//     requires a `--- PASS` for each gate it names (schema#988),
 //   - ci-full.yml's two `go test` steps set SCHEMA_SLOW=1 explicitly, so the
 //     merge and nightly lanes run the whole of both halves.
+//
+// THE SECOND BULLET WAS FALSE FOR ONE DAY AND IT COST US A DAY (schema#988, G5).
+// This comment said "NOTHING IS CHECKED LESS THAN BEFORE" while fourteen
+// positive gate targets — tables-go-fixedform, -containers, -block-build,
+// -block-race-negative-control, -retain, -allocator, -blob-span,
+// -blob-span-negative-control, -builders, -typed-refusals, -view, -release,
+// tables-c-retain and tables-reference-review — ran a BARE `go test`. Under
+// `make test` the gate each one names skipped, `go test` exited 0, and the
+// target went green having run nothing. The claim is a claim about the
+// Makefile, so `make slow-gate-scan` now CHECKS IT on every run: a recipe line
+// that runs `go test` on a package holding gated tests without setting either
+// variable fails by name, and anything deliberately left to ci-full.yml is
+// named with its reason in make/slow-gate-exceptions.txt. A sentence in a
+// comment is not a gate; the scan is.
 //
 // NOTHING IS CHECKED LESS THAN BEFORE. A gate that quietly stopped running is
 // worse than a slow one, which is why Gate never reads a toolchain's presence:

--- a/make/c.mk
+++ b/make/c.mk
@@ -1128,7 +1128,9 @@ test-c tables-c: tables-c-message-negative-control
 
 .PHONY: tables-c-retain tables-c-retain-negative-control
 tables-c-retain: build/conformance-harness build/wire-fuzz-c build/wire-fuzz-c-asan
-	go test ./compiler -run '^TestCTableRetain' -count=1
+	sh test/slowgate/proof tables-c-retain \
+		'TestCTableRetainFile TestCTableRetainCapacityBoundsZeroBitMessage TestCTableRetainFramedDepth/64 TestCTableRetainFramedDepth/65 TestCTableRetainRefusedByName TestCTableRetainMessageDroppedMapKey/false TestCTableRetainMessageDroppedMapKey/true' \
+		./compiler -run '^TestCTableRetain' -count=1
 	./build/conformance-harness wire-fuzz --driver ./build/wire-fuzz-c --retain --seed $(SEED) --n $(N) --failed build/wire-fuzz/failed-c-retain.bin
 	./build/conformance-harness wire-fuzz --driver ./build/wire-fuzz-c-asan --retain --seed $(SEED) --n $(N) --failed build/wire-fuzz/failed-c-retain-asan.bin
 

--- a/make/checks/reference-review.mk
+++ b/make/checks/reference-review.mk
@@ -1,7 +1,9 @@
 # Compiled closure and widening regressions from the shared reference review.
 .PHONY: tables-reference-review
 tables-reference-review:
-	go test ./compiler -run '^Test(CppVariableWideAlignment|CppCollectionWidening|FlagsElementWidening|CppHiddenUnionExtentRefusal|RepeatedArrayTailDefaults)$$' -count=1
+	sh test/slowgate/proof tables-reference-review \
+		'TestCppVariableWideAlignment/narrow TestCppVariableWideAlignment/direct TestCppVariableWideAlignment/pointer TestCppVariableWideAlignment/union TestCppVariableWideAlignment/list TestCppVariableWideAlignment/map TestCppVariableWideAlignment/array TestCppVariableWideAlignment/nested TestCppCollectionWidening/list TestCppCollectionWidening/map TestFlagsElementWidening TestCppHiddenUnionExtentRefusal/false TestCppHiddenUnionExtentRefusal/true TestRepeatedArrayTailDefaults/c TestRepeatedArrayTailDefaults/cpp TestRepeatedArrayTailDefaults/c-bounded-extent' \
+		./compiler -run '^Test(CppVariableWideAlignment|CppCollectionWidening|FlagsElementWidening|CppHiddenUnionExtentRefusal|RepeatedArrayTailDefaults)$$' -count=1
 
 test: tables-reference-review
 

--- a/make/go.mk
+++ b/make/go.mk
@@ -57,7 +57,9 @@ generated/go/.stamp: bin/schema $(SCHEMAS)
 # every unit of the corpus.
 .PHONY: tables-go-fixedform
 tables-go-fixedform:
-	go test ./internal/codegen/gotable -run 'TestFixedForm' -count=1
+	sh test/slowgate/proof tables-go-fixedform \
+		'TestFixedFormRoundTrip TestFixedFormHostileBoolByte TestFixedFormHostileUnionTag TestFixedFormArgLaneOldEncodingControl TestFixedFormClampLiveCount' \
+		./internal/codegen/gotable -run 'TestFixedForm' -count=1
 test-go: tables-go-fixedform
 
 .PHONY: tables-go-json-walk
@@ -347,7 +349,9 @@ test-go: tables-go-wire-fuzz tables-go-wire-fuzz-negative-control
 
 .PHONY: tables-go-containers tables-go-containers-negative-controls
 tables-go-containers:
-	go test ./internal/codegen/gotable -run 'Test(RegionLists|ListsThroughUnionArrays|BuilderCountRecovery|NestedTerminationAndStringDefault|RegionMaps|MapReadReports|MapJsonKeyDomains)'
+	sh test/slowgate/proof tables-go-containers \
+		'TestRegionLists TestListsThroughUnionArrays TestBuilderCountRecovery TestNestedTerminationAndStringDefault TestRegionMaps TestMapReadReports TestMapJsonKeyDomains' \
+		./internal/codegen/gotable -run 'Test(RegionLists|ListsThroughUnionArrays|BuilderCountRecovery|NestedTerminationAndStringDefault|RegionMaps|MapReadReports|MapJsonKeyDomains)' -count=1
 tables-go-containers-negative-controls:
 	@set -e; for mode in sort ascending duplicate key-domain dead cap; do sh test/conformance/go/container-negative-control $$mode; done
 
@@ -357,9 +361,13 @@ test-go: tables-go-containers tables-go-containers-negative-controls
 # every worker fill the whole array; byte identity alone cannot see that race.
 .PHONY: tables-go-block-build tables-go-block-race-negative-control tables-go-block-fill-refuser tables-go-block-fill-refuser-negative-control
 tables-go-block-build:
-	go test ./internal/codegen/gotable -run '^TestBlockBuilderStorageAndParallelFill$$' -count=1
+	sh test/slowgate/proof tables-go-block-build \
+		'TestBlockBuilderStorageAndParallelFill' \
+		./internal/codegen/gotable -run '^TestBlockBuilderStorageAndParallelFill$$' -count=1
 tables-go-block-race-negative-control:
-	go test ./internal/codegen/gotable -run '^TestBlockBuilderRaceNegativeControl$$' -count=1
+	sh test/slowgate/proof tables-go-block-race-negative-control \
+		'TestBlockBuilderRaceNegativeControl' \
+		./internal/codegen/gotable -run '^TestBlockBuilderRaceNegativeControl$$' -count=1
 tables-go-block-fill-refuser:
 	go test ./internal/codegen/gotable -run '^TestBlockFillRefuser$$' -count=1
 tables-go-block-fill-refuser-negative-control:
@@ -369,13 +377,17 @@ test-go: tables-go-block-build tables-go-block-fill-refuser
 
 .PHONY: tables-go-retain
 tables-go-retain:
-	go test ./internal/codegen/gotable -run '^TestRetain' -count=1
+	sh test/slowgate/proof tables-go-retain \
+		'TestRetainMatchesIndependentRewrite TestRetainMessageBoundsBeforeExpansion TestRetainReplacementAndShapeChanges TestRetainFileCapacityBeforeExpansion TestRetainUnknownNodeRecord TestRetainMessageMapKeyProbe TestRetainMessageMapRepeatedKeyKeepsWidening' \
+		./internal/codegen/gotable -run '^TestRetain' -count=1
 test-go: tables-go-retain
 
 .PHONY: tables-go-allocator tables-go-allocator-negative-controls tables-go-allocator-runtime-negative-control tables-go-retain-negative-controls
 tables-go-allocator:
 	@if [ "$${SCHEMA_GO_ALLOC_ANY_GO:-}" = 1 ]; then echo "Go allocation observation mode: NOT CERTIFIED"; fi
-	GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
+	GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-allocator \
+		'TestAllocatorOwnershipAndStandaloneWriters' \
+		./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
 
 # THE SPAN, on its own (docs/SPEC-TABLES.md §2.5, M17). A blob larger than a
 # slab takes a span of the arena's address space. The negative control makes
@@ -383,9 +395,13 @@ tables-go-allocator:
 # and later allocations overwrite it.
 .PHONY: tables-go-blob-span tables-go-blob-span-negative-control
 tables-go-blob-span:
-	go test ./internal/codegen/gotable -run '^TestBlobSpanHoldsAfterLaterAllocations$$' -count=1
+	sh test/slowgate/proof tables-go-blob-span \
+		'TestBlobSpanHoldsAfterLaterAllocations' \
+		./internal/codegen/gotable -run '^TestBlobSpanHoldsAfterLaterAllocations$$' -count=1
 tables-go-blob-span-negative-control:
-	go test ./internal/codegen/gotable -run '^TestBlobSpanNegativeControl$$' -count=1
+	sh test/slowgate/proof tables-go-blob-span-negative-control \
+		'TestBlobSpanNegativeControl' \
+		./internal/codegen/gotable -run '^TestBlobSpanNegativeControl$$' -count=1
 test-go: tables-go-blob-span tables-go-blob-span-negative-control
 tables-go-allocator-negative-controls:
 	@set -e; for mode in original-slice pair frame; do sh test/conformance/go/ownership-negative-control $$mode; done
@@ -398,19 +414,27 @@ test-go: tables-go-allocator tables-go-allocator-negative-controls tables-go-all
 
 .PHONY: tables-go-builders tables-go-builders-negative-control tables-go-typed-refusals
 tables-go-builders: build/conformance-harness build/conformance-go
-	go test ./internal/codegen/gotable -run '^TestBuilderRefusalThroughUnion$$' -count=1
+	sh test/slowgate/proof tables-go-builders \
+		'TestBuilderRefusalThroughUnion' \
+		./internal/codegen/gotable -run '^TestBuilderRefusalThroughUnion$$' -count=1
 	./build/conformance-harness wire-fuzz --builder --driver 'build/conformance-go wire-fuzz-builder' --seed $(SEED) --n $(N)
 tables-go-builders-negative-control:
 	sh test/conformance/go/ownership-negative-control builder-union
 tables-go-typed-refusals:
-	GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^Test(AcceleratorTypedRefusals|MeasureRefusalReasons)$$' -count=1
+	GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-typed-refusals \
+		'TestAcceleratorTypedRefusals TestMeasureRefusalReasons' \
+		./internal/codegen/gotable -run '^Test(AcceleratorTypedRefusals|MeasureRefusalReasons)$$' -count=1
 
 test-go: tables-go-builders tables-go-builders-negative-control tables-go-typed-refusals
 
 .PHONY: tables-go-view tables-go-view-negative-controls
 tables-go-view:
-	go test ./compiler -run '^TestGoUnitViewCorpus$$' -count=1
-	go test ./internal/codegen/gotable -run '^TestUnitViewPacketStorage$$' -count=1
+	sh test/slowgate/proof tables-go-view-corpus \
+		'TestGoUnitViewCorpus' \
+		./compiler -run '^TestGoUnitViewCorpus$$' -count=1
+	sh test/slowgate/proof tables-go-view-packet-storage \
+		'TestUnitViewPacketStorage' \
+		./internal/codegen/gotable -run '^TestUnitViewPacketStorage$$' -count=1
 tables-go-view-negative-controls:
 	@set -e; for mode in identity packet-offset arm-offset; do sh test/tables/view-go-control $$mode; done
 
@@ -432,7 +456,9 @@ tables-go-release: build/conformance-harness build/conformance-go tables-go-benc
 	$(MAKE) tables-go-wire-fuzz tables-go-retain-wire-fuzz tables-go-builders N=100000 SEED=$(GO_RELEASE_SEED)
 	$(MAKE) tables-go-wire-fuzz-negative-control
 	cd test/go-tables && GOTOOLCHAIN=go1.26.0 go test -run '^TestSoak$$' -count=1 -timeout 2h -soak $(GO_SOAK)
-	SCHEMA_GO_ALLOC_RUNS=200 GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
+	SCHEMA_GO_ALLOC_RUNS=200 GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-release-allocator \
+		'TestAllocatorOwnershipAndStandaloneWriters' \
+		./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
 tables-go-clean: build/tables-generated-go/.stamp
 	@set -e; for d in build/tables-generated-go/*; do \
 		[ -f "$$d/go.mod" ] || continue; \

--- a/make/slow-gate-exceptions.txt
+++ b/make/slow-gate-exceptions.txt
@@ -1,0 +1,54 @@
+# THE WRITTEN EXCEPTION LIST for `make slow-gate-scan` (schema#988, G5).
+#
+# A recipe line that runs `go test` on a package holding slowtest-gated tests
+# and sets NEITHER SCHEMA_SLOW=1 NOR SCHEMA_REQUIRE_CORPUS goes green having
+# run nothing. tools/slowgatescan fails on every such line BY NAME. A line may
+# stand only if it is named here WITH A REASON — the point of this file is that
+# a deliberate omission is written where the next reader trips over it, and
+# silence never passes for a decision again.
+#
+# Format: target<TAB>package<TAB>reason. All three fields are required.
+#
+# An entry that matches no recipe line any more FAILS THE SCAN TOO: a stale
+# excuse is exactly how the next bare `go test` slips in behind a line nobody
+# reads. Delete it when the line it excuses is gone or armed.
+
+# --- the two umbrella lines: the fast half, by design (issue completion gate 2)
+#
+# `go test ./...` is the DEFAULT half — pure Go, under two minutes, the half a
+# child will actually run (internal/slowtest, the owner's 1-2 minute rule). The
+# slow half is NOT left to silence and NOT left to nightly: `test` and `test-go`
+# depend on the fourteen positive gate targets, and every one of those runs its
+# `go test` through test/slowgate/proof, which sets SCHEMA_SLOW=1, refuses a
+# gate skip in its own log and requires a named `--- PASS` per gate. So the
+# skips under this line are accounted for by the targets in the same `make`
+# invocation, and `make slow-gate-coverage` checks that accounting test by test
+# against a real transcript rather than trusting this paragraph.
+test	./...	the fast half by design (the 1-2 minute rule); the slow half runs in the fourteen positive gate targets `test`/`test-go` depend on, each through test/slowgate/proof, and `make slow-gate-coverage` proves test by test that no gated test is left to nobody
+update-goldens	./...	regenerates goldens with -update; it is the pure-Go golden half, and the toolchain gates it cannot regenerate are run by the fourteen positive gate targets (same accounting as `test`)
+slow-gate-coverage	./...	it MUST run plain: the accounting reads which tests skip at the gate under a DEFAULT `go test ./...`, so setting the variable here would erase the very thing being counted
+
+# --- lines whose selected tests are NOT gated (measured, not assumed)
+#
+# The scan is package-granular on purpose: it cannot know which tests a -run
+# pattern selects without running them. These three lines name tests that reach
+# no slowtest.Gate at all — measured on darwin at this head with a plain
+# `go test -v -run <the same pattern>`: 0 lines of slowtest's skip message.
+# `make slow-gate-coverage` is the check that keeps that true.
+tables-go-block-fill-refuser	./internal/codegen/gotable	TestBlockFillRefuser reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.03s under a plain go test); it emits and reads in-process
+tables-go-block-fill-refuser-negative-control	./internal/codegen/gotable	TestBlockFillRefuserNegativeControl reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.02s under a plain go test)
+tables-dart-names-negative-control	./compiler	TestDartTableRuntimeNamesAreClaimed reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.01s under a plain go test); it compares emitted source to internal/tablenames, no dart toolchain
+
+# --- REMOVE THESE FIVE WHEN #987 MERGES (they are that PR's lines, not this one's)
+#
+# PR #987 (rowan/fix-negative-controls, G1+G2) arms exactly these five lines
+# with SCHEMA_SLOW=1 plus its own SKIP/PASS scan. This branch shares its base
+# (fixed-table-form at b7ab66a8) and does not touch another lane's files. When
+# #987 lands, these five entries go stale and THE SCAN WILL FAIL UNTIL THEY ARE
+# DELETED — which is the handshake: whoever merges deletes them, and the scan
+# says so by name.
+tables-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-ref-ordinal-shared-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-message-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-retain-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges

--- a/test/slowgate/proof
+++ b/test/slowgate/proof
@@ -1,0 +1,78 @@
+#!/bin/sh
+# THE POSITIVE GATE'S RUN-PROOF (schema#988, G5).
+#
+# internal/slowtest.Gate SKIPS a test that shells out to a foreign toolchain or
+# reads the C++ reference corpus unless SCHEMA_SLOW=1 (or SCHEMA_REQUIRE_CORPUS)
+# is set — and a skipped test makes `go test` exit 0. A POSITIVE gate target
+# that ran a bare `go test` therefore went green having run nothing. Fourteen
+# did.
+#
+# So every positive gate target calls its `go test` THROUGH HERE, and this
+# script does three things no exit code can do on its own:
+#
+#   1. it SETS SCHEMA_SLOW=1, so the gate the target names actually runs,
+#   2. it REFUSES A GATE SKIP: one slowtest skip line in the log is a failure,
+#      even at exit 0 — inside a positive gate target a skip is the defect,
+#   3. it REQUIRES A NAMED `--- PASS` PER GATE, because Go prints `--- PASS`
+#      for the PARENT of a skipped subtest, so the parent's PASS proves nothing
+#      about `TestCppVariableWideAlignment/direct`. The names are matched with
+#      their trailing ` (` so a prefix (TestRetain) cannot stand in for the
+#      whole (TestRetainUnknownNodeRecord).
+#
+# A `t.Skip` for a RETIRED test is not a gate skip and is not touched here: only
+# slowtest's own skip line is a failure. That distinction is the whole point —
+# the check must see the gate that stopped running, not the test somebody
+# deliberately retired with a reason.
+#
+# usage: sh test/slowgate/proof <label> '<required --- PASS names>' <go test args...>
+#
+# The log is build/slowgate/<label>.log. Output is bounded by design (one line
+# on success, the log only on failure): a target's receipt is a count, not a
+# transcript.
+set -e
+
+label="$1"; shift || true
+required="$1"; shift || true
+
+if [ -z "$label" ] || [ $# -eq 0 ]; then
+	echo "test/slowgate/proof: usage: proof <label> '<required PASS names>' <go test args...>" >&2
+	exit 2
+fi
+if [ -z "$required" ]; then
+	echo "test/slowgate/proof: $label names no required gate. A positive gate target that cannot name one gated test it proves does not belong here: run it with a bare \`go test\` and say so in make/slow-gate-exceptions.txt." >&2
+	exit 2
+fi
+
+mkdir -p build/slowgate
+log="build/slowgate/$label.log"
+
+rc=0
+SCHEMA_SLOW=1 go test -v "$@" > "$log" 2>&1 || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+	cat "$log"
+	echo "SLOW GATE $label: go test exited $rc — the gate ran and is RED. Fix the red; do not loosen the gate."
+	exit "$rc"
+fi
+
+if grep -q 'SCHEMA_SLOW: this test shells out' "$log"; then
+	echo "SLOW GATE $label FAILED: a test skipped at internal/slowtest.Gate INSIDE A POSITIVE GATE TARGET, so this target is watching nothing (schema#988). SCHEMA_SLOW=1 was set by this script, so the environment was lost between here and the test binary:"
+	grep -n 'SCHEMA_SLOW: this test shells out' "$log"
+	exit 1
+fi
+
+missing=""
+for want in $required; do
+	if ! grep -q -- "--- PASS: $want (" "$log"; then
+		missing="$missing $want"
+	fi
+done
+if [ -n "$missing" ]; then
+	echo "SLOW GATE $label FAILED: no \`--- PASS\` for the gate(s) this target names, so the target proved nothing about them (schema#988):$missing"
+	echo "(a parent's --- PASS is printed even when a named subtest skipped, which is why the name is required verbatim)"
+	cat "$log"
+	exit 1
+fi
+
+count=$(printf '%s\n' $required | wc -l | tr -d ' ')
+echo "SLOW GATE $label: $count named gate(s) ran and PASS under SCHEMA_SLOW=1 ($log)"

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -1,0 +1,521 @@
+// Command slowgatescan is the mechanical check behind schema#988 (G5).
+//
+// THE DEFECT IT EXISTS TO CATCH. internal/slowtest.Gate skips a test that
+// shells out to a foreign toolchain or reads the C++ reference corpus unless
+// SCHEMA_SLOW=1 or SCHEMA_REQUIRE_CORPUS is set, and a skipped test makes
+// `go test` exit 0. So a make target that runs a BARE `go test` on a package
+// holding gated tests GOES GREEN HAVING RUN NOTHING. Fourteen positive gate
+// targets did exactly that, for a day, while internal/slowtest's own package
+// comment claimed every make gate set the variable. A claim about the Makefile
+// belongs in a check, not in a comment.
+//
+// TWO MODES.
+//
+//	slowgatescan                 the static audit: every recipe line in
+//	                             Makefile, make/*.mk and make/checks/*.mk that
+//	                             runs `go test` on a package holding gated
+//	                             tests must set SCHEMA_SLOW=1, set
+//	                             SCHEMA_REQUIRE_CORPUS, or run through
+//	                             test/slowgate/proof. Anything else fails BY
+//	                             NAME unless make/slow-gate-exceptions.txt
+//	                             names it with a reason. Costs milliseconds, so
+//	                             it can ride every lane.
+//
+//	slowgatescan -coverage LOG   the accounting: LOG is a plain (no SCHEMA_SLOW)
+//	                             `go test -v ./...` transcript. Every test that
+//	                             skipped at slowtest.Gate in it must be selected
+//	                             by at least one recipe line that DOES set the
+//	                             variable — that is the "247 skips accounted for
+//	                             line by line, to zero or to the exception
+//	                             list" the issue asks for. Anything covered by
+//	                             no target fails by name.
+//
+// The exception file is TSV: target<TAB>package<TAB>reason. A reason is not
+// optional: the point of the file is that a deliberate omission is written
+// down where the next reader will find it, and silence never passes again.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const gateSkipMarker = "SCHEMA_SLOW: this test shells out"
+
+type recipe struct {
+	file     string
+	line     int
+	target   string
+	cmd      string
+	packages []string
+	armed    bool // sets SCHEMA_SLOW / SCHEMA_REQUIRE_CORPUS, or runs through test/slowgate/proof
+	runPat   string
+}
+
+type exception struct {
+	target, pkg, reason string
+}
+
+func main() {
+	coverage := flag.String("coverage", "", "a plain `go test -v ./...` transcript to account for, test by test")
+	root := flag.String("C", ".", "repository root")
+	flag.Parse()
+
+	gated, err := gatedPackages(*root)
+	if err != nil {
+		fail("reading the tree for slowtest.Gate call sites: %v", err)
+	}
+	if len(gated) == 0 {
+		fail("no package in this tree calls internal/slowtest.Gate — either the gate was deleted (say so, loudly) or this scan is looking in the wrong place")
+	}
+
+	recipes, err := scanMakefiles(*root, gated)
+	if err != nil {
+		fail("scanning the makefiles: %v", err)
+	}
+	exceptions, err := readExceptions(filepath.Join(*root, "make", "slow-gate-exceptions.txt"))
+	if err != nil {
+		fail("reading make/slow-gate-exceptions.txt: %v", err)
+	}
+
+	if *coverage != "" {
+		lanes, err := workflowLanes(*root)
+		if err != nil {
+			fail("scanning .github/workflows: %v", err)
+		}
+		os.Exit(runCoverage(*root, *coverage, recipes, exceptions, lanes))
+	}
+	os.Exit(runStatic(recipes, exceptions, gated))
+}
+
+func runStatic(recipes []recipe, exceptions []exception, gated map[string]bool) int {
+	var bare []recipe
+	usedException := map[int]bool{}
+	for _, r := range recipes {
+		if r.armed {
+			continue
+		}
+		if i := matchException(exceptions, r); i >= 0 {
+			usedException[i] = true
+			continue
+		}
+		bare = append(bare, r)
+	}
+	armed := 0
+	for _, r := range recipes {
+		if r.armed {
+			armed++
+		}
+	}
+	if len(bare) > 0 {
+		fmt.Printf("SLOW GATE SCAN FAILED: %d recipe line(s) run `go test` on a package holding slowtest-gated tests without SCHEMA_SLOW=1, SCHEMA_REQUIRE_CORPUS or test/slowgate/proof — each one goes green having run nothing (schema#988):\n", len(bare))
+		for _, r := range bare {
+			fmt.Printf("  %s:%d: %s: %s\n", r.file, r.line, r.target, strings.Join(r.packages, " "))
+		}
+		fmt.Println("remedy: run it through `sh test/slowgate/proof <label> '<required --- PASS names>' <go test args>`, or name it in make/slow-gate-exceptions.txt with the reason it is left to ci-full.yml.")
+		return 1
+	}
+	stale := 0
+	for i := range exceptions {
+		if !usedException[i] {
+			if stale == 0 {
+				fmt.Println("SLOW GATE SCAN FAILED: make/slow-gate-exceptions.txt excuses a recipe line that no longer exists — a stale excuse is how the next bare `go test` slips in behind it:")
+			}
+			stale++
+			fmt.Printf("  %s\t%s\t%s\n", exceptions[i].target, exceptions[i].pkg, exceptions[i].reason)
+		}
+	}
+	if stale > 0 {
+		return 1
+	}
+	fmt.Printf("slow gate scan: %d gated package(s), %d armed `go test` recipe line(s), %d written exception(s), 0 bare\n", len(gated), armed, len(exceptions))
+	return 0
+}
+
+// runCoverage is the LINE-BY-LINE ACCOUNTING the issue's completion gate 2 asks
+// for: every test that skips at slowtest.Gate under a plain `go test ./...` is
+// placed in exactly one of three buckets, and the whole table is written to
+// build/slowgate/coverage.tsv so the accounting can be read, not believed.
+//
+//	make    a make target that sets the variable runs it — named in the table
+//	ci      no make target runs it; it runs ONLY on ci-full.yml's SCHEMA_SLOW=1
+//	        steps. Not silence: a named lane, counted here, listed in the file.
+//	NOBODY  nothing in the repo runs it. That is the failure.
+func runCoverage(root, logPath string, recipes []recipe, exceptions []exception, lanes []string) int {
+	skipped, err := gateSkips(logPath)
+	if err != nil {
+		fail("reading %s: %v", logPath, err)
+	}
+	if len(skipped) == 0 {
+		fmt.Printf("slow gate coverage: %s holds no slowtest skip — either it was produced WITH SCHEMA_SLOW set (it must not be) or the gate is gone\n", logPath)
+		return 1
+	}
+	byMake, byCI, var0 := 0, 0, 0
+	var uncovered []string
+	var rows []string
+	for _, name := range skipped {
+		switch {
+		case coveredBy(recipes, name) != "":
+			byMake++
+			rows = append(rows, fmt.Sprintf("make\t%s\t%s", name, coveredBy(recipes, name)))
+		case coveredByException(exceptions, name):
+			byMake++
+			rows = append(rows, fmt.Sprintf("exception\t%s\tmake/slow-gate-exceptions.txt", name))
+		case len(lanes) > 0:
+			byCI++
+			rows = append(rows, fmt.Sprintf("ci\t%s\t%s", name, strings.Join(lanes, ",")))
+		default:
+			var0++
+			uncovered = append(uncovered, name)
+			rows = append(rows, fmt.Sprintf("NOBODY\t%s\t-", name))
+		}
+	}
+	out := filepath.Join(root, "build", "slowgate", "coverage.tsv")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err == nil {
+		_ = os.WriteFile(out, []byte("# bucket\ttest\trun by\n"+strings.Join(rows, "\n")+"\n"), 0o644)
+	}
+	if len(uncovered) > 0 {
+		fmt.Printf("SLOW GATE COVERAGE FAILED: %d of %d tests that skip at slowtest.Gate under a plain `go test ./...` are run by NOTHING — no make target and no SCHEMA_SLOW=1 CI step (schema#988):\n", len(uncovered), len(skipped))
+		for _, n := range uncovered {
+			fmt.Printf("  %s\n", n)
+		}
+		fmt.Println("remedy: give it a positive gate target that goes through test/slowgate/proof, or name it in make/slow-gate-exceptions.txt with the reason.")
+		return 1
+	}
+	fmt.Printf("slow gate coverage: %d slowtest skips in %s accounted for — %d run by a make target that sets the variable, %d run only by %s, 0 run by nobody (table: build/slowgate/coverage.tsv)\n",
+		len(skipped), logPath, byMake, byCI, strings.Join(lanes, ","))
+	return 0
+}
+
+// workflowLanes returns the workflow steps that run `go test` with SCHEMA_SLOW
+// set. A gated test that no make target runs is not "unchecked" if one of these
+// runs it — but it is not covered by `make` either, and the coverage table says
+// which, by name, rather than leaving the reader to guess.
+func workflowLanes(root string) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	var lanes []string
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		rel, _ := filepath.Rel(root, p)
+		lines := strings.Split(string(b), "\n")
+		slowAt := -1
+		for i, l := range lines {
+			if strings.Contains(l, "SCHEMA_SLOW") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+				slowAt = i
+			}
+			if slowAt >= 0 && i-slowAt <= 3 && strings.Contains(l, "go test") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+				lanes = append(lanes, fmt.Sprintf("%s:%d", rel, i+1))
+				slowAt = -1
+			}
+		}
+	}
+	return lanes, nil
+}
+
+// coveredBy reports the first armed recipe whose package and -run pattern select
+// name, using Go's own -run semantics: the pattern is split on "/" and each
+// element is an unanchored regexp matched against the corresponding element of
+// the test's name.
+func coveredBy(recipes []recipe, name string) string {
+	for _, r := range recipes {
+		if !r.armed {
+			continue
+		}
+		if r.runPat == "" {
+			// No -run at all: the whole package runs.
+			return r.target
+		}
+		if matchesRun(r.runPat, name) {
+			return r.target
+		}
+	}
+	return ""
+}
+
+func coveredByException(exceptions []exception, name string) bool {
+	for _, e := range exceptions {
+		if e.pkg == "./..." || strings.HasPrefix(name, e.pkg) {
+			// A ./... exception is about the umbrella line, never about a test:
+			// it may not excuse a test nothing else runs.
+			continue
+		}
+		if e.target == name || matchesRun(e.pkg, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesRun(pattern, name string) bool {
+	pelems := strings.Split(pattern, "/")
+	nelems := strings.Split(name, "/")
+	if len(pelems) > len(nelems) {
+		return false
+	}
+	for i, p := range pelems {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return false
+		}
+		if !re.MatchString(nelems[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchException(exceptions []exception, r recipe) int {
+	for i, e := range exceptions {
+		if e.target != r.target {
+			continue
+		}
+		for _, p := range r.packages {
+			if p == e.pkg {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// gatedPackages returns the set of package directories (as "./dir" import
+// spellings, relative to root) whose tests reach internal/slowtest.Gate. Gate
+// takes a *testing.T, so a call site is always in the package under test —
+// including the ones inside a shared helper, which is why this is a grep over
+// the package's _test.go files and not a static call graph.
+func gatedPackages(root string) (map[string]bool, error) {
+	gated := map[string]bool{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "build", "generated", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil || !strings.Contains(string(b), "slowtest.Gate(") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return nil
+		}
+		gated["./"+filepath.ToSlash(rel)] = true
+		return nil
+	})
+	return gated, err
+}
+
+var targetLine = regexp.MustCompile(`^([A-Za-z0-9_./$()%-][^:=]*):(?:[^=]|$)`)
+
+func scanMakefiles(root string, gated map[string]bool) ([]recipe, error) {
+	var files []string
+	files = append(files, filepath.Join(root, "Makefile"))
+	for _, pat := range []string{"make/*.mk", "make/checks/*.mk"} {
+		m, err := filepath.Glob(filepath.Join(root, pat))
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(m)
+		files = append(files, m...)
+	}
+	var out []recipe
+	for _, f := range files {
+		rs, err := scanOne(root, f, gated)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rs...)
+	}
+	return out, nil
+}
+
+func scanOne(root, path string, gated map[string]bool) ([]recipe, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+	rel, _ := filepath.Rel(root, path)
+	var out []recipe
+	target := "(no target)"
+	sc := bufio.NewScanner(fh)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+		if !strings.HasPrefix(line, "\t") {
+			if m := targetLine.FindStringSubmatch(line); m != nil && !strings.HasPrefix(line, "#") {
+				names := strings.Fields(m[1])
+				if len(names) > 0 {
+					target = names[0]
+				}
+			}
+			continue
+		}
+		// One logical recipe line: join backslash continuations.
+		start := lineNo
+		cmd := line
+		for strings.HasSuffix(strings.TrimRight(cmd, " "), `\`) && sc.Scan() {
+			lineNo++
+			cmd = strings.TrimSuffix(strings.TrimRight(cmd, " "), `\`) + " " + sc.Text()
+		}
+		// A line that goes through the proof helper no longer SPELLS `go test` —
+		// the helper does — so it has to be recognised here or the armed half of
+		// the audit would be invisible to it.
+		if !strings.Contains(cmd, "go test") && !strings.Contains(cmd, "test/slowgate/proof") {
+			continue
+		}
+		if strings.Contains(cmd, "#") && strings.HasPrefix(strings.TrimSpace(cmd), "#") {
+			continue
+		}
+		pkgs := packagesOf(cmd, gated)
+		if len(pkgs) == 0 {
+			continue
+		}
+		armed := strings.Contains(cmd, "SCHEMA_SLOW=1") ||
+			strings.Contains(cmd, "SCHEMA_REQUIRE_CORPUS") ||
+			strings.Contains(cmd, "test/slowgate/proof")
+		out = append(out, recipe{
+			file: rel, line: start, target: target, cmd: cmd,
+			packages: pkgs, armed: armed, runPat: runPattern(cmd),
+		})
+	}
+	return out, sc.Err()
+}
+
+// packagesOf returns the gated package arguments a recipe's `go test` names.
+// "./..." counts: it walks every gated package there is. A `cd dir && go test .`
+// is resolved against dir, which is how the sibling-module legs spell it.
+func packagesOf(cmd string, gated map[string]bool) []string {
+	base := ""
+	if i := strings.Index(cmd, "cd "); i >= 0 && strings.Contains(cmd[i:], "&&") {
+		rest := strings.TrimSpace(cmd[i+3:])
+		if j := strings.IndexAny(rest, " \t"); j > 0 {
+			base = strings.Trim(rest[:j], "\"'")
+		}
+	}
+	var found []string
+	seen := map[string]bool{}
+	for _, tok := range strings.Fields(cmd) {
+		tok = strings.Trim(tok, "\"'")
+		spelled := ""
+		switch {
+		case tok == "./...":
+			spelled = "./..."
+		case tok == "." || tok == "./":
+			if base == "" {
+				continue
+			}
+			spelled = "./" + filepath.ToSlash(filepath.Clean(base))
+		case strings.HasPrefix(tok, "./"):
+			spelled = "./" + filepath.ToSlash(filepath.Clean(strings.TrimSuffix(tok, "/")))
+			if base != "" {
+				spelled = "./" + filepath.ToSlash(filepath.Clean(filepath.Join(base, tok)))
+			}
+		default:
+			continue
+		}
+		if spelled != "./..." && !gated[spelled] {
+			continue
+		}
+		if !seen[spelled] {
+			seen[spelled] = true
+			found = append(found, spelled)
+		}
+	}
+	return found
+}
+
+var runFlag = regexp.MustCompile(`-run[= ]+'?"?([^'"\s]+)'?"?`)
+
+func runPattern(cmd string) string {
+	m := runFlag.FindStringSubmatch(cmd)
+	if m == nil {
+		return ""
+	}
+	// Make doubles a literal '$' as '$$' in a recipe.
+	return strings.ReplaceAll(m[1], "$$", "$")
+}
+
+func readExceptions(path string) ([]exception, error) {
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var out []exception
+	for i, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimRight(line, " \t\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		var f []string
+		for _, p := range parts {
+			if strings.TrimSpace(p) != "" {
+				f = append(f, strings.TrimSpace(p))
+			}
+		}
+		if len(f) < 3 {
+			return nil, fmt.Errorf("line %d: want target<TAB>package<TAB>reason, got %q — a reason is not optional", i+1, line)
+		}
+		out = append(out, exception{target: f[0], pkg: f[1], reason: strings.Join(f[2:], " ")})
+	}
+	return out, nil
+}
+
+// gateSkips returns the test names that skipped at slowtest.Gate in a plain
+// `go test -v` transcript. The name comes from the `=== RUN` line that opened
+// the test, NOT from the `--- SKIP` line, because Go prints a parent's
+// `--- PASS` before its skipped subtests and a scan that reads only result
+// lines cannot tell a gate skip from a retirement.
+func gateSkips(path string) ([]string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	runLine := regexp.MustCompile(`^=== RUN\s+(\S+)`)
+	cur := ""
+	seen := map[string]bool{}
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if m := runLine.FindStringSubmatch(line); m != nil {
+			cur = m[1]
+		}
+		if strings.Contains(line, gateSkipMarker) && cur != "" && !seen[cur] {
+			seen[cur] = true
+			out = append(out, cur)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func fail(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "slowgatescan: "+format+"\n", a...)
+	os.Exit(2)
+}


### PR DESCRIPTION
Fixes the G5 fault in #988: **fourteen positive `make` targets ran a bare `go test`** on packages holding `internal/slowtest`-gated tests, so under `make test` / `make test-go` the gate each one names skipped, `go test` exited **0**, and the target went green having run nothing.

Base: **`fixed-table-form` at `b7ab66a8`** (#986's merge — `git branch -r --contains b7ab66a8` lists `origin/fixed-table-form`, so the lane has it; no merge of `main` was needed).

**Shared base with #987.** PR #987 (`rowan/fix-negative-controls`, head `3bf02a4a`, G1+G2 negative controls) sits on the same `b7ab66a8`. This branch does **not** touch its lines: #987 edits `Makefile:4821/4851`, `make/c.mk:793/1117/1136` and five control shards; this branch edits `Makefile` at the end plus `:3347`/`:4334`'s accounting, `make/go.mk`, `make/c.mk:1131` (`tables-c-retain`, the positive target beside its control), `make/checks/reference-review.mk`, `internal/slowtest`, both workflows. The five lines #987 arms are named in `make/slow-gate-exceptions.txt` and **the scan fails when #987 merges until those five entries are deleted** — that is the handshake, and it says so by name.

## What runs the gates now

`test/slowgate/proof` — one script, three things no exit code does on its own:

1. **sets `SCHEMA_SLOW=1`**, so the gate the target names runs;
2. **refuses a slowtest skip in its own log, even at exit 0** — inside a positive gate target a skip *is* the defect;
3. **requires a named `--- PASS` per gate**, because Go prints `--- PASS` for the **parent** of a skipped subtest, so the parent's line proves nothing about `TestCppVariableWideAlignment/direct` (Stella's point on #987). Names are matched with their trailing ` (` so `TestRetain` cannot stand in for `TestRetainUnknownNodeRecord`.

A `t.Skip` for a **retired** test is not touched: only slowtest's own skip line fails. Nothing was narrowed, weakened or deleted. `tables-go-containers` gains `-count=1` so a cached green cannot stand in for a run.

## Inventory — all fourteen, red then green, on this bench (darwin/arm64, go1.27.1)

`gates` is the number of tests that skipped at `slowtest.Gate` under that target's own package and `-run` pattern before this change (matches #988's table exactly). `secs` is `make <target>` after it.

| target | what it runs | gates | secs | the sabotage that made it red | receipt |
|---|---|---|---|---|---|
| `tables-go-fixedform` | `./internal/codegen/gotable -run TestFixedForm` | 5 | 3.5 | `SCHEMA_SLOW=1` stripped from the proof script | `SLOW GATE tables-go-fixedform FAILED: a test skipped at internal/slowtest.Gate INSIDE A POSITIVE GATE TARGET` → rc=1; restored: `5 named gate(s) ran and PASS` |
| `tables-go-containers` | `gotable -run Test(RegionLists\|…\|MapJsonKeyDomains)` | 7 | 5.6 | same | red rc=1 by name; green `7 named gate(s) ran and PASS` |
| `tables-go-block-build` | `^TestBlockBuilderStorageAndParallelFill$` | 1 | 2.5 | same | red rc=1; green `1 named gate(s) ran and PASS` |
| `tables-go-block-race-negative-control` | `^TestBlockBuilderRaceNegativeControl$` | 1 | 1.8 | same | red rc=1; green `1 named gate(s) ran and PASS` |
| `tables-go-retain` | `^TestRetain` | 7 | 7.2 | same | red rc=1; green `7 named gate(s) ran and PASS` |
| `tables-go-allocator` | `^TestAllocatorOwnershipAndStandaloneWriters$` (`GOTOOLCHAIN=go1.26.0`) | 1 | 2.4 | same | red rc=1; green `1 named gate(s) ran and PASS` |
| `tables-go-blob-span` | `^TestBlobSpanHoldsAfterLaterAllocations$` | 1 | 1.3 | same, **and** the target reverted to a bare `go test` → `make slow-gate-scan` red: `make/go.mk:398: tables-go-blob-span: ./internal/codegen/gotable` | red rc=1 both ways; green `1 named gate(s) ran and PASS`, scan `0 bare` |
| `tables-go-blob-span-negative-control` | `^TestBlobSpanNegativeControl$` | 1 | 1.3 | same | red rc=1; green `1 named gate(s) ran and PASS` |
| `tables-go-builders` | `^TestBuilderRefusalThroughUnion$` + the builder wire-fuzz | 1 | 18.3 | same | red rc=1; green `1 named gate(s) ran and PASS`, then 183434 mutants, 0 divergences |
| `tables-go-typed-refusals` | `^Test(AcceleratorTypedRefusals\|MeasureRefusalReasons)$` (`GOTOOLCHAIN=go1.26.0`) | 2 | 2.0 | same | red rc=1; green `2 named gate(s) ran and PASS` |
| `tables-go-view` | `./compiler -run ^TestGoUnitViewCorpus$` **and** `gotable -run ^TestUnitViewPacketStorage$` (two labels, two logs) | 1 + 1 | 43.9 | same, both lines | red rc=1 on `tables-go-view-corpus` and on `tables-go-view-packet-storage` separately; green both `1 named gate(s) ran and PASS` |
| `tables-go-release` | the release re-run + `SCHEMA_GO_ALLOC_RUNS=200 … ^TestAllocatorOwnershipAndStandaloneWriters$` | 1 | 128 | same | red rc=1 on `tables-go-release-allocator` (and on the `tables-go-builders` line it re-enters); green both. **Run with `GO_SOAK=30s N=1000`** — the 1 h soak and `N=100000` at the release seed are not a three-hour bench's to run; the gate line itself is unshortened |
| `tables-c-retain` | `./compiler -run ^TestCTableRetain` + retain wire-fuzz (cc, + asan) | 7 | 164.7 | same | red rc=1; green `7 named gate(s) ran and PASS`, then 2× 183434 mutants, 0 divergences |
| `tables-reference-review` | `./compiler -run ^Test(CppVariableWideAlignment\|CppCollectionWidening\|FlagsElementWidening\|CppHiddenUnionExtentRefusal\|RepeatedArrayTailDefaults)$` | 16 | 47.3 | same, **plus a real defect**: `tools/sabotage -name reference-wide-alignment` over `cpptable/arena.go` through `-overlay` | red rc=1 with `static assertion failed due to requirement 'alignof(fixture::Root) <= kTableAlign'`; green `16 named gate(s) ran and PASS` |

**No target could not run**: every toolchain these fourteen need (cc, c++, go1.26.0) is on this bench. Bench preparation, not a repo change: the four pinned sibling runtimes `serialize@v1.16.2`, `serialize.c@v1.10.0`, `serialize.go@v1.15.1`, `serialize.cs@v1.9.1` were cloned beside the checkout exactly as `ci-full.yml:189` does — without them the Go-toolchain gates go red on `replacement directory …/serialize.go does not exist`, which is #986's G4 in local form.

### Why the gate-strip is the sabotage each target must catch

The defect class is *a gate that did not run*, so the sabotage is removing exactly what the fix adds: a copy of `test/slowgate/proof` with the `SCHEMA_SLOW=1` prefix deleted and nothing else (`diff` is that one line). All fourteen went **red, rc=1, naming the cause**; before this change all fourteen were **green, rc=0, having run nothing**. `tables-reference-review` additionally carries a real emitter defect so the column is not only about plumbing.

## The completion gate in #988, item by item

1. **All fourteen run what they name** — table above. No `-run` narrowed, no assertion weakened, no target deleted.
2. **`make test` / `make test-go` accounted for, to zero.** `make slow-gate-coverage` reads a plain `go test -v ./...` transcript and places **every** gate skip in a bucket: **178 skips → 53 run by a make target that sets the variable, 125 run only by `ci-full.yml:313` and `:321`, 0 run by nobody.** The table is written to `build/slowgate/coverage.tsv`. The two `go test ./...` umbrella lines (`test`, `update-goldens`) stay the fast half **by design** and are named in `make/slow-gate-exceptions.txt` with that reason — a written exception list, not silence. (178, not #988's 247: with the sibling runtimes present, fewer tests skip.)
3. **A run-proof per target, not an exit code** — the named `--- PASS` requirement, subtest-shaped gates included (`TestCppVariableWideAlignment/direct`, `TestRepeatedArrayTailDefaults/cpp`, `TestCppHiddenUnionExtentRefusal/*`, `TestCTableRetainFramedDepth/64`, `TestGoUnitViewCorpus`).
4. **A mechanical check in CI** — `make slow-gate-scan` (`tools/slowgatescan`), on `test` and on **ci-fast's `lint-fast`**, milliseconds: any recipe line in `Makefile`, `make/*.mk`, `make/checks/*.mk` that runs `go test` on a gated package without the variable fails **by name**. Proven red by reverting `tables-go-blob-span` (row above). A **stale** exception fails too. `make slow-gate-coverage` rides ci-full beside the two steps it credits (27 s warm, 2 m 35 s cold).
5. **`internal/slowtest`'s comment is made true** — and now says which day it was false, what it cost, and that `make slow-gate-scan` is what checks it, because a sentence in a comment is not a gate.
6. **Red before green, per target** — the sabotage column; every row is the same paste, one target at a time.
7. **Windows and Linux** — **not done on this bench and owed before #988 closes.** darwin/arm64 only here. `ci-full.yml` carries the new coverage step; the scan rides ci-fast on every platform that job runs.

## Open, and not hidden

- **`TestIdentityCompiledBytesN` (`internal/codegen/javatable`) shells out to `javac` and is NOT `slowtest`-gated**, so a plain `go test ./...` is **red** on any machine without a JDK on `PATH` (`Unable to locate a Java Runtime`). Found while measuring the baseline; a sibling of this fault, not this fault, and not fixed here.
- The scan is **package-granular** — it cannot know which tests a `-run` pattern selects without running them. Three lines whose selected tests reach no gate are named in the exception file **with the measurement** (`0` gate skips, and the PASS time): `tables-go-block-fill-refuser`, its control, and `tables-dart-names-negative-control`. `make slow-gate-coverage` is the check that keeps that honest.
- The scan reads **`make` recipe lines only**, not `go test` inside the `test/**` control shells. Those are #987's lane.
- `go vet ./...` clean; `gofmt` clean; `go test ./internal/ci/` (CI lints itself) green — it caught `tools/slowgatescan` untracked before this commit existed.

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
