### PR TITLE
Verify fixed array element widening across all nine language ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ SCHEMAS_VERSIONING := test/tables/VOLD_array_bounded_grow.schema \
 	test/tables/VOLD_range_widen.schema \
 	test/tables/VOLD_bits_grow.schema \
 	test/tables/VOLD_fixed_I_grow.schema \
+	test/tables/VOLD_fixed_I_grow_element.schema \
 	test/tables/VOLD_optional_add.schema \
 	test/tables/VNEW_array_bounded_grow.schema \
 	test/tables/VNEW_array_fixed_grow.schema \
@@ -218,6 +219,7 @@ SCHEMAS_VERSIONING := test/tables/VOLD_array_bounded_grow.schema \
 	test/tables/VNEW_range_widen.schema \
 	test/tables/VNEW_bits_grow.schema \
 	test/tables/VNEW_fixed_I_grow.schema \
+	test/tables/VNEW_fixed_I_grow_element.schema \
 	test/tables/VNEW_optional_add.schema \
 	test/tables/VOLD_floor.schema \
 	test/tables/VMID_floor.schema \

--- a/internal/codegen/cstable/fixedversioning_test.go
+++ b/internal/codegen/cstable/fixedversioning_test.go
@@ -106,6 +106,21 @@ var csVersionRows = []csVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+            {
+                int[] wantRaw = { -1, -1, -1, -1 };
+                for (int k = 0; k < 4; ++k)
+                {
+                    if (back[0].Vals[k] != wantRaw[k])
+                    {
+                        bad += ProbeLog.Fail(@NAME@, "slot " + k + " did not land the raw scaled value exact: " + back[0].Vals[k]);
+                    }
+                }
+                if (back[0].Lead != 0xAAAAAAAAu || back[0].Trail != 0xBBBBBBBBu)
+                {
+                    bad += ProbeLog.Fail(@NAME@, "a neighbour moved: lead=" + back[0].Lead + " trail=" + back[0].Trail);
+                }
+            }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true},

--- a/internal/codegen/cstable/fixedversioning_test.go
+++ b/internal/codegen/cstable/fixedversioning_test.go
@@ -108,7 +108,7 @@ var csVersionRows = []csVersionRow{
 	{row: "fixed_I_grow", widens: true},
 	{row: "fixed_I_grow_element", widens: true, check: `
             {
-                int[] wantRaw = { -1, -1, -1, -1 };
+                int[] wantRaw = { -1, -128, 0, 112 };
                 for (int k = 0; k < 4; ++k)
                 {
                     if (back[0].Vals[k] != wantRaw[k])

--- a/internal/codegen/ctable/fixedversioning_test.go
+++ b/internal/codegen/ctable/fixedversioning_test.go
@@ -114,6 +114,17 @@ var cVersionRows = []cVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+    if ( n != 1 ) { printf( "the fixed_I_grow_element file carries one record, not %lld\n", (long long) n ); return 1; }
+    {
+        const int32_t want[4] = { -1, -2, -3, -4 };
+        int k;
+        for ( k = 0; k < 4; ++k )
+        {
+            if ( (int32_t) back[0].v[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].v[k] ); return 1; }
+        }
+        if ( back[0].lead != 0xAAAAAAAAu || back[0].trail != 0xBBBBBBBBu ) { printf( "the row moved a neighbour\n" ); return 1; }
+    }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/ctable/fixedversioning_test.go
+++ b/internal/codegen/ctable/fixedversioning_test.go
@@ -117,11 +117,11 @@ var cVersionRows = []cVersionRow{
 	{row: "fixed_I_grow_element", widens: true, check: `
     if ( n != 1 ) { printf( "the fixed_I_grow_element file carries one record, not %lld\n", (long long) n ); return 1; }
     {
-        const int32_t want[4] = { -1, -2, -3, -4 };
+        const int32_t want[4] = { -1, -128, 0, 112 };
         int k;
         for ( k = 0; k < 4; ++k )
         {
-            if ( (int32_t) back[0].v[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].v[k] ); return 1; }
+            if ( (int32_t) back[0].vals[k] != want[k] ) { printf( "slot %d widened wrong: %d\n", k, (int) back[0].vals[k] ); return 1; }
         }
         if ( back[0].lead != 0xAAAAAAAAu || back[0].trail != 0xBBBBBBBBu ) { printf( "the row moved a neighbour\n" ); return 1; }
     }`},

--- a/internal/codegen/darttable/fixedversioning_test.go
+++ b/internal/codegen/darttable/fixedversioning_test.go
@@ -96,6 +96,14 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  const want = <int>[-1, -1, -1, -1];
+  for (var i = 0; i < 4; i++) {
+    check(values[0].vals[i] == want[i],
+        'slot $i is not the raw scaled value the writer packed: ${values[0].vals[i]}');
+  }
+  check(values[0].lead == 0xAAAAAAAA && values[0].trail == 0xBBBBBBBB,
+      'fixed_I_grow_element moved a neighbour: ${values[0].lead} ${values[0].trail}');`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/darttable/fixedversioning_test.go
+++ b/internal/codegen/darttable/fixedversioning_test.go
@@ -97,7 +97,7 @@ var versionRows = []versionRow{
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
 	{row: "fixed_I_grow_element", widens: true, check: `
-  const want = <int>[-1, -1, -1, -1];
+  const want = <int>[-1, -128, 0, 112];
   for (var i = 0; i < 4; i++) {
     check(values[0].vals[i] == want[i],
         'slot $i is not the raw scaled value the writer packed: ${values[0].vals[i]}');

--- a/internal/codegen/elixirtable/fixedversioning_test.go
+++ b/internal/codegen/elixirtable/fixedversioning_test.go
@@ -103,6 +103,12 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  check(length(values) == 1, "the fixed_I_grow_element file carries one record, not #{length(values)}")
+  v = hd(values)
+  want = [-1, -128, 0, 112]
+  check(v.vals == want, "the RAW SCALED VALUE did not land per slot: #{inspect(v.vals)}")
+  leadtrail(v, want_lead, want_trail)`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/gotable/fixedversioning_test.go
+++ b/internal/codegen/gotable/fixedversioning_test.go
@@ -80,6 +80,19 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+	if n != 1 {
+		t.Fatalf("the fixed_I_grow_element file carries one record, not %d", n)
+	}
+	want := []int32{-1, -2, -3, -4}
+	for k := range want {
+		if int32(back[0].V[k]) != want[k] {
+			t.Fatalf("slot %d did not land its raw scaled value: %+v", k, back[0])
+		}
+	}
+	if back[0].Lead != 0xAAAAAAAA || back[0].Trail != 0xBBBBBBBB {
+		t.Fatalf("the element row moved a neighbour: %+v", back[0])
+	}`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/gotable/fixedversioning_test.go
+++ b/internal/codegen/gotable/fixedversioning_test.go
@@ -84,9 +84,9 @@ var versionRows = []versionRow{
 	if n != 1 {
 		t.Fatalf("the fixed_I_grow_element file carries one record, not %d", n)
 	}
-	want := []int32{-1, -2, -3, -4}
+	want := []int32{-1, -128, 0, 112}
 	for k := range want {
-		if int32(back[0].V[k]) != want[k] {
+		if int32(back[0].Vals[k]) != want[k] {
 			t.Fatalf("slot %d did not land its raw scaled value: %+v", k, back[0])
 		}
 	}

--- a/internal/codegen/javatable/fixedversioning_test.go
+++ b/internal/codegen/javatable/fixedversioning_test.go
@@ -81,6 +81,7 @@ var versioningRows = []versioningRow{
 	{name: "bytes_grow"},
 	{name: "constant_grow"},
 	{name: "fixed_I_grow", widen: true},
+	{name: "fixed_I_grow_element", widen: true},
 	{name: "float_widen", widen: true},
 	{name: "int_widen", widen: true},
 	{name: "optional_add"},

--- a/internal/codegen/jstable/fixedversioning_test.go
+++ b/internal/codegen/jstable/fixedversioning_test.go
@@ -106,6 +106,17 @@ var jsVersionRows = []jsVersionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+  // THE RAW SCALED VALUE, SLOT BY SLOT (SPEC §4.6: I is the raw value's width
+  // and F is held), and the two neighbours that bracket the array, exactly as
+  // the scalar row asserts one value and its bracket.
+  const want = [-1, -128, 112, 0];
+  for (let k = 0; k < want.length; k++) {
+    if (Number(back[0].Vals[k]) !== want[k]) { fail("slot " + k + " widened wrong: " + show(back[0])); }
+  }
+  if (back[0].Lead !== 0xAAAAAAAA || back[0].Trail !== 0xBBBBBBBB) {
+    fail("the row moved a neighbour: " + show(back[0]));
+  }`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/jstable/fixedversioning_test.go
+++ b/internal/codegen/jstable/fixedversioning_test.go
@@ -110,7 +110,7 @@ var jsVersionRows = []jsVersionRow{
   // THE RAW SCALED VALUE, SLOT BY SLOT (SPEC §4.6: I is the raw value's width
   // and F is held), and the two neighbours that bracket the array, exactly as
   // the scalar row asserts one value and its bracket.
-  const want = [-1, -128, 112, 0];
+  const want = [-1, -128, 0, 112];
   for (let k = 0; k < want.length; k++) {
     if (Number(back[0].Vals[k]) !== want[k]) { fail("slot " + k + " widened wrong: " + show(back[0])); }
   }

--- a/internal/codegen/rusttable/fixedversioning_test.go
+++ b/internal/codegen/rusttable/fixedversioning_test.go
@@ -139,6 +139,27 @@ var versionRows = []versionRow{
 	{row: "field_deprecate", sameHash: true},
 	{row: "field_undeprecate", sameHash: true},
 	{row: "fixed_I_grow", widens: true},
+	{row: "fixed_I_grow_element", widens: true, check: `
+    // ONE RECORD, FOUR SLOTS (§5.9 #33). The OLD writer's [4]fixed(12,4) holds
+    // the RAW SCALED VALUE per slot; the NEW reader's element is [4]fixed(28,4),
+    // whose storage is twice as wide, so every old element must land
+    // SIGN-EXTENDED and exact. The values are the ends of the old element's raw
+    // range and the one a zero-extension gets wrong.
+    let want: [i32; 4] = [-1, -128, 112, 0];
+    for k in 0..4 {
+        assert!(
+            values[0].v[k] == want[k],
+            "slot {k} widened wrong: {} and not {}", values[0].v[k], want[k]
+        );
+    }
+    assert!(
+        values[0].lead == 0xAAAA_AAAA && values[0].trail == 0xBBBB_BBBB,
+        "a neighbour moved: lead={:#x} trail={:#x}", values[0].lead, values[0].trail
+    );
+    assert!(
+        report.widened == 4,
+        "a widened [4]fixed element owes EXACTLY 4 widen entries, not {}", report.widened
+    );`},
 	{row: "flags_append"},
 	{row: "float_widen", widens: true},
 	{row: "int_widen", widens: true, check: `

--- a/internal/codegen/rusttable/fixedversioning_test.go
+++ b/internal/codegen/rusttable/fixedversioning_test.go
@@ -145,11 +145,11 @@ var versionRows = []versionRow{
     // whose storage is twice as wide, so every old element must land
     // SIGN-EXTENDED and exact. The values are the ends of the old element's raw
     // range and the one a zero-extension gets wrong.
-    let want: [i32; 4] = [-1, -128, 112, 0];
+    let want: [i32; 4] = [-1, -128, 0, 112];
     for k in 0..4 {
         assert!(
-            values[0].v[k] == want[k],
-            "slot {k} widened wrong: {} and not {}", values[0].v[k], want[k]
+            values[0].vals[k] == want[k],
+            "slot {k} widened wrong: {} and not {}", values[0].vals[k], want[k]
         );
     }
     assert!(

--- a/test/tables/VNEW_fixed_I_grow_element.schema
+++ b/test/tables/VNEW_fixed_I_grow_element.schema
@@ -11,6 +11,6 @@ package vnew_fixed_i_grow_element
 fixed table FixedIGrowElement
 {
     lead  uint32 = 1
-    v     [4]fixed(28, 4) | min = -8, max = 7
+    vals  [4]fixed(28, 4) | min = -8, max = 7
     trail uint32 = 2
 }

--- a/test/tables/VNEW_fixed_I_grow_element.schema
+++ b/test/tables/VNEW_fixed_I_grow_element.schema
@@ -1,0 +1,16 @@
+// VNEW_fixed_I_grow_element.schema — NEW: [4]fixed(28,4) — I grows, F EQUAL (the scale may not move)
+//
+// One of the fixed form's versioning rows (docs/FIXED-FORM-VERSIONING-TESTS.md).
+// The OLD and the NEW file of this pair differ by EXACTLY the row named above,
+// so a case in test/tables/versioning_numbers.cpp can say which change the read
+// answered for. `lead` and `trail` bracket the row's field: a mislaid size
+// moves a neighbour, and the equality check sees it.
+
+package vnew_fixed_i_grow_element
+
+fixed table FixedIGrowElement
+{
+    lead  uint32 = 1
+    v     [4]fixed(28, 4) | min = -8, max = 7
+    trail uint32 = 2
+}

--- a/test/tables/VOLD_fixed_I_grow_element.schema
+++ b/test/tables/VOLD_fixed_I_grow_element.schema
@@ -11,6 +11,6 @@ package vold_fixed_i_grow_element
 fixed table FixedIGrowElement
 {
     lead  uint32 = 1
-    v     [4]fixed(12, 4) | min = -8, max = 7
+    vals  [4]fixed(12, 4) | min = -8, max = 7
     trail uint32 = 2
 }

--- a/test/tables/VOLD_fixed_I_grow_element.schema
+++ b/test/tables/VOLD_fixed_I_grow_element.schema
@@ -1,0 +1,16 @@
+// VOLD_fixed_I_grow_element.schema — OLD: [4]fixed(12,4)
+//
+// One of the fixed form's versioning rows (docs/FIXED-FORM-VERSIONING-TESTS.md).
+// The OLD and the NEW file of this pair differ by EXACTLY the row named above,
+// so a case in test/tables/versioning_numbers.cpp can say which change the read
+// answered for. `lead` and `trail` bracket the row's field: a mislaid size
+// moves a neighbour, and the equality check sees it.
+
+package vold_fixed_i_grow_element
+
+fixed table FixedIGrowElement
+{
+    lead  uint32 = 1
+    v     [4]fixed(12, 4) | min = -8, max = 7
+    trail uint32 = 2
+}

--- a/test/tables/fixedform_dump.cpp
+++ b/test/tables/fixedform_dump.cpp
@@ -61,6 +61,8 @@
 #include "VNEW_bits_growTable.h"
 #include "VOLD_fixed_I_growTable.h"
 #include "VNEW_fixed_I_growTable.h"
+#include "VOLD_fixed_I_grow_elementTable.h"
+#include "VNEW_fixed_I_grow_elementTable.h"
 #include "VOLD_optional_addTable.h"
 #include "VNEW_optional_addTable.h"
 #include "VOLD_floorTable.h"
@@ -800,6 +802,14 @@ static bool versioning_numbers_files( const char * dir )
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].v, -1 ); MS( v[0].trail, 0xBBBBBBBBu ); );
     VROW( vnew_fixed_i_grow, FixedIGrow, "new_fixed_I_grow.bin",
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].v, 1000 ); MS( v[0].trail, 0xBBBBBBBBu ); );
+
+    // THE ARRAY-ELEMENT PORT, per slot: the OLD element's raw floor, -1 (the
+    // value a zero-extension gets wrong), zero, and its raw ceiling.
+    VROW( vold_fixed_i_grow_element, FixedIGrowElement, "old_fixed_I_grow_element.bin",
+          MS( v[0].lead, 0xAAAAAAAAu ); MSI( v[0].vals[0], -1, 0 ); MSI( v[0].vals[1], -128, 1 );
+          MSI( v[0].vals[2], 0, 2 ); MSI( v[0].vals[3], 112, 3 ); MS( v[0].trail, 0xBBBBBBBBu ); );
+    VROW( vnew_fixed_i_grow_element, FixedIGrowElement, "new_fixed_I_grow_element.bin",
+          MS( v[0].lead, 0xAAAAAAAAu ); MSI( v[0].vals[0], 1000, 0 ); MS( v[0].trail, 0xBBBBBBBBu ); );
 
     VROW( vold_optional_add, OptionalAdd, "old_optional_add.bin",
           MS( v[0].lead, 0xAAAAAAAAu ); MS( v[0].link.value, 777 ); MS( v[0].trail, 0xBBBBBBBBu ); );

--- a/test/tables/versioning_numbers.cpp
+++ b/test/tables/versioning_numbers.cpp
@@ -10,7 +10,7 @@
 //
 //   array_bounded_grow  array_fixed_grow  array_elem_widen  constant_grow
 //   string_grow  wstring_grow  bytes_grow  int_widen  uint_widen  float_widen
-//   range_widen  bits_grow  fixed_I_grow  optional_add
+//   range_widen  bits_grow  fixed_I_grow  fixed_I_grow_element  optional_add
 //   floor_at  floor_below  floor_raise_live
 //   hash_unknown  hash_known_bytes_differ  hash_identity  lineage_merge
 //
@@ -80,6 +80,8 @@
 #include "VNEW_bits_growTable.h"
 #include "VOLD_fixed_I_growTable.h"
 #include "VNEW_fixed_I_growTable.h"
+#include "VOLD_fixed_I_grow_elementTable.h"
+#include "VNEW_fixed_I_grow_elementTable.h"
 #include "VOLD_optional_addTable.h"
 #include "VNEW_optional_addTable.h"
 #include "VOLD_floorTable.h"
@@ -847,6 +849,56 @@ void fixed_I_grow_case()
 }
 
 // ---------------------------------------------------------------------------
+// 13b. fixed_I_grow_element — [4]fixed(12,4) -> [4]fixed(28,4). The ELEMENT's I
+//      GROWS, F IS EQUAL: the array-element port of the row above, so the scale
+//      may not move and the RAW SCALED VALUE is what must land exactly, PER SLOT.
+
+void fixed_I_grow_element_case()
+{
+    ROW_MOVES_THE_HASH( vold_fixed_i_grow_element::FixedIGrowElementFixedHash,
+                        vnew_fixed_i_grow_element::FixedIGrowElementFixedHash, "fixed_I_grow_element" );
+
+    vold_fixed_i_grow_element::FixedIGrowElement old;
+    vold_fixed_i_grow_element::FixedIGrowElementReset( old );
+    old.lead = 0xAAAAAAAAu;
+    old.vals[0] = -1;   // the one value a zero-extension gets wrong
+    old.vals[1] = -128; // the OLD element's raw floor
+    old.vals[2] = 0;
+    old.vals[3] = 112;  // the OLD element's raw ceiling
+    old.trail = 0xBBBBBBBBu;
+    std::vector<uint8_t> ob = one( old, vold_fixed_i_grow_element::FixedIGrowElementFixedMeasure,
+                                   vold_fixed_i_grow_element::FixedIGrowElementFixedSave,
+                                   "fixed_I_grow_element: OLD save" );
+    {
+        vnew_fixed_i_grow_element::FixedIGrowElement back;
+        vnew_fixed_i_grow_element::FixedIGrowElementReset( back );
+        vnew_fixed_i_grow_element::TableReport r;
+        std::vector<vnew_fixed_i_grow_element::TableFixedEntry> plan( 4096 );
+        check( vnew_fixed_i_grow_element::FixedIGrowElementFixedLoad( &back, 1, ob.data(), (int64_t) ob.size(),
+                                                                      plan.data(), 4096, NULL, &r ) == 1,
+               "fixed_I_grow_element/NEW-READS-OLD: one record" );
+        check( back.lead == 0xAAAAAAAAu && back.trail == 0xBBBBBBBBu,
+               "fixed_I_grow_element/NEW-READS-OLD: lead and trail bracket the row exactly" );
+        // The element's I widens with F held: the raw scaled value every older
+        // writer packed is the same number in a wider slot, so each slot lands
+        // exactly and the element WIDENED, not kind_mismatch.
+        check( back.vals[0] == -1 && back.vals[1] == -128 && back.vals[2] == 0 && back.vals[3] == 112,
+               "fixed_I_grow_element/NEW-READS-OLD: the RAW SCALED VALUE lands exactly, per slot (F equal)" );
+        check( r.kind_mismatch == 0,
+               "fixed_I_grow_element/NEW-READS-OLD: the element widened, not kind_mismatch" );
+        check( r.unknown == 0 && r.clamped == 0 && !r.malformed && !r.refused,
+               "fixed_I_grow_element/NEW-READS-OLD: nothing else fired" );
+    }
+    vnew_fixed_i_grow_element::FixedIGrowElement nv;
+    vnew_fixed_i_grow_element::FixedIGrowElementReset( nv );
+    nv.vals[0] = 1000; // a raw value fixed(12,4) has no room for
+    std::vector<uint8_t> nb = one( nv, vnew_fixed_i_grow_element::FixedIGrowElementFixedMeasure,
+                                   vnew_fixed_i_grow_element::FixedIGrowElementFixedSave,
+                                   "fixed_I_grow_element: NEW save" );
+    OLD_REFUSES_NEW( vold_fixed_i_grow_element, FixedIGrowElement, "fixed_I_grow_element", nb );
+}
+
+// ---------------------------------------------------------------------------
 // 14. optional_add — T -> ?T: every old value lands PRESENT
 
 void optional_add_case()
@@ -1194,6 +1246,7 @@ int versioning_numbers_cases()
     range_widen_hostile_case();
     bits_grow_case();
     fixed_I_grow_case();
+    fixed_I_grow_element_case();
     optional_add_case();
     floor_cases();
     hash_cases();


### PR DESCRIPTION
The fixed-array element widening case was missing from the shared corpus and language versioning rows. This brings the existing #984 implementation onto current `fixed-table-form` (babacdaa): `[4]fixed(12,4)` to `[4]fixed(28,4)`, preserving each raw scaled value and the neighboring fields, and refusing the newer layout in the older reader.

The change adds two fixture schemas, the C++ reference/corpus case, and a named row on all eight other ports. It preserves #984 author history and contains no runtime/emitter change. Source implementation1eca760f; independently reviewed integration88b8e151.

Validation on Studio/macOS at88b8e151:
- Fresh C++ corpus:68files, including both new fixtures. Built and ran `build/schema_test_fixedform`: versioning numbers0RED/0failures; exit0.
- Go,C,Rust,C#,Java,JavaScript,Dart,Elixir: ran only the named `fixed_I_grow_element` row with required corpus and toolchains enabled. All actually executed and passed. Java's single row checks both directions; other ports have separate direction subtests. JSON events retained locally; no skip credited.
- Raw values `[-1,-128,0,112]` and neighboring fields are checked directly by seven ports and through Java's paired reflection/value oracle; unknown-new-layout refusal assertions use existing harnesses.
- `git diff --check` passes.

This closes this one previously owed versioning row. It is not full Fixed Tables/platform certification; Windows/G5 and the other audit obligations remain open. CI is the remaining merge gate. Supersedes #984 through retained ancestry; no duplicate implementation.
