### PR TITLE
spec: enums have no headroom; width derives from the variant count; an unnamed value is refused (docs for #1004)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -756,23 +756,22 @@ FloatExpr   = float expression over float literals, int literals and const names
   makes a typed constant** — `const MaxBounds uint64 = 12000` — which pins
   the exported type in every target.
 - **Enum max references:** **`E.Max`** in any integer expression names enum
-  `E`'s max — the derived count, or the widened `| max = K` — the same number
+  `E`'s max — the derived variant count — the same number
   the enum's wire range and storage derive from. The count of wire values is
   `E.Max + 1` by ordinary constant arithmetic; the count of real (non-`None`)
   variants is `E.Max` (see the sentinel-zero convention below), and that is
   the count an enum-indexed array is sized to: `[E.Max]T`, or the `[E]T`
-  spelling that resolves to it (SPEC-TABLES.md §2.4). Under `max` headroom
-  the reserved values above the last variant are wire-legal and name no slot.
+  spelling that resolves to it (SPEC-TABLES.md §2.4). Every wire value names
+  a variant or `None`; there are no reserved values above the last variant.
   It works on the generated tag set
   too (a union's `<Union>Type.Max` — §4.8); generated sets resolve in
   constant expressions and nowhere else.
 - **Declared-count references:** **`.Count`** in any integer expression names
   the DECLARED variant count of an enum or a flags declaration — one word
   meaning one thing in both. `E.Count` excludes an enum's implicit `None`;
-  `F.Count` counts the named bits. Under `| max = K` headroom the count and
-  the extent part — an enum's `Max` is the widened extent and a flags
-  declaration's wire width is K, while `Count` stays the count — and without
-  headroom `E.Count` equals `E.Max`. `[..E.Count]T` is therefore a counted
+  `F.Count` counts the named bits. An enum takes no headroom, so `E.Count`
+  always equals `E.Max`; under a flags declaration's `| max = K` headroom the
+  wire width is K while `F.Count` stays the count. `[..E.Count]T` is therefore a counted
   array over the declared variants, where `[E.Max]T` is the keyed array with
   one slot per admitted ordinal. **Flags
   have `F.Count`, not `F.Max`** — a flags declaration is a set of
@@ -793,9 +792,12 @@ FloatExpr   = float expression over float literals, int literals and const names
   hand-written recursive descent is the intended implementation.
 - **Enum variants** are comma-separated identifiers, trailing comma allowed.
   **Every enum has `None = 0` implicitly — universal, never declared.**
-  Declared variants pack tightly from 1; max derives as the count; the
-  `| max = K` headroom attribute can widen the wire. **Enum storage derives
-  from the enum's own max** — the smallest unsigned integer that fits.
+  Declared variants pack tightly from 1; max derives as the count. An enum
+  takes no `| max` attribute: its wire width derives from its variant count
+  alone, `None` included, and nothing widens it. **Enum storage derives
+  from the enum's own max** — the smallest unsigned integer that fits. **An
+  enum reads as one of its variants or the read fails**: a wire value above
+  max is refused, so no unnamed enum value exists in any target.
 - **Canonical form only.** Enums are always `0 = None`, then `[1, max]`,
   dense. There are no explicit variant values and no sparse enums.
 - **The enum family is two declaration forms:**
@@ -879,8 +881,8 @@ sequence    uint16
   fresh value holds, so it belongs to the definition, not the
   qualification: `w fixed(2, 30) = 1.0 | min = -1, max = 1`.
 - **Declaration lines take the same section**: a tag or a native-type
-  binding, an enum's or flags' `max` headroom —
-  `type Quat | quat4`, `enum Weapon | max = 15`, `flags Damage | max = 8` —
+  binding, a flags declaration's `max` headroom —
+  `type Quat | quat4`, `flags Damage | max = 8` —
   and the body brace opens on the next line — with a qualification section
   that is forced (the section runs to the end of the line), and everywhere
   else it is the Allman house style (§4.1):
@@ -892,8 +894,8 @@ sequence    uint16
       ...
   }
 
-  enum Weapon | max = 15
-  { Laser, Missile, Railgun }
+  flags Damage | max = 8
+  { Fire, Ice, Poison }
   ```
 
   A one-line body (`{ Laser, Missile }`, `type Box { x uint8 }`) stays
@@ -917,7 +919,7 @@ sequence    uint16
 - **The line between positional and attribute:** a *size* that defines the
   type's shape stays positional — `bits(64)`, `string(64)`, `wstring(64)`,
   `bytes(N)`, `fixed(I, F)`, array bounds. A *constraint or refinement* of a
-  named type is a qualifier. The enum's `| max = 15` is the same syntax; it is one
+  named type is a qualifier. A flags declaration's `| max = 8` is the same syntax; it is one
   general mechanism. The glyph is deliberately the language's own — a DSL
   owns its spelling, and familiarity to other languages' readers is not a
   design constraint where clarity is better served ("let's be bold and do
@@ -1140,8 +1142,8 @@ extent as a member named `Max` in the target's own convention: `E::Max`
 (C), `E.max` (Dart and Java), `E.max/0` (Elixir). Its value is the enum's
 max — the same number `E.Max` names in schema
 expressions (§4.2): the highest wire-legal value, which under the
-sentinel-zero convention is the count of real variants when no `max`
-headroom widens it. Application code states ranges and asserts directly
+sentinel-zero convention is the count of real variants. Application code
+states ranges and asserts directly
 against it (`ShipType`'s wire range is `[0, ShipType.Max]`, its real
 variants `[1, ShipType.Max]`) instead of exporting a hand-declared count
 constant that re-derives it. `Max` is therefore a reserved variant name —
@@ -1151,8 +1153,9 @@ is.
 **The declared count is exported too.** Every declared enum carries its
 **`Count`** beside its `Max`: the number of DECLARED variants, excluding the
 implicit `None`. It is the same number `E.Count` names in schema expressions
-(§4.2), it equals `Max` when no `| max = K` headroom widens the enum, and it
-is below `Max` when one does — which is the whole reason it is exported. All
+(§4.2), and it equals `Max` on every declared enum, since an enum takes no
+headroom; it is exported so an enum and a flags declaration present one
+`Count` surface to a reader. All
 nine targets spell it their own way, the spelling each already uses for a
 flags declaration's `Count`: `E::Count` (C++), `E.Count` (C#), `ECount`
 (Go), `E::COUNT` (Rust), `E.Count` (JS), `E_COUNT` (C), `E.count` (Dart and
@@ -1161,9 +1164,8 @@ reason `Max` is, and it is a claimed name under §4.6 — a declaration whose
 generated symbol would collide with an enum's `Count` is refused, naming the
 enum. A union's generated `<Union>Type` tag enum carries `Count`
 beside `Max` too, in the same nine spellings (§4.8), so a tag enum and a
-declared enum present one surface to a reader. A tag set takes no headroom, so
-its `Count` and its `Max` are one number, and the member is there because the
-surface is uniform rather than because the two numbers ever differ. A
+declared enum present one surface to a reader. A tag set's `Count` and `Max`
+are one number too, as a declared enum's are. A
 TABLE-CLOSURE union's tag shape is a different emitter, written beside the
 tables, and it carries the same members (docs/SPEC-TABLES.md §2.6).
 
@@ -1221,7 +1223,7 @@ classic twin, which is the wire oracle for the stated model.
 | `f float32` | 32 raw IEEE-754 bits — the pattern, with no canonicalisation: a signalling NaN and a NaN payload ride through unchanged, and a backend holding the field in a wider cell moves the pattern by bit surgery | `serialize_float` |
 | `f float64` | 64 raw bits (low dword first) — the pattern, with no canonicalisation, exactly as `float32`'s row | `serialize_double` |
 | `f float32 | min = A, max = B, resolution = R` | quantized to ceil((B−A)/R) steps — the actual step is (B−A)/ceil((B−A)/R), ≤ R; read rejects values above the step count | `serialize_compressed_float` (exact formulas incl. the ceil, +0.5f rounding and clamp); storage stays `float32` — the attributes describe the wire |
-| `f Weapon` (an enum) | minimal bits for [0, max]; read rejects above max | `serialize_int` over [0, max] |
+| `f Weapon` (an enum) | minimal bits for [0, max], max being the variant count; read rejects above max, so an unnamed value never reaches the object | `serialize_int` over [0, max] |
 | `f Damage` (a `flags` declaration, §4.2) | W raw bits, W = variant count (or the widened max); every pattern legal; storage `uint64` in every target | `serialize_bits` |
 | `f Inner` (a type) | Inner's fields, in place | `serialize_object` |
 | `f Shape` (a `union`, §4.8) | tag in minimal bits for [0, variant count] (0 = None, no payload), then the selected variant's payload only; read rejects a tag above the count | `serialize_int` over [0, count] + the selected arm's own call: `serialize_object` for a declared `type`, this table's row for that arm's type otherwise, and no call at all for a payload-free arm |
@@ -1439,7 +1441,7 @@ All compile errors with positions:
   a `table` and a handful of reflection spellings in every unit;
   SPEC-TABLES.md §11 states which is which and why, and a schema that declares
   no `table` is refused none of the rest.
-- Enum `| max = K` below the variant count.
+- `| max = K` on an enum: an enum takes no headroom (§4.2).
 - **Duplicate field names anywhere in one type — including across branch
   sides.** One name, one field, declared once. (schema owns the type, and
   unique names keep the flattened generated output unambiguous.)
@@ -2321,10 +2323,10 @@ Per `type`, per target:
    buffer is fixed at its declared capacity with a used length/count beside
    it — no Go slices as storage, no Rust `Vec`, no growing containers.
 
-   Enums are integer-backed named types in every target because `| max = ...`
-   headroom makes non-variant values wire-legal; a native Rust `enum` cannot
-   hold them — C#'s `enum E : uint` can, natively, which is why it needs no
-   newtype.
+   An enum's representation is the target's choice — today an integer-backed
+   named type in every target (a Rust newtype, C#'s `enum E : uint`). Nothing
+   on the wire requires it: a wire value above max is refused on read (§4.2),
+   so no unnamed enum value is ever representable on the read side.
 
 2. **`Write(buffer, object) -> bytesWritten`** — straight-line write code in
    wire order.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -679,7 +679,7 @@ If          = "if" [ "!" ] ident Block [ "else" Block ] NL .
                                                                  // as variants first)
 
 IntExpr     = integer expression over literals, const names, and enum max
-              references ( ident "." "Max" | ident "." "Count" ):
+              references ( ident "." "Max" on an enum | ident "." "Count" on a flags declaration ):
               "+" "-" "*" "/" "%", unary "-", parentheses.
 FloatExpr   = float expression over float literals, int literals and const names:
               "+" "-" "*" "/", unary "-", parentheses — float64 arithmetic, no "%".
@@ -767,13 +767,12 @@ FloatExpr   = float expression over float literals, int literals and const names
   too (a union's `<Union>Type.Max` — §4.8); generated sets resolve in
   constant expressions and nowhere else.
 - **Declared-count references:** **`.Count`** in any integer expression names
-  the DECLARED variant count of an enum or a flags declaration — one word
-  meaning one thing in both. `E.Count` excludes an enum's implicit `None`;
-  `F.Count` counts the named bits. An enum takes no headroom, so `E.Count`
-  always equals `E.Max`; under a flags declaration's `| max = K` headroom the
-  wire width is K while `F.Count` stays the count. `[..E.Count]T` is therefore a counted
-  array over the declared variants, where `[E.Max]T` is the keyed array with
-  one slot per admitted ordinal. **Flags
+  the DECLARED variant count of a flags declaration: `F.Count` counts the
+  named bits, and under `| max = K` headroom the wire width is K while
+  `F.Count` stays the count. An enum has no `.Count`: its variant count is
+  its `Max`, so `[..E.Max]T` is a counted array over the declared variants,
+  where `[E.Max]T` is the keyed array with one slot per admitted ordinal.
+  **Flags
   have `F.Count`, not `F.Max`** — a flags declaration is a set of
   independent bits, not a range with a top, so max-of-what is exactly the
   confusion `.Max` would invite and the compiler refuses it naming the
@@ -814,8 +813,8 @@ FloatExpr   = float expression over float literals, int literals and const names
     variant, and the storage is `uint64`. Each target exports one mask
     constant per variant (`1 << bit`),
     because mask tests are how flag state is consumed, **plus the `Count`
-    constant** — the declared variant count, spelled per target beside the
-    enum extents — the spelling is each target's own, and all nine emit it:
+    constant** — the declared variant count, the one `.Count` in the
+    language — the spelling is each target's own, and all nine emit it:
     `CapsCount` in C++, C#, Go and JS; `CAPS_COUNT` in C and Rust;
     `capsCount` in Dart and Java; `caps_count/0` in Elixir.
     **`flags` is a
@@ -1150,24 +1149,16 @@ constant that re-derives it. `Max` is therefore a reserved variant name —
 declaring a variant named `Max` is refused at check time, exactly as `None`
 is.
 
-**The declared count is exported too.** Every declared enum carries its
-**`Count`** beside its `Max`: the number of DECLARED variants, excluding the
-implicit `None`. It is the same number `E.Count` names in schema expressions
-(§4.2), and it equals `Max` on every declared enum, since an enum takes no
-headroom; it is exported so an enum and a flags declaration present one
-`Count` surface to a reader. All
-nine targets spell it their own way, the spelling each already uses for a
-flags declaration's `Count`: `E::Count` (C++), `E.Count` (C#), `ECount`
-(Go), `E::COUNT` (Rust), `E.Count` (JS), `E_COUNT` (C), `E.count` (Dart and
-Java), `E.count/0` (Elixir). `Count` is a reserved variant name for the same
-reason `Max` is, and it is a claimed name under §4.6 — a declaration whose
-generated symbol would collide with an enum's `Count` is refused, naming the
-enum. A union's generated `<Union>Type` tag enum carries `Count`
-beside `Max` too, in the same nine spellings (§4.8), so a tag enum and a
-declared enum present one surface to a reader. A tag set's `Count` and `Max`
-are one number too, as a declared enum's are. A
-TABLE-CLOSURE union's tag shape is a different emitter, written beside the
-tables, and it carries the same members (docs/SPEC-TABLES.md §2.6).
+**`Max` is the enum's only exported number.** An enum exports no `Count`:
+its declared variant count is its `Max`, and one number needs one name. A
+flags declaration exports `Count` (§4.2) because it has no `Max`. A union's
+generated `<Union>Type` tag enum carries `Max` in the same nine spellings
+(§4.8) and no `Count` either, so a tag enum and a declared enum present one
+surface to a reader. A TABLE-CLOSURE union's tag shape is a different
+emitter, written beside the tables, and it carries the same members
+(docs/SPEC-TABLES.md §2.6). `Count` is not a reserved variant name on an
+enum and not a reserved arm name on a union; only a flags declaration claims
+it (§4.6).
 
 ### 4.3 Field types and their wire encodings
 
@@ -1434,7 +1425,7 @@ All compile errors with positions:
   and no unit declares `ProtocolId`. The checker likewise refuses user names
   that collide with per-declaration generated symbols
   (`Write*`/`Read*`/`New*`, `*MaxBits`/`*MaxBytes`, companion length/count
-  names, an enum's `Max` and `Count`, a flags declaration's `Count`, a
+  names, an enum's `Max`, a flags declaration's `Count`, a
   union's generated tag surface). Diagnostics name the generated
   artifact that claims the name. A short list of unit-scope names is claimed
   on the table layer's behalf as well, most of it only in a unit that declares
@@ -1650,17 +1641,13 @@ union Value
   disagree with the tag. **Reserved variant names are checked over the
   EXPORTED spelling**: any variant whose exported form (the field-name
   mapping) is `None` or `Max` is refused — `none` and `max` included, not
-  just the literal spellings. **`Count` is refused the same way**, on every
-  union: each tag enum carries the member (below), the packet shape and the
-  table-closure shape alike, so an arm exporting `Count` defines it twice
-  wherever the union lands. The reservation reaches where the member exists,
-  and the member exists on every union (docs/SPEC-TABLES.md §2.6).
+  just the literal spellings. `Count` is not reserved on a union: no tag
+  enum carries a `Count` member.
 - **The tag enum is generated, named `<Union>Type`**: `None = 0`, then
   each variant **in declared order**
   (exported spelling per target, the field-name mapping), dense from 1, then
-  the exported `Count` (the declared variant count, `None` excluded) and the
-  exported `Max` extent. Storage is per the enum storage rule, the
-  smallest unsigned integer fitting max. A tag enum carries the same four
+  the exported `Max` extent. Storage is per the enum storage rule, the
+  smallest unsigned integer fitting max. A tag enum carries the same three
   parts a declared enum carries, so a reader logging which message arrived
   reaches for the enum's own surface and finds it. Declared order, not sorted: a
   union is one declaration whose author states the order, exactly as an
@@ -1683,25 +1670,24 @@ union Value
   path and no write path, and no generated code calls it. Each target spells
   it its own way, for the tag enum `WeaponFireType`:
 
-  | target | count member | debug name |
-  |---|---|---|
-  | c | `WEAPON_FIRE_TYPE_COUNT` | `enum_name_weapon_fire_type` |
-  | cpp | `WeaponFireType::Count` | `EnumName`, overloaded on the enum |
-  | cs | `WeaponFireType.Count` | `EnumNameWeaponFireType(ulong)` |
-  | dart | `WeaponFireType.count` | `enumNameWeaponFireType(int)` |
-  | elixir | `count/0` on the tag module | `enum_name_weapon_fire_type/1` |
-  | go | `WeaponFireTypeCount` | `EnumNameWeaponFireType(uint64)` |
-  | java | `WeaponFireType.count` | `enumNameWeaponFireType(long)` |
-  | js | `WeaponFireType.Count` | `EnumNameWeaponFireType(value)` |
-  | rust | `WeaponFireType::COUNT` | `enum_name_weapon_fire_type` |
+  | target | debug name |
+  |---|---|
+  | c | `enum_name_weapon_fire_type` |
+  | cpp | `EnumName`, overloaded on the enum |
+  | cs | `EnumNameWeaponFireType(ulong)` |
+  | dart | `enumNameWeaponFireType(int)` |
+  | elixir | `enum_name_weapon_fire_type/1` |
+  | go | `EnumNameWeaponFireType(uint64)` |
+  | java | `enumNameWeaponFireType(long)` |
+  | js | `EnumNameWeaponFireType(value)` |
+  | rust | `enum_name_weapon_fire_type` |
 
 - **A TABLE-CLOSURE union's tag shape carries the same surface.** It is a
   different emitter, written beside the tables rather than among the packet
   declarations (docs/SPEC-TABLES.md §2.6), and it emits `None`, the variants,
-  `Count`, `Max` and the debug-name function, because it is the same construct
+  `Max` and the debug-name function, because it is the same construct
   to a reader. The table layer is the C++ reference's, so the shape has one
-  emitter where the packet shape has nine. `Count` is a compile error as an arm
-  name on every union, for the one reason: the member exists.
+  emitter where the packet shape has nine.
 - **The wire.** This bullet is the TYPE wire's, which a union of declared
   `type` arms rides and a table-closure union does not ride at all (above).
   The tag encodes in **minimal bits for `[0, variant
@@ -1902,15 +1888,6 @@ NAME rather than falling into a generic parse error:
 - **`doc`** (the attribute) — documentation is not an attribute: it is the
   `///` doc comment above the item (§4.1), and one text has one spelling.
   `| doc = "..."` is refused with the comment form named.
-- **`Count` as an arm name on any union.** The generated tag enum
-  carries the declared variant count as the member `Count` (§4.8), so the arm
-  would define the member twice, which C++ and C# refuse outright as a
-  redefinition. The refusal is over the EXPORTED spelling, so `count` is
-  refused too, and the diagnostic names the tag enum that claims the name. It
-  is the same reservation `None` and `Max` carry, for the same reason.
-  A table-closure union's tag shape carries the member too
-  (docs/SPEC-TABLES.md §2.6), so the reservation reaches it and one rule
-  covers both shapes.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
@@ -2346,7 +2323,7 @@ Per `type`, per target:
    every serialize runtime requires.**
 5. **`ProtocolId`** — one constant per unit (§3).
 6. **For a `union` declaration (§4.8):** the `<Union>Type` tag enum
-   (`None = 0`, then the variants in declared order, then `Count` and `Max`)
+   (`None = 0`, then the variants in declared order, then `Max`)
    with its debug-name function, the value
    representation in each language's own idiom, and
    `Write<Union>`/`Read<Union>` with the tag framing — representation per

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -126,7 +126,7 @@ zero-initialized enum field is therefore the null, in band, and you never
 need a separate has-flag beside it:
 
 ```cpp
-enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3, Count = 3, Max = 3 };
+enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3, Max = 3 };
 ```
 
 On the wire it costs `bitsRequired(variant count)` — 2 bits here, for four
@@ -150,15 +150,10 @@ carries it too, so ranges and asserts reference the enum directly instead of
 a hand-declared count constant. `Max` is consequently reserved as a variant
 name, like `None`.
 
-The `Count` member beside it is the **declared variant count**, `None`
-excluded — `ShipType::Count` (C++), `ShipType.Count` (C#), `ShipTypeCount`
-(Go), `ShipType::COUNT` (Rust), `ShipType.Count` (JS), `SHIP_TYPE_COUNT` (C),
-`ShipType.count` (Dart and Java), `ShipType.count/0` (Elixir), and
-`E.Count` in schema expressions. On an enum `Count` and `Max` are always the
-same number; both are exported so an enum and a flags declaration, which has
-a `Count` and no `Max`, present one surface. `Count` is a reserved variant name too, and every
-union's tag enum carries it beside `Max`, so `Count` is a reserved arm name
-on every union for the same reason.
+`Max` is the enum's only exported number. An enum has no `Count`: its
+declared variant count is `Max`, and one number gets one name. A flags
+declaration exports `Count` instead, since it has no `Max`. `Count` is not a
+reserved variant name on an enum, and not a reserved arm name on a union.
 
 A union's tag enum carries the debug-name function too, in the same nine
 spellings the declared enum uses, so logging which arm arrived is the same
@@ -166,7 +161,7 @@ call either way.
 
 **Two loop rules, and they are the whole story:**
 
-- A loop over the **declared variants** runs from `1` to `Count` inclusive.
+- A loop over the **declared variants** runs from `1` to `Max` inclusive.
 - A loop over **every ordinal**, `None` included, runs from `0` to `Max`
   inclusive.
 - **Size storage and keyed arrays by `Max`** — the extent is what has to fit.
@@ -196,8 +191,8 @@ inline constexpr int64_t CapabilitiesCount = 3;
 ```
 
 The declared variant count is exported as `Count` and usable in schema
-expressions as `Capabilities.Count` — the same word an enum carries, meaning
-the same thing. Flags have no `.Max` — the variants are
+expressions as `Capabilities.Count`; an enum's count is its `Max` and it
+carries no `Count`. Flags have no `.Max` — the variants are
 independent bits, not a range with a top; the compiler refuses `.Max` on a
 flags type and names `.Count` instead.
 
@@ -248,11 +243,11 @@ type Collider
 **Every union has an implicit `None = 0`** — the empty union, in band, so a
 default-constructed union carries "no shape" without a has-flag. The
 compiler generates the tag enum `ColliderShapeType` (`None = 0`, variants in
-declared order, then `Count` and `Max`), and the wire is the tag in minimal
+declared order, then `Max`), and the wire is the tag in minimal
 bits for `[0, variant count]` followed by **the selected payload only**:
 
 ```cpp
-enum class ColliderShapeType : uint8_t { None = 0, Box = 1, Sphere = 2, Capsule = 3, Hull = 4, Count = 4, Max = 4 };
+enum class ColliderShapeType : uint8_t { None = 0, Box = 1, Sphere = 2, Capsule = 3, Hull = 4, Max = 4 };
 
 struct ColliderShape
 {
@@ -1853,8 +1848,8 @@ Only the table wire keys the slots.
 
 **And a positional array whose bound comes from an enum is REFUSED in a table
 body and a union arm, by name**, with `[E]T` named as the fix. The refusal
-follows where the bound comes from and not how it is spelled, so `[E.Max]T`,
-`[E.Count]T` and `[N]T` under a `const N = E.Max` all take it, at any depth of
+follows where the bound comes from and not how it is spelled, so `[E.Max]T`
+and `[N]T` under a `const N = E.Max` all take it, at any depth of
 constant arithmetic. The diagnostic names the constant where the bound reaches
 the enum through one, and an arm's names the arm and the table that reaches
 the union.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,7 +134,10 @@ values. `None` is one of those values, so an enum whose declared variant
 count is a power of two pays one bit for it: four declared variants are five
 wire values and cost 3 bits, not 2. An enum takes no `| max`: the width
 follows the variant count, and adding a variant that crosses a power of two
-widens the field.
+widens the field. Forward compatibility lives elsewhere: on the packet wire
+both peers share one schema, and on the table wire the field's width is
+recorded per version (the lock file's `width=` line, SPEC-TABLES.md), so a
+newer reader reads the older width.
 
 The `Max` member is the enum's **extent** — the same number `E.Max` names in
 schema expressions: the highest wire-legal value, and the
@@ -789,8 +792,9 @@ maximum, enum values outside the declared range, and reads that run past the
 end of the buffer.
 
 One precision worth having: an enum read is bounded by the enum's variant
-count. For `enum E { A, B, C }` the wire range is `[0, 3]`, `None` included,
-and a value of 4 or more fails the read. A value you have not named cannot
+count, not by the field's width. For `enum E { A, B, C, D }` the wire range
+is `[0, 4]`, `None` included, in 3 bits; 5, 6 and 7 fit the width and are
+refused. A value you have not named cannot
 survive a read, so a `switch` over an enum needs no default arm for one. The same VALIDATION rules hold in all nine languages, because
 the same compiler wrote all nine — the buffer-slack contract above is the one
 thing that differs per language.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -132,13 +132,12 @@ enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3,
 On the wire it costs `bitsRequired(variant count)` — 2 bits here, for four
 values. `None` is one of those values, so an enum whose declared variant
 count is a power of two pays one bit for it: four declared variants are five
-wire values and cost 3 bits, not 2. Declaring `enum E | max = 15` (its variant
-list on the next line) reserves
-headroom so you can
-add variants later without moving the field width.
+wire values and cost 3 bits, not 2. An enum takes no `| max`: the width
+follows the variant count, and adding a variant that crosses a power of two
+widens the field.
 
 The `Max` member is the enum's **extent** — the same number `E.Max` names in
-schema expressions: the highest wire-legal value, and (headroom aside) the
+schema expressions: the highest wire-legal value, and the
 count of real variants under the sentinel-zero convention. All nine targets
 spell it their own way — `ShipType::Max` (C++), `ShipType.Max` (C#),
 `ShipTypeMax` (Go), `ShipType::MAX` (Rust), `ShipType.Max` (JS),
@@ -152,9 +151,9 @@ The `Count` member beside it is the **declared variant count**, `None`
 excluded — `ShipType::Count` (C++), `ShipType.Count` (C#), `ShipTypeCount`
 (Go), `ShipType::COUNT` (Rust), `ShipType.Count` (JS), `SHIP_TYPE_COUNT` (C),
 `ShipType.count` (Dart and Java), `ShipType.count/0` (Elixir), and
-`E.Count` in schema expressions. Without headroom `Count` and `Max` are the
-same number. Under `| max = 15` they are 3 and 15, and that difference is
-what the two words are for. `Count` is a reserved variant name too, and every
+`E.Count` in schema expressions. On an enum `Count` and `Max` are always the
+same number; both are exported so an enum and a flags declaration, which has
+a `Count` and no `Max`, present one surface. `Count` is a reserved variant name too, and every
 union's tag enum carries it beside `Max`, so `Count` is a reserved arm name
 on every union for the same reason.
 
@@ -167,8 +166,7 @@ call either way.
 - A loop over the **declared variants** runs from `1` to `Count` inclusive.
 - A loop over **every ordinal**, `None` included, runs from `0` to `Max`
   inclusive.
-- **Size storage and keyed arrays by `Max`** — the extent is what has to fit,
-  headroom and all.
+- **Size storage and keyed arrays by `Max`** — the extent is what has to fit.
 
 Every target also generates a **debug/log name function**, and the spelling is
 each target's own: `EnumName(value)` in C++ (overloaded per enum),
@@ -790,14 +788,10 @@ That covers ranges, counts past an array bound, string lengths past their
 maximum, enum values outside the declared range, and reads that run past the
 end of the buffer.
 
-One precision worth having: an enum read is bounded by the enum's declared
-**max**, not by its variant count. For a plain `enum E { A, B, C }` those are
-the same thing and a non-variant cannot survive a read. But `enum E | max = 15`
-(variants `{ A, B }` on the next line) deliberately reserves headroom so
-variants can be added later without
-moving the field width — and a read of that enum accepts anything in `[0, 15]`.
-That is the point of the headroom, but it means a value you have not defined
-yet can arrive, and your `switch` should have a default. The same VALIDATION rules hold in all nine languages, because
+One precision worth having: an enum read is bounded by the enum's variant
+count. For `enum E { A, B, C }` the wire range is `[0, 3]`, `None` included,
+and a value of 4 or more fails the read. A value you have not named cannot
+survive a read, so a `switch` over an enum needs no default arm for one. The same VALIDATION rules hold in all nine languages, because
 the same compiler wrote all nine — the buffer-slack contract above is the one
 thing that differs per language.
 
@@ -1872,8 +1866,8 @@ open ([#606](https://github.com/mas-bandwidth/schema/issues/606)), so a
 today.*
 
 A key enum counts as part of the table closure: it rides by variant name, so
-`| max` headroom and colliding variant names are refused for it too, with the
-diagnostic naming the field that keys on it.
+colliding variant names are refused for it too, with the diagnostic naming
+the field that keys on it.
 
 **On the TABLE wire the two spellings are different encodings**, and changing
 a table field from one to the other is a wire break, not a refactor: the keyed


### PR DESCRIPTION
Documents only, for #1004. No code, no generated output, no tests.

**The rule.** An enum takes no `| max` headroom attribute. Its wire width derives from its variant count alone — the smallest unsigned integer that fits `[0, max]`, `None` included under the sentinel-zero convention — and nothing widens it. A wire value above max is refused on read: an enum reads as one of its variants or the read fails, so no unnamed enum value exists in any target, nothing is cast, and no `switch` needs a default arm for a value the schema never named. A flags declaration keeps its `| max = K` width; the packet wire now states the refusal the way the table wire already does (SPEC-TABLES.md §5, `check.go:2902`). **Glenn's ruling, "Just Max for enums": an enum exports `Max` only.** Its declared variant count is its `Max`, so the `Count` member goes from every enum and from every union's generated `<Union>Type` tag enum; `E.Count` leaves the expression language (`[..E.Max]T` is the counted array over declared variants); `Count` stops being a reserved variant name on an enum and a reserved arm name on a union. A flags declaration keeps `Count`, its only count, since it has no `Max`.

**Changed locations**
- `docs/SPEC.md:759` — `E.Max` is the derived variant count (was "or the widened `| max = K`")
- `docs/SPEC.md:764-765` — every wire value names a variant or `None`; no reserved values above the last variant
- `docs/SPEC.md:772-774` — `E.Count` always equals `E.Max`; `| max = K` headroom is a flags matter
- `docs/SPEC.md:795-800` — §4.2 enum definition: no `| max` on an enum; width from the count; **an enum reads as one of its variants or the read fails**
- `docs/SPEC.md:884-885`, `:897-898`, `:922` — the qualification-syntax examples use `flags Damage | max = 8` instead of `enum Weapon | max = 15`
- `docs/SPEC.md:1145-1146` — the exported `Max` is the count of real variants, no headroom clause
- `docs/SPEC.md:1156-1158`, `:1167-1168` — the exported `Count` equals `Max` on every enum; the member exists for a uniform surface
- `docs/SPEC.md:1226` — §6 wire-table row for an enum field: max is the variant count; read rejects above it, so an unnamed value never reaches the object (this is the read algorithm; there is no `docs/ALGORITHM.md` in this repo)
- `docs/SPEC.md:1444` — the refusal list: `| max = K` on an enum is refused
- `docs/SPEC.md:2326-2329` — §6.1: the representation is the target's choice; the headroom reason is gone; an unnamed value is unrepresentable on the read side because it is refused
- `docs/USAGE.md:135-137`, `:140`, `:154-156`, `:169` — the enum section: no `| max`; `Count` and `Max` are one number on an enum
- `docs/USAGE.md:791-794` — the validation section: the read is bounded by the variant count; the default-arm advice is gone, nothing replaces it, the reader refuses
- `docs/USAGE.md:1869-1870` — the table-closure key-enum note no longer names `| max` as a table-only refusal

**Changed for the ruling (second commit)**
- `docs/SPEC.md:682` (grammar: `.Max` on an enum, `.Count` on a flags), `:769-775` (§4.2 declared-count references are flags-only; `[..E.Max]T`), `:816-817`, `:1152-1161` (the exported-members paragraph: `Max` is the enum's only exported number; no `Count` on enums or tag enums; `Count` unreserved), `:1428` (§4.6 claimed names), `:1644-1645` and `:1649-1650` (§4.8: tag enum carries `None`, variants, `Max`), `:1673-1683` (the tag-surface table loses its count-member column), `:1688-1690`, the `Count`-as-arm-name refusal bullet at old `:1905-1913` removed, `:2326` (§6.1 tag enum shape)
- `docs/USAGE.md:129`, `:153-156`, `:164` (declared-variant loop runs 1 to `Max`), `:194-195`, `:246`, `:250`, `:1851-1852`
- `docs/SPEC-TABLES.md:1278` (`const N = E.Count`) and `:11594` (the table-closure tag's `Count`) are outside this PR's two docs and change with the compiler PR.

**Left for the follow-up PRs, on purpose**
- `examples/Wire.schema:16-19` (`enum Weapon | max = 15`) is a generation source (`SCHEMAS := examples/*.schema`); editing it makes every committed `generated/` tree stale and the "generated tree is current" CI job red, and `test/random_main.cpp:334,368` drive unnamed values against it. It changes with the compiler PR.
- `docs/TUTORIAL.md:340`, `:526-548`, `:1183` teach the headroom with compiler output the current compiler still emits (`Max = 15`); it changes with the compiler PR so the printed output stays true.
- `docs/SPEC.md:2968-2970` (settled item 7, the `len(Team)` decision) keeps its historical rationale.

**Follow-up PRs**
1. Compiler: the check refuses `| max` on any enum (the table wire's refusal at `internal/check/check.go:2902`, widened to all enums), with its test; `E.Count` refused in expressions; the generated `Count` member removed from enums and tag enums (packet and table-closure emitters) and its claimed-name/reserved-arm checks dropped; `examples/Wire.schema` and `docs/TUTORIAL.md` regenerated and re-read.
2. Nine legs, C++ reference first, others match bytes: each drops the enum and tag-enum `Count` member and carries the negative control (an unnamed in-range value is REFUSED on read, red before green) and removes the `???` name path — `test/random_main.cpp:334,368`, `test/main.cpp:809`, `test/dart/main.dart:865`, `test/java/Main.java:549`, `test/elixir/suite.exs:672`, and the other legs' equivalents.
3. The `???` name path removal from every emitter once no unnamed value can exist.

Reads owed: Rowan's Fable cold read first, then Stella, Emma, Johnny, Freddy; deadline set by Rowan on the bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
