### PR TITLE
gate: JS and Dart versioning targets run the two fixed-versioning checks their -run regexes excluded

### DIFF
--- a/make/dart.mk
+++ b/make/dart.mk
@@ -328,7 +328,7 @@ tables-dart-fixed-form: build/dart-fixed/.stamp build/fixedform-corpus/.stamp bu
 # SCHEMA_REQUIRE_CORPUS=1, under which that skip is a FAILURE.
 .PHONY: tables-dart-versioning
 tables-dart-versioning: tables-fixedform-corpus
-	SCHEMA_REQUIRE_CORPUS=1 DART=$(DART) go test ./internal/codegen/darttable/ -count=1 -run 'TestFixedVersioning'
+	SCHEMA_REQUIRE_CORPUS=1 DART=$(DART) go test ./internal/codegen/darttable/ -count=1 -run 'TestFixedVersioning|TestFixedCompiledPlanTagPastArmSet'
 	@echo 'tables Dart versioning: §5 read both columns of every row against the C++ reference bytes'
 
 .PHONY: tables-dart-fixed-form-negative-control

--- a/make/js.mk
+++ b/make/js.mk
@@ -466,7 +466,7 @@ tables-js-fixed-form: build/js-fixed/.stamp build/js-fixed-corpus/.stamp build/j
 # first and SCHEMA_REQUIRE_CORPUS=1 makes the skip a FAILURE.
 .PHONY: tables-js-versioning
 tables-js-versioning: build/fixedform-corpus/.stamp
-	SCHEMA_REQUIRE_CORPUS=1 NODE=$(NODE) go test -count=1 ./internal/codegen/jstable/ -run TestJSFixedVersioning
+	SCHEMA_REQUIRE_CORPUS=1 NODE=$(NODE) go test -count=1 ./internal/codegen/jstable/ -run 'TestJSFixedVersioning|TestJSFixedLineageLockBugFailsTheBuild'
 	@echo 'tables JS versioning: every row of §5.7 over the reference own bytes, both columns'
 
 test-js: tables-js-versioning


### PR DESCRIPTION
The two group-C fixed-versioning tests that the versioning targets' `-run` regexes excluded now run, per the audit finding on #898. Two lines, two files.

- `make/js.mk` (`tables-js-versioning`): `-run TestJSFixedVersioning` → `-run 'TestJSFixedVersioning|TestJSFixedLineageLockBugFailsTheBuild'`
- `make/dart.mk` (`tables-dart-versioning`): `-run 'TestFixedVersioning'` → `-run 'TestFixedVersioning|TestFixedCompiledPlanTagPastArmSet'`

`TestFixedCompiledPlanTagPastArmSet` is the one that mattered: it is gated on the corpus and the Dart binary, so under a bare `go test ./...` it silently skipped, a genuine CI coverage gap. `TestJSFixedLineageLockBugFailsTheBuild` also ran ungated, so that one was a selection miss, not a hole. Elixir's selection already covered its checks and is unchanged.

Proof, with `SCHEMA_SLOW=1 SCHEMA_REQUIRE_CORPUS=1` and the corpus built first:

```
--- PASS: TestJSFixedLineageLockBugFailsTheBuild (0.00s)
--- PASS: TestFixedCompiledPlanTagPastArmSet (0.28s)
```

No SKIP, no failure. Wall time per target after the change: JS 2.91s, Dart 2.93s (added work ~0.28s), inside the per-CL 2-minute budget. No test changed; no cell in the #898 audit is upgraded by this, it only makes the two checks execute in the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
