### PR TITLE
Satisfy the pinned modernizer in gate and lock tools

### DIFF
--- a/tools/slowgatescan/main.go
+++ b/tools/slowgatescan/main.go
@@ -44,6 +44,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -261,7 +262,7 @@ func workflowSteps(root string) ([]ciStep, error) {
 func parseWorkflowContent(file, content string) ([]ciStep, error) {
 	// These settings can affect package resolution or test execution outside the
 	// command itself. This scanner does not resolve inherited workflow/job state.
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		key, _, _ := strings.Cut(strings.TrimSpace(line), ":")
 		switch key {
 		case "working-directory", "GOFLAGS", "GOWORK", "GOOS", "GOARCH", "GOEXPERIMENT":
@@ -495,16 +496,16 @@ func parseSupportedCommandLine(cmd string, stepEnvSlow bool) (func(pkg, test str
 	cmd = strings.TrimSpace(cmd)
 	// Only this known assignment is supported. GOFLAGS and arbitrary assignments
 	// can change whether tests execute, so they must never be silently skipped.
-	if strings.HasPrefix(cmd, "env ") {
-		cmd = strings.TrimSpace(strings.TrimPrefix(cmd, "env "))
+	if after, ok := strings.CutPrefix(cmd, "env "); ok {
+		cmd = strings.TrimSpace(after)
 	}
 	fields := strings.Fields(cmd)
 	if len(fields) == 0 {
 		return nil, false, false
 	}
 	slow := stepEnvSlow
-	if strings.HasPrefix(fields[0], "SCHEMA_SLOW=") {
-		value := strings.TrimPrefix(fields[0], "SCHEMA_SLOW=")
+	if after, ok := strings.CutPrefix(fields[0], "SCHEMA_SLOW="); ok {
+		value := after
 		switch value {
 		case "1", "'1'", `"1"`:
 			slow = true
@@ -586,8 +587,8 @@ func parseSupportedCommandLine(cmd string, stepEnvSlow bool) (func(pkg, test str
 			if pattern == "./..." || pattern == pkg {
 				return true
 			}
-			if strings.HasSuffix(pattern, "/...") {
-				base := strings.TrimSuffix(pattern, "/...")
+			if before, ok := strings.CutSuffix(pattern, "/..."); ok {
+				base := before
 				if pkg == base || strings.HasPrefix(pkg, base+"/") {
 					return true
 				}
@@ -631,8 +632,8 @@ func recipeMatchesPkg(r recipe, pkg string) bool {
 		if rp == "./..." {
 			return true
 		}
-		if strings.HasSuffix(rp, "/...") {
-			base := strings.TrimSuffix(rp, "/...")
+		if before, ok := strings.CutSuffix(rp, "/..."); ok {
+			base := before
 			if pkg == base || strings.HasPrefix(pkg, base+"/") {
 				return true
 			}
@@ -683,10 +684,8 @@ func matchException(exceptions []exception, r recipe) int {
 		if e.target != r.target {
 			continue
 		}
-		for _, p := range r.packages {
-			if p == e.pkg {
-				return i
-			}
+		if slices.Contains(r.packages, e.pkg) {
+			return i
 		}
 	}
 	return -1
@@ -807,7 +806,7 @@ func packagesOf(cmd string, gated map[string]bool) []string {
 	}
 	var found []string
 	seen := map[string]bool{}
-	for _, tok := range strings.Fields(cmd) {
+	for tok := range strings.FieldsSeq(cmd) {
 		tok = strings.Trim(tok, "\"'")
 		spelled := ""
 		switch {
@@ -882,8 +881,8 @@ func normalizePkg(pkg string) string {
 		return ""
 	}
 	for _, mod := range []string{"github.com/mas-bandwidth/schema/v2/", "github.com/mas-bandwidth/schema/"} {
-		if strings.HasPrefix(pkg, mod) {
-			pkg = strings.TrimPrefix(pkg, mod)
+		if after, ok := strings.CutPrefix(pkg, mod); ok {
+			pkg = after
 			break
 		}
 	}

--- a/tools/treelock/main.go
+++ b/tools/treelock/main.go
@@ -164,8 +164,7 @@ func run() (code int) {
 	close(sigChan)
 
 	if waitErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(waitErr, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				if status.Signaled() {
 					return 128 + int(status.Signal())


### PR DESCRIPTION
The post-merge full run34739599958 passes golangci-lint and the shape gate, then fails the next lint step: the pinned modernizer reports nine findings in the gate scanner and treelock. The previous lint failure had prevented that later step from running.

Apply modernize v0.23.0's suggested changes to those two files: errors.AsType, strings.CutPrefix/CutSuffix, SplitSeq/FieldsSeq and slices.Contains. Existing parsing and child exit behavior are preserved. No gate configuration changes.

Validation: the complete local lint sequence now passes—gofmt, go mod tidy -diff, internal/ci tests, repository-wide golangci-lint v2.12.2, repository-wide modernize v0.23.0, and bash -n bench/run.sh. Focused treelock/scanner/CI tests passed1.514s/0.418s/2.763s. The small two-file diff was reviewed locally; independent review and exact-head CI remain gates. Go module requires1.26; local execution used1.27.1, and hosted CI supplies the1.26 check.

Local lifecycle fixtures from the previous review contained deliberately synthetic .go bytes under build/, which recursive checks also discovered. Those owned fixtures were preserved outside the module before the clean full lint sequence; no source or gate was excluded.
