### PR TITLE
Strengthen C++ refusal witnesses and run them in fast CI

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -154,9 +154,9 @@ jobs:
           # THE BROAD RULE. These paths can change what EVERY leg emits or what
           # every package compiles, so a diff that touches one of them gets the
           # whole of both selections. The direction of the error is deliberate:
-          # a path nobody classified lands here, never in "skip it".
+          # shared schema fixtures select every leg that consumes them.
           broad=no
-          if echo "$files" | grep -qE '^(ir/|compiler/|tables/|Makefile$|go\.mod$|docs/FIXED-FORM-|internal/codegen/cpp|internal/codegen/ccommon|test/cpp|\.github/workflows/ci-fast\.yml$)'; then
+          if echo "$files" | grep -qE '^(ir/|compiler/|tables/|Makefile$|go\.mod$|docs/FIXED-FORM-|internal/codegen/cpp|internal/codegen/ccommon|test/cpp|test/tables/.*\.schema$|\.github/workflows/ci-fast\.yml$)'; then
             broad=yes
           fi
 
@@ -175,7 +175,7 @@ jobs:
               internal/codegen/ctable/*|internal/codegen/c/*|generated/c/*|test/c-tables/*|make/c.mk) add_leg c ;;
             esac
             case "$f" in
-              internal/codegen/cpptable/*|test/cpp-tables/*) add_leg cpp ;;
+              internal/codegen/cpptable/*|test/cpp-tables/*|test/tables/*.cpp|test/tables/*.h) add_leg cpp ;;
             esac
             case "$f" in
               internal/codegen/rusttable/*|internal/codegen/rust/*|generated/rust/*|test/rust-fixedform/*|make/rust.mk) add_leg rust ;;

--- a/internal/ci/fast_plan_test.go
+++ b/internal/ci/fast_plan_test.go
@@ -1,0 +1,52 @@
+package ci
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Exercise the workflow's actual selector: a green plan that selects no
+// harness must not silently skip a changed C++ fixed-table regression test.
+func TestFastPlanSelectsTableFixtures(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), ".github/workflows/ci-fast.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, tail, ok := strings.Cut(string(data), "          # THE BROAD RULE.")
+	if !ok {
+		t.Fatal("fast workflow broad selector not found")
+	}
+	selector, _, ok := strings.Cut(tail, "          # THE PACKAGES.")
+	if !ok {
+		t.Fatal("fast workflow package boundary not found")
+	}
+	// Remove the remainder of the first comment line and YAML indentation.
+	_, selector, _ = strings.Cut(selector, "\n")
+	var script strings.Builder
+	for _, line := range strings.Split(selector, "\n") {
+		script.WriteString(strings.TrimPrefix(line, "          "))
+		script.WriteByte('\n')
+	}
+	script.WriteString(`printf '%s|%s' "$broad" "$legs"`)
+	for _, tc := range []struct{ name, files, want string }{
+		{"cpp witness", "test/tables/versioning_numbers.cpp", "no| cpp"},
+		{"cpp header", "test/tables/floatnan.h", "no| cpp"},
+		{"shared schema", "test/tables/VNEW_floor.schema", "yes|cpp go c rust js cs java dart elixir"},
+		{"documentation", "README.md", "no|"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("bash", "-euo", "pipefail", "-c", script.String())
+			cmd.Env = append(os.Environ(), "files="+tc.files)
+			got, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("selector: %v: %s", err, got)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("%s selected %q; want %q", tc.files, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/tables/versioning_numbers.cpp
+++ b/test/tables/versioning_numbers.cpp
@@ -1149,8 +1149,10 @@ void hash_cases()
                 else if ( breaks[k].field == 2 ) { vnew_floor::TableFixedPut32( e + 9, breaks[k].value ); }
                 else { vnew_floor::TableFixedPut32( e + 13, breaks[k].value ); }
             }
-            vnew_floor::Floored back;  std::memset( &back, 0, sizeof( back ) );  vnew_floor::FlooredReset( back );
-            vnew_floor::Floored fresh; std::memset( &fresh, 0, sizeof( fresh ) ); vnew_floor::FlooredReset( fresh );
+            // Distinct from reset defaults: even an accidental prefill must be visible.
+            vnew_floor::Floored back; std::memset( &back, 0xA5, sizeof( back ) );
+            back.a = 101; back.b = 202; back.c = 303;
+            vnew_floor::Floored fresh; std::memcpy( &fresh, &back, sizeof( fresh ) );
             vnew_floor::TableReport r;
             std::vector<vnew_floor::TableFixedEntry> plan( 4096 );
             const int64_t n = vnew_floor::FlooredFixedLoad( &back, 1, f.data(), (int64_t) f.size(),
@@ -1159,8 +1161,10 @@ void hash_cases()
             std::snprintf( what, sizeof( what ),
                            "hash_known_bytes_differ: §1.1 case %s, under a KNOWN hash, is layout_malformed",
                            breaks[k].what );
-            check( n < 0 && r.refused && r.reason == vnew_floor::layout_malformed, what );
-            check( n < 0 && r.refused, "hash_known_bytes_differ: broken layout bytes are refused, whatever the name" );
+            check( n == -1 && r.refused && !r.malformed && r.reason == vnew_floor::layout_malformed, what );
+            check( r.unknown == 0 && r.kind_mismatch == 0 && r.widened == 0 && r.clamped == 0 &&
+                   r.duplicate == 0 && r.retained == 0 && r.retain_lost == 0 && r.layout_hash == 0,
+                   "hash_known_bytes_differ: a named refusal moves no counter and reports no hash" );
             check( std::memcmp( &back, &fresh, sizeof( back ) ) == 0,
                    "hash_known_bytes_differ: nothing decoded" );
         }


### PR DESCRIPTION
The seven C++ known-hash layout-corruption probes could pass if refusal also set malformed, moved a report counter, or reset the destination to its defaults. Require the exact -1/refused/layout_malformed result with malformed false, all counters and reported hash zero, and a destination initialized differently from reset defaults remaining byte-identical.

Fast CI also skipped this test because its path selector did not recognize test/tables. Route C++ sources and headers there to the C++ harness, and shared .schema fixtures to every language leg. A regression test executes the actual workflow selector. Runtime, schema and corruption inputs are unchanged. This strengthens the C++ R9 evidence on #898; it does not claim the other language probes or the entire Fixed Tables audit are complete.

Validation: native fixed-form versioning/conformance suite passes with zero named reds/failures. Three separate mutations of the generated known-hash refusal branch (malformed flag, widened counter, destination reset) each pass the original test suite and fail all seven cases with the strengthened test. Generated code was restored byte-for-byte afterward. Mutation builds/runs took about3.6–3.7s each. The linked ASan/UBSan executable also passed the full fixed-form suite. Post-link debug-symbol generation stalled; its redundant wrapper was stopped after the direct instrumented test passed. The Make target itself is not claimed successful.

CI routing validation: the new selector regression fails on the original workflow for C++ source, header and shared schema fixtures; all four cases pass with the routing repair. The complete internal/ci package passes in 1.525s. The original PR CI skipped the C++ harness and is not counted as test proof; the updated revision requires an actual C++ CI run.
