### PR TITLE
Validate emitted empty roots before writing a fixed-table lock

### DIFF
--- a/internal/lockfile/emptyroot_test.go
+++ b/internal/lockfile/emptyroot_test.go
@@ -1,0 +1,67 @@
+package lockfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/lockfile"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func TestEmptyRootFirstLockDisposition(t *testing.T) {
+	for _, tc := range []struct {
+		declaration string
+		emitted     bool
+	}{{"fixed table", true}, {"table", false}} {
+		t.Run(tc.declaration, func(t *testing.T) {
+			dir, paths := fixture(t, pkg(tc.declaration+" Row\n{\n}\n"))
+			u := load(t, paths)
+			if got := ir.TableFixedEmitted(u, u.Tables["Row"]); got != tc.emitted {
+				t.Fatalf("fixture emission=%v, want %v", got, tc.emitted)
+			}
+			_, rewrote, err := lockfile.Update(u, paths)
+			if !tc.emitted {
+				if err != nil || !rewrote {
+					t.Fatalf("Form1-only empty table should remain supported: rewrote=%v err=%v", rewrote, err)
+				}
+				if errs := lockfile.Check(u, paths); len(errs) != 0 {
+					t.Fatalf("Form1-only lock: %v", errs)
+				}
+				return
+			}
+			if err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+				t.Fatalf("emitted zero root must refuse before first write: rewrote=%v err=%v", rewrote, err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, lockfile.FileName)); !os.IsNotExist(err) {
+				t.Fatalf("refusal created a lock: %v", err)
+			}
+		})
+	}
+}
+
+func TestRecordedEmittedEmptyRootCannotBypassValidation(t *testing.T) {
+	dir, paths := fixture(t, rowTable(""))
+	u := load(t, paths)
+	// Model an already recorded zero root with correct hashes and rollup.
+	before := []byte(lockfile.Render(u).Text())
+	file := filepath.Join(dir, lockfile.FileName)
+	if err := os.WriteFile(file, before, 0600); err != nil {
+		t.Fatal(err)
+	}
+	errs := lockfile.Check(u, paths)
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "layout_record_too_large") {
+		t.Fatalf("recorded emitted zero root must refuse: %v", errs)
+	}
+	if _, rewrote, err := lockfile.Update(u, paths); err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+		t.Fatalf("invalid recorded root must not be rewritten: rewrote=%v err=%v", rewrote, err)
+	}
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("refusal changed recorded bytes")
+	}
+}

--- a/internal/lockfile/file.go
+++ b/internal/lockfile/file.go
@@ -128,6 +128,16 @@ func Update(u *ir.Unit, paths []string) (path string, rewrote bool, err error) {
 	path = filepath.Join(dir, FileName)
 
 	live := Render(u)
+	// Validate newly rendered fixed roots before either a first write or an
+	// append. Comparing only the old lock cannot validate a newly added table.
+	for i := range live.Tables {
+		table := &live.Tables[i]
+		if table.Decl == DeclFixedTable && table.FixedEmitted {
+			if err := diffLineage(table, table, Current); err != nil {
+				return "", false, fmt.Errorf("%s: %w", path, err)
+			}
+		}
+	}
 	data, readErr := os.ReadFile(path)
 	switch {
 	case readErr == nil:

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -531,7 +531,7 @@ func (r *renderer) renderTable(decl string, st *ir.Struct) Table {
 		// THE ONE LAYOUT A RENDERING KNOWS (lineage.go): the declaration's own.
 		// [Update] carries the committed history forward onto it.
 		t.Lineage = renderLineage(r.u, st)
-		t.FixedEmitted = ir.TableFixedEmitted(r.u, st) && ir.TableFixedTypeBytes(st) > 0
+		t.FixedEmitted = ir.TableFixedEmitted(r.u, st)
 	}
 	layout := ir.RecordLayout(r.u, st)
 	for _, f := range st.Fields {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -236,22 +236,30 @@ func TestNewTableRefusedUntilLocked(t *testing.T) {
 	}
 }
 
-// TestNewFieldlessTableRefusedUntilLocked is the same finding with no entry to
-// name: a table with no fields is still a table the lock does not carry, and
-// the refusal names the table alone rather than inventing an entry for it.
-func TestNewFieldlessTableRefusedUntilLocked(t *testing.T) {
+// A fieldless table still has a named stale-lock finding, but cannot be
+// appended: the emitted fixed root violates the nonzero rule in §1.1.
+func TestNewFieldlessTableCannotBeLocked(t *testing.T) {
 	after := base + "\nfixed table Marker\n{\n}\n"
-	_, paths, errs := locked(t, after)
+	dir, paths, errs := locked(t, after)
 	refuses(t, errs, "fixed table Marker is in the declaration and not in the lock",
 		"write it with `schema lock`")
 	if strings.Contains(errs[0].Error(), "entry ") {
 		t.Errorf("there is no entry to name: %v", errs[0])
 	}
-	if _, _, err := lockfile.Update(load(t, paths), paths); err != nil {
+	file := filepath.Join(dir, lockfile.FileName)
+	before, err := os.ReadFile(file)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if errs := lockfile.Check(load(t, paths), paths); len(errs) != 0 {
-		t.Errorf("the written lock checks clean: %v", errs)
+	if _, rewrote, err := lockfile.Update(load(t, paths), paths); err == nil || rewrote || !strings.Contains(err.Error(), "layout_record_too_large") {
+		t.Fatalf("emitted zero root must refuse before append: rewrote=%v err=%v", rewrote, err)
+	}
+	afterBytes, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterBytes) != string(before) {
+		t.Fatal("refused append changed the existing lock")
 	}
 }
 


### PR DESCRIPTION
An emitted fieldless fixed table currently bypasses the shared nonzero-root rule because the lock renderer silently labels it non-emitted. Use the actual IR emission classification and validate newly rendered roots before either a first lock write or an append. Existing recorded zero roots are refused too; failed writes preserve existing bytes. Ordinary Form1-only empty tables and tables already past the fixed-form ceiling retain their existing behavior.

This is a four-file correction on top of #999, targeting Emma’s branch for independent review and the final join. The original branch remains unchanged. The current §1.1 contract explicitly requires a nonzero fixed root; one older test that expected an empty fixed table to become valid after locking now checks the required refusal and byte preservation. No runtime behavior or wire format is changed.

Validation: three production-boundary regressions fail on original93999b7 (first write, recorded lock, append). Corrected full `go test -race ./internal/lockfile -count=1` passes in14.312s, including ordinary Form1 empty-table support and the existing already-past-ceiling controls. Tests retain correct hashes/rollups so the structural gate is actually reached.

Precision correction to the earlier review shorthand: `rowTable("")` creates `fixed table Row {}`, not ordinary `table Row {}`. The new paired test explicitly distinguishes those source declarations; the latter is Form1-only here and remains supported.
