### PR TITLE
Keep C# Release in full CI and shorten the fast path

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -545,6 +545,7 @@ jobs:
           otp-version: '27'
           elixir-version: '1.18'
 
+      # C# runs Debug here; full CI keeps both Debug and Release.
       # THE TWO GATES. The target names are the tree's own — the same ones
       # `make test` and ci-full.yml run — so a leg that renames a gate renames
       # it in one place and this row follows.
@@ -557,7 +558,7 @@ jobs:
             c)      make tables-c-fixedform tables-c-versioning ;;
             rust)   make tables-rust-fixedform tables-rust-versioning RUSTUP_BIN="$(dirname "$(command -v cargo)")" ;;
             js)     make tables-js-fixed-form tables-js-versioning NODE=node ;;
-            cs)     make tables-cs-leg tables-cs-versioning ;;
+            cs)     make tables-cs-leg-debug tables-cs-versioning ;;
             java)   make tables-java-fixedform JAVA=java JAVAC=javac ;;
             dart)   make tables-dart-fixed-form tables-dart-versioning DART=dart ;;
             elixir) make tables-elixir-fixed-form tables-elixir-versioning \

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -422,9 +422,11 @@ jobs:
       # to build. The ../serialize.cs checkout this job already makes is the only
       # other thing the probes need. Under SCHEMA_REQUIRE_CORPUS a missing oracle is
       # a failure here, never a quiet skip.
-      - name: the fixed form's versioning suite on the C# leg
+      # Fast CI keeps Debug on its short path; this full tier retains both
+      # configurations alongside the required versioning oracle.
+      - name: the C# leg in Debug and Release, and its versioning suite
         if: matrix.group == 'versioning'
-        run: make tables-cs-versioning
+        run: make tables-cs-leg tables-cs-versioning
 
       # THE SAME SUITE ON THE ELIXIR LEG (§5.7 step 6). Its probes are generated
       # Elixir, one per row per column, run with the leg's own toolchain: the

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -412,7 +412,8 @@ tables-cs-view: build/tables-generated-cs/.stamp
 # TWO CONFIGURATIONS, TWO NAMES, AND A COMBINED ONE — because the pair was 74 s
 # and the owner's rule is one to two minutes for anything a child iterates on.
 # Debug alone is about half that, so `make tables-cs-leg-debug` is the loop and
-# `make tables-cs-leg` is still the gate: CI and the release path run both.
+# `make tables-cs-leg` remains the full-CI and release gate, running both.
+# Fast CI uses Debug with versioning to stay within its two-minute budget.
 tables-cs-leg: tables-cs-leg-debug tables-cs-leg-release
 
 tables-cs-leg-debug: build/tables-generated-cs/.stamp


### PR DESCRIPTION
The broad Fast CI run34746694805 took142s against the120s limit. Its C# job took100s, including87s in the serial Debug+Release and versioning step.

Run the existing C# Debug target plus versioning in Fast CI. The full tier now explicitly runs the unchanged combined Debug+Release target plus versioning. Keep both configurations, oracle requirements and every test body; change their scheduling so Release is outside the short per-change path. `make tables-cs-leg` still runs both configurations for callers and release/certification work.

Validation: `go test ./internal/ci -count=1` passed2.216s and diff whitespace checks pass. The acceptance gate is actual broad FastCI timing plus execution of the full-tier C# step; the142s baseline is measured, the proposed speedup is not yet a result. Tracks the concrete timing follow-up in nova-tools185.
