### PR TITLE
Keep nested Go modules out of the main-module CI package list

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -164,6 +164,14 @@ jobs:
           # package path `go test` takes, plus the codegen package of each
           # selected leg — a make include or a generated tree changing is a
           # reason to run that leg's harness even with no .go file in the diff.
+          #
+          # ONLY A PACKAGE OF THE MAIN MODULE, the set `./...` names. A
+          # generated tree (generated/go, generated/bench/go, test/go) is its
+          # own module, and a testdata/ directory is invisible to the go tool;
+          # a .go file there is the leg gate's business, and naming its
+          # directory here fails by name — #958 and #960, go-test-touched:
+          #   main module (github.com/mas-bandwidth/schema/v2) does not
+          #   contain package .../generated/go
           if [ "$broad" = yes ]; then
             packages="./..."
           else
@@ -171,6 +179,8 @@ jobs:
             for f in $files; do
               case "$f" in
                 *.go) d=$(dirname "$f"); [ -d "$d" ] || continue
+                      case "/$d/" in */testdata/*) continue ;; esac
+                      m=$d; while [ "$m" != . ]; do [ -f "$m/go.mod" ] && continue 2; m=$(dirname "$m"); done
                       case " $packages " in *" ./$d "*) ;; *) packages="$packages ./$d" ;; esac ;;
               esac
             done


### PR DESCRIPTION
A change to `test/go-tables/soak_test.go` makes the fast CI plan pass `./test/go-tables` to `go test` from the main module. The command fails during setup because that directory has its own go.mod. Generated modules and testdata directories have the same problem.

This brings the existing #983 repair onto current fixed-table-form (1e3d6729). The plan skips directories under testdata and directories inside a nested module when forming the main-module package list. Language selection remains intact; those paths still select their language gate. No test implementation or runtime changes.

Independent source-extracted selector control at13269b16: before the repair, the plan selects a nested module, its child directory, a generated module and testdata as main packages; afterward it retains only the ordinary root/internal packages. Existing d8317b83 implementation history is preserved. `git diff --check` passes.

Current reproducer: #995 CI34737894385, job103672890773, failed before tests with `main module ... does not contain package .../test/go-tables`. This repairs that plan error; it does not replace #995's direct controls or required one-hour soak. Supersedes #983 through retained ancestry. Exact-head CI is the remaining merge gate.
