### PR TITLE
G5: prove gated test execution and account for enabled selectors

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -290,6 +290,14 @@ jobs:
         run: go mod tidy -diff
       - name: go vet
         run: go vet ./...
+      # THE SLOW-GATE SCAN (schema#988, G5). internal/slowtest.Gate skips a test
+      # that shells out to a toolchain unless SCHEMA_SLOW=1 is set, and a skipped
+      # test exits 0 — so a make target running a bare `go test` on such a
+      # package goes GREEN HAVING RUN NOTHING. Fourteen did. This scan fails any
+      # such recipe line BY NAME, costs milliseconds, and is on the FAST lane
+      # because the regression it catches is somebody adding the fifteenth.
+      - name: the positive gate targets still set SCHEMA_SLOW (schema#988)
+        run: make slow-gate-scan
       # CI LINTS ITSELF (issues #470, #472), over every workflow file in the
       # tree — this one included: every `uses:` names a full commit SHA with the
       # tag in a trailing comment, nothing runs @latest, and every csproj

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -320,6 +320,18 @@ jobs:
           SCHEMA_SLOW: '1'
         run: go test $(go list ./... | grep -v '/internal/codegen/')
 
+      # AND THE ACCOUNTING FOR THE TWO STEPS ABOVE (schema#988, G5). The two
+      # steps set SCHEMA_SLOW=1, so on this lane every gated test runs; that is
+      # exactly why the accounting belongs here. It runs the DEFAULT half once
+      # (no SCHEMA_SLOW — the point is to see what a developer's `make test`
+      # skips), then places every gate skip in one of three buckets: run by a
+      # make target that sets the variable, run only by the two steps above, or
+      # run by NOBODY. The third bucket fails the job. The table is uploaded as
+      # build/slowgate/coverage.tsv so the accounting is read, not believed.
+      - name: every slowtest gate is run by somebody, by name (schema#988)
+        if: matrix.group == 'unit-rest'
+        run: make slow-gate-coverage
+
       # THE FIXED FORM'S VERSIONING SUITE (§5 of docs/FIXED-FORM-ALGORITHM.md),
       # which the step above does NOT run. Its harness reads the C++
       # reference's byte oracle out of build/fixedform-corpus and SKIPS itself

--- a/Makefile
+++ b/Makefile
@@ -6198,5 +6198,5 @@ test: slow-gate-scan
 .PHONY: slow-gate-coverage
 slow-gate-coverage:
 	@mkdir -p build/slowgate
-	go test -v ./... > build/slowgate/all-plain.log 2>&1 || true
+	go test -json ./... > build/slowgate/all-plain.log 2>&1 || true
 	go run ./tools/slowgatescan -coverage build/slowgate/all-plain.log

--- a/Makefile
+++ b/Makefile
@@ -6142,3 +6142,51 @@ tables-wasrows-negative-control: build/tables-generated/.stamp test/tables/wasro
 	@echo "negative control: stripping was from the variant, the arms and the type's field turns the cross read RED (unknown counted, the value at its default)"
 
 include make/checks/reference-review.mk
+
+# ---------------------------------------------------------------------------
+# THE SLOW-GATE SCAN (schema#988, G5) ---------------------------------------
+#
+# internal/slowtest.Gate SKIPS a test that shells out to a foreign toolchain or
+# reads the C++ reference corpus unless SCHEMA_SLOW=1 or SCHEMA_REQUIRE_CORPUS
+# is set — AND A SKIPPED TEST MAKES `go test` EXIT 0. So a make target that runs
+# a bare `go test` on such a package GOES GREEN HAVING RUN NOTHING. Fourteen
+# positive gate targets did, for a day, while internal/slowtest's own package
+# comment said every make gate set the variable. THE COMMENT WAS THE BUG: a
+# claim about this Makefile belongs in a check.
+#
+# slow-gate-scan IS THAT CHECK and it costs milliseconds, so it rides `test`:
+# every recipe line in Makefile, make/*.mk and make/checks/*.mk that runs
+# `go test` on a package holding gated tests must set SCHEMA_SLOW=1, set
+# SCHEMA_REQUIRE_CORPUS, or go through test/slowgate/proof. Anything else fails
+# BY NAME. A line deliberately left as it is must be named in
+# make/slow-gate-exceptions.txt WITH A REASON, and an entry there that matches
+# no line any more fails too — a stale excuse is how the next bare `go test`
+# slips in behind a line nobody reads.
+.PHONY: slow-gate-scan
+slow-gate-scan:
+	go run ./tools/slowgatescan
+
+test: slow-gate-scan
+
+# AND THE ACCOUNTING, test by test rather than target by target: a plain
+# `go test -v ./...` transcript (the DEFAULT half — no SCHEMA_SLOW, which is the
+# point) is read back and every test that skipped at the gate is placed in one
+# of three buckets — run by a make target that sets the variable, run only by
+# ci-full.yml's SCHEMA_SLOW=1 steps, or run by NOBODY. The third bucket is the
+# failure. The whole table lands in build/slowgate/coverage.tsv so the
+# accounting is READ, not believed.
+#
+# It costs one plain `go test ./...` — 27 s with a warm build cache, 2 m 35 s
+# cold, measured on the Studio — so it is NOT on `test`: it rides ci-full.yml
+# beside the two steps it credits. Nothing is MOVED to nightly by this; the scan
+# above, which is the gate, is on `test`.
+#
+# `|| true` ON THE TRANSCRIPT AND NOWHERE ELSE: this target's job is to read
+# which tests the gate skipped, and it must still read that when some unrelated
+# test is red. The red itself is `test`'s to report, not this target's, and the
+# accounting below exits nonzero on its own finding.
+.PHONY: slow-gate-coverage
+slow-gate-coverage:
+	@mkdir -p build/slowgate
+	go test -v ./... > build/slowgate/all-plain.log 2>&1 || true
+	go run ./tools/slowgatescan -coverage build/slowgate/all-plain.log

--- a/internal/slowtest/slowtest.go
+++ b/internal/slowtest/slowtest.go
@@ -16,11 +16,28 @@
 // emitters' text, the goldens, the refusals. The toolchain half runs under
 // SCHEMA_SLOW=1, and it runs there ALWAYS:
 //
-//   - every make leg gate already exports SCHEMA_REQUIRE_CORPUS=1, and Enabled
-//     counts that as the slow half being ON — so not one of the nine leg gates,
-//     and not one of ci-fast.yml's per-leg rows that drive them, changed at all,
+//   - every make leg gate exports SCHEMA_REQUIRE_CORPUS=1, and Enabled counts
+//     that as the slow half being ON — so not one of the nine leg gates, and
+//     not one of ci-fast.yml's per-leg rows that drive them, changed at all,
+//   - every POSITIVE gate target runs its `go test` through test/slowgate/proof,
+//     which sets SCHEMA_SLOW=1, refuses a slowtest skip in its own log, and
+//     requires a `--- PASS` for each gate it names (schema#988),
 //   - ci-full.yml's two `go test` steps set SCHEMA_SLOW=1 explicitly, so the
 //     merge and nightly lanes run the whole of both halves.
+//
+// THE SECOND BULLET WAS FALSE FOR ONE DAY AND IT COST US A DAY (schema#988, G5).
+// This comment said "NOTHING IS CHECKED LESS THAN BEFORE" while fourteen
+// positive gate targets — tables-go-fixedform, -containers, -block-build,
+// -block-race-negative-control, -retain, -allocator, -blob-span,
+// -blob-span-negative-control, -builders, -typed-refusals, -view, -release,
+// tables-c-retain and tables-reference-review — ran a BARE `go test`. Under
+// `make test` the gate each one names skipped, `go test` exited 0, and the
+// target went green having run nothing. The claim is a claim about the
+// Makefile, so `make slow-gate-scan` now CHECKS IT on every run: a recipe line
+// that runs `go test` on a package holding gated tests without setting either
+// variable fails by name, and anything deliberately left to ci-full.yml is
+// named with its reason in make/slow-gate-exceptions.txt. A sentence in a
+// comment is not a gate; the scan is.
 //
 // NOTHING IS CHECKED LESS THAN BEFORE. A gate that quietly stopped running is
 // worse than a slow one, which is why Gate never reads a toolchain's presence:

--- a/make/c.mk
+++ b/make/c.mk
@@ -1128,7 +1128,9 @@ test-c tables-c: tables-c-message-negative-control
 
 .PHONY: tables-c-retain tables-c-retain-negative-control
 tables-c-retain: build/conformance-harness build/wire-fuzz-c build/wire-fuzz-c-asan
-	go test ./compiler -run '^TestCTableRetain' -count=1
+	sh test/slowgate/proof tables-c-retain \
+		'TestCTableRetainFile TestCTableRetainCapacityBoundsZeroBitMessage TestCTableRetainFramedDepth/64 TestCTableRetainFramedDepth/65 TestCTableRetainRefusedByName TestCTableRetainMessageDroppedMapKey/false TestCTableRetainMessageDroppedMapKey/true' \
+		./compiler -run '^TestCTableRetain' -count=1
 	./build/conformance-harness wire-fuzz --driver ./build/wire-fuzz-c --retain --seed $(SEED) --n $(N) --failed build/wire-fuzz/failed-c-retain.bin
 	./build/conformance-harness wire-fuzz --driver ./build/wire-fuzz-c-asan --retain --seed $(SEED) --n $(N) --failed build/wire-fuzz/failed-c-retain-asan.bin
 

--- a/make/checks/reference-review.mk
+++ b/make/checks/reference-review.mk
@@ -1,7 +1,9 @@
 # Compiled closure and widening regressions from the shared reference review.
 .PHONY: tables-reference-review
 tables-reference-review:
-	go test ./compiler -run '^Test(CppVariableWideAlignment|CppCollectionWidening|FlagsElementWidening|CppHiddenUnionExtentRefusal|RepeatedArrayTailDefaults)$$' -count=1
+	sh test/slowgate/proof tables-reference-review \
+		'TestCppVariableWideAlignment/narrow TestCppVariableWideAlignment/direct TestCppVariableWideAlignment/pointer TestCppVariableWideAlignment/union TestCppVariableWideAlignment/list TestCppVariableWideAlignment/map TestCppVariableWideAlignment/array TestCppVariableWideAlignment/nested TestCppCollectionWidening/list TestCppCollectionWidening/map TestFlagsElementWidening TestCppHiddenUnionExtentRefusal/false TestCppHiddenUnionExtentRefusal/true TestRepeatedArrayTailDefaults/c TestRepeatedArrayTailDefaults/cpp TestRepeatedArrayTailDefaults/c-bounded-extent' \
+		./compiler -run '^Test(CppVariableWideAlignment|CppCollectionWidening|FlagsElementWidening|CppHiddenUnionExtentRefusal|RepeatedArrayTailDefaults)$$' -count=1
 
 test: tables-reference-review
 

--- a/make/go.mk
+++ b/make/go.mk
@@ -57,7 +57,9 @@ generated/go/.stamp: bin/schema $(SCHEMAS)
 # every unit of the corpus.
 .PHONY: tables-go-fixedform
 tables-go-fixedform:
-	go test ./internal/codegen/gotable -run 'TestFixedForm' -count=1
+	sh test/slowgate/proof tables-go-fixedform \
+		'TestFixedFormRoundTrip TestFixedFormHostileBoolByte TestFixedFormHostileUnionTag TestFixedFormArgLaneOldEncodingControl TestFixedFormClampLiveCount' \
+		./internal/codegen/gotable -run 'TestFixedForm' -count=1
 test-go: tables-go-fixedform
 
 .PHONY: tables-go-json-walk
@@ -347,7 +349,9 @@ test-go: tables-go-wire-fuzz tables-go-wire-fuzz-negative-control
 
 .PHONY: tables-go-containers tables-go-containers-negative-controls
 tables-go-containers:
-	go test ./internal/codegen/gotable -run 'Test(RegionLists|ListsThroughUnionArrays|BuilderCountRecovery|NestedTerminationAndStringDefault|RegionMaps|MapReadReports|MapJsonKeyDomains)'
+	sh test/slowgate/proof tables-go-containers \
+		'TestRegionLists TestListsThroughUnionArrays TestBuilderCountRecovery TestNestedTerminationAndStringDefault TestRegionMaps TestMapReadReports TestMapJsonKeyDomains' \
+		./internal/codegen/gotable -run 'Test(RegionLists|ListsThroughUnionArrays|BuilderCountRecovery|NestedTerminationAndStringDefault|RegionMaps|MapReadReports|MapJsonKeyDomains)' -count=1
 tables-go-containers-negative-controls:
 	@set -e; for mode in sort ascending duplicate key-domain dead cap; do sh test/conformance/go/container-negative-control $$mode; done
 
@@ -357,9 +361,13 @@ test-go: tables-go-containers tables-go-containers-negative-controls
 # every worker fill the whole array; byte identity alone cannot see that race.
 .PHONY: tables-go-block-build tables-go-block-race-negative-control tables-go-block-fill-refuser tables-go-block-fill-refuser-negative-control
 tables-go-block-build:
-	go test ./internal/codegen/gotable -run '^TestBlockBuilderStorageAndParallelFill$$' -count=1
+	sh test/slowgate/proof tables-go-block-build \
+		'TestBlockBuilderStorageAndParallelFill' \
+		./internal/codegen/gotable -run '^TestBlockBuilderStorageAndParallelFill$$' -count=1
 tables-go-block-race-negative-control:
-	go test ./internal/codegen/gotable -run '^TestBlockBuilderRaceNegativeControl$$' -count=1
+	sh test/slowgate/proof tables-go-block-race-negative-control \
+		'TestBlockBuilderRaceNegativeControl' \
+		./internal/codegen/gotable -run '^TestBlockBuilderRaceNegativeControl$$' -count=1
 tables-go-block-fill-refuser:
 	go test ./internal/codegen/gotable -run '^TestBlockFillRefuser$$' -count=1
 tables-go-block-fill-refuser-negative-control:
@@ -369,13 +377,17 @@ test-go: tables-go-block-build tables-go-block-fill-refuser
 
 .PHONY: tables-go-retain
 tables-go-retain:
-	go test ./internal/codegen/gotable -run '^TestRetain' -count=1
+	sh test/slowgate/proof tables-go-retain \
+		'TestRetainMatchesIndependentRewrite TestRetainMessageBoundsBeforeExpansion TestRetainReplacementAndShapeChanges TestRetainFileCapacityBeforeExpansion TestRetainUnknownNodeRecord TestRetainMessageMapKeyProbe TestRetainMessageMapRepeatedKeyKeepsWidening' \
+		./internal/codegen/gotable -run '^TestRetain' -count=1
 test-go: tables-go-retain
 
 .PHONY: tables-go-allocator tables-go-allocator-negative-controls tables-go-allocator-runtime-negative-control tables-go-retain-negative-controls
 tables-go-allocator:
 	@if [ "$${SCHEMA_GO_ALLOC_ANY_GO:-}" = 1 ]; then echo "Go allocation observation mode: NOT CERTIFIED"; fi
-	GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
+	GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-allocator \
+		'TestAllocatorOwnershipAndStandaloneWriters' \
+		./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
 
 # THE SPAN, on its own (docs/SPEC-TABLES.md §2.5, M17). A blob larger than a
 # slab takes a span of the arena's address space. The negative control makes
@@ -383,9 +395,13 @@ tables-go-allocator:
 # and later allocations overwrite it.
 .PHONY: tables-go-blob-span tables-go-blob-span-negative-control
 tables-go-blob-span:
-	go test ./internal/codegen/gotable -run '^TestBlobSpanHoldsAfterLaterAllocations$$' -count=1
+	sh test/slowgate/proof tables-go-blob-span \
+		'TestBlobSpanHoldsAfterLaterAllocations' \
+		./internal/codegen/gotable -run '^TestBlobSpanHoldsAfterLaterAllocations$$' -count=1
 tables-go-blob-span-negative-control:
-	go test ./internal/codegen/gotable -run '^TestBlobSpanNegativeControl$$' -count=1
+	sh test/slowgate/proof tables-go-blob-span-negative-control \
+		'TestBlobSpanNegativeControl' \
+		./internal/codegen/gotable -run '^TestBlobSpanNegativeControl$$' -count=1
 test-go: tables-go-blob-span tables-go-blob-span-negative-control
 tables-go-allocator-negative-controls:
 	@set -e; for mode in original-slice pair frame; do sh test/conformance/go/ownership-negative-control $$mode; done
@@ -398,19 +414,27 @@ test-go: tables-go-allocator tables-go-allocator-negative-controls tables-go-all
 
 .PHONY: tables-go-builders tables-go-builders-negative-control tables-go-typed-refusals
 tables-go-builders: build/conformance-harness build/conformance-go
-	go test ./internal/codegen/gotable -run '^TestBuilderRefusalThroughUnion$$' -count=1
+	sh test/slowgate/proof tables-go-builders \
+		'TestBuilderRefusalThroughUnion' \
+		./internal/codegen/gotable -run '^TestBuilderRefusalThroughUnion$$' -count=1
 	./build/conformance-harness wire-fuzz --builder --driver 'build/conformance-go wire-fuzz-builder' --seed $(SEED) --n $(N)
 tables-go-builders-negative-control:
 	sh test/conformance/go/ownership-negative-control builder-union
 tables-go-typed-refusals:
-	GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^Test(AcceleratorTypedRefusals|MeasureRefusalReasons)$$' -count=1
+	GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-typed-refusals \
+		'TestAcceleratorTypedRefusals TestMeasureRefusalReasons' \
+		./internal/codegen/gotable -run '^Test(AcceleratorTypedRefusals|MeasureRefusalReasons)$$' -count=1
 
 test-go: tables-go-builders tables-go-builders-negative-control tables-go-typed-refusals
 
 .PHONY: tables-go-view tables-go-view-negative-controls
 tables-go-view:
-	go test ./compiler -run '^TestGoUnitViewCorpus$$' -count=1
-	go test ./internal/codegen/gotable -run '^TestUnitViewPacketStorage$$' -count=1
+	sh test/slowgate/proof tables-go-view-corpus \
+		'TestGoUnitViewCorpus' \
+		./compiler -run '^TestGoUnitViewCorpus$$' -count=1
+	sh test/slowgate/proof tables-go-view-packet-storage \
+		'TestUnitViewPacketStorage' \
+		./internal/codegen/gotable -run '^TestUnitViewPacketStorage$$' -count=1
 tables-go-view-negative-controls:
 	@set -e; for mode in identity packet-offset arm-offset; do sh test/tables/view-go-control $$mode; done
 
@@ -432,7 +456,9 @@ tables-go-release: build/conformance-harness build/conformance-go tables-go-benc
 	$(MAKE) tables-go-wire-fuzz tables-go-retain-wire-fuzz tables-go-builders N=100000 SEED=$(GO_RELEASE_SEED)
 	$(MAKE) tables-go-wire-fuzz-negative-control
 	cd test/go-tables && GOTOOLCHAIN=go1.26.0 go test -run '^TestSoak$$' -count=1 -timeout 2h -soak $(GO_SOAK)
-	SCHEMA_GO_ALLOC_RUNS=200 GOTOOLCHAIN=go1.26.0 go test ./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
+	SCHEMA_GO_ALLOC_RUNS=200 GOTOOLCHAIN=go1.26.0 sh test/slowgate/proof tables-go-release-allocator \
+		'TestAllocatorOwnershipAndStandaloneWriters' \
+		./internal/codegen/gotable -run '^TestAllocatorOwnershipAndStandaloneWriters$$' -count=1
 tables-go-clean: build/tables-generated-go/.stamp
 	@set -e; for d in build/tables-generated-go/*; do \
 		[ -f "$$d/go.mod" ] || continue; \

--- a/make/slow-gate-exceptions.txt
+++ b/make/slow-gate-exceptions.txt
@@ -1,0 +1,54 @@
+# THE WRITTEN EXCEPTION LIST for `make slow-gate-scan` (schema#988, G5).
+#
+# A recipe line that runs `go test` on a package holding slowtest-gated tests
+# and sets NEITHER SCHEMA_SLOW=1 NOR SCHEMA_REQUIRE_CORPUS goes green having
+# run nothing. tools/slowgatescan fails on every such line BY NAME. A line may
+# stand only if it is named here WITH A REASON — the point of this file is that
+# a deliberate omission is written where the next reader trips over it, and
+# silence never passes for a decision again.
+#
+# Format: target<TAB>package<TAB>reason. All three fields are required.
+#
+# An entry that matches no recipe line any more FAILS THE SCAN TOO: a stale
+# excuse is exactly how the next bare `go test` slips in behind a line nobody
+# reads. Delete it when the line it excuses is gone or armed.
+
+# --- the two umbrella lines: the fast half, by design (issue completion gate 2)
+#
+# `go test ./...` is the DEFAULT half — pure Go, under two minutes, the half a
+# child will actually run (internal/slowtest, the owner's 1-2 minute rule). The
+# slow half is NOT left to silence and NOT left to nightly: `test` and `test-go`
+# depend on the fourteen positive gate targets, and every one of those runs its
+# `go test` through test/slowgate/proof, which sets SCHEMA_SLOW=1, refuses a
+# gate skip in its own log and requires a named `--- PASS` per gate. So the
+# skips under this line are accounted for by the targets in the same `make`
+# invocation, and `make slow-gate-coverage` checks that accounting test by test
+# against a real transcript rather than trusting this paragraph.
+test	./...	the fast half by design (the 1-2 minute rule); the slow half runs in the fourteen positive gate targets `test`/`test-go` depend on, each through test/slowgate/proof, and `make slow-gate-coverage` proves test by test that no gated test is left to nobody
+update-goldens	./...	regenerates goldens with -update; it is the pure-Go golden half, and the toolchain gates it cannot regenerate are run by the fourteen positive gate targets (same accounting as `test`)
+slow-gate-coverage	./...	it MUST run plain: the accounting reads which tests skip at the gate under a DEFAULT `go test ./...`, so setting the variable here would erase the very thing being counted
+
+# --- lines whose selected tests are NOT gated (measured, not assumed)
+#
+# The scan is package-granular on purpose: it cannot know which tests a -run
+# pattern selects without running them. These three lines name tests that reach
+# no slowtest.Gate at all — measured on darwin at this head with a plain
+# `go test -v -run <the same pattern>`: 0 lines of slowtest's skip message.
+# `make slow-gate-coverage` is the check that keeps that true.
+tables-go-block-fill-refuser	./internal/codegen/gotable	TestBlockFillRefuser reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.03s under a plain go test); it emits and reads in-process
+tables-go-block-fill-refuser-negative-control	./internal/codegen/gotable	TestBlockFillRefuserNegativeControl reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.02s under a plain go test)
+tables-dart-names-negative-control	./compiler	TestDartTableRuntimeNamesAreClaimed reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.01s under a plain go test); it compares emitted source to internal/tablenames, no dart toolchain
+
+# --- REMOVE THESE FIVE WHEN #987 MERGES (they are that PR's lines, not this one's)
+#
+# PR #987 (rowan/fix-negative-controls, G1+G2) arms exactly these five lines
+# with SCHEMA_SLOW=1 plus its own SKIP/PASS scan. This branch shares its base
+# (fixed-table-form at b7ab66a8) and does not touch another lane's files. When
+# #987 lands, these five entries go stale and THE SCAN WILL FAIL UNTIL THEY ARE
+# DELETED — which is the handshake: whoever merges deletes them, and the scan
+# says so by name.
+tables-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-ref-ordinal-shared-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-message-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+tables-c-retain-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges

--- a/make/slow-gate-exceptions.txt
+++ b/make/slow-gate-exceptions.txt
@@ -39,16 +39,4 @@ tables-go-block-fill-refuser	./internal/codegen/gotable	TestBlockFillRefuser rea
 tables-go-block-fill-refuser-negative-control	./internal/codegen/gotable	TestBlockFillRefuserNegativeControl reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.02s under a plain go test)
 tables-dart-names-negative-control	./compiler	TestDartTableRuntimeNamesAreClaimed reaches no slowtest.Gate (measured: 0 gate skips, PASS 0.01s under a plain go test); it compares emitted source to internal/tablenames, no dart toolchain
 
-# --- REMOVE THESE FIVE WHEN #987 MERGES (they are that PR's lines, not this one's)
-#
-# PR #987 (rowan/fix-negative-controls, G1+G2) arms exactly these five lines
-# with SCHEMA_SLOW=1 plus its own SKIP/PASS scan. This branch shares its base
-# (fixed-table-form at b7ab66a8) and does not touch another lane's files. When
-# #987 lands, these five entries go stale and THE SCAN WILL FAIL UNTIL THEY ARE
-# DELETED — which is the handshake: whoever merges deletes them, and the scan
-# says so by name.
-tables-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
-tables-ref-ordinal-shared-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
-tables-c-ref-ordinal-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
-tables-c-message-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
-tables-c-retain-negative-control	./compiler	armed by PR #987 (rowan/fix-negative-controls); delete this line when #987 merges
+

--- a/test/slowgate/proof
+++ b/test/slowgate/proof
@@ -63,7 +63,7 @@ fi
 
 missing=""
 for want in $required; do
-	if ! grep -q -- "--- PASS: $want (" "$log"; then
+	if ! grep -F -q -- "--- PASS: $want (" "$log"; then
 		missing="$missing $want"
 	fi
 done

--- a/test/slowgate/proof
+++ b/test/slowgate/proof
@@ -1,0 +1,78 @@
+#!/bin/sh
+# THE POSITIVE GATE'S RUN-PROOF (schema#988, G5).
+#
+# internal/slowtest.Gate SKIPS a test that shells out to a foreign toolchain or
+# reads the C++ reference corpus unless SCHEMA_SLOW=1 (or SCHEMA_REQUIRE_CORPUS)
+# is set — and a skipped test makes `go test` exit 0. A POSITIVE gate target
+# that ran a bare `go test` therefore went green having run nothing. Fourteen
+# did.
+#
+# So every positive gate target calls its `go test` THROUGH HERE, and this
+# script does three things no exit code can do on its own:
+#
+#   1. it SETS SCHEMA_SLOW=1, so the gate the target names actually runs,
+#   2. it REFUSES A GATE SKIP: one slowtest skip line in the log is a failure,
+#      even at exit 0 — inside a positive gate target a skip is the defect,
+#   3. it REQUIRES A NAMED `--- PASS` PER GATE, because Go prints `--- PASS`
+#      for the PARENT of a skipped subtest, so the parent's PASS proves nothing
+#      about `TestCppVariableWideAlignment/direct`. The names are matched with
+#      their trailing ` (` so a prefix (TestRetain) cannot stand in for the
+#      whole (TestRetainUnknownNodeRecord).
+#
+# A `t.Skip` for a RETIRED test is not a gate skip and is not touched here: only
+# slowtest's own skip line is a failure. That distinction is the whole point —
+# the check must see the gate that stopped running, not the test somebody
+# deliberately retired with a reason.
+#
+# usage: sh test/slowgate/proof <label> '<required --- PASS names>' <go test args...>
+#
+# The log is build/slowgate/<label>.log. Output is bounded by design (one line
+# on success, the log only on failure): a target's receipt is a count, not a
+# transcript.
+set -e
+
+label="$1"; shift || true
+required="$1"; shift || true
+
+if [ -z "$label" ] || [ $# -eq 0 ]; then
+	echo "test/slowgate/proof: usage: proof <label> '<required PASS names>' <go test args...>" >&2
+	exit 2
+fi
+if [ -z "$required" ]; then
+	echo "test/slowgate/proof: $label names no required gate. A positive gate target that cannot name one gated test it proves does not belong here: run it with a bare \`go test\` and say so in make/slow-gate-exceptions.txt." >&2
+	exit 2
+fi
+
+mkdir -p build/slowgate
+log="build/slowgate/$label.log"
+
+rc=0
+SCHEMA_SLOW=1 go test -v "$@" > "$log" 2>&1 || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+	cat "$log"
+	echo "SLOW GATE $label: go test exited $rc — the gate ran and is RED. Fix the red; do not loosen the gate."
+	exit "$rc"
+fi
+
+if grep -q 'SCHEMA_SLOW: this test shells out' "$log"; then
+	echo "SLOW GATE $label FAILED: a test skipped at internal/slowtest.Gate INSIDE A POSITIVE GATE TARGET, so this target is watching nothing (schema#988). SCHEMA_SLOW=1 was set by this script, so the environment was lost between here and the test binary:"
+	grep -n 'SCHEMA_SLOW: this test shells out' "$log"
+	exit 1
+fi
+
+missing=""
+for want in $required; do
+	if ! grep -q -- "--- PASS: $want (" "$log"; then
+		missing="$missing $want"
+	fi
+done
+if [ -n "$missing" ]; then
+	echo "SLOW GATE $label FAILED: no \`--- PASS\` for the gate(s) this target names, so the target proved nothing about them (schema#988):$missing"
+	echo "(a parent's --- PASS is printed even when a named subtest skipped, which is why the name is required verbatim)"
+	cat "$log"
+	exit 1
+fi
+
+count=$(printf '%s\n' $required | wc -l | tr -d ' ')
+echo "SLOW GATE $label: $count named gate(s) ran and PASS under SCHEMA_SLOW=1 ($log)"

--- a/tools/slowgatescan/coverage_test.go
+++ b/tools/slowgatescan/coverage_test.go
@@ -449,3 +449,75 @@ jobs:
 		t.Errorf("step with if: false must not certify coverage, got exit 0")
 	}
 }
+
+// TestAdversarialEchoGoTestNotCredited witnesses that `echo go test ./compiler`
+// does not have `go test` at command position and must NOT credit compiler.TestRequiredGate.
+func TestAdversarialEchoGoTestNotCredited(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflowEcho := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: echo command
+        env:
+          SCHEMA_SLOW: '1'
+        run: echo go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowEcho)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("echo go test ./compiler must not credit test, got exit 0")
+	}
+}
+
+// TestAdversarialUnsetSchemaSlowMultilineNotCredited witnesses that an active line
+// like `unset SCHEMA_SLOW` is unsupported and causes the whole run block to be refused.
+func TestAdversarialUnsetSchemaSlowMultilineNotCredited(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflowUnset := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: multiline with unset
+        env:
+          SCHEMA_SLOW: '1'
+        run: |
+          unset SCHEMA_SLOW
+          go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowUnset)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("multiline block containing unset SCHEMA_SLOW must refuse whole block, got exit 0")
+	}
+}

--- a/tools/slowgatescan/coverage_test.go
+++ b/tools/slowgatescan/coverage_test.go
@@ -222,20 +222,159 @@ jobs:
 	}
 }
 
-// TestPlainLogFallback ensures plain text logs (with === RUN and ok/FAIL) are also parsed.
-func TestPlainLogFallback(t *testing.T) {
-	plainText := strings.Join([]string{
-		`=== RUN   compiler.TestRequiredGate`,
-		`    gate_test.go:10: ` + gateSkipMarker,
-		`--- SKIP: compiler.TestRequiredGate (0.00s)`,
+// Adversarial Controls 5A-5D: The five false-credit cases identified by Stella (stella-f42ad3d7317f).
+// Root compiler.TestRequiredGate must NOT be credited in any of these scenarios.
+
+func TestAdversarialSchemaSlowTrueDoesNotCredit(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
 	}, "\n")
 
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "plain.log")
-	if err := os.WriteFile(logPath, []byte(plainText), 0o644); err != nil {
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
 		t.Fatalf("writing test log: %v", err)
 	}
 
+	workflow := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: boolean true
+        env:
+          SCHEMA_SLOW: 'true'
+        run: go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflow)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("SCHEMA_SLOW: 'true' must not credit test (slowtest.Enabled requires exactly '1'), got exit 0")
+	}
+}
+
+func TestAdversarialSchemaSlow10DoesNotCredit(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflow := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: value 10
+        run: SCHEMA_SLOW=10 go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflow)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("SCHEMA_SLOW=10 must not credit test (must not mistake 10 for 1), got exit 0")
+	}
+}
+
+func TestAdversarialCommentedCommandDoesNotCredit(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflow := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: commented out command
+        run: |
+          # SCHEMA_SLOW=1 go test ./compiler
+          true
+`
+	steps, err := parseWorkflowContent("test.yml", workflow)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("commented out test command must not credit test, got exit 0")
+	}
+}
+
+func TestAdversarialCompoundDirectoryChangeRefused(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflow := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: compound command
+        env:
+          SCHEMA_SLOW: '1'
+        run: cd test && go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflow)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("compound cd test && go test ./compiler selects test/compiler, must not credit root compiler, got exit 0")
+	}
+}
+
+func TestAdversarialMalformedOrTruncatedJSONStreamRefused(t *testing.T) {
+	// One complete gate event and one truncated gate event
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestTrunc`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	// Verify gateSkips directly reports error
+	skips, err := gateSkips(logPath)
+	if err == nil {
+		t.Errorf("expected gateSkips to return error on truncated JSON stream, got skips: %v", skips)
+	}
+
+	// Step that would otherwise cover compiler
 	workflowSelecting := `
 name: test
 jobs:
@@ -252,8 +391,61 @@ jobs:
 		t.Fatalf("parseWorkflowContent: %v", err)
 	}
 
+	// runCoverage must return non-zero error, NOT silently retain the first event and exit 0
 	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
-	if rc != 0 {
-		t.Errorf("expected plain text fallback to succeed, got exit %d", rc)
+	if rc == 0 {
+		t.Errorf("expected runCoverage to fail on malformed/truncated stream, got exit 0")
+	}
+}
+
+func TestAdversarialMissingGateIdentityRefused(t *testing.T) {
+	// Missing package or test identity on gate record
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"","Test":"TestGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	_, err := gateSkips(logPath)
+	if err == nil {
+		t.Errorf("expected gateSkips to return error when gate skip record lacks package identity, got nil error")
+	}
+}
+
+func TestAdversarialExplicitlyDisabledStepCondition(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflowDisabledCond := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: disabled condition
+        if: false
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowDisabledCond)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("step with if: false must not certify coverage, got exit 0")
 	}
 }

--- a/tools/slowgatescan/coverage_test.go
+++ b/tools/slowgatescan/coverage_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Adversarial Control 1: Disabled or unrelated CI steps do not credit required tests.
+// A workflow with SCHEMA_SLOW=0 or go test ./unrelated must NOT cover compiler.TestRequiredGate.
+func TestAdversarialDisabledOrUnrelatedCIStep(t *testing.T) {
+	// A synthetic transcript with one required test in ./compiler
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	// Case 1A: Disabled CI step (SCHEMA_SLOW: '0') running the matching package
+	workflowDisabled := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: disabled
+        env:
+          SCHEMA_SLOW: '0'
+        run: go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowDisabled)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("expected runCoverage to fail when CI step has SCHEMA_SLOW: '0', but got exit 0")
+	}
+
+	// Case 1B: Enabled CI step running an unrelated package (./unrelated)
+	workflowUnrelated := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: unrelated
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./unrelated -run '^TestOther$'
+`
+	steps, err = parseWorkflowContent("test.yml", workflowUnrelated)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+	rc = runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("expected runCoverage to fail when CI step only runs ./unrelated, but got exit 0")
+	}
+}
+
+// Adversarial Control 2: Same test name in different packages.
+// Verifies that package identity prevents cross-package false credit.
+func TestAdversarialSameTestNameInDifferentPackages(t *testing.T) {
+	// Two tests with the same name "TestRequiredGate": one in ./compiler, one in ./internal/codegen/gotable
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/internal/codegen/gotable","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	// Workflow that ONLY runs codegen packages
+	workflowCodegenOnly := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: codegen only
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./internal/codegen/...
+`
+	steps, err := parseWorkflowContent("test.yml", workflowCodegenOnly)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	// Should fail because compiler.TestRequiredGate is uncovered
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("expected runCoverage to fail when only codegen is tested, but got exit 0")
+	}
+
+	// Add step covering non-codegen packages
+	workflowBoth := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: codegen
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./internal/codegen/...
+      - name: rest
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test $(go list ./... | grep -v '/internal/codegen/')
+`
+	steps, err = parseWorkflowContent("test.yml", workflowBoth)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc = runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc != 0 {
+		t.Errorf("expected runCoverage to pass when both packages are covered, got exit %d", rc)
+	}
+
+	// Verify coverage.tsv has distinct rows for each package
+	tsvPath := filepath.Join(tmpDir, "build", "slowgate", "coverage.tsv")
+	b, err := os.ReadFile(tsvPath)
+	if err != nil {
+		t.Fatalf("reading coverage.tsv: %v", err)
+	}
+	content := string(b)
+	if !strings.Contains(content, "ci\tcompiler.TestRequiredGate\ttest.yml:") {
+		t.Errorf("expected compiler.TestRequiredGate in ci bucket, got:\n%s", content)
+	}
+	if !strings.Contains(content, "ci\tinternal/codegen/gotable.TestRequiredGate\ttest.yml:") {
+		t.Errorf("expected internal/codegen/gotable.TestRequiredGate in ci bucket, got:\n%s", content)
+	}
+}
+
+// Adversarial Control 3: Restricted -run pattern does not credit non-matching tests.
+func TestAdversarialRestrictedRunPattern(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	// Step specifies -run '^TestOtherOnly$'
+	workflowRestricted := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: restricted
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./compiler -run '^TestOtherOnly$'
+`
+	steps, err := parseWorkflowContent("test.yml", workflowRestricted)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc == 0 {
+		t.Errorf("expected runCoverage to fail when -run does not match test, but got exit 0")
+	}
+}
+
+// Adversarial Control 4: An actually selecting lane credits the test.
+func TestAdversarialActuallySelectingLane(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"Action":"output","Package":"github.com/mas-bandwidth/schema/v2/compiler","Test":"TestRequiredGate","Output":"` + gateSkipMarker + `\n"}`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	// Step genuinely runs ./compiler with SCHEMA_SLOW=1
+	workflowSelecting := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: selecting lane
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowSelecting)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc != 0 {
+		t.Errorf("expected runCoverage to succeed on selecting lane, got exit %d", rc)
+	}
+
+	tsvPath := filepath.Join(tmpDir, "build", "slowgate", "coverage.tsv")
+	b, err := os.ReadFile(tsvPath)
+	if err != nil {
+		t.Fatalf("reading coverage.tsv: %v", err)
+	}
+	if !strings.Contains(string(b), "ci\tcompiler.TestRequiredGate\ttest.yml:") {
+		t.Errorf("expected test in ci bucket, got:\n%s", string(b))
+	}
+}
+
+// TestPlainLogFallback ensures plain text logs (with === RUN and ok/FAIL) are also parsed.
+func TestPlainLogFallback(t *testing.T) {
+	plainText := strings.Join([]string{
+		`=== RUN   compiler.TestRequiredGate`,
+		`    gate_test.go:10: ` + gateSkipMarker,
+		`--- SKIP: compiler.TestRequiredGate (0.00s)`,
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "plain.log")
+	if err := os.WriteFile(logPath, []byte(plainText), 0o644); err != nil {
+		t.Fatalf("writing test log: %v", err)
+	}
+
+	workflowSelecting := `
+name: test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: selecting lane
+        env:
+          SCHEMA_SLOW: '1'
+        run: go test ./compiler
+`
+	steps, err := parseWorkflowContent("test.yml", workflowSelecting)
+	if err != nil {
+		t.Fatalf("parseWorkflowContent: %v", err)
+	}
+
+	rc := runCoverage(tmpDir, logPath, nil, nil, steps)
+	if rc != 0 {
+		t.Errorf("expected plain text fallback to succeed, got exit %d", rc)
+	}
+}

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -178,7 +178,8 @@ func runStatic(recipes []recipe, exceptions []exception, gated map[string]bool) 
 func runCoverage(root, logPath string, recipes []recipe, exceptions []exception, steps []ciStep) int {
 	skipped, err := gateSkips(logPath)
 	if err != nil {
-		fail("reading %s: %v", logPath, err)
+		fmt.Fprintf(os.Stderr, "slow gate coverage: reading %s: %v\n", logPath, err)
+		return 1
 	}
 	if len(skipped) == 0 {
 		fmt.Printf("slow gate coverage: %s holds no slowtest skip — either it was produced WITH SCHEMA_SLOW set (it must not be) or the gate is gone\n", logPath)
@@ -265,6 +266,7 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 		startLine int
 		runLine   int
 		name      string
+		ifCond    string
 		envLines  []string
 		runLines  []string
 	}
@@ -290,6 +292,8 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 			lineAfterDash := strings.TrimSpace(trimmed[2:])
 			if strings.HasPrefix(lineAfterDash, "name:") {
 				cur.name = strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "name:"))
+			} else if strings.HasPrefix(lineAfterDash, "if:") {
+				cur.ifCond = strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "if:"))
 			} else if strings.HasPrefix(lineAfterDash, "run:") {
 				cur.runLine = lineNo
 				runRest := strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "run:"))
@@ -310,6 +314,11 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 
 		if strings.HasPrefix(trimmed, "name:") && !inRun && !inEnv {
 			cur.name = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "if:") && !inRun && !inEnv {
+			cur.ifCond = strings.TrimSpace(strings.TrimPrefix(trimmed, "if:"))
 			continue
 		}
 
@@ -353,32 +362,53 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 	}
 
 	for _, rs := range rawSteps {
-		fullRun := strings.Join(rs.runLines, "\n")
+		// Ignore comment lines and empty lines
+		var activeRunLines []string
+		for _, rl := range rs.runLines {
+			t := strings.TrimSpace(rl)
+			if t == "" || strings.HasPrefix(t, "#") {
+				continue
+			}
+			activeRunLines = append(activeRunLines, t)
+		}
+		if len(activeRunLines) == 0 {
+			continue
+		}
+
+		fullRun := strings.Join(activeRunLines, "\n")
 		if !strings.Contains(fullRun, "go test") {
 			continue
 		}
 
-		enabled := false
+		// Step condition: explicitly disabled steps must not count as enabled;
+		// unresolved execution conditions cannot certify coverage.
+		if !isStepConditionEnabled(rs.ifCond) {
+			steps = append(steps, ciStep{
+				file:     file,
+				line:     rs.runLine,
+				name:     rs.name,
+				enabled:  false,
+				selector: nil,
+				desc:     fmt.Sprintf("%s:%d", file, rs.runLine),
+			})
+			continue
+		}
+
+		// Step env: exact SCHEMA_SLOW: '1' required
+		stepEnvSlow := false
 		for _, el := range rs.envLines {
 			parts := strings.SplitN(el, ":", 2)
 			if len(parts) == 2 && strings.TrimSpace(parts[0]) == "SCHEMA_SLOW" {
 				val := strings.Trim(strings.TrimSpace(parts[1]), `"'`)
-				if val == "1" || strings.EqualFold(val, "true") {
-					enabled = true
-				} else if val == "0" || strings.EqualFold(val, "false") {
-					enabled = false
+				if val == "1" {
+					stepEnvSlow = true
+				} else {
+					stepEnvSlow = false
 				}
 			}
 		}
-		for _, rl := range rs.runLines {
-			if strings.Contains(rl, "SCHEMA_SLOW=1") {
-				enabled = true
-			} else if strings.Contains(rl, "SCHEMA_SLOW=0") {
-				enabled = false
-			}
-		}
 
-		selector := buildCISelector(fullRun)
+		selector, enabled := parseCIStepCommands(activeRunLines, stepEnvSlow)
 
 		steps = append(steps, ciStep{
 			file:     file,
@@ -392,13 +422,107 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 	return steps, nil
 }
 
-func buildCISelector(cmd string) func(pkg, test string) bool {
+func isStepConditionEnabled(ifCond string) bool {
+	ifCond = strings.TrimSpace(ifCond)
+	if ifCond == "" {
+		return true
+	}
+	if strings.HasPrefix(ifCond, "${{") && strings.HasSuffix(ifCond, "}}") {
+		ifCond = strings.TrimSpace(ifCond[3 : len(ifCond)-2])
+	}
+	unquoted := strings.Trim(ifCond, `"'`)
+	if unquoted == "false" {
+		return false
+	}
+	if unquoted == "true" || unquoted == "always()" || unquoted == "success()" {
+		return true
+	}
+	norm := strings.ReplaceAll(ifCond, `"`, `'`)
+	norm = strings.ReplaceAll(norm, " ", "")
+	if norm == "matrix.group=='unit-codegen'" || norm == "matrix.group=='unit-rest'" {
+		return true
+	}
+	return false
+}
+
+var reInlineSlow = regexp.MustCompile(`(?:^|\s)SCHEMA_SLOW=([^\s]+)`)
+
+func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test string) bool, bool) {
+	for _, l := range lines {
+		if strings.Contains(l, "cd ") || strings.Contains(l, "cd\t") || strings.TrimSpace(l) == "cd" {
+			return nil, false
+		}
+		if strings.Contains(l, "&&") || strings.Contains(l, "||") || strings.Contains(l, ";") || strings.Contains(l, "&") {
+			return nil, false
+		}
+		if strings.Contains(l, "|") {
+			if !strings.Contains(l, "grep -v '/internal/codegen/'") && !strings.Contains(l, `grep -v "/internal/codegen/"`) {
+				return nil, false
+			}
+		}
+		if strings.Contains(l, "$(") {
+			if !strings.Contains(l, "$(go list ./... | grep -v '/internal/codegen/')") && !strings.Contains(l, `$(go list ./... | grep -v "/internal/codegen/")`) {
+				return nil, false
+			}
+		}
+		if strings.Contains(l, "`") {
+			return nil, false
+		}
+	}
+
+	var selectors []func(pkg, test string) bool
+	anyEnabled := false
+
+	for _, l := range lines {
+		if !strings.Contains(l, "go test") {
+			continue
+		}
+
+		lineSlow := stepEnvSlow
+		if m := reInlineSlow.FindStringSubmatch(l); m != nil {
+			val := strings.Trim(m[1], `"'`)
+			if val == "1" {
+				lineSlow = true
+			} else {
+				lineSlow = false
+			}
+		}
+
+		if !lineSlow {
+			continue
+		}
+
+		sel := parseSingleSupportedCommand(l)
+		if sel != nil {
+			selectors = append(selectors, sel)
+			anyEnabled = true
+		}
+	}
+
+	if !anyEnabled || len(selectors) == 0 {
+		return nil, false
+	}
+
+	if len(selectors) == 1 {
+		return selectors[0], true
+	}
+
+	return func(pkg, test string) bool {
+		for _, s := range selectors {
+			if s(pkg, test) {
+				return true
+			}
+		}
+		return false
+	}, true
+}
+
+func parseSingleSupportedCommand(cmd string) func(pkg, test string) bool {
 	runPat := runPattern(cmd)
 
-	// Complementary selection 1: everything that is not an emitter package
 	if strings.Contains(cmd, "grep -v '/internal/codegen/'") || strings.Contains(cmd, `grep -v "/internal/codegen/"`) {
 		return func(pkg, test string) bool {
-			if strings.Contains(pkg, "/internal/codegen/") || pkg == "./internal/codegen" {
+			if pkg == "./internal/codegen" || strings.HasPrefix(pkg, "./internal/codegen/") {
 				return false
 			}
 			if runPat != "" && !matchesRun(runPat, test) {
@@ -408,7 +532,6 @@ func buildCISelector(cmd string) func(pkg, test string) bool {
 		}
 	}
 
-	// Complementary selection 2: emitter packages ./internal/codegen/...
 	if strings.Contains(cmd, "./internal/codegen/...") {
 		return func(pkg, test string) bool {
 			if pkg != "./internal/codegen" && !strings.HasPrefix(pkg, "./internal/codegen/") {
@@ -421,8 +544,7 @@ func buildCISelector(cmd string) func(pkg, test string) bool {
 		}
 	}
 
-	// Umbrella selection: go test ./...
-	if strings.Contains(cmd, "go test ./...") || strings.Contains(cmd, "go test \"./...\"") {
+	if strings.Contains(cmd, "go test ./...") || strings.Contains(cmd, `go test "./..."`) {
 		return func(pkg, test string) bool {
 			if runPat != "" && !matchesRun(runPat, test) {
 				return false
@@ -431,69 +553,67 @@ func buildCISelector(cmd string) func(pkg, test string) bool {
 		}
 	}
 
-	// Specific packages: parse tokens
+	fields := strings.Fields(cmd)
+	idx := -1
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] == "go" && fields[i+1] == "test" {
+			idx = i + 2
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+
 	var pkgs []string
-	for _, line := range strings.Split(cmd, "\n") {
-		if !strings.Contains(line, "go test") {
+	for i := idx; i < len(fields); i++ {
+		f := fields[i]
+		if f == "-run" && i+1 < len(fields) {
+			i++
 			continue
 		}
-		fields := strings.Fields(line)
-		isGoTest := false
-		for i := 0; i < len(fields); i++ {
-			f := fields[i]
-			if f == "go" && i+1 < len(fields) && fields[i+1] == "test" {
-				isGoTest = true
+		if strings.HasPrefix(f, "-run=") {
+			continue
+		}
+		if strings.HasPrefix(f, "-") {
+			if (f == "-timeout" || f == "-count" || f == "-tags") && i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "-") {
 				i++
-				continue
 			}
-			if !isGoTest {
-				continue
-			}
-			if strings.HasPrefix(f, "-") {
-				if f == "-run" && i+1 < len(fields) {
-					i++
-				}
-				continue
-			}
-			if strings.HasPrefix(f, "./") || (!strings.Contains(f, "=") && !strings.Contains(f, "$") && !strings.Contains(f, "|") && !strings.Contains(f, ";")) {
-				pkgs = append(pkgs, normalizePkg(f))
-			}
+			continue
 		}
+		pkgs = append(pkgs, normalizePkg(f))
 	}
 
-	if len(pkgs) > 0 {
-		return func(pkg, test string) bool {
-			matchedPkg := false
-			for _, p := range pkgs {
-				if p == "./..." {
-					matchedPkg = true
-					break
-				}
-				if strings.HasSuffix(p, "/...") {
-					base := strings.TrimSuffix(p, "/...")
-					if pkg == base || strings.HasPrefix(pkg, base+"/") {
-						matchedPkg = true
-						break
-					}
-				}
-				if p == pkg {
-					matchedPkg = true
-					break
-				}
-			}
-			if !matchedPkg {
-				return false
-			}
-			if runPat != "" && !matchesRun(runPat, test) {
-				return false
-			}
-			return true
-		}
+	if len(pkgs) == 0 {
+		pkgs = []string{"."}
 	}
 
-	// Unsupported or unresolved command: selects nothing
 	return func(pkg, test string) bool {
-		return false
+		matchedPkg := false
+		for _, p := range pkgs {
+			if p == "./..." {
+				matchedPkg = true
+				break
+			}
+			if strings.HasSuffix(p, "/...") {
+				base := strings.TrimSuffix(p, "/...")
+				if pkg == base || strings.HasPrefix(pkg, base+"/") {
+					matchedPkg = true
+					break
+				}
+			}
+			if p == pkg {
+				matchedPkg = true
+				break
+			}
+		}
+		if !matchedPkg {
+			return false
+		}
+		if runPat != "" && !matchesRun(runPat, test) {
+			return false
+		}
+		return true
 	}
 }
 
@@ -807,88 +927,50 @@ func makeGatedTest(pkg, name string) gatedTest {
 }
 
 // gateSkips extracts test names and packages that skipped at slowtest.Gate.
-// Supports both Go test JSON streams (from `go test -json`) and plain -v text logs.
+// Requires a Go test JSON stream (from `go test -json`).
 func gateSkips(path string) ([]gatedTest, error) {
-	b, err := os.ReadFile(path)
+	fh, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	lines := strings.Split(string(b), "\n")
-
-	isJSON := false
-	for _, l := range lines {
-		trimmed := strings.TrimSpace(l)
-		if strings.HasPrefix(trimmed, "{") && strings.Contains(trimmed, `"Action":`) {
-			isJSON = true
-			break
-		}
-	}
+	defer fh.Close()
 
 	var results []gatedTest
 	seen := map[string]bool{}
 
-	if isJSON {
-		for _, l := range lines {
-			trimmed := strings.TrimSpace(l)
-			if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
-				continue
+	sc := bufio.NewScanner(fh)
+	sc.Buffer(make([]byte, 10<<20), 10<<20)
+	lineNo := 0
+
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Action  string `json:"Action"`
+			Package string `json:"Package"`
+			Test    string `json:"Test"`
+			Output  string `json:"Output"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			return nil, fmt.Errorf("line %d: malformed JSON event: %w", lineNo, err)
+		}
+		if strings.Contains(ev.Output, gateSkipMarker) {
+			if strings.TrimSpace(ev.Package) == "" || strings.TrimSpace(ev.Test) == "" {
+				return nil, fmt.Errorf("line %d: gate skip record missing package or test identity", lineNo)
 			}
-			var ev struct {
-				Action  string `json:"Action"`
-				Package string `json:"Package"`
-				Test    string `json:"Test"`
-				Output  string `json:"Output"`
-			}
-			if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
-				continue
-			}
-			if strings.Contains(ev.Output, gateSkipMarker) {
-				pkg := ev.Package
-				testName := ev.Test
-				if testName == "" {
-					continue
-				}
-				if strings.Contains(testName, ".") && pkg == "" {
-					parts := strings.SplitN(testName, ".", 2)
-					pkg = parts[0]
-					testName = parts[1]
-				}
-				gt := makeGatedTest(pkg, testName)
-				key := gt.pkg + ":" + gt.name
-				if !seen[key] {
-					seen[key] = true
-					results = append(results, gt)
-				}
+			gt := makeGatedTest(ev.Package, ev.Test)
+			key := gt.pkg + ":" + gt.name
+			if !seen[key] {
+				seen[key] = true
+				results = append(results, gt)
 			}
 		}
-	} else {
-		runLine := regexp.MustCompile(`^=== RUN\s+(\S+)`)
-		pkgHeader := regexp.MustCompile(`^(?:ok|\?|FAIL)\s+(\S+)`)
-		curPkg := ""
-		curTest := ""
-		for _, line := range lines {
-			if m := pkgHeader.FindStringSubmatch(line); m != nil {
-				curPkg = m[1]
-			}
-			if m := runLine.FindStringSubmatch(line); m != nil {
-				curTest = m[1]
-			}
-			if strings.Contains(line, gateSkipMarker) && curTest != "" {
-				pkg := curPkg
-				testName := curTest
-				if strings.Contains(testName, ".") {
-					parts := strings.SplitN(testName, ".", 2)
-					pkg = parts[0]
-					testName = parts[1]
-				}
-				gt := makeGatedTest(pkg, testName)
-				key := gt.pkg + ":" + gt.name
-				if !seen[key] {
-					seen[key] = true
-					results = append(results, gt)
-				}
-			}
-		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
 	sort.Slice(results, func(i, j int) bool {

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -445,9 +445,8 @@ func isStepConditionEnabled(ifCond string) bool {
 	return false
 }
 
-var reInlineSlow = regexp.MustCompile(`(?:^|\s)SCHEMA_SLOW=([^\s]+)`)
-
 func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test string) bool, bool) {
+	// First check: any compound/unresolved shell feature across lines causes immediate refusal
 	for _, l := range lines {
 		if strings.Contains(l, "cd ") || strings.Contains(l, "cd\t") || strings.TrimSpace(l) == "cd" {
 			return nil, false
@@ -470,36 +469,24 @@ func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test strin
 		}
 	}
 
+	// Second check: EVERY active line must be an explicitly supported command form.
+	// Stella: "exact supported command grammar starting at command position, and refuse unsupported active lines for the whole block."
 	var selectors []func(pkg, test string) bool
-	anyEnabled := false
+	allSlow := true
 
 	for _, l := range lines {
-		if !strings.Contains(l, "go test") {
-			continue
+		sel, isSlow, ok := parseSupportedCommandLine(l, stepEnvSlow)
+		if !ok {
+			// Unsupported command on an active line (e.g. echo, unset, etc.): refuse whole block!
+			return nil, false
 		}
-
-		lineSlow := stepEnvSlow
-		if m := reInlineSlow.FindStringSubmatch(l); m != nil {
-			val := strings.Trim(m[1], `"'`)
-			if val == "1" {
-				lineSlow = true
-			} else {
-				lineSlow = false
-			}
+		if !isSlow {
+			allSlow = false
 		}
-
-		if !lineSlow {
-			continue
-		}
-
-		sel := parseSingleSupportedCommand(l)
-		if sel != nil {
-			selectors = append(selectors, sel)
-			anyEnabled = true
-		}
+		selectors = append(selectors, sel)
 	}
 
-	if !anyEnabled || len(selectors) == 0 {
+	if !allSlow || len(selectors) == 0 {
 		return nil, false
 	}
 
@@ -517,10 +504,52 @@ func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test strin
 	}, true
 }
 
-func parseSingleSupportedCommand(cmd string) func(pkg, test string) bool {
-	runPat := runPattern(cmd)
+func parseSupportedCommandLine(cmd string, stepEnvSlow bool) (func(pkg, test string) bool, bool, bool) {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return nil, false, false
+	}
 
+	idx := 0
+	lineSlow := stepEnvSlow
+
+	// Optional leading 'env'
+	if fields[idx] == "env" {
+		idx++
+		if idx >= len(fields) {
+			return nil, false, false
+		}
+	}
+
+	// Optional leading env assignments like SCHEMA_SLOW=1 or SCHEMA_SLOW=10
+	for idx < len(fields) && strings.Contains(fields[idx], "=") {
+		pair := strings.SplitN(fields[idx], "=", 2)
+		if pair[0] == "SCHEMA_SLOW" {
+			val := strings.Trim(pair[1], `"'`)
+			if val == "1" {
+				lineSlow = true
+			} else {
+				lineSlow = false
+			}
+		}
+		idx++
+	}
+
+	// At command position, we MUST have "go" followed by "test"
+	if idx+1 >= len(fields) || fields[idx] != "go" || fields[idx+1] != "test" {
+		// Not a go test command at command position (e.g. echo, unset, etc.)
+		return nil, false, false
+	}
+	idx += 2 // skip "go", "test"
+
+	restCmd := strings.Join(fields[idx:], " ")
+
+	// Form 1: Full-CI complement
 	if strings.Contains(cmd, "grep -v '/internal/codegen/'") || strings.Contains(cmd, `grep -v "/internal/codegen/"`) {
+		if !strings.Contains(cmd, "$(go list ./... | grep -v '/internal/codegen/')") && !strings.Contains(cmd, `$(go list ./... | grep -v "/internal/codegen/")`) {
+			return nil, false, false
+		}
+		runPat := runPattern(cmd)
 		return func(pkg, test string) bool {
 			if pkg == "./internal/codegen" || strings.HasPrefix(pkg, "./internal/codegen/") {
 				return false
@@ -529,10 +558,12 @@ func parseSingleSupportedCommand(cmd string) func(pkg, test string) bool {
 				return false
 			}
 			return true
-		}
+		}, lineSlow, true
 	}
 
-	if strings.Contains(cmd, "./internal/codegen/...") {
+	// Form 2: Full-CI codegen emitter packages
+	if strings.Contains(restCmd, "./internal/codegen/...") {
+		runPat := runPattern(cmd)
 		return func(pkg, test string) bool {
 			if pkg != "./internal/codegen" && !strings.HasPrefix(pkg, "./internal/codegen/") {
 				return false
@@ -541,38 +572,32 @@ func parseSingleSupportedCommand(cmd string) func(pkg, test string) bool {
 				return false
 			}
 			return true
-		}
+		}, lineSlow, true
 	}
 
-	if strings.Contains(cmd, "go test ./...") || strings.Contains(cmd, `go test "./..."`) {
+	// Form 3: Umbrella selector ./...
+	if strings.Contains(restCmd, "./...") {
+		runPat := runPattern(cmd)
 		return func(pkg, test string) bool {
 			if runPat != "" && !matchesRun(runPat, test) {
 				return false
 			}
 			return true
-		}
+		}, lineSlow, true
 	}
 
-	fields := strings.Fields(cmd)
-	idx := -1
-	for i := 0; i < len(fields)-1; i++ {
-		if fields[i] == "go" && fields[i+1] == "test" {
-			idx = i + 2
-			break
-		}
-	}
-	if idx < 0 {
-		return nil
-	}
-
+	// Form 4: Simple direct package/-run command
 	var pkgs []string
+	runPat := ""
 	for i := idx; i < len(fields); i++ {
 		f := fields[i]
 		if f == "-run" && i+1 < len(fields) {
 			i++
+			runPat = strings.Trim(fields[i], `"'`)
 			continue
 		}
 		if strings.HasPrefix(f, "-run=") {
+			runPat = strings.Trim(strings.TrimPrefix(f, "-run="), `"'`)
 			continue
 		}
 		if strings.HasPrefix(f, "-") {
@@ -614,7 +639,7 @@ func parseSingleSupportedCommand(cmd string) func(pkg, test string) bool {
 			return false
 		}
 		return true
-	}
+	}, lineSlow, true
 }
 
 func coveredByCI(steps []ciStep, t gatedTest) string {

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -22,13 +22,14 @@
 //	                             it can ride every lane.
 //
 //	slowgatescan -coverage LOG   the accounting: LOG is a plain (no SCHEMA_SLOW)
-//	                             `go test -v ./...` transcript. Every test that
-//	                             skipped at slowtest.Gate in it must be selected
-//	                             by at least one recipe line that DOES set the
-//	                             variable — that is the "247 skips accounted for
-//	                             line by line, to zero or to the exception
-//	                             list" the issue asks for. Anything covered by
-//	                             no target fails by name.
+//	                             `go test` transcript (JSON or -v text). Every
+//	                             test that skipped at slowtest.Gate in it must
+//	                             be selected by at least one recipe line that
+//	                             DOES set the variable or an enabled CI step —
+//	                             that is the "247 skips accounted for line by line,
+//	                             to zero or to the exception list" the issue
+//	                             asks for. Anything covered by no target fails by
+//	                             name.
 //
 // The exception file is TSV: target<TAB>package<TAB>reason. A reason is not
 // optional: the point of the file is that a deliberate omission is written
@@ -37,6 +38,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -47,6 +49,22 @@ import (
 )
 
 const gateSkipMarker = "SCHEMA_SLOW: this test shells out"
+
+type gatedTest struct {
+	pkg  string // normalized to "./dir", e.g. "./compiler" or "./internal/codegen/gotable"
+	name string // test name, e.g. "TestRequiredGate" or "TestGoUnitViewCorpus"
+}
+
+func (t gatedTest) Display() string {
+	p := strings.TrimPrefix(t.pkg, "./")
+	if p == "" || p == "." {
+		return t.name
+	}
+	if strings.HasPrefix(t.name, p+".") {
+		return t.name
+	}
+	return p + "." + t.name
+}
 
 type recipe struct {
 	file     string
@@ -62,8 +80,17 @@ type exception struct {
 	target, pkg, reason string
 }
 
+type ciStep struct {
+	file     string
+	line     int
+	name     string
+	enabled  bool
+	selector func(pkg, test string) bool
+	desc     string
+}
+
 func main() {
-	coverage := flag.String("coverage", "", "a plain `go test -v ./...` transcript to account for, test by test")
+	coverage := flag.String("coverage", "", "a plain `go test -v ./...` or `go test -json ./...` transcript to account for, test by test")
 	root := flag.String("C", ".", "repository root")
 	flag.Parse()
 
@@ -85,11 +112,11 @@ func main() {
 	}
 
 	if *coverage != "" {
-		lanes, err := workflowLanes(*root)
+		steps, err := workflowSteps(*root)
 		if err != nil {
 			fail("scanning .github/workflows: %v", err)
 		}
-		os.Exit(runCoverage(*root, *coverage, recipes, exceptions, lanes))
+		os.Exit(runCoverage(*root, *coverage, recipes, exceptions, steps))
 	}
 	os.Exit(runStatic(recipes, exceptions, gated))
 }
@@ -143,11 +170,12 @@ func runStatic(recipes []recipe, exceptions []exception, gated map[string]bool) 
 // placed in exactly one of three buckets, and the whole table is written to
 // build/slowgate/coverage.tsv so the accounting can be read, not believed.
 //
-//	make    a make target that sets the variable runs it — named in the table
-//	ci      no make target runs it; it runs ONLY on ci-full.yml's SCHEMA_SLOW=1
-//	        steps. Not silence: a named lane, counted here, listed in the file.
-//	NOBODY  nothing in the repo runs it. That is the failure.
-func runCoverage(root, logPath string, recipes []recipe, exceptions []exception, lanes []string) int {
+//	make       a make target that sets the variable runs it — named in the table
+//	exception  an entry in make/slow-gate-exceptions.txt names it
+//	ci         no make target runs it; it runs ONLY on ci-full.yml's SCHEMA_SLOW=1
+//	           steps. Not silence: a named lane, counted here, listed in the file.
+//	NOBODY     nothing in the repo runs it. That is the failure.
+func runCoverage(root, logPath string, recipes []recipe, exceptions []exception, steps []ciStep) int {
 	skipped, err := gateSkips(logPath)
 	if err != nil {
 		fail("reading %s: %v", logPath, err)
@@ -157,23 +185,26 @@ func runCoverage(root, logPath string, recipes []recipe, exceptions []exception,
 		return 1
 	}
 	byMake, byCI, var0 := 0, 0, 0
-	var uncovered []string
+	var uncovered []gatedTest
 	var rows []string
-	for _, name := range skipped {
-		switch {
-		case coveredBy(recipes, name) != "":
+	usedCILanes := map[string]bool{}
+
+	for _, t := range skipped {
+		tDisplay := t.Display()
+		if target := coveredBy(recipes, t); target != "" {
 			byMake++
-			rows = append(rows, fmt.Sprintf("make\t%s\t%s", name, coveredBy(recipes, name)))
-		case coveredByException(exceptions, name):
+			rows = append(rows, fmt.Sprintf("make\t%s\t%s", tDisplay, target))
+		} else if ok, _ := coveredByException(exceptions, t); ok {
 			byMake++
-			rows = append(rows, fmt.Sprintf("exception\t%s\tmake/slow-gate-exceptions.txt", name))
-		case len(lanes) > 0:
+			rows = append(rows, fmt.Sprintf("exception\t%s\tmake/slow-gate-exceptions.txt", tDisplay))
+		} else if lane := coveredByCI(steps, t); lane != "" {
 			byCI++
-			rows = append(rows, fmt.Sprintf("ci\t%s\t%s", name, strings.Join(lanes, ",")))
-		default:
+			usedCILanes[lane] = true
+			rows = append(rows, fmt.Sprintf("ci\t%s\t%s", tDisplay, lane))
+		} else {
 			var0++
-			uncovered = append(uncovered, name)
-			rows = append(rows, fmt.Sprintf("NOBODY\t%s\t-", name))
+			uncovered = append(uncovered, t)
+			rows = append(rows, fmt.Sprintf("NOBODY\t%s\t-", tDisplay))
 		}
 	}
 	out := filepath.Join(root, "build", "slowgate", "coverage.tsv")
@@ -183,80 +214,350 @@ func runCoverage(root, logPath string, recipes []recipe, exceptions []exception,
 	if len(uncovered) > 0 {
 		fmt.Printf("SLOW GATE COVERAGE FAILED: %d of %d tests that skip at slowtest.Gate under a plain `go test ./...` are run by NOTHING — no make target and no SCHEMA_SLOW=1 CI step (schema#988):\n", len(uncovered), len(skipped))
 		for _, n := range uncovered {
-			fmt.Printf("  %s\n", n)
+			fmt.Printf("  %s\n", n.Display())
 		}
 		fmt.Println("remedy: give it a positive gate target that goes through test/slowgate/proof, or name it in make/slow-gate-exceptions.txt with the reason.")
 		return 1
 	}
+	var laneNames []string
+	for l := range usedCILanes {
+		laneNames = append(laneNames, l)
+	}
+	sort.Strings(laneNames)
+	ciDesc := strings.Join(laneNames, ",")
+	if ciDesc == "" {
+		ciDesc = "none"
+	}
 	fmt.Printf("slow gate coverage: %d slowtest skips in %s accounted for — %d run by a make target that sets the variable, %d run only by %s, 0 run by nobody (table: build/slowgate/coverage.tsv)\n",
-		len(skipped), logPath, byMake, byCI, strings.Join(lanes, ","))
+		len(skipped), logPath, byMake, byCI, ciDesc)
 	return 0
 }
 
-// workflowLanes returns the workflow steps that run `go test` with SCHEMA_SLOW
-// set. A gated test that no make target runs is not "unchecked" if one of these
-// runs it — but it is not covered by `make` either, and the coverage table says
-// which, by name, rather than leaving the reader to guess.
-func workflowLanes(root string) ([]string, error) {
+// workflowSteps parses workflow files in .github/workflows/*.yml and extracts
+// steps that run `go test` with SCHEMA_SLOW enabled.
+func workflowSteps(root string) ([]ciStep, error) {
 	paths, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
 	if err != nil {
 		return nil, err
 	}
 	sort.Strings(paths)
-	var lanes []string
+	var steps []ciStep
 	for _, p := range paths {
 		b, err := os.ReadFile(p)
 		if err != nil {
 			return nil, err
 		}
 		rel, _ := filepath.Rel(root, p)
-		lines := strings.Split(string(b), "\n")
-		slowAt := -1
-		for i, l := range lines {
-			if strings.Contains(l, "SCHEMA_SLOW") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
-				slowAt = i
+		parsed, err := parseWorkflowContent(rel, string(b))
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", rel, err)
+		}
+		steps = append(steps, parsed...)
+	}
+	return steps, nil
+}
+
+func parseWorkflowContent(file, content string) ([]ciStep, error) {
+	lines := strings.Split(content, "\n")
+	var steps []ciStep
+
+	type rawStep struct {
+		startLine int
+		runLine   int
+		name      string
+		envLines  []string
+		runLines  []string
+	}
+
+	var rawSteps []rawStep
+	var cur *rawStep
+	inRun := false
+	inEnv := false
+	runIndent := 0
+	envIndent := 0
+
+	for idx, line := range lines {
+		lineNo := idx + 1
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "- ") {
+			if cur != nil {
+				rawSteps = append(rawSteps, *cur)
 			}
-			if slowAt >= 0 && i-slowAt <= 3 && strings.Contains(l, "go test") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
-				lanes = append(lanes, fmt.Sprintf("%s:%d", rel, i+1))
-				slowAt = -1
+			cur = &rawStep{startLine: lineNo, runLine: lineNo}
+			inRun = false
+			inEnv = false
+			lineAfterDash := strings.TrimSpace(trimmed[2:])
+			if strings.HasPrefix(lineAfterDash, "name:") {
+				cur.name = strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "name:"))
+			} else if strings.HasPrefix(lineAfterDash, "run:") {
+				cur.runLine = lineNo
+				runRest := strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "run:"))
+				if runRest != "" && runRest != "|" && runRest != ">" {
+					cur.runLines = append(cur.runLines, runRest)
+				}
+				inRun = true
+				runIndent = len(line) - len(strings.TrimLeft(line, " "))
+			}
+			continue
+		}
+
+		if cur == nil {
+			continue
+		}
+
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+
+		if strings.HasPrefix(trimmed, "name:") && !inRun && !inEnv {
+			cur.name = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "env:") {
+			inEnv = true
+			inRun = false
+			envIndent = indent
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "run:") {
+			inRun = true
+			inEnv = false
+			runIndent = indent
+			cur.runLine = lineNo
+			runRest := strings.TrimSpace(strings.TrimPrefix(trimmed, "run:"))
+			if runRest != "" && runRest != "|" && runRest != ">" {
+				cur.runLines = append(cur.runLines, runRest)
+			}
+			continue
+		}
+
+		if inEnv {
+			if indent > envIndent && strings.Contains(trimmed, ":") {
+				cur.envLines = append(cur.envLines, trimmed)
+			} else if trimmed != "" {
+				inEnv = false
+			}
+		}
+
+		if inRun {
+			if indent > runIndent {
+				cur.runLines = append(cur.runLines, trimmed)
+			} else if trimmed != "" {
+				inRun = false
 			}
 		}
 	}
-	return lanes, nil
+	if cur != nil {
+		rawSteps = append(rawSteps, *cur)
+	}
+
+	for _, rs := range rawSteps {
+		fullRun := strings.Join(rs.runLines, "\n")
+		if !strings.Contains(fullRun, "go test") {
+			continue
+		}
+
+		enabled := false
+		for _, el := range rs.envLines {
+			parts := strings.SplitN(el, ":", 2)
+			if len(parts) == 2 && strings.TrimSpace(parts[0]) == "SCHEMA_SLOW" {
+				val := strings.Trim(strings.TrimSpace(parts[1]), `"'`)
+				if val == "1" || strings.EqualFold(val, "true") {
+					enabled = true
+				} else if val == "0" || strings.EqualFold(val, "false") {
+					enabled = false
+				}
+			}
+		}
+		for _, rl := range rs.runLines {
+			if strings.Contains(rl, "SCHEMA_SLOW=1") {
+				enabled = true
+			} else if strings.Contains(rl, "SCHEMA_SLOW=0") {
+				enabled = false
+			}
+		}
+
+		selector := buildCISelector(fullRun)
+
+		steps = append(steps, ciStep{
+			file:     file,
+			line:     rs.runLine,
+			name:     rs.name,
+			enabled:  enabled,
+			selector: selector,
+			desc:     fmt.Sprintf("%s:%d", file, rs.runLine),
+		})
+	}
+	return steps, nil
+}
+
+func buildCISelector(cmd string) func(pkg, test string) bool {
+	runPat := runPattern(cmd)
+
+	// Complementary selection 1: everything that is not an emitter package
+	if strings.Contains(cmd, "grep -v '/internal/codegen/'") || strings.Contains(cmd, `grep -v "/internal/codegen/"`) {
+		return func(pkg, test string) bool {
+			if strings.Contains(pkg, "/internal/codegen/") || pkg == "./internal/codegen" {
+				return false
+			}
+			if runPat != "" && !matchesRun(runPat, test) {
+				return false
+			}
+			return true
+		}
+	}
+
+	// Complementary selection 2: emitter packages ./internal/codegen/...
+	if strings.Contains(cmd, "./internal/codegen/...") {
+		return func(pkg, test string) bool {
+			if pkg != "./internal/codegen" && !strings.HasPrefix(pkg, "./internal/codegen/") {
+				return false
+			}
+			if runPat != "" && !matchesRun(runPat, test) {
+				return false
+			}
+			return true
+		}
+	}
+
+	// Umbrella selection: go test ./...
+	if strings.Contains(cmd, "go test ./...") || strings.Contains(cmd, "go test \"./...\"") {
+		return func(pkg, test string) bool {
+			if runPat != "" && !matchesRun(runPat, test) {
+				return false
+			}
+			return true
+		}
+	}
+
+	// Specific packages: parse tokens
+	var pkgs []string
+	for _, line := range strings.Split(cmd, "\n") {
+		if !strings.Contains(line, "go test") {
+			continue
+		}
+		fields := strings.Fields(line)
+		isGoTest := false
+		for i := 0; i < len(fields); i++ {
+			f := fields[i]
+			if f == "go" && i+1 < len(fields) && fields[i+1] == "test" {
+				isGoTest = true
+				i++
+				continue
+			}
+			if !isGoTest {
+				continue
+			}
+			if strings.HasPrefix(f, "-") {
+				if f == "-run" && i+1 < len(fields) {
+					i++
+				}
+				continue
+			}
+			if strings.HasPrefix(f, "./") || (!strings.Contains(f, "=") && !strings.Contains(f, "$") && !strings.Contains(f, "|") && !strings.Contains(f, ";")) {
+				pkgs = append(pkgs, normalizePkg(f))
+			}
+		}
+	}
+
+	if len(pkgs) > 0 {
+		return func(pkg, test string) bool {
+			matchedPkg := false
+			for _, p := range pkgs {
+				if p == "./..." {
+					matchedPkg = true
+					break
+				}
+				if strings.HasSuffix(p, "/...") {
+					base := strings.TrimSuffix(p, "/...")
+					if pkg == base || strings.HasPrefix(pkg, base+"/") {
+						matchedPkg = true
+						break
+					}
+				}
+				if p == pkg {
+					matchedPkg = true
+					break
+				}
+			}
+			if !matchedPkg {
+				return false
+			}
+			if runPat != "" && !matchesRun(runPat, test) {
+				return false
+			}
+			return true
+		}
+	}
+
+	// Unsupported or unresolved command: selects nothing
+	return func(pkg, test string) bool {
+		return false
+	}
+}
+
+func coveredByCI(steps []ciStep, t gatedTest) string {
+	for _, s := range steps {
+		if !s.enabled {
+			continue
+		}
+		if s.selector != nil && s.selector(t.pkg, t.name) {
+			return s.desc
+		}
+	}
+	return ""
 }
 
 // coveredBy reports the first armed recipe whose package and -run pattern select
-// name, using Go's own -run semantics: the pattern is split on "/" and each
-// element is an unanchored regexp matched against the corresponding element of
-// the test's name.
-func coveredBy(recipes []recipe, name string) string {
+// t, using Go's own -run semantics.
+func coveredBy(recipes []recipe, t gatedTest) string {
 	for _, r := range recipes {
 		if !r.armed {
 			continue
 		}
-		if r.runPat == "" {
-			// No -run at all: the whole package runs.
-			return r.target
+		if !recipeMatchesPkg(r, t.pkg) {
+			continue
 		}
-		if matchesRun(r.runPat, name) {
+		if r.runPat == "" || matchesRun(r.runPat, t.name) {
 			return r.target
 		}
 	}
 	return ""
 }
 
-func coveredByException(exceptions []exception, name string) bool {
-	for _, e := range exceptions {
-		if e.pkg == "./..." || strings.HasPrefix(name, e.pkg) {
-			// A ./... exception is about the umbrella line, never about a test:
-			// it may not excuse a test nothing else runs.
-			continue
+func recipeMatchesPkg(r recipe, pkg string) bool {
+	for _, rp := range r.packages {
+		if rp == "./..." {
+			return true
 		}
-		if e.target == name || matchesRun(e.pkg, name) {
+		if strings.HasSuffix(rp, "/...") {
+			base := strings.TrimSuffix(rp, "/...")
+			if pkg == base || strings.HasPrefix(pkg, base+"/") {
+				return true
+			}
+		}
+		if normalizePkg(rp) == pkg {
 			return true
 		}
 	}
 	return false
+}
+
+func coveredByException(exceptions []exception, t gatedTest) (bool, string) {
+	for _, e := range exceptions {
+		if e.pkg == "./..." {
+			continue
+		}
+		ePkg := normalizePkg(e.pkg)
+		if ePkg != t.pkg {
+			continue
+		}
+		if e.target == t.name || matchesRun(e.target, t.name) {
+			return true, e.reason
+		}
+	}
+	return false, ""
 }
 
 func matchesRun(pattern, name string) bool {
@@ -291,11 +592,6 @@ func matchException(exceptions []exception, r recipe) int {
 	return -1
 }
 
-// gatedPackages returns the set of package directories (as "./dir" import
-// spellings, relative to root) whose tests reach internal/slowtest.Gate. Gate
-// takes a *testing.T, so a call site is always in the package under test —
-// including the ones inside a shared helper, which is why this is a grep over
-// the package's _test.go files and not a static call graph.
 func gatedPackages(root string) (map[string]bool, error) {
 	gated := map[string]bool{}
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -374,16 +670,12 @@ func scanOne(root, path string, gated map[string]bool) ([]recipe, error) {
 			}
 			continue
 		}
-		// One logical recipe line: join backslash continuations.
 		start := lineNo
 		cmd := line
 		for strings.HasSuffix(strings.TrimRight(cmd, " "), `\`) && sc.Scan() {
 			lineNo++
 			cmd = strings.TrimSuffix(strings.TrimRight(cmd, " "), `\`) + " " + sc.Text()
 		}
-		// A line that goes through the proof helper no longer SPELLS `go test` —
-		// the helper does — so it has to be recognised here or the armed half of
-		// the audit would be invisible to it.
 		if !strings.Contains(cmd, "go test") && !strings.Contains(cmd, "test/slowgate/proof") {
 			continue
 		}
@@ -405,9 +697,6 @@ func scanOne(root, path string, gated map[string]bool) ([]recipe, error) {
 	return out, sc.Err()
 }
 
-// packagesOf returns the gated package arguments a recipe's `go test` names.
-// "./..." counts: it walks every gated package there is. A `cd dir && go test .`
-// is resolved against dir, which is how the sibling-module legs spell it.
 func packagesOf(cmd string, gated map[string]bool) []string {
 	base := ""
 	if i := strings.Index(cmd, "cd "); i >= 0 && strings.Contains(cmd[i:], "&&") {
@@ -455,7 +744,6 @@ func runPattern(cmd string) string {
 	if m == nil {
 		return ""
 	}
-	// Make doubles a literal '$' as '$$' in a recipe.
 	return strings.ReplaceAll(m[1], "$$", "$")
 }
 
@@ -488,31 +776,128 @@ func readExceptions(path string) ([]exception, error) {
 	return out, nil
 }
 
-// gateSkips returns the test names that skipped at slowtest.Gate in a plain
-// `go test -v` transcript. The name comes from the `=== RUN` line that opened
-// the test, NOT from the `--- SKIP` line, because Go prints a parent's
-// `--- PASS` before its skipped subtests and a scan that reads only result
-// lines cannot tell a gate skip from a retirement.
-func gateSkips(path string) ([]string, error) {
+func normalizePkg(pkg string) string {
+	pkg = strings.TrimSpace(pkg)
+	if pkg == "" {
+		return ""
+	}
+	for _, mod := range []string{"github.com/mas-bandwidth/schema/v2/", "github.com/mas-bandwidth/schema/"} {
+		if strings.HasPrefix(pkg, mod) {
+			pkg = strings.TrimPrefix(pkg, mod)
+			break
+		}
+	}
+	pkg = strings.TrimPrefix(pkg, "./")
+	pkg = strings.TrimSuffix(pkg, "/")
+	if pkg == "" || pkg == "." {
+		return "."
+	}
+	return "./" + filepath.ToSlash(pkg)
+}
+
+func makeGatedTest(pkg, name string) gatedTest {
+	pkg = normalizePkg(pkg)
+	if pkg == "" {
+		pkg = "."
+	}
+	return gatedTest{
+		pkg:  pkg,
+		name: name,
+	}
+}
+
+// gateSkips extracts test names and packages that skipped at slowtest.Gate.
+// Supports both Go test JSON streams (from `go test -json`) and plain -v text logs.
+func gateSkips(path string) ([]gatedTest, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	runLine := regexp.MustCompile(`^=== RUN\s+(\S+)`)
-	cur := ""
-	seen := map[string]bool{}
-	var out []string
-	for _, line := range strings.Split(string(b), "\n") {
-		if m := runLine.FindStringSubmatch(line); m != nil {
-			cur = m[1]
-		}
-		if strings.Contains(line, gateSkipMarker) && cur != "" && !seen[cur] {
-			seen[cur] = true
-			out = append(out, cur)
+	lines := strings.Split(string(b), "\n")
+
+	isJSON := false
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "{") && strings.Contains(trimmed, `"Action":`) {
+			isJSON = true
+			break
 		}
 	}
-	sort.Strings(out)
-	return out, nil
+
+	var results []gatedTest
+	seen := map[string]bool{}
+
+	if isJSON {
+		for _, l := range lines {
+			trimmed := strings.TrimSpace(l)
+			if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
+				continue
+			}
+			var ev struct {
+				Action  string `json:"Action"`
+				Package string `json:"Package"`
+				Test    string `json:"Test"`
+				Output  string `json:"Output"`
+			}
+			if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+				continue
+			}
+			if strings.Contains(ev.Output, gateSkipMarker) {
+				pkg := ev.Package
+				testName := ev.Test
+				if testName == "" {
+					continue
+				}
+				if strings.Contains(testName, ".") && pkg == "" {
+					parts := strings.SplitN(testName, ".", 2)
+					pkg = parts[0]
+					testName = parts[1]
+				}
+				gt := makeGatedTest(pkg, testName)
+				key := gt.pkg + ":" + gt.name
+				if !seen[key] {
+					seen[key] = true
+					results = append(results, gt)
+				}
+			}
+		}
+	} else {
+		runLine := regexp.MustCompile(`^=== RUN\s+(\S+)`)
+		pkgHeader := regexp.MustCompile(`^(?:ok|\?|FAIL)\s+(\S+)`)
+		curPkg := ""
+		curTest := ""
+		for _, line := range lines {
+			if m := pkgHeader.FindStringSubmatch(line); m != nil {
+				curPkg = m[1]
+			}
+			if m := runLine.FindStringSubmatch(line); m != nil {
+				curTest = m[1]
+			}
+			if strings.Contains(line, gateSkipMarker) && curTest != "" {
+				pkg := curPkg
+				testName := curTest
+				if strings.Contains(testName, ".") {
+					parts := strings.SplitN(testName, ".", 2)
+					pkg = parts[0]
+					testName = parts[1]
+				}
+				gt := makeGatedTest(pkg, testName)
+				key := gt.pkg + ":" + gt.name
+				if !seen[key] {
+					seen[key] = true
+					results = append(results, gt)
+				}
+			}
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].pkg != results[j].pkg {
+			return results[i].pkg < results[j].pkg
+		}
+		return results[i].name < results[j].name
+	})
+	return results, nil
 }
 
 func fail(format string, a ...any) {

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -1,0 +1,521 @@
+// Command slowgatescan is the mechanical check behind schema#988 (G5).
+//
+// THE DEFECT IT EXISTS TO CATCH. internal/slowtest.Gate skips a test that
+// shells out to a foreign toolchain or reads the C++ reference corpus unless
+// SCHEMA_SLOW=1 or SCHEMA_REQUIRE_CORPUS is set, and a skipped test makes
+// `go test` exit 0. So a make target that runs a BARE `go test` on a package
+// holding gated tests GOES GREEN HAVING RUN NOTHING. Fourteen positive gate
+// targets did exactly that, for a day, while internal/slowtest's own package
+// comment claimed every make gate set the variable. A claim about the Makefile
+// belongs in a check, not in a comment.
+//
+// TWO MODES.
+//
+//	slowgatescan                 the static audit: every recipe line in
+//	                             Makefile, make/*.mk and make/checks/*.mk that
+//	                             runs `go test` on a package holding gated
+//	                             tests must set SCHEMA_SLOW=1, set
+//	                             SCHEMA_REQUIRE_CORPUS, or run through
+//	                             test/slowgate/proof. Anything else fails BY
+//	                             NAME unless make/slow-gate-exceptions.txt
+//	                             names it with a reason. Costs milliseconds, so
+//	                             it can ride every lane.
+//
+//	slowgatescan -coverage LOG   the accounting: LOG is a plain (no SCHEMA_SLOW)
+//	                             `go test -v ./...` transcript. Every test that
+//	                             skipped at slowtest.Gate in it must be selected
+//	                             by at least one recipe line that DOES set the
+//	                             variable — that is the "247 skips accounted for
+//	                             line by line, to zero or to the exception
+//	                             list" the issue asks for. Anything covered by
+//	                             no target fails by name.
+//
+// The exception file is TSV: target<TAB>package<TAB>reason. A reason is not
+// optional: the point of the file is that a deliberate omission is written
+// down where the next reader will find it, and silence never passes again.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const gateSkipMarker = "SCHEMA_SLOW: this test shells out"
+
+type recipe struct {
+	file     string
+	line     int
+	target   string
+	cmd      string
+	packages []string
+	armed    bool // sets SCHEMA_SLOW / SCHEMA_REQUIRE_CORPUS, or runs through test/slowgate/proof
+	runPat   string
+}
+
+type exception struct {
+	target, pkg, reason string
+}
+
+func main() {
+	coverage := flag.String("coverage", "", "a plain `go test -v ./...` transcript to account for, test by test")
+	root := flag.String("C", ".", "repository root")
+	flag.Parse()
+
+	gated, err := gatedPackages(*root)
+	if err != nil {
+		fail("reading the tree for slowtest.Gate call sites: %v", err)
+	}
+	if len(gated) == 0 {
+		fail("no package in this tree calls internal/slowtest.Gate — either the gate was deleted (say so, loudly) or this scan is looking in the wrong place")
+	}
+
+	recipes, err := scanMakefiles(*root, gated)
+	if err != nil {
+		fail("scanning the makefiles: %v", err)
+	}
+	exceptions, err := readExceptions(filepath.Join(*root, "make", "slow-gate-exceptions.txt"))
+	if err != nil {
+		fail("reading make/slow-gate-exceptions.txt: %v", err)
+	}
+
+	if *coverage != "" {
+		lanes, err := workflowLanes(*root)
+		if err != nil {
+			fail("scanning .github/workflows: %v", err)
+		}
+		os.Exit(runCoverage(*root, *coverage, recipes, exceptions, lanes))
+	}
+	os.Exit(runStatic(recipes, exceptions, gated))
+}
+
+func runStatic(recipes []recipe, exceptions []exception, gated map[string]bool) int {
+	var bare []recipe
+	usedException := map[int]bool{}
+	for _, r := range recipes {
+		if r.armed {
+			continue
+		}
+		if i := matchException(exceptions, r); i >= 0 {
+			usedException[i] = true
+			continue
+		}
+		bare = append(bare, r)
+	}
+	armed := 0
+	for _, r := range recipes {
+		if r.armed {
+			armed++
+		}
+	}
+	if len(bare) > 0 {
+		fmt.Printf("SLOW GATE SCAN FAILED: %d recipe line(s) run `go test` on a package holding slowtest-gated tests without SCHEMA_SLOW=1, SCHEMA_REQUIRE_CORPUS or test/slowgate/proof — each one goes green having run nothing (schema#988):\n", len(bare))
+		for _, r := range bare {
+			fmt.Printf("  %s:%d: %s: %s\n", r.file, r.line, r.target, strings.Join(r.packages, " "))
+		}
+		fmt.Println("remedy: run it through `sh test/slowgate/proof <label> '<required --- PASS names>' <go test args>`, or name it in make/slow-gate-exceptions.txt with the reason it is left to ci-full.yml.")
+		return 1
+	}
+	stale := 0
+	for i := range exceptions {
+		if !usedException[i] {
+			if stale == 0 {
+				fmt.Println("SLOW GATE SCAN FAILED: make/slow-gate-exceptions.txt excuses a recipe line that no longer exists — a stale excuse is how the next bare `go test` slips in behind it:")
+			}
+			stale++
+			fmt.Printf("  %s\t%s\t%s\n", exceptions[i].target, exceptions[i].pkg, exceptions[i].reason)
+		}
+	}
+	if stale > 0 {
+		return 1
+	}
+	fmt.Printf("slow gate scan: %d gated package(s), %d armed `go test` recipe line(s), %d written exception(s), 0 bare\n", len(gated), armed, len(exceptions))
+	return 0
+}
+
+// runCoverage is the LINE-BY-LINE ACCOUNTING the issue's completion gate 2 asks
+// for: every test that skips at slowtest.Gate under a plain `go test ./...` is
+// placed in exactly one of three buckets, and the whole table is written to
+// build/slowgate/coverage.tsv so the accounting can be read, not believed.
+//
+//	make    a make target that sets the variable runs it — named in the table
+//	ci      no make target runs it; it runs ONLY on ci-full.yml's SCHEMA_SLOW=1
+//	        steps. Not silence: a named lane, counted here, listed in the file.
+//	NOBODY  nothing in the repo runs it. That is the failure.
+func runCoverage(root, logPath string, recipes []recipe, exceptions []exception, lanes []string) int {
+	skipped, err := gateSkips(logPath)
+	if err != nil {
+		fail("reading %s: %v", logPath, err)
+	}
+	if len(skipped) == 0 {
+		fmt.Printf("slow gate coverage: %s holds no slowtest skip — either it was produced WITH SCHEMA_SLOW set (it must not be) or the gate is gone\n", logPath)
+		return 1
+	}
+	byMake, byCI, var0 := 0, 0, 0
+	var uncovered []string
+	var rows []string
+	for _, name := range skipped {
+		switch {
+		case coveredBy(recipes, name) != "":
+			byMake++
+			rows = append(rows, fmt.Sprintf("make\t%s\t%s", name, coveredBy(recipes, name)))
+		case coveredByException(exceptions, name):
+			byMake++
+			rows = append(rows, fmt.Sprintf("exception\t%s\tmake/slow-gate-exceptions.txt", name))
+		case len(lanes) > 0:
+			byCI++
+			rows = append(rows, fmt.Sprintf("ci\t%s\t%s", name, strings.Join(lanes, ",")))
+		default:
+			var0++
+			uncovered = append(uncovered, name)
+			rows = append(rows, fmt.Sprintf("NOBODY\t%s\t-", name))
+		}
+	}
+	out := filepath.Join(root, "build", "slowgate", "coverage.tsv")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err == nil {
+		_ = os.WriteFile(out, []byte("# bucket\ttest\trun by\n"+strings.Join(rows, "\n")+"\n"), 0o644)
+	}
+	if len(uncovered) > 0 {
+		fmt.Printf("SLOW GATE COVERAGE FAILED: %d of %d tests that skip at slowtest.Gate under a plain `go test ./...` are run by NOTHING — no make target and no SCHEMA_SLOW=1 CI step (schema#988):\n", len(uncovered), len(skipped))
+		for _, n := range uncovered {
+			fmt.Printf("  %s\n", n)
+		}
+		fmt.Println("remedy: give it a positive gate target that goes through test/slowgate/proof, or name it in make/slow-gate-exceptions.txt with the reason.")
+		return 1
+	}
+	fmt.Printf("slow gate coverage: %d slowtest skips in %s accounted for — %d run by a make target that sets the variable, %d run only by %s, 0 run by nobody (table: build/slowgate/coverage.tsv)\n",
+		len(skipped), logPath, byMake, byCI, strings.Join(lanes, ","))
+	return 0
+}
+
+// workflowLanes returns the workflow steps that run `go test` with SCHEMA_SLOW
+// set. A gated test that no make target runs is not "unchecked" if one of these
+// runs it — but it is not covered by `make` either, and the coverage table says
+// which, by name, rather than leaving the reader to guess.
+func workflowLanes(root string) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	var lanes []string
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		rel, _ := filepath.Rel(root, p)
+		lines := strings.Split(string(b), "\n")
+		slowAt := -1
+		for i, l := range lines {
+			if strings.Contains(l, "SCHEMA_SLOW") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+				slowAt = i
+			}
+			if slowAt >= 0 && i-slowAt <= 3 && strings.Contains(l, "go test") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+				lanes = append(lanes, fmt.Sprintf("%s:%d", rel, i+1))
+				slowAt = -1
+			}
+		}
+	}
+	return lanes, nil
+}
+
+// coveredBy reports the first armed recipe whose package and -run pattern select
+// name, using Go's own -run semantics: the pattern is split on "/" and each
+// element is an unanchored regexp matched against the corresponding element of
+// the test's name.
+func coveredBy(recipes []recipe, name string) string {
+	for _, r := range recipes {
+		if !r.armed {
+			continue
+		}
+		if r.runPat == "" {
+			// No -run at all: the whole package runs.
+			return r.target
+		}
+		if matchesRun(r.runPat, name) {
+			return r.target
+		}
+	}
+	return ""
+}
+
+func coveredByException(exceptions []exception, name string) bool {
+	for _, e := range exceptions {
+		if e.pkg == "./..." || strings.HasPrefix(name, e.pkg) {
+			// A ./... exception is about the umbrella line, never about a test:
+			// it may not excuse a test nothing else runs.
+			continue
+		}
+		if e.target == name || matchesRun(e.pkg, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesRun(pattern, name string) bool {
+	pelems := strings.Split(pattern, "/")
+	nelems := strings.Split(name, "/")
+	if len(pelems) > len(nelems) {
+		return false
+	}
+	for i, p := range pelems {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return false
+		}
+		if !re.MatchString(nelems[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchException(exceptions []exception, r recipe) int {
+	for i, e := range exceptions {
+		if e.target != r.target {
+			continue
+		}
+		for _, p := range r.packages {
+			if p == e.pkg {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// gatedPackages returns the set of package directories (as "./dir" import
+// spellings, relative to root) whose tests reach internal/slowtest.Gate. Gate
+// takes a *testing.T, so a call site is always in the package under test —
+// including the ones inside a shared helper, which is why this is a grep over
+// the package's _test.go files and not a static call graph.
+func gatedPackages(root string) (map[string]bool, error) {
+	gated := map[string]bool{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "build", "generated", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil || !strings.Contains(string(b), "slowtest.Gate(") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return nil
+		}
+		gated["./"+filepath.ToSlash(rel)] = true
+		return nil
+	})
+	return gated, err
+}
+
+var targetLine = regexp.MustCompile(`^([A-Za-z0-9_./$()%-][^:=]*):(?:[^=]|$)`)
+
+func scanMakefiles(root string, gated map[string]bool) ([]recipe, error) {
+	var files []string
+	files = append(files, filepath.Join(root, "Makefile"))
+	for _, pat := range []string{"make/*.mk", "make/checks/*.mk"} {
+		m, err := filepath.Glob(filepath.Join(root, pat))
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(m)
+		files = append(files, m...)
+	}
+	var out []recipe
+	for _, f := range files {
+		rs, err := scanOne(root, f, gated)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rs...)
+	}
+	return out, nil
+}
+
+func scanOne(root, path string, gated map[string]bool) ([]recipe, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+	rel, _ := filepath.Rel(root, path)
+	var out []recipe
+	target := "(no target)"
+	sc := bufio.NewScanner(fh)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+		if !strings.HasPrefix(line, "\t") {
+			if m := targetLine.FindStringSubmatch(line); m != nil && !strings.HasPrefix(line, "#") {
+				names := strings.Fields(m[1])
+				if len(names) > 0 {
+					target = names[0]
+				}
+			}
+			continue
+		}
+		// One logical recipe line: join backslash continuations.
+		start := lineNo
+		cmd := line
+		for strings.HasSuffix(strings.TrimRight(cmd, " "), `\`) && sc.Scan() {
+			lineNo++
+			cmd = strings.TrimSuffix(strings.TrimRight(cmd, " "), `\`) + " " + sc.Text()
+		}
+		// A line that goes through the proof helper no longer SPELLS `go test` —
+		// the helper does — so it has to be recognised here or the armed half of
+		// the audit would be invisible to it.
+		if !strings.Contains(cmd, "go test") && !strings.Contains(cmd, "test/slowgate/proof") {
+			continue
+		}
+		if strings.Contains(cmd, "#") && strings.HasPrefix(strings.TrimSpace(cmd), "#") {
+			continue
+		}
+		pkgs := packagesOf(cmd, gated)
+		if len(pkgs) == 0 {
+			continue
+		}
+		armed := strings.Contains(cmd, "SCHEMA_SLOW=1") ||
+			strings.Contains(cmd, "SCHEMA_REQUIRE_CORPUS") ||
+			strings.Contains(cmd, "test/slowgate/proof")
+		out = append(out, recipe{
+			file: rel, line: start, target: target, cmd: cmd,
+			packages: pkgs, armed: armed, runPat: runPattern(cmd),
+		})
+	}
+	return out, sc.Err()
+}
+
+// packagesOf returns the gated package arguments a recipe's `go test` names.
+// "./..." counts: it walks every gated package there is. A `cd dir && go test .`
+// is resolved against dir, which is how the sibling-module legs spell it.
+func packagesOf(cmd string, gated map[string]bool) []string {
+	base := ""
+	if i := strings.Index(cmd, "cd "); i >= 0 && strings.Contains(cmd[i:], "&&") {
+		rest := strings.TrimSpace(cmd[i+3:])
+		if j := strings.IndexAny(rest, " \t"); j > 0 {
+			base = strings.Trim(rest[:j], "\"'")
+		}
+	}
+	var found []string
+	seen := map[string]bool{}
+	for _, tok := range strings.Fields(cmd) {
+		tok = strings.Trim(tok, "\"'")
+		spelled := ""
+		switch {
+		case tok == "./...":
+			spelled = "./..."
+		case tok == "." || tok == "./":
+			if base == "" {
+				continue
+			}
+			spelled = "./" + filepath.ToSlash(filepath.Clean(base))
+		case strings.HasPrefix(tok, "./"):
+			spelled = "./" + filepath.ToSlash(filepath.Clean(strings.TrimSuffix(tok, "/")))
+			if base != "" {
+				spelled = "./" + filepath.ToSlash(filepath.Clean(filepath.Join(base, tok)))
+			}
+		default:
+			continue
+		}
+		if spelled != "./..." && !gated[spelled] {
+			continue
+		}
+		if !seen[spelled] {
+			seen[spelled] = true
+			found = append(found, spelled)
+		}
+	}
+	return found
+}
+
+var runFlag = regexp.MustCompile(`-run[= ]+'?"?([^'"\s]+)'?"?`)
+
+func runPattern(cmd string) string {
+	m := runFlag.FindStringSubmatch(cmd)
+	if m == nil {
+		return ""
+	}
+	// Make doubles a literal '$' as '$$' in a recipe.
+	return strings.ReplaceAll(m[1], "$$", "$")
+}
+
+func readExceptions(path string) ([]exception, error) {
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var out []exception
+	for i, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimRight(line, " \t\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		var f []string
+		for _, p := range parts {
+			if strings.TrimSpace(p) != "" {
+				f = append(f, strings.TrimSpace(p))
+			}
+		}
+		if len(f) < 3 {
+			return nil, fmt.Errorf("line %d: want target<TAB>package<TAB>reason, got %q — a reason is not optional", i+1, line)
+		}
+		out = append(out, exception{target: f[0], pkg: f[1], reason: strings.Join(f[2:], " ")})
+	}
+	return out, nil
+}
+
+// gateSkips returns the test names that skipped at slowtest.Gate in a plain
+// `go test -v` transcript. The name comes from the `=== RUN` line that opened
+// the test, NOT from the `--- SKIP` line, because Go prints a parent's
+// `--- PASS` before its skipped subtests and a scan that reads only result
+// lines cannot tell a gate skip from a retirement.
+func gateSkips(path string) ([]string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	runLine := regexp.MustCompile(`^=== RUN\s+(\S+)`)
+	cur := ""
+	seen := map[string]bool{}
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if m := runLine.FindStringSubmatch(line); m != nil {
+			cur = m[1]
+		}
+		if strings.Contains(line, gateSkipMarker) && cur != "" && !seen[cur] {
+			seen[cur] = true
+			out = append(out, cur)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func fail(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "slowgatescan: "+format+"\n", a...)
+	os.Exit(2)
+}

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -22,7 +22,7 @@
 //	                             it can ride every lane.
 //
 //	slowgatescan -coverage LOG   the accounting: LOG is a plain (no SCHEMA_SLOW)
-//	                             `go test` transcript (JSON or -v text). Every
+//	                             `go test -json` transcript. Every
 //	                             test that skipped at slowtest.Gate in it must
 //	                             be selected by at least one recipe line that
 //	                             DOES set the variable or an enabled CI step —
@@ -259,6 +259,15 @@ func workflowSteps(root string) ([]ciStep, error) {
 }
 
 func parseWorkflowContent(file, content string) ([]ciStep, error) {
+	// These settings can affect package resolution or test execution outside the
+	// command itself. This scanner does not resolve inherited workflow/job state.
+	for _, line := range strings.Split(content, "\n") {
+		key, _, _ := strings.Cut(strings.TrimSpace(line), ":")
+		switch key {
+		case "working-directory", "GOFLAGS", "GOWORK", "GOOS", "GOARCH", "GOEXPERIMENT":
+			return nil, nil // no coverage credit from an unsupported workflow shape
+		}
+	}
 	lines := strings.Split(content, "\n")
 	var steps []ciStep
 
@@ -297,7 +306,7 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 			} else if strings.HasPrefix(lineAfterDash, "run:") {
 				cur.runLine = lineNo
 				runRest := strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "run:"))
-				if runRest != "" && runRest != "|" && runRest != ">" {
+				if runRest != "" && runRest != "|" {
 					cur.runLines = append(cur.runLines, runRest)
 				}
 				inRun = true
@@ -311,6 +320,15 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 		}
 
 		indent := len(line) - len(strings.TrimLeft(line, " "))
+		// End a block before interpreting a sibling property such as if: false.
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			if inEnv && indent <= envIndent {
+				inEnv = false
+			}
+			if inRun && indent <= runIndent {
+				inRun = false
+			}
+		}
 
 		if strings.HasPrefix(trimmed, "name:") && !inRun && !inEnv {
 			cur.name = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
@@ -335,7 +353,7 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 			runIndent = indent
 			cur.runLine = lineNo
 			runRest := strings.TrimSpace(strings.TrimPrefix(trimmed, "run:"))
-			if runRest != "" && runRest != "|" && runRest != ">" {
+			if runRest != "" && runRest != "|" {
 				cur.runLines = append(cur.runLines, runRest)
 			}
 			continue
@@ -445,58 +463,23 @@ func isStepConditionEnabled(ifCond string) bool {
 	return false
 }
 
+// CI coverage recognizes an intentionally small shell subset. Unsupported lines
+// refuse the whole step: ignoring one could miss a directory or environment change.
 func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test string) bool, bool) {
-	// First check: any compound/unresolved shell feature across lines causes immediate refusal
-	for _, l := range lines {
-		if strings.Contains(l, "cd ") || strings.Contains(l, "cd\t") || strings.TrimSpace(l) == "cd" {
-			return nil, false
-		}
-		if strings.Contains(l, "&&") || strings.Contains(l, "||") || strings.Contains(l, ";") || strings.Contains(l, "&") {
-			return nil, false
-		}
-		if strings.Contains(l, "|") {
-			if !strings.Contains(l, "grep -v '/internal/codegen/'") && !strings.Contains(l, `grep -v "/internal/codegen/"`) {
-				return nil, false
-			}
-		}
-		if strings.Contains(l, "$(") {
-			if !strings.Contains(l, "$(go list ./... | grep -v '/internal/codegen/')") && !strings.Contains(l, `$(go list ./... | grep -v "/internal/codegen/")`) {
-				return nil, false
-			}
-		}
-		if strings.Contains(l, "`") {
-			return nil, false
-		}
-	}
-
-	// Second check: EVERY active line must be an explicitly supported command form.
-	// Stella: "exact supported command grammar starting at command position, and refuse unsupported active lines for the whole block."
 	var selectors []func(pkg, test string) bool
-	allSlow := true
-
-	for _, l := range lines {
-		sel, isSlow, ok := parseSupportedCommandLine(l, stepEnvSlow)
-		if !ok {
-			// Unsupported command on an active line (e.g. echo, unset, etc.): refuse whole block!
+	for _, line := range lines {
+		selector, slow, ok := parseSupportedCommandLine(line, stepEnvSlow)
+		if !ok || !slow {
 			return nil, false
 		}
-		if !isSlow {
-			allSlow = false
-		}
-		selectors = append(selectors, sel)
+		selectors = append(selectors, selector)
 	}
-
-	if !allSlow || len(selectors) == 0 {
+	if len(selectors) == 0 {
 		return nil, false
 	}
-
-	if len(selectors) == 1 {
-		return selectors[0], true
-	}
-
 	return func(pkg, test string) bool {
-		for _, s := range selectors {
-			if s(pkg, test) {
+		for _, selector := range selectors {
+			if selector(pkg, test) {
 				return true
 			}
 		}
@@ -504,142 +487,113 @@ func parseCIStepCommands(lines []string, stepEnvSlow bool) (func(pkg, test strin
 	}, true
 }
 
+var ciPackage = regexp.MustCompile(`^\./[A-Za-z0-9_./-]+$`)
+var ciBareRun = regexp.MustCompile(`^[A-Za-z0-9_./^-]+$`)
+
 func parseSupportedCommandLine(cmd string, stepEnvSlow bool) (func(pkg, test string) bool, bool, bool) {
+	cmd = strings.TrimSpace(cmd)
+	// Only this known assignment is supported. GOFLAGS and arbitrary assignments
+	// can change whether tests execute, so they must never be silently skipped.
+	if strings.HasPrefix(cmd, "env ") {
+		cmd = strings.TrimSpace(strings.TrimPrefix(cmd, "env "))
+	}
 	fields := strings.Fields(cmd)
 	if len(fields) == 0 {
 		return nil, false, false
 	}
-
-	idx := 0
-	lineSlow := stepEnvSlow
-
-	// Optional leading 'env'
-	if fields[idx] == "env" {
-		idx++
-		if idx >= len(fields) {
+	slow := stepEnvSlow
+	if strings.HasPrefix(fields[0], "SCHEMA_SLOW=") {
+		value := strings.TrimPrefix(fields[0], "SCHEMA_SLOW=")
+		switch value {
+		case "1", "'1'", `"1"`:
+			slow = true
+		default:
 			return nil, false, false
 		}
+		cmd = strings.TrimSpace(strings.TrimPrefix(cmd, fields[0]))
 	}
-
-	// Optional leading env assignments like SCHEMA_SLOW=1 or SCHEMA_SLOW=10
-	for idx < len(fields) && strings.Contains(fields[idx], "=") {
-		pair := strings.SplitN(fields[idx], "=", 2)
-		if pair[0] == "SCHEMA_SLOW" {
-			val := strings.Trim(pair[1], `"'`)
-			if val == "1" {
-				lineSlow = true
-			} else {
-				lineSlow = false
-			}
-		}
-		idx++
+	// This is the one supported substitution, compared as a complete command.
+	// Its package selection cannot be inferred from a substring in another argument.
+	if cmd == "go test $(go list ./... | grep -v '/internal/codegen/')" ||
+		cmd == `go test $(go list ./... | grep -v "/internal/codegen/")` {
+		return func(pkg, test string) bool {
+			return pkg != "./internal/codegen" && !strings.HasPrefix(pkg, "./internal/codegen/")
+		}, slow, true
 	}
-
-	// At command position, we MUST have "go" followed by "test"
-	if idx+1 >= len(fields) || fields[idx] != "go" || fields[idx+1] != "test" {
-		// Not a go test command at command position (e.g. echo, unset, etc.)
+	fields = strings.Fields(cmd)
+	if len(fields) < 3 || fields[0] != "go" || fields[1] != "test" {
 		return nil, false, false
 	}
-	idx += 2 // skip "go", "test"
-
-	restCmd := strings.Join(fields[idx:], " ")
-
-	// Form 1: Full-CI complement
-	if strings.Contains(cmd, "grep -v '/internal/codegen/'") || strings.Contains(cmd, `grep -v "/internal/codegen/"`) {
-		if !strings.Contains(cmd, "$(go list ./... | grep -v '/internal/codegen/')") && !strings.Contains(cmd, `$(go list ./... | grep -v "/internal/codegen/")`) {
-			return nil, false, false
-		}
-		runPat := runPattern(cmd)
-		return func(pkg, test string) bool {
-			if pkg == "./internal/codegen" || strings.HasPrefix(pkg, "./internal/codegen/") {
-				return false
+	var packages []string
+	run := ""
+	seenRun := false
+	for i := 2; i < len(fields); i++ {
+		field := fields[i]
+		switch {
+		case field == "-run" || strings.HasPrefix(field, "-run="):
+			if seenRun {
+				return nil, false, false
 			}
-			if runPat != "" && !matchesRun(runPat, test) {
-				return false
-			}
-			return true
-		}, lineSlow, true
-	}
-
-	// Form 2: Full-CI codegen emitter packages
-	if strings.Contains(restCmd, "./internal/codegen/...") {
-		runPat := runPattern(cmd)
-		return func(pkg, test string) bool {
-			if pkg != "./internal/codegen" && !strings.HasPrefix(pkg, "./internal/codegen/") {
-				return false
-			}
-			if runPat != "" && !matchesRun(runPat, test) {
-				return false
-			}
-			return true
-		}, lineSlow, true
-	}
-
-	// Form 3: Umbrella selector ./...
-	if strings.Contains(restCmd, "./...") {
-		runPat := runPattern(cmd)
-		return func(pkg, test string) bool {
-			if runPat != "" && !matchesRun(runPat, test) {
-				return false
-			}
-			return true
-		}, lineSlow, true
-	}
-
-	// Form 4: Simple direct package/-run command
-	var pkgs []string
-	runPat := ""
-	for i := idx; i < len(fields); i++ {
-		f := fields[i]
-		if f == "-run" && i+1 < len(fields) {
-			i++
-			runPat = strings.Trim(fields[i], `"'`)
-			continue
-		}
-		if strings.HasPrefix(f, "-run=") {
-			runPat = strings.Trim(strings.TrimPrefix(f, "-run="), `"'`)
-			continue
-		}
-		if strings.HasPrefix(f, "-") {
-			if (f == "-timeout" || f == "-count" || f == "-tags") && i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "-") {
+			seenRun = true
+			value := strings.TrimPrefix(field, "-run=")
+			if field == "-run" {
 				i++
+				if i == len(fields) {
+					return nil, false, false
+				}
+				value = fields[i]
 			}
-			continue
+			// Single quotes preserve regex metacharacters literally. Bare values are
+			// limited to words without shell expansion; other quoting is unsupported.
+			if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+				run = value[1 : len(value)-1]
+				if strings.ContainsRune(run, '\'') {
+					return nil, false, false
+				}
+			} else {
+				if !ciBareRun.MatchString(value) {
+					return nil, false, false
+				}
+				run = value
+			}
+			if _, err := regexp.Compile(run); err != nil {
+				return nil, false, false
+			}
+		case field == "-count=1", field == "-v", field == "-json":
+			// These options do not remove selected tests.
+		default:
+			// Unknown options, redirections, substitutions and command separators all
+			// fail this package grammar. In particular -list/-skip do not earn credit.
+			if field != "." && !ciPackage.MatchString(field) {
+				return nil, false, false
+			}
+			base := strings.TrimSuffix(field, "/...")
+			if strings.Contains(base, "..") || strings.Contains(base, "//") {
+				return nil, false, false
+			}
+			packages = append(packages, strings.TrimSuffix(field, "/"))
 		}
-		pkgs = append(pkgs, normalizePkg(f))
 	}
-
-	if len(pkgs) == 0 {
-		pkgs = []string{"."}
+	if len(packages) == 0 {
+		return nil, false, false
 	}
-
 	return func(pkg, test string) bool {
-		matchedPkg := false
-		for _, p := range pkgs {
-			if p == "./..." {
-				matchedPkg = true
-				break
+		if seenRun && !matchesRun(run, test) {
+			return false
+		}
+		for _, pattern := range packages {
+			if pattern == "./..." || pattern == pkg {
+				return true
 			}
-			if strings.HasSuffix(p, "/...") {
-				base := strings.TrimSuffix(p, "/...")
+			if strings.HasSuffix(pattern, "/...") {
+				base := strings.TrimSuffix(pattern, "/...")
 				if pkg == base || strings.HasPrefix(pkg, base+"/") {
-					matchedPkg = true
-					break
+					return true
 				}
 			}
-			if p == pkg {
-				matchedPkg = true
-				break
-			}
 		}
-		if !matchedPkg {
-			return false
-		}
-		if runPat != "" && !matchesRun(runPat, test) {
-			return false
-		}
-		return true
-	}, lineSlow, true
+		return false
+	}, slow, true
 }
 
 func coveredByCI(steps []ciStep, t gatedTest) string {

--- a/tools/slowgatescan/selection_test.go
+++ b/tools/slowgatescan/selection_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCIUnsupportedSelectionMustNotCredit(t *testing.T) {
+	for name, body := range map[string]string{
+		"if-after-env-is-disabled":              "env:\n          SCHEMA_SLOW: '1'\n        if: false\n        run: go test ./compiler",
+		"workflow-go-flags-change-execution":    "env:\n          SCHEMA_SLOW: '1'\n          GOFLAGS: '-list=.'\n        run: go test ./compiler",
+		"directory-changes-package":             "env:\n          SCHEMA_SLOW: '1'\n        working-directory: test\n        run: go test ./compiler",
+		"folded-block-is-not-separate-commands": "env:\n          SCHEMA_SLOW: '1'\n        run: >\n          go test ./compiler\n          go test ./unrelated",
+		"list-does-not-execute":                 "env:\n          SCHEMA_SLOW: '1'\n        run: go test ./compiler -list .",
+		"skip-excludes-required-test":           "env:\n          SCHEMA_SLOW: '1'\n        run: go test ./compiler -skip .",
+		"run-pattern-is-not-package-selector":   "env:\n          SCHEMA_SLOW: '1'\n        run: go test ./unrelated -run './...'",
+		"echo-is-not-execution":                 "env:\n          SCHEMA_SLOW: '1'\n        run: echo go test ./compiler",
+		"unset-disables-following-command":      "env:\n          SCHEMA_SLOW: '1'\n        run: |\n          unset SCHEMA_SLOW\n          go test ./compiler",
+		"true-is-not-one":                       "env:\n          SCHEMA_SLOW: 'true'\n        run: go test ./compiler",
+		"comment-is-not-command":                "run: |\n          # SCHEMA_SLOW=1 go test ./compiler\n          true",
+		"cd-changes-package":                    "env:\n          SCHEMA_SLOW: '1'\n        run: cd test && go test ./compiler",
+		"ten-is-not-one":                        "run: SCHEMA_SLOW=10 go test ./compiler",
+	} {
+		t.Run(name, func(t *testing.T) {
+			steps, err := parseWorkflowContent("ci.yml", "jobs:\n  test:\n    steps:\n      - name: witness\n        "+body+"\n")
+			if err != nil {
+				return
+			} // An unsupported shape may refuse explicitly.
+			if got := coveredByCI(steps, gatedTest{pkg: "./compiler", name: "TestRequiredGate"}); got != "" {
+				t.Fatalf("credited unsupported/disabled selection to %s", got)
+			}
+		})
+	}
+}
+
+func TestMalformedEventsAreNotSilentlyDropped(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "events.jsonl")
+	data := `{"Action":"output","Package":"github.com/mas-bandwidth/schema/compiler","Test":"TestA","Output":"SCHEMA_SLOW: this test shells out"}` + "\n" + `{"Action":"output","Package":"github.com/mas-bandwidth/schema/compiler","Test":"TestB","Output":"SCHEMA_SLOW: this test shells out"` + "\n"
+	if err := os.WriteFile(p, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := gateSkips(p); err == nil {
+		t.Fatalf("accepted malformed stream, keeping only %d of two gate events", len(got))
+	}
+}
+
+func TestCIExplicitCommandsSelectOnlyTheirPackagesAndTests(t *testing.T) {
+	for _, command := range []string{"go test ./compiler -run '^TestRequiredGate$'", "SCHEMA_SLOW=1 go test ./compiler -run '^TestRequiredGate$'", "env SCHEMA_SLOW=1 go test ./compiler -count=1 -run='^TestRequiredGate$'"} {
+		selector, slow, ok := parseSupportedCommandLine(command, true)
+		if !ok || !slow || !selector("./compiler", "TestRequiredGate") {
+			t.Fatalf("supported command refused: %s", command)
+		}
+		if selector("./unrelated", "TestRequiredGate") || selector("./compiler", "TestOther") {
+			t.Fatalf("selected outside command scope: %s", command)
+		}
+	}
+}


### PR DESCRIPTION
Gated tests previously disappeared behind successful skips, and coverage accounting could credit a disabled or unrelated CI command. Arm the required Make/CI selectors, require named positive execution proof, and account for every skipped package/test pair from strict Go JSON events.

This integrates #990 and Emma's coverage repairs with the current fixed-table-form branch, including #987 and #991. The final selector repair accepts a small explicit command/flag set. Comments, echo/unset, -list/-skip, unresolved shell forms, folded run blocks and unsupported workflow settings cannot earn coverage credit; no general shell interpreter is added. Ordinary go test package/-run commands and the two literal full-CI package groups remain supported.

Validation at 541e7b252f3b731fc2a7a6058e512ae8b14e3ad6:
- Focused scanner tests pass (0.235s after joining current base), including independent false-credit regressions and strict malformed-event rejection.
- Static scan: 2 gated packages, 21 armed recipes, 6 written exceptions, 0 bare.
- Executed full plain JSON transcript and accounting before the base join: 178 skips; 56 selected by Make, 122 by the two full-CI selectors, 0 unowned. The base join changes no scanner/source content; focused checks repeated after the join.

This proves static selection/accounting for the supported command forms, not that every platform/toolchain test has executed successfully. Windows/Linux full G5 and release/soak certification remain required on #988/#423. The historical skipped runtime tests keep their named relocation notes. No full-feature completion claim.

Supersedes #990 once reviewed and landed; preserve the original PR's review history. Exact-head independent review requested before merge.
