### PR TITLE
Fix full CI lint and classify treelock deadlines

### DIFF
--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -201,3 +201,7 @@ paths test/elixir-fixedform/bench.exs 1 the Elixir leg's byte-for-byte check of 
 # the bench-shaped PATH trip a check, exactly as its two neighbours' do.
 timing test/bench/fixedform_wires.cpp 2 the third row's clock: form 3 beside the packet wire and form 1, over the committed corpus, one process, median of N beside min and max
 paths test/bench/fixedform_wires.cpp 1 the same file: its path names a benchmark because it IS one, and it lives beside the corpus it measures rather than in a runner directory
+
+# Generated-tree exclusion uses wall-clock deadlines, not schema measurements.
+timing tools/treelock/main.go 2 Bounded lock-owner diagnostic retry; no benchmark or schema-shape timing.
+timing tools/treelock/treelock_test.go 7 Bounded subprocess readiness/release and contention controls; no benchmark measurement.

--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -299,11 +299,12 @@ func parseWorkflowContent(file, content string) ([]ciStep, error) {
 			inRun = false
 			inEnv = false
 			lineAfterDash := strings.TrimSpace(trimmed[2:])
-			if strings.HasPrefix(lineAfterDash, "name:") {
+			switch {
+			case strings.HasPrefix(lineAfterDash, "name:"):
 				cur.name = strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "name:"))
-			} else if strings.HasPrefix(lineAfterDash, "if:") {
+			case strings.HasPrefix(lineAfterDash, "if:"):
 				cur.ifCond = strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "if:"))
-			} else if strings.HasPrefix(lineAfterDash, "run:") {
+			case strings.HasPrefix(lineAfterDash, "run:"):
 				cur.runLine = lineNo
 				runRest := strings.TrimSpace(strings.TrimPrefix(lineAfterDash, "run:"))
 				if runRest != "" && runRest != "|" {
@@ -750,7 +751,7 @@ func scanOne(root, path string, gated map[string]bool) ([]recipe, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer fh.Close()
+	defer func() { _ = fh.Close() }() // Read-only input; Scanner reports read errors.
 	rel, _ := filepath.Rel(root, path)
 	var out []recipe
 	target := "(no target)"
@@ -912,7 +913,7 @@ func gateSkips(path string) ([]gatedTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer fh.Close()
+	defer func() { _ = fh.Close() }() // Read-only input; Scanner reports read errors.
 
 	var results []gatedTest
 	seen := map[string]bool{}

--- a/tools/treelock/exit_test.go
+++ b/tools/treelock/exit_test.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestChildExitStatusAndLockRelease(t *testing.T) {
+	bin := buildTreelock(t)
+	for _, tc := range []struct {
+		name, command string
+		want          int
+	}{
+		{"success", "exit 0", 0},
+		{"nonzero", "exit 7", 7},
+		{"signal", "kill -TERM $$", 143},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lock := filepath.Join(t.TempDir(), "lock")
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, "-lock", lock, "sh", "-c", tc.command)
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("child command did not terminate: %v", ctx.Err())
+			}
+			if cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != tc.want {
+				t.Fatalf("want exit %d, state %v, error %v, output %s", tc.want, cmd.ProcessState, err, out)
+			}
+			// Every terminal path must leave the same lock usable by the next command.
+			next := exec.CommandContext(ctx, bin, "-lock", lock, "sh", "-c", "exit 0")
+			if out, err := next.CombinedOutput(); err != nil {
+				t.Fatalf("lock was not reusable after child exit: %v: %s", err, out)
+			}
+		})
+	}
+}

--- a/tools/treelock/lock_unix.go
+++ b/tools/treelock/lock_unix.go
@@ -14,7 +14,7 @@ func isAlive(pidStr string) bool {
 		return false
 	}
 	err = syscall.Kill(pid, 0)
-	return err == nil || err == syscall.EPERM
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 func acquireFlock(fd uintptr) error {

--- a/tools/treelock/main.go
+++ b/tools/treelock/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -58,6 +59,10 @@ func readOwnerPid(ownerFile, lockPath string) string {
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() (code int) {
 	var (
 		lockPath  = flag.String("lock", "", "path to lock file")
 		ownerFile = flag.String("owner-file", "", "path to owner file to inspect on contention")
@@ -67,13 +72,13 @@ func main() {
 
 	if *lockPath == "" {
 		fmt.Fprintf(os.Stderr, "usage: treelock -lock <lockfile> [-owner-file <ownerfile>] [-name <name>] <command> [args...]\n")
-		os.Exit(2)
+		return 2
 	}
 
 	cmdArgs := flag.Args()
 	if len(cmdArgs) == 0 {
 		fmt.Fprintf(os.Stderr, "treelock: no command specified\n")
-		os.Exit(2)
+		return 2
 	}
 
 	name := *lockName
@@ -84,28 +89,35 @@ func main() {
 	lockDir := filepath.Dir(*lockPath)
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "treelock: mkdir %s: %v\n", lockDir, err)
-		os.Exit(1)
+		return 1
 	}
 
 	f, err := os.OpenFile(*lockPath, os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "treelock: open %s: %v\n", *lockPath, err)
-		os.Exit(1)
+		return 1
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "treelock: close lock: %v\n", err)
+			if code == 0 {
+				code = 1
+			}
+		}
+	}()
 
 	if err := acquireFlock(f.Fd()); err != nil {
 		if isLockBlocked(err) {
 			ownerPid := readOwnerPid(*ownerFile, *lockPath)
 			fmt.Fprintf(os.Stderr, "REFUSED — another generated-tree verification (pid %s) holds %s; not touching either tree.\n", ownerPid, name)
-			os.Exit(1)
+			return 1
 		}
 		if strings.HasPrefix(err.Error(), "treelock:") {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 		} else {
 			fmt.Fprintf(os.Stderr, "treelock: flock %s: %v\n", *lockPath, err)
 		}
-		os.Exit(1)
+		return 1
 	}
 
 	// We now hold the exclusive kernel advisory lock.
@@ -130,7 +142,7 @@ func main() {
 
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "treelock: start %s: %v\n", cmdArgs[0], err)
-		os.Exit(1)
+		return 1
 	}
 
 	// Update lock file with child's PID as well.
@@ -152,16 +164,17 @@ func main() {
 	close(sigChan)
 
 	if waitErr != nil {
-		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				if status.Signaled() {
-					os.Exit(128 + int(status.Signal()))
+					return 128 + int(status.Signal())
 				}
-				os.Exit(status.ExitStatus())
+				return status.ExitStatus()
 			}
-			os.Exit(exitErr.ExitCode())
+			return exitErr.ExitCode()
 		}
-		os.Exit(1)
+		return 1
 	}
-	os.Exit(0)
+	return 0
 }


### PR DESCRIPTION
The full run on59ee185f fails seven Go lint findings and treats treelock deadline checks as unregistered benchmark timing. This fixes those concrete failures without removing checks.

Treelock now returns its child status through `run()` so the lock file's deferred close actually executes before main exits. Close failures are reported, existing failure statuses preserved, and wrapped process/permission errors use errors.As/Is. The workflow scanner retains its parsing behavior and explicitly closes read-only inputs. Two exact-count shape-ledger entries explain production and test deadlines; neither measures a schema shape.

Validation at4838d2e1: affected golangci-lint v2.12.2 packages report0issues; treelock tests1.286s and scanner tests0.843s pass; new process controls preserve child exit0/7/SIGTERM143 and reacquire the lock afterward; all9 generated-tree lifecycle controls pass; shape gate passes with46 ledger entries. `git diff --check` passes. Independent review and exact-head CI remain gates.

Failure evidence: full run34738697908, lint job103675129389, shape job103675129390. No claim of complete Fixed Tables certification; the hour soak and remaining shared-lock/platform work retain their own gates.
