### PR TITLE
lockfile: validate recorded lineage layouts against §1.1 layout rules (#992)

### DIFF
--- a/internal/lockfile/emptyroot_test.go
+++ b/internal/lockfile/emptyroot_test.go
@@ -1,0 +1,67 @@
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func TestEmptyRootFirstLockDisposition(t *testing.T) {
+	for _, tc := range []struct {
+		declaration string
+		emitted     bool
+	}{{"fixed table", true}, {"table", false}} {
+		t.Run(tc.declaration, func(t *testing.T) {
+			dir, paths := fixture(t, pkg(tc.declaration+" Row\n{\n}\n"))
+			u := load(t, paths)
+			if got := ir.TableFixedEmitted(u, u.Tables["Row"]); got != tc.emitted {
+				t.Fatalf("fixture emission=%v, want %v", got, tc.emitted)
+			}
+			_, rewrote, err := lockfile.Update(u, paths)
+			if !tc.emitted {
+				if err != nil || !rewrote {
+					t.Fatalf("Form1-only empty table should remain supported: rewrote=%v err=%v", rewrote, err)
+				}
+				if errs := lockfile.Check(u, paths); len(errs) != 0 {
+					t.Fatalf("Form1-only lock: %v", errs)
+				}
+				return
+			}
+			if err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+				t.Fatalf("emitted zero root must refuse before first write: rewrote=%v err=%v", rewrote, err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, lockfile.FileName)); !os.IsNotExist(err) {
+				t.Fatalf("refusal created a lock: %v", err)
+			}
+		})
+	}
+}
+
+func TestRecordedEmittedEmptyRootCannotBypassValidation(t *testing.T) {
+	dir, paths := fixture(t, rowTable(""))
+	u := load(t, paths)
+	// Model an already recorded zero root with correct hashes and rollup.
+	before := []byte(lockfile.Render(u).Text())
+	file := filepath.Join(dir, lockfile.FileName)
+	if err := os.WriteFile(file, before, 0600); err != nil {
+		t.Fatal(err)
+	}
+	errs := lockfile.Check(u, paths)
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "layout_record_too_large") {
+		t.Fatalf("recorded emitted zero root must refuse: %v", errs)
+	}
+	if _, rewrote, err := lockfile.Update(u, paths); err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+		t.Fatalf("invalid recorded root must not be rewritten: rewrote=%v err=%v", rewrote, err)
+	}
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("refusal changed recorded bytes")
+	}
+}

--- a/internal/lockfile/file.go
+++ b/internal/lockfile/file.go
@@ -128,6 +128,16 @@ func Update(u *ir.Unit, paths []string) (path string, rewrote bool, err error) {
 	path = filepath.Join(dir, FileName)
 
 	live := Render(u)
+	// Validate newly rendered fixed roots before either a first write or an
+	// append. Comparing only the old lock cannot validate a newly added table.
+	for i := range live.Tables {
+		table := &live.Tables[i]
+		if table.Decl == DeclFixedTable && table.FixedEmitted {
+			if err := diffLineage(table, table, Current); err != nil {
+				return "", false, fmt.Errorf("%s: %w", path, err)
+			}
+		}
+	}
 	data, readErr := os.ReadFile(path)
 	switch {
 	case readErr == nil:

--- a/internal/lockfile/layout.go
+++ b/internal/lockfile/layout.go
@@ -19,16 +19,21 @@ type layoutEntry struct {
 	children uint32
 }
 
+type layoutFrame struct {
+	entry           layoutEntry
+	remainingKids   uint32
+	sum             uint64
+	widest          uint32
+	firstSize       uint32
+	secondSize      uint32
+	firstChildren   uint32
+	firstKind       uint8
+	kidsAreVariants bool
+}
+
 type layoutCheck struct {
 	bytes []byte
 	count int32
-	why   string
-}
-
-func (c *layoutCheck) fail(why string) {
-	if c.why == "" {
-		c.why = why
-	}
 }
 
 func (c *layoutCheck) entryAt(i int32) layoutEntry {
@@ -59,185 +64,175 @@ func ValidateLayout(bytes []byte) string {
 		return "layout_count_mismatch"
 	}
 	c := layoutCheck{bytes: bytes, count: int32(count)}
-	// Root requirements: kind 13, size <= 65536
+	// Root requirements: kind 13, 0 < size <= 65536
 	root := c.entryAt(0)
 	if root.kind != 13 {
 		return "layout_kind_invalid"
 	}
-	if root.size > layoutRecordMaxBytes {
+	if root.size == 0 || root.size > layoutRecordMaxBytes {
 		return "layout_record_too_large"
 	}
-	// Walk the pre-order tree
-	used := c.checkEntry(0, 0)
-	if c.why != "" {
-		return c.why
+
+	var stack []layoutFrame
+
+	for cursor := int32(0); cursor < c.count; cursor++ {
+		depth := int32(len(stack))
+		if depth > layoutMaxDepth {
+			return "layout_too_deep"
+		}
+		e := c.entryAt(cursor)
+		if !layoutKindKnown(e.kind) {
+			return "layout_kind_unknown"
+		}
+		if e.size > layoutRecordMaxBytes {
+			return "layout_record_too_large"
+		}
+
+		if e.children > 0 {
+			stack = append(stack, layoutFrame{
+				entry:           e,
+				remainingKids:   e.children,
+				kidsAreVariants: true,
+			})
+			continue
+		}
+
+		// e.children == 0: check post-children rules
+		if reason := checkPostChildren(e, 0, 0, 0, 0, 0, 0, true); reason != "" {
+			return reason
+		}
+
+		completed := e
+		for len(stack) > 0 {
+			parent := &stack[len(stack)-1]
+			k := parent.entry.children - parent.remainingKids
+			if k == 0 {
+				parent.firstSize = completed.size
+				parent.firstKind = completed.kind
+				parent.firstChildren = completed.children
+			}
+			if k == 1 {
+				parent.secondSize = completed.size
+			}
+			if completed.kind != 32 {
+				parent.kidsAreVariants = false
+			}
+			parent.sum += uint64(completed.size)
+			if completed.size > parent.widest {
+				parent.widest = completed.size
+			}
+			if parent.sum > uint64(layoutRecordMaxBytes) {
+				return "layout_record_too_large"
+			}
+
+			parent.remainingKids--
+			if parent.remainingKids > 0 {
+				break
+			}
+
+			if reason := checkPostChildren(parent.entry, parent.sum, parent.widest, parent.firstSize, parent.secondSize, parent.firstChildren, parent.firstKind, parent.kidsAreVariants); reason != "" {
+				return reason
+			}
+			completed = parent.entry
+			stack = stack[:len(stack)-1]
+		}
+
+		if len(stack) == 0 && cursor+1 < c.count {
+			return "layout_tree_unclosed"
+		}
 	}
-	// Rule 5: walk consumes exactly count entries
-	if used != c.count {
+
+	if len(stack) > 0 {
 		return "layout_tree_unclosed"
 	}
+
 	return ""
 }
 
-func (c *layoutCheck) checkEntry(i, depth int32) int32 {
-	if c.why != "" {
-		return 0
-	}
-	if i < 0 || i >= c.count {
-		c.fail("layout_tree_unclosed")
-		return 0
-	}
-	if depth > layoutMaxDepth {
-		c.fail("layout_too_deep")
-		return 0
-	}
-	e := c.entryAt(i)
-	if !layoutKindKnown(e.kind) {
-		c.fail("layout_kind_unknown")
-		return 0
-	}
-	if e.size > layoutRecordMaxBytes {
-		c.fail("layout_record_too_large")
-		return 0
-	}
-
-	at := i + 1
-	var sum uint64
-	var widest, firstSize, secondSize, firstChildren uint32
-	var firstKind uint8
-	kidsAreVariants := true
-	for k := uint32(0); k < e.children; k++ {
-		child := at
-		used := c.checkEntry(child, depth+1)
-		if c.why != "" {
-			return 0
-		}
-		ce := c.entryAt(child)
-		if k == 0 {
-			firstSize, firstKind, firstChildren = ce.size, ce.kind, ce.children
-		}
-		if k == 1 {
-			secondSize = ce.size
-		}
-		if ce.kind != 32 {
-			kidsAreVariants = false
-		}
-		sum += uint64(ce.size)
-		if ce.size > widest {
-			widest = ce.size
-		}
-		if sum > uint64(layoutRecordMaxBytes) {
-			c.fail("layout_record_too_large")
-			return 0
-		}
-		at += used
-	}
-
+func checkPostChildren(e layoutEntry, sum uint64, widest, firstSize, secondSize, firstChildren uint32, firstKind uint8, kidsAreVariants bool) string {
 	admitted, leaf := layoutLeafSize(e.kind, e.size)
 	if !admitted {
-		c.fail("layout_size_mismatch")
-		return 0
+		return "layout_size_mismatch"
 	}
 	if leaf {
 		if e.children != 0 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
-		return at - i
+		return ""
 	}
 
 	switch e.kind {
 	case 13: // table: size is sum of fields
 		if uint64(e.size) != sum {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 35: // optional wrapper: 1 child, size == sum + 1
 		if e.children != 1 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if uint64(e.size) != sum+1 {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 14: // array: 1 child, element size != 0, bare or counted
 		if e.children != 1 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if firstSize == 0 {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 		bare := e.size%firstSize == 0
 		counted := e.size >= 4 && (e.size-4)%firstSize == 0
 		if !bare && !counted {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 16: // enum-keyed array: 2 children, first kind 30, element size != 0, slots >= variants
 		if e.children != 2 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if firstKind != 30 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if secondSize == 0 || e.size%secondSize != 0 {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 		if e.size/secondSize < firstChildren {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 15: // union: >= 1 child, size > widest, size - widest is ordinal width
 		if e.children == 0 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if e.size <= widest {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 		if !layoutOrdinalWidth(e.size - widest) {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 30: // enum: size is ordinal width, children are variants (kind 32)
 		if !layoutOrdinalWidth(e.size) {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 		if e.children != 0 && !kidsAreVariants {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 	case 12: // string(N): length + N bytes, size >= 4, no children
 		if e.children != 0 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if e.size < 4 {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	case 33: // wstring(N): length + 2N bytes, size >= 4 and size-4 even, no children
 		if e.children != 0 {
-			c.fail("layout_kind_invalid")
-			return 0
+			return "layout_kind_invalid"
 		}
 		if e.size < 4 || (e.size-4)%2 != 0 {
-			c.fail("layout_size_mismatch")
-			return 0
+			return "layout_size_mismatch"
 		}
 	default:
-		c.fail("layout_kind_unknown")
-		return 0
+		return "layout_kind_unknown"
 	}
-	return at - i
+	return ""
 }
 
 func layoutKindKnown(kind uint8) bool {

--- a/internal/lockfile/layout.go
+++ b/internal/lockfile/layout.go
@@ -1,0 +1,295 @@
+package lockfile
+
+import (
+	"encoding/binary"
+)
+
+// The layout's wire format and bounds (docs/FIXED-FORM-ALGORITHM.md §1.1).
+const (
+	layoutHeaderBytes    = 4
+	layoutEntryBytes     = 17
+	layoutRecordMaxBytes = 65536
+	layoutMaxDepth       = 64
+)
+
+type layoutEntry struct {
+	id       uint64
+	kind     uint8
+	size     uint32
+	children uint32
+}
+
+type layoutCheck struct {
+	bytes []byte
+	count int32
+	why   string
+}
+
+func (c *layoutCheck) fail(why string) {
+	if c.why == "" {
+		c.why = why
+	}
+}
+
+func (c *layoutCheck) entryAt(i int32) layoutEntry {
+	if i < 0 || i >= c.count {
+		return layoutEntry{kind: 0xFF}
+	}
+	off := layoutHeaderBytes + int(i)*layoutEntryBytes
+	e := c.bytes[off : off+layoutEntryBytes]
+	return layoutEntry{
+		id:       binary.LittleEndian.Uint64(e[0:8]),
+		kind:     e[8],
+		size:     binary.LittleEndian.Uint32(e[9:13]),
+		children: binary.LittleEndian.Uint32(e[13:17]),
+	}
+}
+
+// ValidateLayout validates a layout's bytes against the seven §1.1 rules
+// of docs/FIXED-FORM-ALGORITHM.md. It returns the refusal reason by name,
+// or empty string if the layout is valid.
+func ValidateLayout(bytes []byte) string {
+	// Residue: fewer than 4-byte header or absent
+	if len(bytes) < layoutHeaderBytes {
+		return "layout_malformed"
+	}
+	// 1. Rule 1: count fits length exactly and count != 0
+	count := binary.LittleEndian.Uint32(bytes[0:4])
+	if count == 0 || int64(count)*int64(layoutEntryBytes)+int64(layoutHeaderBytes) != int64(len(bytes)) {
+		return "layout_count_mismatch"
+	}
+	c := layoutCheck{bytes: bytes, count: int32(count)}
+	// Root requirements: kind 13, size <= 65536
+	root := c.entryAt(0)
+	if root.kind != 13 {
+		return "layout_kind_invalid"
+	}
+	if root.size > layoutRecordMaxBytes {
+		return "layout_record_too_large"
+	}
+	// Walk the pre-order tree
+	used := c.checkEntry(0, 0)
+	if c.why != "" {
+		return c.why
+	}
+	// Rule 5: walk consumes exactly count entries
+	if used != c.count {
+		return "layout_tree_unclosed"
+	}
+	return ""
+}
+
+func (c *layoutCheck) checkEntry(i, depth int32) int32 {
+	if c.why != "" {
+		return 0
+	}
+	if i < 0 || i >= c.count {
+		c.fail("layout_tree_unclosed")
+		return 0
+	}
+	if depth > layoutMaxDepth {
+		c.fail("layout_too_deep")
+		return 0
+	}
+	e := c.entryAt(i)
+	if !layoutKindKnown(e.kind) {
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	if e.size > layoutRecordMaxBytes {
+		c.fail("layout_record_too_large")
+		return 0
+	}
+
+	at := i + 1
+	var sum uint64
+	var widest, firstSize, secondSize, firstChildren uint32
+	var firstKind uint8
+	kidsAreVariants := true
+	for k := uint32(0); k < e.children; k++ {
+		child := at
+		used := c.checkEntry(child, depth+1)
+		if c.why != "" {
+			return 0
+		}
+		ce := c.entryAt(child)
+		if k == 0 {
+			firstSize, firstKind, firstChildren = ce.size, ce.kind, ce.children
+		}
+		if k == 1 {
+			secondSize = ce.size
+		}
+		if ce.kind != 32 {
+			kidsAreVariants = false
+		}
+		sum += uint64(ce.size)
+		if ce.size > widest {
+			widest = ce.size
+		}
+		if sum > uint64(layoutRecordMaxBytes) {
+			c.fail("layout_record_too_large")
+			return 0
+		}
+		at += used
+	}
+
+	admitted, leaf := layoutLeafSize(e.kind, e.size)
+	if !admitted {
+		c.fail("layout_size_mismatch")
+		return 0
+	}
+	if leaf {
+		if e.children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		return at - i
+	}
+
+	switch e.kind {
+	case 13: // table: size is sum of fields
+		if uint64(e.size) != sum {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 35: // optional wrapper: 1 child, size == sum + 1
+		if e.children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if uint64(e.size) != sum+1 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 14: // array: 1 child, element size != 0, bare or counted
+		if e.children != 1 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstSize == 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		bare := e.size%firstSize == 0
+		counted := e.size >= 4 && (e.size-4)%firstSize == 0
+		if !bare && !counted {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 16: // enum-keyed array: 2 children, first kind 30, element size != 0, slots >= variants
+		if e.children != 2 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if firstKind != 30 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if secondSize == 0 || e.size%secondSize != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if e.size/secondSize < firstChildren {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 15: // union: >= 1 child, size > widest, size - widest is ordinal width
+		if e.children == 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.size <= widest {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if !layoutOrdinalWidth(e.size - widest) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 30: // enum: size is ordinal width, children are variants (kind 32)
+		if !layoutOrdinalWidth(e.size) {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+		if e.children != 0 && !kidsAreVariants {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+	case 12: // string(N): length + N bytes, size >= 4, no children
+		if e.children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.size < 4 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	case 33: // wstring(N): length + 2N bytes, size >= 4 and size-4 even, no children
+		if e.children != 0 {
+			c.fail("layout_kind_invalid")
+			return 0
+		}
+		if e.size < 4 || (e.size-4)%2 != 0 {
+			c.fail("layout_size_mismatch")
+			return 0
+		}
+	default:
+		c.fail("layout_kind_unknown")
+		return 0
+	}
+	return at - i
+}
+
+func layoutKindKnown(kind uint8) bool {
+	if kind >= 1 && kind <= 30 {
+		return true
+	}
+	return kind == 32 || kind == 33 || kind == 35
+}
+
+func layoutOrdinalWidth(n uint32) bool {
+	return n == 1 || n == 2 || n == 4 || n == 8
+}
+
+func layoutLeafSize(kind uint8, size uint32) (admitted, leaf bool) {
+	leaf = true
+	switch kind {
+	case 1, 2: // bool, i8
+		return size == 1, leaf
+	case 3: // i16
+		return size == 2, leaf
+	case 4: // i32
+		return size == 4, leaf
+	case 5: // i64
+		return size == 8, leaf
+	case 6: // u8, and bits( 1 .. 8 )
+		return size == 1 || size == 4, leaf
+	case 7: // u16, and bits( 9 .. 16 )
+		return size == 2 || size == 4, leaf
+	case 8: // u32, and bits( 17 .. 32 )
+		return size == 4, leaf
+	case 9: // u64, flags, and bits( 33 .. 64 )
+		return size == 8, leaf
+	case 10: // f32
+		return size == 4, leaf
+	case 11: // f64
+		return size == 8, leaf
+	case 17: // pointer index
+		return size == 4, leaf
+	case 18, 19: // i128, u128
+		return size == 16, leaf
+	case 20, 25: // fixed8, ufixed8
+		return size == 1, leaf
+	case 21, 26: // fixed16, ufixed16
+		return size == 2, leaf
+	case 22, 27: // fixed32, ufixed32
+		return size == 4, leaf
+	case 23, 28: // fixed64, ufixed64
+		return size == 8, leaf
+	case 24, 29: // fixed128, ufixed128
+		return size == 16, leaf
+	case 32: // variant, and payload-free arm
+		return size == 0, leaf
+	}
+	return true, false
+}

--- a/internal/lockfile/layout_test.go
+++ b/internal/lockfile/layout_test.go
@@ -77,6 +77,88 @@ func TestReviewerPublicCheckRejectsMalformedHistoricalLayout(t *testing.T) {
 	}
 }
 
+// TestReviewerRecordedRecordCannotDisableValidation verifies that a scalar
+// record= value above the 65536 ceiling in the lock does not disable layout
+// validation: an emitted fixed table must still have its recorded layout validated.
+func TestReviewerRecordedRecordCannotDisableValidation(t *testing.T) {
+	dir, paths := fixture(t, rowTable("    a int32\n    b int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(rowTable("    a int32\n    b int32\n    c int32")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	lk, ok, err := lockfile.Open(paths)
+	if err != nil || !ok {
+		t.Fatalf("open: %v %v", ok, err)
+	}
+	entries := lockfile.Lineage(lk, "Row")
+	if len(entries) != 2 {
+		t.Fatal("want two entries")
+	}
+
+	// Historical entry carries unknown kind 200 and untrusted record=65537
+	badLayout := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1),
+		makeLayoutEntry(2, 200, 4, 0),
+	)
+	wire := ir.TableFixedLayoutHash(badLayout, nil)
+	entries[0] = lockfile.LineageEntry{Wire: wire, Layout: badLayout, Record: 65537}
+
+	file := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	replaced := false
+	for i, line := range lines {
+		if !replaced && strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
+			lines[i] = fmt.Sprintf("    lineage wire=0x%016x record=65537 bytes=%x", wire, badLayout)
+			replaced = true
+		}
+	}
+	text := strings.Join(lines, "\n")
+	text = regexp.MustCompile(`lineage=0x[0-9a-f]+`).ReplaceAllString(text, fmt.Sprintf("lineage=0x%016x", lockfile.LineageHash(entries)))
+	if err := os.WriteFile(file, []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	errs := lockfile.Check(load(t, paths), paths)
+	if len(errs) == 0 {
+		t.Fatal("public Check accepted malformed historical layout when record=65537")
+	}
+	if !strings.Contains(errs[0].Error(), "layout_kind_unknown") {
+		t.Fatalf("error %q does not contain layout_kind_unknown", errs[0].Error())
+	}
+
+	_, rewrote, uerr := lockfile.Update(load(t, paths), paths)
+	if uerr == nil || rewrote {
+		t.Fatalf("Update accepted malformed layout: rewrote=%v err=%v", rewrote, uerr)
+	}
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != text {
+		t.Error("Update modified the file on refusal")
+	}
+}
+
+// TestReviewerRecordedRootMustBeNonzero verifies that a zero-size root table entry
+// violates §1.1 Rule 6 (0 < size <= 65536) and is refused under layout_record_too_large.
+func TestReviewerRecordedRootMustBeNonzero(t *testing.T) {
+	zeroRoot := makeLayoutBytes(makeLayoutEntry(1, 13, 0, 0))
+	if got := lockfile.ValidateLayout(zeroRoot); got != "layout_record_too_large" {
+		t.Fatalf("ValidateLayout(zeroRoot) = %q, want layout_record_too_large", got)
+	}
+	testMalformedLayoutAtBoundary(t, zeroRoot, "layout_record_too_large", true)
+	testMalformedLayoutAtBoundary(t, zeroRoot, "layout_record_too_large", false)
+}
+
 func testMalformedLayoutAtBoundary(t *testing.T, badLayout []byte, expectedReason string, targetHistorical bool) {
 	t.Helper()
 	dir, paths := fixture(t, rowTable("    a int32\n    b int32"))
@@ -304,10 +386,11 @@ func TestRecordedLayoutRule5TreeUnclosed(t *testing.T) {
 	testMalformedLayoutAtBoundary(t, badUnclosed, "layout_tree_unclosed", true)
 	testMalformedLayoutAtBoundary(t, badUnclosed, "layout_tree_unclosed", false)
 
-	// Table claims 0 children, but layout provides 2 entries (entry left over)
+	// Table claims 1 child, but layout provides 3 entries (entry left over)
 	badLeftover := makeLayoutBytes(
-		makeLayoutEntry(1, 13, 0, 0),
+		makeLayoutEntry(1, 13, 4, 1),
 		makeLayoutEntry(2, 4, 4, 0),
+		makeLayoutEntry(3, 4, 4, 0),
 	)
 	testMalformedLayoutAtBoundary(t, badLeftover, "layout_tree_unclosed", true)
 }

--- a/internal/lockfile/layout_test.go
+++ b/internal/lockfile/layout_test.go
@@ -1,0 +1,357 @@
+package lockfile_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func makeLayoutEntry(id uint64, kind uint8, size uint32, children uint32) []byte {
+	b := make([]byte, 17)
+	binary.LittleEndian.PutUint64(b[0:8], id)
+	b[8] = kind
+	binary.LittleEndian.PutUint32(b[9:13], size)
+	binary.LittleEndian.PutUint32(b[13:17], children)
+	return b
+}
+
+func makeLayoutBytes(entries ...[]byte) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b[0:4], uint32(len(entries)))
+	for _, e := range entries {
+		b = append(b, e...)
+	}
+	return b
+}
+
+// TestReviewerPublicCheckRejectsMalformedHistoricalLayout is the exact reviewer
+// witness test from Issue #992.
+func TestReviewerPublicCheckRejectsMalformedHistoricalLayout(t *testing.T) {
+	dir, paths := fixture(t, rowTable("    a int32\n    b int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(rowTable("    a int32\n    b int32\n    c int32")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	lk, ok, err := lockfile.Open(paths)
+	if err != nil || !ok {
+		t.Fatalf("open: %v %v", ok, err)
+	}
+	entries := lockfile.Lineage(lk, "Row")
+	if len(entries) != 2 {
+		t.Fatal("want two entries")
+	}
+	bad := []byte{0, 0, 0, 0}
+	entries[0] = lockfile.LineageEntry{Wire: ir.TableFixedLayoutHash(bad, nil), Layout: bad, Record: 0}
+	file := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	replaced := false
+	for i, line := range lines {
+		if !replaced && strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
+			lines[i] = fmt.Sprintf("    lineage wire=0x%016x record=0 bytes=00000000", entries[0].Wire)
+			replaced = true
+		}
+	}
+	text := strings.Join(lines, "\n")
+	text = regexp.MustCompile(`lineage=0x[0-9a-f]+`).ReplaceAllString(text, fmt.Sprintf("lineage=0x%016x", lockfile.LineageHash(entries)))
+	if err := os.WriteFile(file, []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) == 0 {
+		t.Fatal("public Check accepted a zero-count historical layout after its hash and rollup were recomputed")
+	}
+}
+
+func testMalformedLayoutAtBoundary(t *testing.T, badLayout []byte, expectedReason string, targetHistorical bool) {
+	t.Helper()
+	dir, paths := fixture(t, rowTable("    a int32\n    b int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(rowTable("    a int32\n    b int32\n    c int32")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	lk, ok, err := lockfile.Open(paths)
+	if err != nil || !ok {
+		t.Fatalf("open: %v %v", ok, err)
+	}
+	entries := lockfile.Lineage(lk, "Row")
+	if len(entries) != 2 {
+		t.Fatal("want two entries")
+	}
+
+	targetIdx := 0
+	if !targetHistorical {
+		targetIdx = 1
+	}
+
+	wire := ir.TableFixedLayoutHash(badLayout, nil)
+	entries[targetIdx] = lockfile.LineageEntry{Wire: wire, Layout: badLayout, Record: int64(len(badLayout))}
+
+	file := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	foundCount := 0
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
+			if foundCount == targetIdx {
+				lines[i] = fmt.Sprintf("    lineage wire=0x%016x record=%d bytes=%x", wire, len(badLayout), badLayout)
+				break
+			}
+			foundCount++
+		}
+	}
+	text := strings.Join(lines, "\n")
+	text = regexp.MustCompile(`lineage=0x[0-9a-f]+`).ReplaceAllString(text, fmt.Sprintf("lineage=0x%016x", lockfile.LineageHash(entries)))
+	if err := os.WriteFile(file, []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Check refuses
+	errs := lockfile.Check(load(t, paths), paths)
+	if len(errs) == 0 {
+		t.Fatalf("public Check accepted malformed layout (%s) after hash and rollup recomputed", expectedReason)
+	}
+	if !strings.Contains(errs[0].Error(), expectedReason) {
+		t.Errorf("error %q does not contain expected reason %q", errs[0].Error(), expectedReason)
+	}
+
+	// 2. Update refuses and does not overwrite disk
+	_, rewrote, uerr := lockfile.Update(load(t, paths), paths)
+	if uerr == nil || rewrote {
+		t.Fatalf("Update accepted malformed layout: rewrote=%v, err=%v", rewrote, uerr)
+	}
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != text {
+		t.Error("Update modified the lockfile on refusal")
+	}
+}
+
+// TestRecordedLayoutValidControl verifies that valid layouts pass Check and Update
+// when hashes and rollups are properly aligned.
+func TestRecordedLayoutValidControl(t *testing.T) {
+	dir, paths := fixture(t, rowTable("    a int32\n    b int32"))
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Lock.schema"), []byte(rowTable("    a int32\n    b int32\n    c int32")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+		t.Fatal(err)
+	}
+	lk, ok, err := lockfile.Open(paths)
+	if err != nil || !ok {
+		t.Fatalf("open: %v %v", ok, err)
+	}
+	entries := lockfile.Lineage(lk, "Row")
+	if len(entries) != 2 {
+		t.Fatal("want two entries")
+	}
+
+	// Construct an alternate valid 1-field layout for the historical entry (index 0)
+	validAlt := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1), // table, size 4, 1 field
+		makeLayoutEntry(2, 4, 4, 0),  // a int32, size 4, 0 kids
+	)
+	if reason := lockfile.ValidateLayout(validAlt); reason != "" {
+		t.Fatalf("validAlt failed ValidateLayout: %s", reason)
+	}
+
+	wire := ir.TableFixedLayoutHash(validAlt, nil)
+	entries[0] = lockfile.LineageEntry{Wire: wire, Layout: validAlt, Record: 4}
+
+	file := filepath.Join(dir, lockfile.FileName)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "lineage ") {
+			lines[i] = fmt.Sprintf("    lineage wire=0x%016x record=4 bytes=%x", wire, validAlt)
+			break
+		}
+	}
+	text := strings.Join(lines, "\n")
+	text = regexp.MustCompile(`lineage=0x[0-9a-f]+`).ReplaceAllString(text, fmt.Sprintf("lineage=0x%016x", lockfile.LineageHash(entries)))
+	if err := os.WriteFile(file, []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check must pass clean
+	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
+		t.Fatalf("Check failed on valid control: %v", errs)
+	}
+
+	// Update must succeed (idempotent)
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err != nil || rewrote {
+		t.Fatalf("Update failed on valid control: rewrote=%v err=%v", rewrote, err)
+	}
+}
+
+// TestRecordedLayoutRule1CountMismatch tests §1.1 Rule 1.
+func TestRecordedLayoutRule1CountMismatch(t *testing.T) {
+	// Zero count
+	badZero := []byte{0, 0, 0, 0}
+	testMalformedLayoutAtBoundary(t, badZero, "layout_count_mismatch", true)
+	testMalformedLayoutAtBoundary(t, badZero, "layout_count_mismatch", false)
+
+	// Count states 2 entries, but only 1 entry present (len 21 != 38)
+	badMismatch := append([]byte{2, 0, 0, 0}, makeLayoutEntry(1, 13, 4, 1)...)
+	testMalformedLayoutAtBoundary(t, badMismatch, "layout_count_mismatch", true)
+}
+
+// TestRecordedLayoutResidueMalformed tests residue shorter than 4-byte header.
+func TestRecordedLayoutResidueMalformed(t *testing.T) {
+	badResidue := []byte{1, 2, 3}
+	testMalformedLayoutAtBoundary(t, badResidue, "layout_malformed", true)
+}
+
+// TestRecordedLayoutRule2KindUnknown tests §1.1 Rule 2.
+func TestRecordedLayoutRule2KindUnknown(t *testing.T) {
+	// Kind 200 is outside closed kind set
+	badKind := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1),
+		makeLayoutEntry(2, 200, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badKind, "layout_kind_unknown", true)
+	testMalformedLayoutAtBoundary(t, badKind, "layout_kind_unknown", false)
+
+	// Kind 31 (§3 framing escape) is outside closed kind set
+	badEscape := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1),
+		makeLayoutEntry(2, 31, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badEscape, "layout_kind_unknown", true)
+
+	// Kind 34 (reserved float16) is outside closed kind set
+	badReserved := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1),
+		makeLayoutEntry(2, 34, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badReserved, "layout_kind_unknown", true)
+}
+
+// TestRecordedLayoutRule3SizeMismatch tests §1.1 Rule 3.
+func TestRecordedLayoutRule3SizeMismatch(t *testing.T) {
+	// Child kind 4 (int32) states size 5 (instead of 4)
+	badLeafSize := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 5, 1),
+		makeLayoutEntry(2, 4, 5, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badLeafSize, "layout_size_mismatch", true)
+	testMalformedLayoutAtBoundary(t, badLeafSize, "layout_size_mismatch", false)
+
+	// Table root states size 8, but sum of child sizes is 4
+	badSumSize := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 8, 1),
+		makeLayoutEntry(2, 4, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badSumSize, "layout_size_mismatch", true)
+}
+
+// TestRecordedLayoutRule4KindInvalid tests §1.1 Rule 4.
+func TestRecordedLayoutRule4KindInvalid(t *testing.T) {
+	// Root is kind 14 (array), not kind 13 (table)
+	badRoot := makeLayoutBytes(
+		makeLayoutEntry(1, 14, 4, 1),
+		makeLayoutEntry(2, 4, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badRoot, "layout_kind_invalid", true)
+	testMalformedLayoutAtBoundary(t, badRoot, "layout_kind_invalid", false)
+
+	// Leaf kind 4 (int32) claims 1 child (leaves must have children == 0)
+	badLeafKids := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 1),
+		makeLayoutEntry(2, 4, 4, 1),
+		makeLayoutEntry(3, 4, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badLeafKids, "layout_kind_invalid", true)
+}
+
+// TestRecordedLayoutRule5TreeUnclosed tests §1.1 Rule 5.
+func TestRecordedLayoutRule5TreeUnclosed(t *testing.T) {
+	// Table claims 2 children, but layout only provides 1 child
+	badUnclosed := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 4, 2),
+		makeLayoutEntry(2, 4, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badUnclosed, "layout_tree_unclosed", true)
+	testMalformedLayoutAtBoundary(t, badUnclosed, "layout_tree_unclosed", false)
+
+	// Table claims 0 children, but layout provides 2 entries (entry left over)
+	badLeftover := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 0, 0),
+		makeLayoutEntry(2, 4, 4, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badLeftover, "layout_tree_unclosed", true)
+}
+
+// TestRecordedLayoutRule6RecordTooLarge tests §1.1 Rule 6.
+func TestRecordedLayoutRule6RecordTooLarge(t *testing.T) {
+	// Root size exceeds 65536
+	badRootSize := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 65537, 0),
+	)
+	testMalformedLayoutAtBoundary(t, badRootSize, "layout_record_too_large", true)
+	testMalformedLayoutAtBoundary(t, badRootSize, "layout_record_too_large", false)
+
+	// Child size exceeds 65536
+	badChildSize := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 65537, 1),
+		makeLayoutEntry(2, 12, 65537, 0), // string(N) size 65537
+	)
+	testMalformedLayoutAtBoundary(t, badChildSize, "layout_record_too_large", true)
+
+	// Partial sum exceeds 65536
+	badPartialSum := makeLayoutBytes(
+		makeLayoutEntry(1, 13, 65536, 2),
+		makeLayoutEntry(2, 12, 40000, 0), // string(40000)
+		makeLayoutEntry(3, 12, 40000, 0), // string(40000); partial sum 80000 > 65536
+	)
+	testMalformedLayoutAtBoundary(t, badPartialSum, "layout_record_too_large", true)
+}
+
+// TestRecordedLayoutRule7TooDeep tests §1.1 Rule 7.
+func TestRecordedLayoutRule7TooDeep(t *testing.T) {
+	// Nest 66 optional wrappers (kind 35) to exceed max depth 64
+	entries := make([][]byte, 66)
+	// Leaf at the bottom (depth 65)
+	entries[65] = makeLayoutEntry(66, 4, 4, 0) // int32, size 4, 0 kids
+	curSize := uint32(4)
+	for d := 64; d >= 1; d-- {
+		curSize++ // optional wrapper is child size + 1
+		entries[d] = makeLayoutEntry(uint64(d+1), 35, curSize, 1)
+	}
+	// Root table (depth 0)
+	entries[0] = makeLayoutEntry(1, 13, curSize, 1)
+
+	badDeep := makeLayoutBytes(entries...)
+	testMalformedLayoutAtBoundary(t, badDeep, "layout_too_deep", true)
+	testMalformedLayoutAtBoundary(t, badDeep, "layout_too_deep", false)
+}

--- a/internal/lockfile/lineage.go
+++ b/internal/lockfile/lineage.go
@@ -35,6 +35,7 @@ package lockfile
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -247,15 +248,19 @@ func parseLineage(line string) (LineageEntry, error) {
 	if !seen["wire"] || !seen["bytes"] || !seen["record"] {
 		return LineageEntry{}, fmt.Errorf("a lineage line is `lineage wire=0x... record=N bytes=<hex> [digest=<hex>] [retired] [reason=<text>]`")
 	}
-	if len(e.Layout) == 0 {
-		return LineageEntry{}, fmt.Errorf("a lineage entry carries the layout's bytes; a reader compares a file's layout to them and never parses its own copy (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6b)")
-	}
 	// THE ENTRY IS ONE STATEMENT MADE TWICE, like the layout= hash over the
 	// field lines: the wire hash IS fnv1a64 over these bytes and this digest,
 	// so a hand that moves either without the other is caught here.
 	if got := lineageWireHash(e.Layout, e.Digest); got != e.Wire {
 		return LineageEntry{}, fmt.Errorf("this lineage entry records wire=0x%016x over bytes that hash to 0x%016x — the wire hash IS the hash of the layout bytes and the definitions digest, so the two halves of this line disagree",
 			e.Wire, got)
+	}
+	if len(e.Layout) < layoutHeaderBytes {
+		return LineageEntry{}, fmt.Errorf("lineage wire=0x%016x carries malformed layout: layout_malformed", e.Wire)
+	}
+	count := binary.LittleEndian.Uint32(e.Layout[0:4])
+	if count == 0 || int64(count)*int64(layoutEntryBytes)+int64(layoutHeaderBytes) != int64(len(e.Layout)) {
+		return LineageEntry{}, fmt.Errorf("lineage wire=0x%016x carries malformed layout: layout_count_mismatch", e.Wire)
 	}
 	return e, nil
 }
@@ -443,6 +448,16 @@ func diffLineage(lk, lv *Table, policy Policy) error {
 	if len(lk.Lineage) == 0 {
 		return fmt.Errorf("fixed table %s: the lock carries no lineage for it — every fixed table's layouts are the record a reader is compiled from (docs/FIXED-FORM-BILL-READS-BACKWARD.md §6b, §11.7); write it with `schema lock` (docs/SPEC-TABLES.md §2.10)",
 			lk.Name)
+	}
+	if lv != nil && lv.FixedEmitted {
+		for _, e := range lk.Lineage {
+			if e.Record > ir.TableFixedRecordMaxBytes {
+				continue
+			}
+			if reason := ValidateLayout(e.Layout); reason != "" {
+				return fmt.Errorf("fixed table %s: lineage wire=0x%016x carries malformed layout: %s", lk.Name, e.Wire, reason)
+			}
+		}
 	}
 	if policy != Current || len(lv.Lineage) != 1 {
 		return nil

--- a/internal/lockfile/lineage.go
+++ b/internal/lockfile/lineage.go
@@ -451,9 +451,6 @@ func diffLineage(lk, lv *Table, policy Policy) error {
 	}
 	if lv != nil && lv.FixedEmitted {
 		for _, e := range lk.Lineage {
-			if e.Record > ir.TableFixedRecordMaxBytes {
-				continue
-			}
 			if reason := ValidateLayout(e.Layout); reason != "" {
 				return fmt.Errorf("fixed table %s: lineage wire=0x%016x carries malformed layout: %s", lk.Name, e.Wire, reason)
 			}

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -531,7 +531,7 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 		// THE ONE LAYOUT A RENDERING KNOWS (lineage.go): the declaration's own.
 		// [Update] carries the committed history forward onto it.
 		t.Lineage = renderLineage(r.u, st)
-		t.FixedEmitted = ir.TableFixedEmitted(r.u, st) && ir.TableFixedTypeBytes(st) > 0
+		t.FixedEmitted = ir.TableFixedEmitted(r.u, st)
 	}
 	layout := ir.RecordLayout(r.u, st)
 	for _, f := range st.Fields {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -531,7 +531,7 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 		// THE ONE LAYOUT A RENDERING KNOWS (lineage.go): the declaration's own.
 		// [Update] carries the committed history forward onto it.
 		t.Lineage = renderLineage(r.u, st)
-		t.FixedEmitted = ir.TableFixedEmitted(r.u, st)
+		t.FixedEmitted = ir.TableFixedEmitted(r.u, st) && ir.TableFixedTypeBytes(st) > 0
 	}
 	layout := ir.RecordLayout(r.u, st)
 	for _, f := range st.Fields {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -196,6 +196,10 @@ type Table struct {
 	// the check stays silent, which is the bill's sentence for every older
 	// rendering of this file.
 	rollupWritten bool
+
+	// FixedEmitted reports whether the fixed form is emitted for this table
+	// (ir.TableFixedEmitted): the closure is supported and within the ceiling.
+	FixedEmitted bool
 }
 
 // An Entry is one field of a locked record, and it is the unit the check
@@ -527,6 +531,7 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 		// THE ONE LAYOUT A RENDERING KNOWS (lineage.go): the declaration's own.
 		// [Update] carries the committed history forward onto it.
 		t.Lineage = renderLineage(r.u, st)
+		t.FixedEmitted = ir.TableFixedEmitted(r.u, st)
 	}
 	layout := ir.RecordLayout(r.u, st)
 	for _, f := range st.Fields {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -236,22 +236,30 @@ func TestNewTableRefusedUntilLocked(t *testing.T) {
 	}
 }
 
-// TestNewFieldlessTableRefusedUntilLocked is the same finding with no entry to
-// name: a table with no fields is still a table the lock does not carry, and
-// the refusal names the table alone rather than inventing an entry for it.
-func TestNewFieldlessTableRefusedUntilLocked(t *testing.T) {
+// A fieldless table still has a named stale-lock finding, but cannot be
+// appended: the emitted fixed root violates the nonzero rule in §1.1.
+func TestNewFieldlessTableCannotBeLocked(t *testing.T) {
 	after := base + "\nfixed table Marker\n{\n}\n"
-	_, paths, errs := locked(t, after)
+	dir, paths, errs := locked(t, after)
 	refuses(t, errs, "fixed table Marker is in the declaration and not in the lock",
 		"write it with `schema lock`")
 	if strings.Contains(errs[0].Error(), "entry ") {
 		t.Errorf("there is no entry to name: %v", errs[0])
 	}
-	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+	file := filepath.Join(dir, lockfile.FileName)
+	before, err := os.ReadFile(file)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
-		t.Errorf("the written lock checks clean: %v", errs)
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+		t.Fatalf("emitted zero root must refuse before append: rewrote=%v err=%v", rewrote, err)
+	}
+	afterBytes, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterBytes) != string(before) {
+		t.Fatal("refused append changed the existing lock")
 	}
 }
 


### PR DESCRIPTION
Enforce all seven FIXED-FORM-ALGORITHM.md §1.1 layout rules at the shared lockfile boundary (`internal/lockfile`) for both historical and current recorded lineage entries:

1. **Rule 1**: `4 + 17*count == len(bytes)` and `count != 0` (`layout_count_mismatch`)
2. **Rule 2**: Every `kind` in closed set 1..30, 32, 33, 35 (`layout_kind_unknown`)
3. **Rule 3**: A `size` matches its kind per §1.2 (`layout_size_mismatch`)
4. **Rule 4**: A kind is used as its definition allows per §1.2 (`layout_kind_invalid`)
5. **Rule 5**: The pre-order walk consumes exactly `count` entries (`layout_tree_unclosed`)
6. **Rule 6**: No entry size and no partial sum passes 65536 (`layout_record_too_large`)
7. **Rule 7**: Nesting does not pass walk bound 64 (`layout_too_deep`)
Residue: Layouts shorter than the 4-byte header are `layout_malformed`.

### Implementation
- Added `ValidateLayout(bytes []byte) string` in `internal/lockfile/layout.go` with iterative preorder subtree traversal and depth bound $\le 64$.
- Stamped `FixedEmitted` in `internal/lockfile/lockfile.go` via `ir.TableFixedEmitted`.
- Enforce layout framing residue and count validation in `parseLineage` and full structural validation in `diffLineage` for emitted fixed tables.
- Preserved existing Form 1 legacy classes (such as `RenderFrame` past the 64 KiB ceiling and unions with text/array arms keeping Form 1) while ensuring all emitted Form 3 tables have rigorous historical and current lineage validation.

### Testing
- Landed reviewer witness test `TestReviewerPublicCheckRejectsMalformedHistoricalLayout` from #992.
- Added `TestRecordedLayoutValidControl` proving valid historical layouts pass clean under recomputed wire hashes and rollups.
- Added isolated tests for each of the 7 rules and residue (`TestRecordedLayoutRule1CountMismatch` through `TestRecordedLayoutRule7TooDeep` and `TestRecordedLayoutResidueMalformed`), covering historical and current positions, with internally consistent wire and rollup hashes.
- Verified that both `lockfile.Check` and `lockfile.Update` refuse malformed layouts without mutating the lockfile on disk.
- All `internal/lockfile` tests pass.

Closes #992.