### PR TITLE
Use SplitSeq in the fast CI selector regression

### DIFF
--- a/internal/ci/fast_plan_test.go
+++ b/internal/ci/fast_plan_test.go
@@ -26,7 +26,7 @@ func TestFastPlanSelectsTableFixtures(t *testing.T) {
 	// Remove the remainder of the first comment line and YAML indentation.
 	_, selector, _ = strings.Cut(selector, "\n")
 	var script strings.Builder
-	for _, line := range strings.Split(selector, "\n") {
+	for line := range strings.SplitSeq(selector, "\n") {
 		script.WriteString(strings.TrimPrefix(line, "          "))
 		script.WriteByte('\n')
 	}


### PR DESCRIPTION
The full post-merge lint gate rejected the new CI selector regression for allocating a slice with strings.Split when it only iterates the lines. Use strings.SplitSeq in that loop. Selector logic and all four regression cases remain unchanged.

Validation: go test ./internal/ci -count=1 and the pinned modernize v0.23.0 check on ./internal/ci pass. Repairs the exact diagnostic from full run34757129162, lint job103723319653.
